### PR TITLE
fix(a11y): general a11y fixes

### DIFF
--- a/internal/cli-layout/formatHTML.ts
+++ b/internal/cli-layout/formatHTML.ts
@@ -47,7 +47,7 @@ export function htmlFormatText(
 			return `<span style="color: Orange;">${value}</span>`;
 
 		case "info":
-			return `<span style="color: DodgerBlue;">${value}</span>`;
+			return `<span style="color: rgb(38, 148, 255);">${value}</span>`;
 
 		case "code":
 			return `<i>${value}</i>`;

--- a/website/src/_includes/docs/cli-screenshots/check.md
+++ b/website/src/_includes/docs/cli-screenshots/check.md
@@ -45,4 +45,4 @@
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Found </span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"> </span><span style="color: Tomato;">problems</span></code><div aria-hidden="true" class="expand">Click to Expand</div></pre>
+<strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Found </span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"> </span><span style="color: Tomato;">problems</span></code><button aria-hidden="true" class="expand">Click to Expand</button></pre>

--- a/website/src/_includes/docs/cli-screenshots/init.md
+++ b/website/src/_includes/docs/cli-screenshots/init.md
@@ -34,4 +34,4 @@
      GitHub (<a href="https://github.com/romefrontend/rome">https://github.com/romefrontend/rome</a>) or our community
      Discord (<a href="https://discord.gg/rome">https://discord.gg/rome</a>)
 
-</code><div aria-hidden="true" class="expand">Click to Expand</div></pre>
+</code><button aria-hidden="true" class="expand">Click to Expand</button></pre>

--- a/website/src/_includes/docs/cli-screenshots/lint-review.md
+++ b/website/src/_includes/docs/cli-screenshots/lint-review.md
@@ -24,4 +24,4 @@
   ◯ Exit <span style="opacity: 0.8;">(shortcut escape)</span>
   ◯ More options... <span style="opacity: 0.8;">(shortcut m)</span>
 
-</code><div aria-hidden="true" class="expand">Click to Expand</div></pre>
+</code><button aria-hidden="true" class="expand">Click to Expand</button></pre>

--- a/website/src/_includes/docs/cli-screenshots/lint-suggestions.md
+++ b/website/src/_includes/docs/cli-screenshots/lint-suggestions.md
@@ -17,4 +17,4 @@
   <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">username</span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">&middot;</span></span><span style="color: MediumSeaGreen;">==</span><span style="color: MediumSeaGreen;"><strong>=</strong></span><span style="color: MediumSeaGreen;"><span style="opacity: 0.8;">&middot;</span></span><span style="color: MediumSeaGreen;">&quot;sebmck&quot;</span>
 
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">This may be unsafe if you are relying on type coercion</span>
- </code><div aria-hidden="true" class="expand">Click to Expand</div></pre>
+ </code><button aria-hidden="true" class="expand">Click to Expand</button></pre>

--- a/website/src/_includes/docs/cli-screenshots/recover-list.md
+++ b/website/src/_includes/docs/cli-screenshots/recover-list.md
@@ -19,4 +19,4 @@
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">To apply </span><span style="color: DodgerBlue;"><strong>everything</strong></span><span style="color: DodgerBlue;"> in this patch run:</span>
   <span style="opacity: 0.8;">$ rome recover apply 1595570309210-lint-0</span>"
 
-</code><div aria-hidden="true" class="expand">Click to Expand</div></pre>
+</code><button aria-hidden="true" class="expand">Click to Expand</button></pre>

--- a/website/src/_includes/layouts/base.liquid
+++ b/website/src/_includes/layouts/base.liquid
@@ -68,7 +68,7 @@
 			<div class="sidebar-container">
 				<div class="sidebar-stripe"></div>
 
-				<div class="sidebar">
+				<aside class="sidebar">
 					<div class="header-desktop">
 						<a class="logo" href="/">
 							{% include svg/rome-logo.svg %}
@@ -131,7 +131,7 @@
 							{% include svg/sun.svg %}
 						</button>
 					</div>
-				</div>
+				</aside>
 			</div>
 
 			<div class="main">

--- a/website/src/_includes/layouts/base.liquid
+++ b/website/src/_includes/layouts/base.liquid
@@ -150,7 +150,7 @@
 							<a href="https://github.com/romefrontend/rome/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
 						</li>
 						<li>
-							<a href="https://discord.gg/9WxHa5d">Discord</a>
+							<a href="https://discord.gg/rome">Discord</a>
 						</li>
 						<li>
 							<a href="https://twitter.com/romefrontend">Twitter</a>

--- a/website/src/_includes/layouts/base.liquid
+++ b/website/src/_includes/layouts/base.liquid
@@ -125,11 +125,11 @@
 					</div>
 
 					<div class="color-scheme-switch-container">
-						<div class="color-scheme-switch">
+						<button class="color-scheme-switch" title="Toggle theme" aria-label="Toggle theme">
 							<div class="selector"></div>
 							{% include svg/moon.svg %}
 							{% include svg/sun.svg %}
-						</div>
+						</button>
 					</div>
 				</div>
 			</div>

--- a/website/src/_includes/layouts/homepage.liquid
+++ b/website/src/_includes/layouts/homepage.liquid
@@ -17,7 +17,7 @@ layout: layouts/base.liquid
 	</div>
 </article>
 
-<div class="hero">
+<header class="hero">
 
 	<h1>
 		<div>
@@ -27,7 +27,7 @@ layout: layouts/base.liquid
 		</div>
 	</h1>
 	<h2>Unifying the frontend development toolchain</h2>
-</div>
+</header>
 
 <main id="main-content" class="content split homepage">
 	{{ content | safe }}

--- a/website/src/_includes/layouts/homepage.liquid
+++ b/website/src/_includes/layouts/homepage.liquid
@@ -4,8 +4,8 @@ layout: layouts/base.liquid
 
 {% assign post = collections.post | reverse | first %}
 
-<article class="latest-post">
-	<h2>Latest blog post</h2>
+<aside class="latest-post" aria-labelledby="latest-post">
+	<h2 id="latest-post">Latest blog post</h2>
 	<div class="info">
 		<h3>
 		 <a href="{{ post.url }}">{{ post.data.title }}</a>
@@ -15,7 +15,7 @@ layout: layouts/base.liquid
 			at {{ post.date | dateFormat }}
 		</div>
 	</div>
-</article>
+</aside>
 
 <header class="hero">
 

--- a/website/src/styles/_homepage.scss
+++ b/website/src/styles/_homepage.scss
@@ -148,6 +148,9 @@ pre.collapsable {
 		line-height: 40px;
 		color: #fff;
 		font-family: inherit;
+		font-size: 1rem;
+		border: none;
+		width: 100%;
 	}
 
 	&.collapsed {

--- a/website/src/styles/_homepage.scss
+++ b/website/src/styles/_homepage.scss
@@ -168,7 +168,7 @@ pre.collapsable {
 	}
 }
 
-article.latest-post {
+.latest-post {
 	border-bottom: 1px solid var(--soft-border-color);
 	padding: $unit $unit;
 	margin-left: $unit;

--- a/website/src/styles/_prism.scss
+++ b/website/src/styles/_prism.scss
@@ -111,7 +111,7 @@ pre[class*="language-"] {
 
 .token.important,
 .token.variable {
-	color: rgb(224, 108, 117);
+	color: rgb(227, 110, 119);
 }
 
 .token.important,

--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -278,6 +278,7 @@ html[data-theme='dark'] {
 	flex-shrink: 0;
 	cursor: pointer;
 	display: flex;
+	border: none;
 
 	svg {
 		pointer-events: none;


### PR DESCRIPTION
This PR is related to 📎 Website accessibility audit, https://github.com/romefrontend/rome/issues/839#issuecomment-672338554

Pasting fixed points here for context:

- Theme toggler should contain `role="button"` and a descriptive label
- `.token.variable` (code syntax highlighting) have a contrast ratio of 4.38 and fails WCAG AA recommended 4.5
- Info messages in code (the ones with an ℹ) have a contrast ratio of 4.33
- Code examples with "Click to Expand" areas are not keyboard accessible
- Sidebar content, top "Latest blog post" and main "Rome" logo + slogan are outside landmarks. Could be solved with some `aside`/`header`/`section` for example.
- Discord links have different `href` (triggers "Links with the same name have a similar purpose"). Footer link points to `https://discord.gg/9WxHa5d` (the same place as the top one, but that points to the pretty URL)

Let me know what you think.