### PR TITLE
test(lint): correct test case in noTemplateCurlyInString

### DIFF
--- a/internal/compiler/lint/rules/js/noTemplateCurlyInString.test.md
+++ b/internal/compiler/lint/rules/js/noTemplateCurlyInString.test.md
@@ -8,13 +8,15 @@
 
 ```
 
- lint/js/noTemplateCurlyInString/reject/1/file.ts:2:49 parse/js ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/js/noTemplateCurlyInString/reject/1/file.ts:2:33 lint/js/noTemplateCurlyInString ━━━━━━━━━━━━━
 
-  ✖ Unterminated string constant
+  ✖ This string contains an unexpected template string expression.
 
     1 │ const user = 'Faustina';
-  > 2 │                const helloUser = 'Hello, ${user};
-      │                                                  ^
+  > 2 │                const helloUser = 'Hello, ${user}';
+      │                                  ^^^^^^^^^^^^^^^^
+
+  ℹ Using template string expressions in regular strings is usually a typo.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -24,6 +26,8 @@
 
 ### `0: formatted`
 
-```javascript
-undefined
+```
+const user = "Faustina";
+const helloUser = "Hello, ${user}";
+
 ```

--- a/internal/compiler/lint/rules/js/noTemplateCurlyInString.test.rjson
+++ b/internal/compiler/lint/rules/js/noTemplateCurlyInString.test.rjson
@@ -2,6 +2,6 @@ filename: "file.ts"
 invalid: [
 	"
 					const user = 'Faustina';
-                    const helloUser = 'Hello, ${user};
+                    const helloUser = 'Hello, ${user}';
 				"
 ]

--- a/website/src/docs/lint/rules/js/noTemplateCurlyInString.md
+++ b/website/src/docs/lint/rules/js/noTemplateCurlyInString.md
@@ -17,21 +17,24 @@ disallow template literal placeholder syntax in regular strings
 **ESLint Equivalent:** [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:330363838e19ef1a05b3b089894511fd09257961,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:c3e179345a8fb2e8fd65fd751a0ae6649e12204a,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
 
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">const</span> <span class="token variable">user</span> <span class="token operator">=</span> <span class="token string">&apos;Faustina&apos;</span><span class="token punctuation">;</span>
-               <span class="token keyword">const</span> <span class="token variable">helloUser</span> <span class="token operator">=</span> <span class="token string">&apos;Hello, ${user};</span></code></pre>{% endraw %}
+               <span class="token keyword">const</span> <span class="token variable">helloUser</span> <span class="token operator">=</span> <span class="token string">&apos;Hello, ${user}&apos;</span><span class="token punctuation">;</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:2:49</span> <strong>parse/js</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.ts:2:33</span> <strong>lint/js/noTemplateCurlyInString</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Unterminated string constant</span>
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">This string contains an </span><span style="color: Tomato;"><strong>unexpected template string</strong></span><span style="color: Tomato;"> expression.</span>
 
   <strong>  1</strong><strong> │ </strong><span class="token keyword">const</span> <span class="token variable">user</span> <span class="token operator">=</span> <span class="token string">&apos;Faustina&apos;</span><span class="token punctuation">;</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>               <span class="token keyword">const</span> <span class="token variable">helloUser</span> <span class="token operator">=</span> <span class="token string">&apos;Hello, ${user};</span>
-     <strong> │ </strong>                                                 <span style="color: Tomato;"><strong>^</strong></span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong>               <span class="token keyword">const</span> <span class="token variable">helloUser</span> <span class="token operator">=</span> <span class="token string">&apos;Hello, ${user}&apos;</span><span class="token punctuation">;</span>
+     <strong> │ </strong>                                 <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Using template string expressions in regular strings is usually a</span>
+    <span style="color: DodgerBlue;">typo.</span>
 
 </code></pre>{% endraw %}
 <!-- GENERATED:END(id:examples) -->


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Correct test case.
There is an incorrect syntax test case in `noTemplateCurlyInString`.

```js
 const helloUser = 'Hello, ${user};
                                    ^ missing quote
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
