### PR TITLE
fix: opencollective link

### DIFF
--- a/website/src/_includes/action-links.liquid
+++ b/website/src/_includes/action-links.liquid
@@ -5,7 +5,7 @@
 		</a>
 	</li>
 	<li>
-		<a href="https://opencollective.com/romefrontend">
+		<a href="https://opencollective.com/rometools">
 			{% include layouts/svg/open-collective.svg %} Open Collective
 		</a>
 	</li>


### PR DESCRIPTION
## Summary

The link to open collective is actually: romefrontend.

This PR fix to opencollective.com/rometools.