### PR TITLE
feat: remove Flow from TypeNode

### DIFF
--- a/internal/js-ast-utils/isTypeNode.ts
+++ b/internal/js-ast-utils/isTypeNode.ts
@@ -8,10 +8,7 @@
 import {AnyNode} from "@internal/ast";
 
 export function isTypeNode(node: AnyNode): boolean {
-	if (
-		node.type.startsWith("TS") ||
-		node.type.endsWith("TypeAnnotation")
-	) {
+	if (node.type.startsWith("TS") || node.type.endsWith("TypeAnnotation")) {
 		return true;
 	} else if (node.type === "JSImportDeclaration") {
 		return node.importKind === "type" || node.importKind === "typeof";

--- a/internal/js-ast-utils/isTypeNode.ts
+++ b/internal/js-ast-utils/isTypeNode.ts
@@ -9,7 +9,6 @@ import {AnyNode} from "@internal/ast";
 
 export function isTypeNode(node: AnyNode): boolean {
 	if (
-		node.type.startsWith("Flow") ||
 		node.type.startsWith("TS") ||
 		node.type.endsWith("TypeAnnotation")
 	) {

--- a/scripts/vendor/rome.cjs
+++ b/scripts/vendor/rome.cjs
@@ -14520,6 +14520,7 @@ function ___R$project$rome$$internal$js$ast$utils$isFunctionNode_ts$isFunctionNo
   // project-rome/@internal/js-ast-utils/isTypeNode.ts
 function ___R$project$rome$$internal$js$ast$utils$isTypeNode_ts$isTypeNode(node) {
 		if (
+			node.type.startsWith("Flow") ||
 			node.type.startsWith("TS") ||
 			node.type.endsWith("TypeAnnotation")
 		) {

--- a/scripts/vendor/rome.cjs
+++ b/scripts/vendor/rome.cjs
@@ -14520,7 +14520,6 @@ function ___R$project$rome$$internal$js$ast$utils$isFunctionNode_ts$isFunctionNo
   // project-rome/@internal/js-ast-utils/isTypeNode.ts
 function ___R$project$rome$$internal$js$ast$utils$isTypeNode_ts$isTypeNode(node) {
 		if (
-			node.type.startsWith("Flow") ||
 			node.type.startsWith("TS") ||
 			node.type.endsWith("TypeAnnotation")
 		) {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
Flow syntax support has been removed since #440 , and all ast nodes no longer has a `Flow` prefix.

This pr removes Flow from `isTypeNode`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
verified in `ast/index.ts` that no ast node starts with `Flow`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
