### PR TITLE
fix(lint): add suppression to exiting ones

### DIFF
--- a/internal/compiler/lint/index.test.ts
+++ b/internal/compiler/lint/index.test.ts
@@ -44,7 +44,7 @@ function createLintTransformSuppressions(
 					{
 						action: "suppress",
 						category: "lint/js/noVar",
-						categoryValue: undefined
+						categoryValue: undefined,
 					},
 				],
 			},
@@ -135,8 +135,8 @@ test(
 	"should add a new suppression on an existing suppression",
 	async (t) => {
 		const code = dedent`
-		// rome-ignore lint/js/noUnusedVariables: suppressed via --review
-		var foo = 5;
+			// rome-ignore lint/js/noUnusedVariables: suppressed via --review
+			var foo = 5;
 		`;
 		const res = await lint(
 			createLintTransformSuppressions(

--- a/internal/compiler/lint/index.test.ts
+++ b/internal/compiler/lint/index.test.ts
@@ -44,11 +44,13 @@ function createLintTransformSuppressions(
 					{
 						action: "suppress",
 						category: "lint/js/noVar",
+						categoryValue: undefined
 					},
 				],
 			},
 		},
 		project: {
+			configHashes: [],
 			config: mutateConfig(createDefaultProjectConfig()),
 			directory: undefined,
 		},

--- a/internal/compiler/lint/rules/harness.test.ts
+++ b/internal/compiler/lint/rules/harness.test.ts
@@ -8,6 +8,7 @@ for (const name in tests) {
 	test(
 		name,
 		async (t) => {
+			t.extendTimeout(10000);
 			let cases = tests[name];
 
 			if (!Array.isArray(cases)) {

--- a/internal/compiler/lint/rules/harness.test.ts
+++ b/internal/compiler/lint/rules/harness.test.ts
@@ -8,7 +8,7 @@ for (const name in tests) {
 	test(
 		name,
 		async (t) => {
-			t.extendTimeout(10000);
+			t.extendTimeout(10_000);
 			let cases = tests[name];
 
 			if (!Array.isArray(cases)) {

--- a/internal/compiler/lint/suppressions.ts
+++ b/internal/compiler/lint/suppressions.ts
@@ -68,7 +68,6 @@ export function addSuppressions(
 		) {
 			updateComment = lastComment;
 		}
-
 		// Insert new comment if there's none to update
 		if (updateComment === undefined) {
 			const id = injectComment(
@@ -97,14 +96,21 @@ export function addSuppressions(
 
 		// We may have eliminated them all
 		if (suppressionCategories.size > 0) {
+			// get from comment possible existing categories
+			// TODO: make sure that category matches the rules we have (remove "lint/" from category)
+			updateComment.value.slice(
+				updateComment.value.indexOf(SUPPRESSION_START),
+				updateComment.value.indexOf(":"),
+			).replace(SUPPRESSION_START, "").split(" ").filter(Boolean).forEach((
+				category,
+			) => {
+				suppressionCategories.add(category);
+			});
 			injectComment(
 				path,
 				{
 					...updateComment,
-					value: updateComment.value.replace(
-						SUPPRESSION_START,
-						buildSuppressionCommentValue(suppressionCategories),
-					),
+					value: buildSuppressionCommentValue(suppressionCategories),
 				},
 			);
 		}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes the case when there's a suppression and we attempt to add a new one.

The previous code was generating a comment that is not correct for Rome. This PR fixes this case.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Created a new test case.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
