### PR TITLE
feat: add (and enable) --changed support to the ci CLI command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.16.0'
-          fetch-depth: 0
+          all_commits: true
       - name: rome ci
-        run: ./rome ci --changed
+        run: ./rome ci --changed=main
 
   tests:
     name: rome test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.16.0'
+          fetch-depth: 0
       - name: rome ci
         run: ./rome ci --changed
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: '14.16.0'
       - name: rome ci
-        run: ./rome ci
+        run: ./rome ci --changed
 
   tests:
     name: rome test

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -62,7 +62,6 @@ export default createServerCommand<Flags>({
 		if (checkVSC) {
 			const vcsClient = await getVCSClient(
 				cwd,
-				currentProject.config.vcs.baseBranch,
 			);
 			if (vcsClient === undefined) {
 				throw createSingleDiagnosticsError({

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -60,7 +60,10 @@ export default createServerCommand<Flags>({
 
 		// Check for no or dirty repo
 		if (checkVSC) {
-			const vcsClient = await getVCSClient(cwd);
+			const vcsClient = await getVCSClient(
+				cwd,
+				currentProject.config.vcs.baseBranch,
+			);
 			if (vcsClient === undefined) {
 				throw createSingleDiagnosticsError({
 					location: req.getDiagnosticLocationForClientCwd(),

--- a/internal/core/server/commands/check.ts
+++ b/internal/core/server/commands/check.ts
@@ -110,7 +110,7 @@ export default createServerCommand<Flags>({
 
 			const client = await req.getVCSClient();
 			const target =
-				flags.changed === "" ? await client.getDefaultBranch() : flags.changed;
+				flags.changed === "" ? client.getDefaultBranch() : flags.changed;
 			const modifiedFiles = await client.getModifiedFiles(target);
 			const flagLoc = req.getDiagnosticLocationFromFlags({
 				type: "flag",

--- a/internal/core/server/commands/ci.ts
+++ b/internal/core/server/commands/ci.ts
@@ -40,7 +40,7 @@ export default createServerCommand({
 			).asBoolean(false),
 		};
 	},
-	async callback(req: ServerRequest, { fix, changed }: Flags): Promise<void> {
+	async callback(req: ServerRequest, {fix, changed}: Flags): Promise<void> {
 		req.updateRequestFlags({
 			truncateDiagnostics: false,
 			maxDiagnostics: Infinity,

--- a/internal/core/server/commands/ci.ts
+++ b/internal/core/server/commands/ci.ts
@@ -15,6 +15,7 @@ import {markup} from "@internal/markup";
 
 type Flags = {
 	fix: boolean;
+	changed?: string;
 };
 
 export default createServerCommand({
@@ -25,6 +26,12 @@ export default createServerCommand({
 	examples: [],
 	defineFlags(consumer: Consumer): Flags {
 		return {
+			changed: consumer.get(
+				"changed",
+				{
+					description: markup`only check files that have changed from the specified branch/commit (defaults to main)`,
+				},
+			).asStringOrVoid(),
 			fix: consumer.get(
 				"fix",
 				{
@@ -33,7 +40,7 @@ export default createServerCommand({
 			).asBoolean(false),
 		};
 	},
-	async callback(req: ServerRequest, flags: Flags): Promise<void> {
+	async callback(req: ServerRequest, { fix, changed }: Flags): Promise<void> {
 		req.updateRequestFlags({
 			truncateDiagnostics: false,
 			maxDiagnostics: Infinity,
@@ -50,8 +57,8 @@ export default createServerCommand({
 							{
 								formatOnly: false,
 								decisions: [],
-								apply: flags.fix,
-								changed: undefined,
+								apply: fix,
+								changed,
 								suppressionExplanation: undefined,
 							},
 						);
@@ -66,8 +73,8 @@ export default createServerCommand({
 								filter: undefined,
 								focusAllowed: false,
 								coverage: false,
-								freezeSnapshots: !flags.fix,
-								updateSnapshots: flags.fix,
+								freezeSnapshots: !fix,
+								updateSnapshots: fix,
 								showAllCoverage: false,
 								runInSync: false,
 								sourceMaps: true,

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -495,7 +495,7 @@ export default class ProjectManager {
 	public async maybeGetVCSClient(
 		project: ProjectDefinition,
 	): Promise<undefined | VCSClient> {
-		return await getVCSClient(project.config.vcs.root);
+		return await getVCSClient(project.config.vcs.root, project.config.vcs.baseBranch);
 	}
 
 	public addDiskProject(

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -495,7 +495,10 @@ export default class ProjectManager {
 	public async maybeGetVCSClient(
 		project: ProjectDefinition,
 	): Promise<undefined | VCSClient> {
-		return await getVCSClient(project.config.vcs.root, project.config.vcs.baseBranch);
+		return await getVCSClient(
+			project.config.vcs.root,
+			project.config.vcs.baseBranch,
+		);
 	}
 
 	public addDiskProject(

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -497,7 +497,6 @@ export default class ProjectManager {
 	): Promise<undefined | VCSClient> {
 		return await getVCSClient(
 			project.config.vcs.root,
-			project.config.vcs.baseBranch,
 		);
 	}
 

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -428,9 +428,6 @@ export async function normalizeProjectConfig(
 		if (vcs.has("root")) {
 			config.vcs.root = projectDirectory.resolve(vcs.get("root").asFilePath());
 		}
-		if (vcs.has("baseBranch")) {
-			config.vcs.baseBranch = vcs.get("baseBranch").asString();
-		}
 		vcs.enforceUsedProperties("vcs config property");
 	}
 

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -428,6 +428,9 @@ export async function normalizeProjectConfig(
 		if (vcs.has("root")) {
 			config.vcs.root = projectDirectory.resolve(vcs.get("root").asFilePath());
 		}
+		if (vcs.has("baseBranch")) {
+			config.vcs.baseBranch = vcs.get("baseBranch").asString();
+		}
 		vcs.enforceUsedProperties("vcs config property");
 	}
 

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -90,7 +90,6 @@ export type ProjectConfigObjects = {
 	};
 	vcs: {
 		root: AbsoluteFilePath;
-		baseBranch: string;
 	};
 	files: {
 		assetExtensions: string[];
@@ -207,7 +206,6 @@ export type RawUserProjectConfig = DeepPartial<{
 	};
 	vcs: {
 		root: string;
-		baseBranch: string;
 	};
 	targets: {
 		[key: string]: {
@@ -284,7 +282,6 @@ export function createDefaultProjectConfig(): ProjectConfig {
 		},
 		vcs: {
 			root: createAbsoluteFilePath("/"),
-			baseBranch: "main",
 		},
 		files: {
 			vendorPath: TEMP_PATH.append("rome-remote"),

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -90,6 +90,7 @@ export type ProjectConfigObjects = {
 	};
 	vcs: {
 		root: AbsoluteFilePath;
+		baseBranch: string;
 	};
 	files: {
 		assetExtensions: string[];
@@ -206,6 +207,7 @@ export type RawUserProjectConfig = DeepPartial<{
 	};
 	vcs: {
 		root: string;
+		baseBranch: string;
 	};
 	targets: {
 		[key: string]: {
@@ -282,6 +284,7 @@ export function createDefaultProjectConfig(): ProjectConfig {
 		},
 		vcs: {
 			root: createAbsoluteFilePath("/"),
+			baseBranch: "main",
 		},
 		files: {
 			vendorPath: TEMP_PATH.append("rome-remote"),

--- a/internal/vcs/index.ts
+++ b/internal/vcs/index.ts
@@ -76,8 +76,9 @@ class GitVCSClient extends VCSClient {
 			).waitSuccess()).getOutput(true, false);
 			return extractFileList(stdout);
 		} catch (_) {
+			// TODO: temporary
 			throw new Error(
-				`Unexpected error when checking for modified files on the "${this.baseBranch}" branch`,
+				`Unexpected error when checking for modified files on the "${this.baseBranch}" branch \n\n\ ${_.message}`,
 			);
 		}
 	}

--- a/internal/vcs/index.ts
+++ b/internal/vcs/index.ts
@@ -49,29 +49,44 @@ class GitVCSClient extends VCSClient {
 	}
 
 	public async getDefaultBranch(): Promise<string> {
-		const exitCode = await spawn(
-			"git",
-			["show-ref", "--verify", "--quiet", "refs/heads/main"],
-			{cwd: this.root},
-		).wait();
-		return exitCode === 0 ? "main" : "master";
+		try {
+			const exitCode = await spawn(
+				"git",
+				["show-ref", "--verify", "--quiet", "refs/heads/main"],
+				{cwd: this.root},
+			).wait();
+			return exitCode === 0 ? "main" : "master";
+		} catch (_) {
+			throw new Error("Unexpected error when checking the default branch");
+		}
 	}
 
 	public async getUncommittedFiles(): Promise<string[]> {
-		const stdout = (await spawn("git", ["status", "--short"], {cwd: this.root}).waitSuccess()).getOutput(
-			true,
-			false,
-		);
-		return extractFileList(stdout);
+		try {
+			const stdout = (await spawn(
+				"git",
+				["status", "--short"],
+				{cwd: this.root},
+			).waitSuccess()).getOutput(true, false);
+			return extractFileList(stdout);
+		} catch (_) {
+			throw new Error("Unexpected error when checking for uncommitted files");
+		}
 	}
 
 	public async getModifiedFiles(branch: string): Promise<string[]> {
-		const stdout = (await spawn(
-			"git",
-			["diff", "--name-status", branch],
-			{cwd: this.root},
-		).waitSuccess()).getOutput(true, false);
-		return extractFileList(stdout);
+		try {
+			const stdout = (await spawn(
+				"git",
+				["diff", "--name-status", branch],
+				{cwd: this.root},
+			).waitSuccess()).getOutput(true, false);
+			return extractFileList(stdout);
+		} catch (_) {
+			throw new Error(
+				`Unexpected error when checking for modified files on the "${branch}" branch`,
+			);
+		}
 	}
 }
 

--- a/internal/vcs/index.ts
+++ b/internal/vcs/index.ts
@@ -69,9 +69,10 @@ class GitVCSClient extends VCSClient {
 
 	public async getModifiedFiles(): Promise<string[]> {
 		try {
+			const currentBranch = (await spawn("git", ["branch", "--show-current"], {cwd: this.root}).waitSuccess()).getOutput(true, false)
 			const stdout = (await spawn(
 				"git",
-				["diff", "--name-status", this.baseBranch],
+				["--no-pager", "diff", "--name-status", `origin/${this.baseBranch}...${currentBranch}`, "--"],
 				{cwd: this.root},
 			).waitSuccess()).getOutput(true, false);
 			return extractFileList(stdout);

--- a/internal/vcs/index.ts
+++ b/internal/vcs/index.ts
@@ -39,11 +39,19 @@ export class VCSClient {
 	public getUncommittedFiles(): Promise<string[]> {
 		throw new Error("unimplemented");
 	}
+
+	public getDefaultBranch(): string {
+		throw new Error("unimplemented");
+	}
 }
 
 class GitVCSClient extends VCSClient {
 	constructor(root: AbsoluteFilePath, baseBranch: string) {
 		super(root, baseBranch);
+	}
+
+	public getDefaultBranch(): string {
+		return this.baseBranch;
 	}
 
 	public async getUncommittedFiles(): Promise<string[]> {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
 	"rome": {
 		"name": "project-rome",
 		"root": true,
+		"vcs": {
+			"baseBranch": "main"
+		},
 		"lint": {
 			"ignore": [
 				"build",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
 	"rome": {
 		"name": "project-rome",
 		"root": true,
-		"vcs": {
-			"baseBranch": "main"
-		},
 		"lint": {
 			"ignore": [
 				"build",


### PR DESCRIPTION
## Summary

This pull request updates the `rome ci` command to accept a `--changed` flag that's in turn passed through to the underlying `rome check` command. This approach should safely allow unnecessary file checks to be avoided, leading to a reduced `rome ci` execution time.

This flag has been enabled for Rome's internal GitHub action.

Resolves #978
Resolves #1087

## Test Plan

```sh
>   ./rome test
```
