### PR TITLE
fix: Typo on "uncommitted", updates file to return early

### DIFF
--- a/scripts/generate-all-files.ts
+++ b/scripts/generate-all-files.ts
@@ -38,17 +38,17 @@ export async function main(args: string[]) {
 	reporter.hr();
 
 	// Check that `git status` is fine
-	const gitStatusChanges = child.spawnSync("git", ["ls-files", "-m"]).stdout.toString();
-	if (gitStatusChanges === "") {
+	const uncommittedFiles = child.spawnSync("git", ["ls-files", "-m"]).stdout.toString();
+	if (uncommittedFiles === "") {
 		reporter.success(markup`Generated files up-to-date`);
 		return 0;
 	}
 	reporter.info(markup`Modified uncommitted files:`);
 	reporter.list(
-		gitStatusChanges.trim().split("\n").map((filename) => markup`${filename}`),
+		uncommittedFiles.trim().split("\n").map((filename) => markup`${filename}`),
 	);
 	reporter.info(
-		markup`To fix this run <code>./rome run scripts/generate-all-files</code> and commit the results`,
+		markup`To fix this, run <code>./rome run scripts/generate-all-files</code> and commit the results`,
 	);
 	return 1;
 }

--- a/scripts/generate-all-files.ts
+++ b/scripts/generate-all-files.ts
@@ -38,17 +38,17 @@ export async function main(args: string[]) {
 	reporter.hr();
 
 	// Check that `git status` is fine
-	const out = child.spawnSync("git", ["ls-files", "-m"]).stdout.toString();
-	if (out === "") {
+	const gitStatusChanges = child.spawnSync("git", ["ls-files", "-m"]).stdout.toString();
+	if (gitStatusChanges === "") {
 		reporter.success(markup`Generated files up-to-date`);
-	} else {
-		reporter.info(markup`Modified uncomitted files:`);
-		reporter.list(out.trim().split("\n").map((filename) => markup`${filename}`));
-		reporter.info(
-			markup`To fix this run <code>./rome run scripts/generate-all-files</code> and commit the results`,
-		);
-		return 1;
+		return 0;
 	}
-
-	return 0;
+	reporter.info(markup`Modified uncommitted files:`);
+	reporter.list(
+		gitStatusChanges.trim().split("\n").map((filename) => markup`${filename}`),
+	);
+	reporter.info(
+		markup`To fix this run <code>./rome run scripts/generate-all-files</code> and commit the results`,
+	);
+	return 1;
 }

--- a/website/src/_includes/scripts/funding.js
+++ b/website/src/_includes/scripts/funding.js
@@ -1,8 +1,6 @@
 // {% include scripts/funding-utils.js %}
 // global formatCurrency, setRecentContributions
-
 //# State
-
 let selectedTier = undefined;
 let existingToast = undefined;
 
@@ -706,10 +704,9 @@ function processStats(res, interactive) {
 
 	if (interactive) {
 		function show() {
-
 			const percent = Math.min(100, 100 / res.target * res.current);
 			progressFillContainer.style.minWidth = `${progressFillContainer.clientWidth}px`;
-			progressFillContainer.style.width = `0`;
+			progressFillContainer.style.width = "0";
 
 			requestAnimationFrame(() => {
 				progressFillContainer.style.width = `${percent}%`;


### PR DESCRIPTION
## Summary

- Fixes a typo with "uncommitted"
- Returns early when git status returns an empty string

## Test Plan

`./rome test`
`./rome check --apply`

Additional testing included modifying an existing lint rule, running this script and verifying the exit code of 1, and running this script without any modifications and verifying an exit code of 0.
