### PR TITLE
chore: ignore scss, sass and less

### DIFF
--- a/internal/core/common/file-handlers/index.ts
+++ b/internal/core/common/file-handlers/index.ts
@@ -145,7 +145,12 @@ function setHandler(handler: ExtensionHandler) {
 const DEFAULT_HANDLERS: ExtensionsMap = new Map();
 
 const DEFAULT_ASSET_EXTENSIONS = [
+	// CSS
 	"css",
+	// Extra css types to be ignored while we don't have a proper integration
+  "scss",
+	"sass",
+	"less",
 	// Images
 	"png",
 	"jpg",

--- a/internal/core/common/file-handlers/index.ts
+++ b/internal/core/common/file-handlers/index.ts
@@ -148,7 +148,7 @@ const DEFAULT_ASSET_EXTENSIONS = [
 	// CSS
 	"css",
 	// Extra css types to be ignored while we don't have a proper integration
-  "scss",
+	"scss",
 	"sass",
 	"less",
 	// Images


### PR DESCRIPTION
Ignore scss, sass and less as they make rome crash.

Better strategy should be used instead later.
