### PR TITLE
fix(init): remove space between ext in generated editorconfig

### DIFF
--- a/internal/core/server/commands/init.ts
+++ b/internal/core/server/commands/init.ts
@@ -305,7 +305,7 @@ export default createServerCommand<Flags>({
 
 					if (editorConfigTabExtensions.length > 0) {
 						editorConfigTemplate = dedent`
-							[{${editorConfigTabExtensions.sort().join(", ")}}]
+							[{${editorConfigTabExtensions.sort().join(",")}}]
 							end_of_line = lf
 							trim_trailing_whitespace = true
 							insert_final_newline = true


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

fixes #1245 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

```
yarn rome init
```

Checks generated `.editorconfig`
```
[{*.js,*.json,*.rjson}]
...
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
