### PR TITLE
fix(formatter): correct checking extends clause

### DIFF
--- a/internal/formatter/node/parentheses.ts
+++ b/internal/formatter/node/parentheses.ts
@@ -35,10 +35,7 @@ import {
 } from "@internal/js-ast-utils";
 
 function isClassExtendsClause(node: AnyNode, parent: AnyNode): boolean {
-	return (
-		(parent.type === "JSClassDeclaration" || parent.type === "JSClassExpression") &&
-		parent.meta.superClass === node
-	);
+	return parent.type === "JSClassHead" && parent.superClass === node;
 }
 
 function isCalleeOfParent(node: AnyNode, parent: AnyNode): boolean {

--- a/internal/formatter/test-fixtures/js/parentheses/input.test.md
+++ b/internal/formatter/test-fixtures/js/parentheses/input.test.md
@@ -19,6 +19,9 @@ async () => {
   (await foo)?.();
 }
 (+foo)?.();
+class Foo extends (+Bar) {}
+class Foo extends (Bar ?? Baz) {}
+const foo = class extends (Bar ?? Baz) {}
 
 ```
 
@@ -30,5 +33,8 @@ async () => {
 	(await foo)?.();
 };
 (+foo)?.();
+class Foo extends (+Bar) {}
+class Foo extends (Bar ?? Baz) {}
+const foo = class extends (Bar ?? Baz) {};
 
 ```

--- a/internal/formatter/test-fixtures/js/parentheses/input.ts
+++ b/internal/formatter/test-fixtures/js/parentheses/input.ts
@@ -3,3 +3,6 @@ async () => {
   (await foo)?.();
 }
 (+foo)?.();
+class Foo extends (+Bar) {}
+class Foo extends (Bar ?? Baz) {}
+const foo = class extends (Bar ?? Baz) {}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The checking logic in `isClassExtendsClause ` function is incorrect with the current at structure.
so rome formatter makes incorrect result (syntax error).

* target.js
```ts
class Foo extends (+Bar) {}
class Bar extends (Baz ?? Qux) {}
const foo = class extends (Bar ?? Baz) {}
```

```
$ ./rome format target.js

class Foo extends +Bar {} // syntax error
class Bar extends Baz ?? Qux {} // syntax error
const foo = class extends Bar ?? Baz {}; // syntax error
``` 

I made a pr handle it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
