### PR TITLE
Add path property to TestLintOptions

### DIFF
--- a/packages/@romejs/compiler/lint/rules/testHelpers.ts
+++ b/packages/@romejs/compiler/lint/rules/testHelpers.ts
@@ -8,7 +8,7 @@
 import {TestHelper} from "rome";
 import lint from "../index";
 import {parseJS} from "@romejs/js-parser";
-import {createUnknownFilePath} from "@romejs/path";
+import {UnknownFilePath, createUnknownFilePath} from "@romejs/path";
 import {createDefaultProjectConfig} from "@romejs/project";
 import {ConstProgramSyntax, ConstSourceType} from "@romejs/ast";
 import {DiagnosticCategory, DiagnosticsProcessor} from "@romejs/diagnostics";
@@ -18,6 +18,7 @@ type TestLintOptions = {
 	category: undefined | DiagnosticCategory;
 	sourceType?: ConstSourceType;
 	syntax?: Array<ConstProgramSyntax>;
+	path?: UnknownFilePath | string;
 };
 
 type TestLintInput = {
@@ -41,7 +42,12 @@ export async function testLint(
 async function testLintExpect(
 	t: TestHelper,
 	input: string,
-	{syntax = ["jsx", "ts"], category, sourceType = "module"}: TestLintOptions,
+	{
+		syntax = ["jsx", "ts"],
+		category,
+		sourceType = "module",
+		path = createUnknownFilePath("unknown"),
+	}: TestLintOptions,
 	expectValid: boolean,
 ) {
 	t.addToAdvice({
@@ -73,7 +79,7 @@ async function testLintExpect(
 	const ast = parseJS({
 		input,
 		sourceType,
-		path: createUnknownFilePath("unknown"),
+		path,
 		syntax,
 	});
 


### PR DESCRIPTION
This adds a path property to `TestLintOptions`. I didn't think it was worth complicating `testLint` to support specifying a unique path for each input, so the specified path applies to all the inputs in a single `testLint` call.

You can call `testLint` multiple times in the same test file if it's necessary.