### PR TITLE
fix(website): a11y header anchors

### DIFF
--- a/website/.eleventy.js
+++ b/website/.eleventy.js
@@ -57,6 +57,7 @@ module.exports = function(eleventyConfig) {
 		{
 			permalink: true,
 			permalinkSymbol: "",
+			permalinkAttrs: (slug) => ({"aria-label": slug}),
 			slugify: (title) => {
 				return encodeURIComponent(
 					String(title).trim().toLowerCase().replace(/\s+/g, "-"),


### PR DESCRIPTION
This is part of a series of PRs concerning **📎 Website accessibility audit** (https://github.com/romefrontend/rome/issues/839#issuecomment-672338554)

This PR fixes: 

Header anchors (the `#` link after titles) don't have text, so titles are announced as (117 times):
>    Heading level 2, "Development Status", Heading Level 2, Link, "Number"

`markdown-it-anchor` provides a `slug` argument that is used here as `aria-label` for all header anchors. The above example would now be:

>    Heading level 2, "Development Status", Heading Level 2, Link, "Development Status"
