### PR TITLE
test: js-ast-utils/isInTypeAnnotation

### DIFF
--- a/internal/js-ast-utils/isInTypeAnnotation.test.ts
+++ b/internal/js-ast-utils/isInTypeAnnotation.test.ts
@@ -1,0 +1,77 @@
+import {test} from "rome";
+import {isInTypeAnnotation} from "@internal/js-ast-utils/isInTypeAnnotation";
+import {
+	AnyNode,
+	MOCK_PARENT,
+	jsArrayExpression,
+	jsCommentLine,
+	jsRoot,
+	tsArrayType,
+	tsAsExpression,
+	tsNonNullExpression,
+	tsNullKeywordTypeAnnotation,
+	tsThisType,
+	tsTypeAssertion,
+} from "@internal/ast";
+import {CompilerContext, Path} from "@internal/compiler";
+
+function helper(node: AnyNode) {
+	let path = new Path(
+		MOCK_PARENT,
+		new CompilerContext({
+			ast: jsRoot.create({
+				body: [],
+				comments: [],
+				corrupt: false,
+				diagnostics: [],
+				directives: [],
+				filename: "",
+				hasHoistedVars: false,
+				interpreter: undefined,
+				mtime: undefined,
+				sourceType: "script",
+				syntax: [],
+			}),
+		}),
+		{},
+	);
+
+	path.parent = node;
+
+	return isInTypeAnnotation(path);
+}
+
+test(
+	"returns true if the node is in type annotation",
+	async (t) => {
+		t.false(helper(jsCommentLine.create({id: "", value: "hello"})));
+
+		t.false(
+			helper(
+				tsAsExpression.create({
+					expression: jsArrayExpression.quick([]),
+					typeAnnotation: tsThisType.create({}),
+				}),
+			),
+		);
+
+		t.false(
+			helper(
+				tsTypeAssertion.create({
+					expression: jsArrayExpression.quick([]),
+					typeAnnotation: tsThisType.create({}),
+				}),
+			),
+		);
+
+		t.false(
+			helper(
+				tsNonNullExpression.create({expression: jsArrayExpression.quick([])}),
+			),
+		);
+
+		t.true(helper(tsArrayType.create({elementType: tsThisType.create({})})));
+
+		t.true(helper(tsNullKeywordTypeAnnotation.create({})));
+	},
+);


### PR DESCRIPTION
## Summary
Part of #1023 

Adds test for js-ast-utils/isInTypeAnnotation.ts

## Test Plan

`rome check` is successful.
`rome test` passes all tests.