### PR TITLE
fix(lint): handle optional call expression in useKey

### DIFF
--- a/internal/compiler/lint/rules/react/useKey.test.md
+++ b/internal/compiler/lint/rules/react/useKey.test.md
@@ -70,7 +70,37 @@ const a = [1, 2].map((x) =>
 
 ```
 
- lint/react/useKey/reject/3/file.tsx:1:34 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/react/useKey/reject/3/file.tsx:1:24 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Provide a key prop with a unique value for each element in iterator.
+
+    const a = foo?.map(x => <div>{x}</div>);
+                            ^^^^^^^^^^^^^^
+
+  ℹ Keys help React identify which items have changed, are added, or are removed.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `2: formatted`
+
+```tsx
+const a = foo?.map((x) =>
+	<div>
+		{x}
+	</div>
+);
+
+```
+
+### `3`
+
+```
+
+ lint/react/useKey/reject/4/file.tsx:1:34 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
@@ -85,43 +115,10 @@ const a = [1, 2].map((x) =>
 
 ```
 
-### `2: formatted`
-
-```tsx
-React.Children.map(
-	children,
-	(x) =>
-		<div>
-			{x}
-		</div>
-	,
-);
-
-```
-
-### `3`
-
-```
-
- lint/react/useKey/reject/4/file.tsx:1:28 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ Provide a key prop with a unique value for each element in iterator.
-
-    Children.map(children, x => <div>{x}</div>);
-                                ^^^^^^^^^^^^^^
-
-  ℹ Keys help React identify which items have changed, are added, or are removed.
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-✖ Found 1 problem
-
-```
-
 ### `3: formatted`
 
 ```tsx
-Children.map(
+React.Children.map(
 	children,
 	(x) =>
 		<div>
@@ -136,7 +133,40 @@ Children.map(
 
 ```
 
- lint/react/useKey/reject/5/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/react/useKey/reject/5/file.tsx:1:28 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Provide a key prop with a unique value for each element in iterator.
+
+    Children.map(children, x => <div>{x}</div>);
+                                ^^^^^^^^^^^^^^
+
+  ℹ Keys help React identify which items have changed, are added, or are removed.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `4: formatted`
+
+```tsx
+Children.map(
+	children,
+	(x) =>
+		<div>
+			{x}
+		</div>
+	,
+);
+
+```
+
+### `5`
+
+```
+
+ lint/react/useKey/reject/6/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
@@ -153,7 +183,7 @@ Children.map(
 
 ```
 
-### `4: formatted`
+### `5: formatted`
 
 ```tsx
 const a = [1, 2].map((x) => {
@@ -164,11 +194,11 @@ const a = [1, 2].map((x) => {
 
 ```
 
-### `5`
+### `6`
 
 ```
 
- lint/react/useKey/reject/6/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/react/useKey/reject/7/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
@@ -185,45 +215,10 @@ const a = [1, 2].map((x) => {
 
 ```
 
-### `5: formatted`
-
-```tsx
-React.Children.map(
-	children,
-	(x) => {
-		return <div>
-			{x}
-		</div>;
-	},
-);
-
-```
-
-### `6`
-
-```
-
- lint/react/useKey/reject/7/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ Provide a key prop with a unique value for each element in iterator.
-
-    1 │ Children.map(children, x => {
-  > 2 │   return <div>{x}</div>;
-      │          ^^^^^^^^^^^^^^
-    3 │ });
-
-  ℹ Keys help React identify which items have changed, are added, or are removed.
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-✖ Found 1 problem
-
-```
-
 ### `6: formatted`
 
 ```tsx
-Children.map(
+React.Children.map(
 	children,
 	(x) => {
 		return <div>
@@ -242,7 +237,7 @@ Children.map(
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
-    1 │ const a = [1, 2].map(function(x) {
+    1 │ Children.map(children, x => {
   > 2 │   return <div>{x}</div>;
       │          ^^^^^^^^^^^^^^
     3 │ });
@@ -258,11 +253,14 @@ Children.map(
 ### `7: formatted`
 
 ```tsx
-const a = [1, 2].map(function(x) {
-	return <div>
-		{x}
-	</div>;
-});
+Children.map(
+	children,
+	(x) => {
+		return <div>
+			{x}
+		</div>;
+	},
+);
 
 ```
 
@@ -271,6 +269,38 @@ const a = [1, 2].map(function(x) {
 ```
 
  lint/react/useKey/reject/9/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Provide a key prop with a unique value for each element in iterator.
+
+    1 │ const a = [1, 2].map(function(x) {
+  > 2 │   return <div>{x}</div>;
+      │          ^^^^^^^^^^^^^^
+    3 │ });
+
+  ℹ Keys help React identify which items have changed, are added, or are removed.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `8: formatted`
+
+```tsx
+const a = [1, 2].map(function(x) {
+	return <div>
+		{x}
+	</div>;
+});
+
+```
+
+### `9`
+
+```
+
+ lint/react/useKey/reject/10/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
@@ -287,7 +317,7 @@ const a = [1, 2].map(function(x) {
 
 ```
 
-### `8: formatted`
+### `9: formatted`
 
 ```tsx
 React.Children.map(
@@ -301,11 +331,11 @@ React.Children.map(
 
 ```
 
-### `9`
+### `10`
 
 ```
 
- lint/react/useKey/reject/10/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ lint/react/useKey/reject/11/file.tsx:2:8 lint/react/useKey ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Provide a key prop with a unique value for each element in iterator.
 
@@ -322,7 +352,7 @@ React.Children.map(
 
 ```
 
-### `9: formatted`
+### `10: formatted`
 
 ```tsx
 Children.map(
@@ -336,20 +366,6 @@ Children.map(
 
 ```
 
-### `10`
-
-```
-✔ No known problems!
-
-```
-
-### `10: formatted`
-
-```tsx
-const a = [<div key="a" />, <div key={"b"} />];
-
-```
-
 ### `11`
 
 ```
@@ -360,11 +376,7 @@ const a = [<div key="a" />, <div key={"b"} />];
 ### `11: formatted`
 
 ```tsx
-const a = [1, 2].map((x) =>
-	<div key={x}>
-		{x}
-	</div>
-);
+const a = [<div key="a" />, <div key={"b"} />];
 
 ```
 
@@ -378,13 +390,10 @@ const a = [1, 2].map((x) =>
 ### `12: formatted`
 
 ```tsx
-React.Children.map(
-	children,
-	(x) =>
-		<div key={x}>
-			{x}
-		</div>
-	,
+const a = [1, 2].map((x) =>
+	<div key={x}>
+		{x}
+	</div>
 );
 
 ```
@@ -399,7 +408,7 @@ React.Children.map(
 ### `13: formatted`
 
 ```tsx
-Children.map(
+React.Children.map(
 	children,
 	(x) =>
 		<div key={x}>
@@ -420,11 +429,14 @@ Children.map(
 ### `14: formatted`
 
 ```tsx
-const a = [1, 2].map((x) => {
-	return <div key={x}>
-		{x}
-	</div>;
-});
+Children.map(
+	children,
+	(x) =>
+		<div key={x}>
+			{x}
+		</div>
+	,
+);
 
 ```
 
@@ -438,14 +450,11 @@ const a = [1, 2].map((x) => {
 ### `15: formatted`
 
 ```tsx
-React.Children.map(
-	children,
-	(x) => {
-		return <div key={x}>
-			{x}
-		</div>;
-	},
-);
+const a = [1, 2].map((x) => {
+	return <div key={x}>
+		{x}
+	</div>;
+});
 
 ```
 
@@ -459,7 +468,7 @@ React.Children.map(
 ### `16: formatted`
 
 ```tsx
-Children.map(
+React.Children.map(
 	children,
 	(x) => {
 		return <div key={x}>
@@ -480,11 +489,14 @@ Children.map(
 ### `17: formatted`
 
 ```tsx
-const a = [1, 2].map(function(x) {
-	return <div key={x}>
-		{x}
-	</div>;
-});
+Children.map(
+	children,
+	(x) => {
+		return <div key={x}>
+			{x}
+		</div>;
+	},
+);
 
 ```
 
@@ -498,14 +510,11 @@ const a = [1, 2].map(function(x) {
 ### `18: formatted`
 
 ```tsx
-React.Children.map(
-	children,
-	function(x) {
-		return <div key={x}>
-			{x}
-		</div>;
-	},
-);
+const a = [1, 2].map(function(x) {
+	return <div key={x}>
+		{x}
+	</div>;
+});
 
 ```
 
@@ -517,6 +526,27 @@ React.Children.map(
 ```
 
 ### `19: formatted`
+
+```tsx
+React.Children.map(
+	children,
+	function(x) {
+		return <div key={x}>
+			{x}
+		</div>;
+	},
+);
+
+```
+
+### `20`
+
+```
+✔ No known problems!
+
+```
+
+### `20: formatted`
 
 ```tsx
 Children.map(

--- a/internal/compiler/lint/rules/react/useKey.test.rjson
+++ b/internal/compiler/lint/rules/react/useKey.test.rjson
@@ -2,6 +2,7 @@ filename: "file.tsx"
 invalid: [
 	"const a = [<div />, <div />]"
 	"const a = [1, 2].map(x => <div>{x}</div>);"
+	"const a = foo?.map(x => <div>{x}</div>);"
 	"React.Children.map(children, x => <div>{x}</div>);"
 	"Children.map(children, x => <div>{x}</div>);"
 	"

--- a/internal/compiler/lint/rules/react/useKey.ts
+++ b/internal/compiler/lint/rules/react/useKey.ts
@@ -6,7 +6,11 @@
  */
 
 import {createVisitor, signals} from "@internal/compiler";
-import {JSCallExpression, JSXElement} from "@internal/ast";
+import {
+	JSCallExpression,
+	JSOptionalCallExpression,
+	JSXElement,
+} from "@internal/ast";
 import {descriptions} from "@internal/diagnostics";
 import {doesNodeMatchPattern} from "@internal/js-ast-utils";
 
@@ -17,7 +21,7 @@ function containsKeyAttr(node: JSXElement): boolean {
 	);
 }
 
-function getMapCallback(node: JSCallExpression) {
+function getMapCallback(node: JSCallExpression | JSOptionalCallExpression) {
 	if (
 		doesNodeMatchPattern(node.callee, "React.Children.map") ||
 		doesNodeMatchPattern(node.callee, "Children.map")
@@ -50,7 +54,10 @@ export default createVisitor({
 			context.addNodeDiagnostic(node, descriptions.LINT.REACT_USE_KEY("array"));
 		}
 
-		const fn = node.type === "JSCallExpression" && getMapCallback(node);
+		const fn =
+			(node.type === "JSCallExpression" ||
+			node.type === "JSOptionalCallExpression") &&
+			getMapCallback(node);
 
 		// Array.prototype.map
 		if (fn) {

--- a/website/src/docs/lint/rules/react/useKey.md
+++ b/website/src/docs/lint/rules/react/useKey.md
@@ -17,7 +17,7 @@ This rule detects a missing `key` prop in a element that requires it. Keys help 
 **ESLint Equivalent:** [jsx-key](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md)
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:65843eb61af5760bff50ccfaead94d23880dded4,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:5de559e7182478912c7155e484be01212a5e442f,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
@@ -53,6 +53,22 @@ This rule detects a missing `key` prop in a element that requires it. Keys help 
 
     <span class="token keyword">const</span> <span class="token variable">a</span> <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token number">1</span><span class="token punctuation">,</span> <span class="token number">2</span><span class="token punctuation">]</span><span class="token punctuation">.</span><span class="token function">map</span><span class="token punctuation">(</span><span class="token variable">x</span> <span class="token operator">=&gt;</span> &lt;<span class="token variable">div</span>&gt;<span class="token punctuation">{</span><span class="token variable">x</span><span class="token punctuation">}</span>&lt;<span class="token operator">/</span><span class="token variable">div</span>&gt;<span class="token punctuation">)</span><span class="token punctuation">;</span>
                               <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Keys help React identify which items have changed, are added, or are</span>
+    <span style="color: DodgerBlue;">removed.</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">const</span> <span class="token variable">a</span> <span class="token operator">=</span> <span class="token variable">foo</span><span class="token punctuation">?.</span><span class="token function">map</span><span class="token punctuation">(</span><span class="token variable">x</span> <span class="token operator">=&gt;</span> &lt;<span class="token variable">div</span>&gt;<span class="token punctuation">{</span><span class="token variable">x</span><span class="token punctuation">}</span>&lt;<span class="token operator">/</span><span class="token variable">div</span>&gt;<span class="token punctuation">)</span><span class="token punctuation">;</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">file.tsx:1:24</span> <strong>lint/react/useKey</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Provide a </span><span style="color: Tomato;"><strong>key</strong></span><span style="color: Tomato;"> prop with a unique value for each element in </span><span style="color: Tomato;"><strong>iterator</strong></span><span style="color: Tomato;">.</span>
+
+    <span class="token keyword">const</span> <span class="token variable">a</span> <span class="token operator">=</span> <span class="token variable">foo</span><span class="token punctuation">?.</span><span class="token function">map</span><span class="token punctuation">(</span><span class="token variable">x</span> <span class="token operator">=&gt;</span> &lt;<span class="token variable">div</span>&gt;<span class="token punctuation">{</span><span class="token variable">x</span><span class="token punctuation">}</span>&lt;<span class="token operator">/</span><span class="token variable">div</span>&gt;<span class="token punctuation">)</span><span class="token punctuation">;</span>
+                            <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
 
   <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Keys help React identify which items have changed, are added, or are</span>
     <span style="color: DodgerBlue;">removed.</span>


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

`useKey` rule didn't report the below case even if there is no key props

```jsx
const a = foo?.map((x) =>
	<div> {/*missing key props*/}
		{x}
	</div>
);

```

I made a pr handle it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test case
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
