### PR TITLE
fix: safely update per-token context

### DIFF
--- a/internal/js-parser/tokenizer/context.ts
+++ b/internal/js-parser/tokenizer/context.ts
@@ -65,11 +65,7 @@ tt.parenR.updateContext = tt.braceR.updateContext = function(parser) {
 		}
 	}
 
-	if (out === undefined) {
-		throw new Error("No context found");
-	}
-
-	parser.state.exprAllowed = !out.isExpr;
+	parser.state.exprAllowed = !out || !out.isExpr;
 };
 
 tt.name.updateContext = function(parser, prevType) {


### PR DESCRIPTION
## Summary

This pull request updates the JavaScript parser to safely handle per-token context updates in the event that the parser context stack is empty. I'm a little suspicious that this fix may be paving over a deeper issue around incorrect context population in the first place, but the resulting AST looked correct and other upstream parser implementations do not throw in this case.

Resolves #1134

## Test Plan

Run `./rome check` on a file with the following content and verify that no internal error is thrown:

```jsx
const Test = () => {
  return (
    <div>
      {true && (false ? <div /> : <div />)}
      <div />
    </div>
  );
};
```
