### PR TITLE
feat(lint): add autofix in noExtraBooleanCast

### DIFF
--- a/internal/compiler/lint/rules/js/noExtraBooleanCast.test.md
+++ b/internal/compiler/lint/rules/js/noExtraBooleanCast.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- lint/js/noExtraBooleanCast/reject/1/file.ts:1:4 lint/js/noExtraBooleanCast ━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/js/noExtraBooleanCast/reject/1/file.ts:1:4 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
 
   ✖ Avoid redundant double-negation.
 
@@ -16,6 +16,11 @@
         ^^^^^^^^^^^^
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - Boolean(foo)
+  + foo
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -26,7 +31,7 @@
 ### `0: formatted`
 
 ```
-if (Boolean(foo)) {
+if (foo) {
 }
 
 ```
@@ -35,25 +40,42 @@ if (Boolean(foo)) {
 
 ```
 
- lint/js/noExtraBooleanCast/reject/2/file.ts:1:7 lint/js/noExtraBooleanCast ━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/js/noExtraBooleanCast/reject/2/file.ts:1:4 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
 
   ✖ Avoid redundant double-negation.
 
-    while (!!foo) {}
-           ^^^^^
+    if (!!Boolean(foo)) {}
+        ^^^^^^^^^^^^^^
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
 
+  ℹ Safe fix
+
+  - !!Boolean(foo)
+  + Boolean(foo)
+
+ lint/js/noExtraBooleanCast/reject/2/file.ts:1:6 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - Boolean(foo)
+  + foo
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-✖ Found 1 problem
+✖ Found 2 problems
 
 ```
 
 ### `1: formatted`
 
 ```
-while (!!foo) {}
+if (foo) {
+}
 
 ```
 
@@ -61,16 +83,19 @@ while (!!foo) {}
 
 ```
 
- lint/js/noExtraBooleanCast/reject/3/file.ts:4:9 lint/js/noExtraBooleanCast ━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/js/noExtraBooleanCast/reject/3/file.ts:1:5 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
 
   ✖ Avoid redundant double-negation.
 
-    2 │ do {
-    3 │   1 + 1;
-  > 4 │ } while (Boolean(x));
-      │          ^^^^^^^^^^
+    if (!Boolean(foo)) {}
+         ^^^^^^^^^^^^
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - Boolean(foo)
+  + foo
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -81,10 +106,8 @@ while (!!foo) {}
 ### `2: formatted`
 
 ```
-let x = 1;
-do {
-	1 + 1;
-} while (Boolean(x));
+if (!foo) {
+}
 
 ```
 
@@ -92,14 +115,19 @@ do {
 
 ```
 
- lint/js/noExtraBooleanCast/reject/4/file.ts:1:7 lint/js/noExtraBooleanCast ━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/js/noExtraBooleanCast/reject/4/file.ts:1:7 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
 
   ✖ Avoid redundant double-negation.
 
-    for (; !!foo; ) {}
+    while (!!foo) {}
            ^^^^^
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - !!foo
+  + foo
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -110,6 +138,208 @@ do {
 ### `3: formatted`
 
 ```
-while (!!foo) {}
+while (foo) {}
+
+```
+
+### `4`
+
+```
+
+ lint/js/noExtraBooleanCast/reject/5/file.ts:4:9 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+    2 │ do {
+    3 │   1 + 1;
+  > 4 │ } while (Boolean(x));
+      │          ^^^^^^^^^^
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - Boolean(x)
+  + x
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `4: formatted`
+
+```
+let x = 1;
+do {
+	1 + 1;
+} while (x);
+
+```
+
+### `5`
+
+```
+
+ lint/js/noExtraBooleanCast/reject/6/file.ts:1:7 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+    for (; !!foo; ) {}
+           ^^^^^
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - !!foo
+  + foo
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `5: formatted`
+
+```
+while (foo) {}
+
+```
+
+### `6`
+
+```
+
+ lint/js/noExtraBooleanCast/reject/7/file.ts:1:12 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+    new Boolean(!!x);
+                ^^^
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - !!x
+  + x
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `6: formatted`
+
+```
+new Boolean(x);
+
+```
+
+### `7`
+
+```
+
+ lint/js/noExtraBooleanCast/reject/8/file.ts:1:1 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+    !!!x;
+     ^^^
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - !!x
+  + x
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `7: formatted`
+
+```
+!x;
+
+```
+
+### `8`
+
+```
+
+ lint/js/noExtraBooleanCast/reject/9/file.ts:1:1 lint/js/noExtraBooleanCast  FIXABLE  ━━━━━━━━━━━━━━
+
+  ✖ Avoid redundant double-negation.
+
+    !Boolean(x);
+     ^^^^^^^^^^
+
+  ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
+
+  ℹ Safe fix
+
+  - Boolean(x)
+  + x
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `8: formatted`
+
+```
+!x;
+
+```
+
+### `9`
+
+```
+✔ No known problems!
+
+```
+
+### `9: formatted`
+
+```
+Boolean(!x);
+
+```
+
+### `10`
+
+```
+✔ No known problems!
+
+```
+
+### `10: formatted`
+
+```
+!x;
+
+```
+
+### `11`
+
+```
+✔ No known problems!
+
+```
+
+### `11: formatted`
+
+```
+!!x;
 
 ```

--- a/internal/compiler/lint/rules/js/noExtraBooleanCast.test.rjson
+++ b/internal/compiler/lint/rules/js/noExtraBooleanCast.test.rjson
@@ -4,6 +4,12 @@ invalid: [
 		if (Boolean(foo)) {}
 	"
 	"
+		if (!!Boolean(foo)) {}
+	"
+	"
+		if (!Boolean(foo)) {}
+	"
+	"
 		while (!!foo) {}
 	"
 	"
@@ -14,5 +20,25 @@ invalid: [
 	"
 	"
 		for (; !!foo; ) {}
+	"
+	"
+		new Boolean(!!x);
+	"
+	"
+		!!!x;
+	"
+	"
+		!Boolean(x);
+	"
+]
+valid: [
+	"
+		Boolean(!x);
+	"
+	"
+		!x;
+	"
+	"
+		!!x;
 	"
 ]

--- a/website/src/docs/lint/rules/js/noExtraBooleanCast.md
+++ b/website/src/docs/lint/rules/js/noExtraBooleanCast.md
@@ -17,14 +17,14 @@ disallow unnecessary boolean casts
 **ESLint Equivalent:** [no-extra-boolean-cast](https://eslint.org/docs/rules/no-extra-boolean-cast)
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:cbe830d8d5d7e7baa2b44233f603416dd3f5b284,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:20313da064b1e52d7f4692c2383b533ef1558090,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
 
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">foo</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:4</span> <strong>lint/js/noExtraBooleanCast</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:4</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
 
@@ -34,13 +34,72 @@ disallow unnecessary boolean casts
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
     <span style="color: DodgerBlue;">be coerced to a boolean.</span>
 
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>Boolean(</strong></span><span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong>)</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">foo</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:4</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">foo</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+        <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>!!</strong></span><span style="color: Tomato;">Boolean(foo)</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">Boolean(foo)</span>
+
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:6</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>Boolean(</strong></span><span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong>)</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">foo</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:5</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">foo</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+         <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>Boolean(</strong></span><span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong>)</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span>
+
 </code></pre>{% endraw %}
 
 ---
 
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">while</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">foo</span><span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:7</span> <strong>lint/js/noExtraBooleanCast</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:7</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
 
@@ -49,6 +108,11 @@ disallow unnecessary boolean casts
 
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
     <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>!!</strong></span><span style="color: Tomato;">foo</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span>
 
 </code></pre>{% endraw %}
 
@@ -59,7 +123,7 @@ disallow unnecessary boolean casts
 	<span class="token number">1</span> <span class="token operator">+</span> <span class="token number">1</span><span class="token punctuation">;</span>
 <span class="token punctuation">}</span> <span class="token keyword">while</span> <span class="token punctuation">(</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:4:9</span> <strong>lint/js/noExtraBooleanCast</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:4:9</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
 
@@ -71,13 +135,18 @@ disallow unnecessary boolean casts
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
     <span style="color: DodgerBlue;">be coerced to a boolean.</span>
 
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>Boolean(</strong></span><span style="color: Tomato;">x</span><span style="color: Tomato;"><strong>)</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">x</span>
+
 </code></pre>{% endraw %}
 
 ---
 
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">for</span> <span class="token punctuation">(</span><span class="token punctuation">;</span> <span class="token operator">!</span><span class="token operator">!</span><span class="token variable">foo</span><span class="token punctuation">;</span> <span class="token punctuation">)</span> <span class="token punctuation">{</span><span class="token punctuation">}</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:7</span> <strong>lint/js/noExtraBooleanCast</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:7</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
 
@@ -87,5 +156,79 @@ disallow unnecessary boolean casts
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
     <span style="color: DodgerBlue;">be coerced to a boolean.</span>
 
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>!!</strong></span><span style="color: Tomato;">foo</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span>
+
 </code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">new</span> <span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:12</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token keyword">new</span> <span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+                <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>!!</strong></span><span style="color: Tomato;">x</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">x</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token operator">!</span><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:1</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token operator">!</span><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">;</span>
+     <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>!!</strong></span><span style="color: Tomato;">x</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">x</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:1:1</span> <strong>lint/js/noExtraBooleanCast</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Avoid </span><span style="color: Tomato;"><strong>redundant double-negation</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token operator">!</span><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+     <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">It is not necessary to use double-negation when a value will already</span>
+    <span style="color: DodgerBlue;">be coerced to a boolean.</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;"><strong>Boolean(</strong></span><span style="color: Tomato;">x</span><span style="color: Tomato;"><strong>)</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">x</span>
+
+</code></pre>{% endraw %}
+
+### Valid
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token function">Boolean</span><span class="token punctuation">(</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token operator">!</span><span class="token operator">!</span><span class="token variable">x</span><span class="token punctuation">;</span></code></pre>{% endraw %}
 <!-- GENERATED:END(id:examples) -->


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

I made a pr improving `noExtraBooleanCase` rule.

First, I made it fix problems automatically

```js
while (!!foo) {}

// autofixed
while (foo) {}
```

Second, I made it report some problems even if it's not in a boolean context (`if`, `for`...).

- For example, in the current version, these are lint-free
```js
let a = 1;
const foo = {};
a += !Boolean(foo); // lint-free
``` 

- In this PR, these are reported and auto fixed
```js
let a = 1;
const foo = {};
a += !Boolean(foo); // Error and it's fixed to "a += !foo"
``` 



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
