### PR TITLE
fix(html-parser, formatter): handle boolean attribute

### DIFF
--- a/internal/ast/html/attributes/HTMLAttribute.ts
+++ b/internal/ast/html/attributes/HTMLAttribute.ts
@@ -5,7 +5,7 @@ import {createBuilder} from "../../utils";
 export interface HTMLAttribute extends NodeBaseWithComments {
 	readonly type: "HTMLAttribute";
 	readonly name: HTMLIdentifier;
-	readonly value: HTMLString;
+	readonly value?: HTMLString;
 }
 
 export const htmlAttribute = createBuilder<HTMLAttribute>(

--- a/internal/compiler/lint/rules/html/useHtmlLang.ts
+++ b/internal/compiler/lint/rules/html/useHtmlLang.ts
@@ -8,7 +8,7 @@ export default createVisitor({
 
 		if (node.type === "HTMLElement" && node.name.name === "html") {
 			const langAttr = node.attributes.find((a) => a.name.name === "lang");
-			if (!langAttr || langAttr?.value.value === "") {
+			if (!langAttr || langAttr?.value?.value === "") {
 				path.context.addNodeDiagnostic(
 					node,
 					descriptions.LINT.HTML_USE_HTML_LANG,

--- a/internal/compiler/lint/rules/html/useValidLang.ts
+++ b/internal/compiler/lint/rules/html/useValidLang.ts
@@ -6,8 +6,8 @@ import {langSupported} from "@internal/compiler/lint/utils/getLangSupported";
 
 // Will return the attribute value if invalid
 function isSupportedLang(attribute: HTMLAttribute): undefined | string {
-	if (!langSupported(attribute.value.value)) {
-		return attribute.value.value;
+	if (!langSupported(attribute.value?.value ?? "")) {
+		return attribute.value?.value;
 	}
 
 	return undefined;

--- a/internal/formatter/builders/html/attributes/HTMLAttribute.ts
+++ b/internal/formatter/builders/html/attributes/HTMLAttribute.ts
@@ -5,9 +5,12 @@ export default function HTMLAttribute(
 	builder: Builder,
 	node: HTMLAttribute,
 ): Token {
-	return concat([
-		builder.tokenize(node.name, node),
-		"=",
-		builder.tokenize(node.value, node),
-	]);
+	const tokens: Token[] = [builder.tokenize(node.name, node)];
+
+	if (node.value) {
+		tokens.push("=");
+		tokens.push(builder.tokenize(node.value, node));
+	}
+
+	return concat(tokens);
 }

--- a/internal/formatter/builders/html/tags/HTMLElement.ts
+++ b/internal/formatter/builders/html/tags/HTMLElement.ts
@@ -17,9 +17,7 @@ export default function HTMLElement(builder: Builder, node: HTMLElement): Token 
 
 	for (const attr of node.attributes) {
 		tokens.push(space);
-		tokens.push(builder.tokenize(attr.name, attr));
-		tokens.push("=");
-		tokens.push(builder.tokenize(attr.value, attr));
+		tokens.push(builder.tokenize(attr, node));
 	}
 
 	if (

--- a/internal/formatter/test-fixtures/html/attributes/input.html
+++ b/internal/formatter/test-fixtures/html/attributes/input.html
@@ -7,3 +7,5 @@ title
 "
 aria-atomic="true"
 ></a>
+
+<input checked>

--- a/internal/formatter/test-fixtures/html/attributes/input.test.md
+++ b/internal/formatter/test-fixtures/html/attributes/input.test.md
@@ -24,6 +24,8 @@ title
 aria-atomic="true"
 ></a>
 
+<input checked>
+
 ```
 
 ### `Output`
@@ -31,5 +33,7 @@ aria-atomic="true"
 ```html
 <a href="input.html" title="title" aria-atomic="true">
 </a>
+
+<input checked />
 
 ```

--- a/internal/html-parser/index.ts
+++ b/internal/html-parser/index.ts
@@ -247,19 +247,20 @@ function parseAttribute(parser: HTMLParser): HTMLAttribute | undefined {
 	if (token.type === "Identifier") {
 		const name = parseIdentifier(parser);
 		const valueToken = parser.getToken();
+		let value: HTMLString | undefined;
 		if (valueToken.type === "Equals") {
 			parser.nextToken();
-			const value = parseString(parser);
-			if (value && name) {
-				return parser.finishNode(
-					start,
-					{
-						type: "HTMLAttribute",
-						name,
-						value,
-					},
-				);
-			}
+			value = parseString(parser);
+		}
+		if (name) {
+			return parser.finishNode(
+				start,
+				{
+					type: "HTMLAttribute",
+					name,
+					value,
+				},
+			);
 		}
 		parser.unexpectedDiagnostic({
 			description: descriptions.HTML_PARSER.EXPECTED_ATTRIBUTE_NAME,

--- a/internal/html-parser/test-fixtures/attributes/input.html
+++ b/internal/html-parser/test-fixtures/attributes/input.html
@@ -1,2 +1,4 @@
 <a href="
 "></a>
+
+<input checked>

--- a/internal/html-parser/test-fixtures/attributes/input.test.md
+++ b/internal/html-parser/test-fixtures/attributes/input.test.md
@@ -16,8 +16,8 @@ HTMLRoot {
 	loc: Object {
 		filename: "attributes/input.html"
 		end: Object {
-			column: 6
-			line: 2
+			column: 15
+			line: 4
 		}
 		start: Object {
 			column: 0
@@ -92,6 +92,65 @@ HTMLRoot {
 						start: Object {
 							column: 3
 							line: 1
+						}
+					}
+				}
+			]
+		}
+		HTMLElement {
+			name: HTMLIdentifier {
+				name: "input"
+				loc: Object {
+					filename: "attributes/input.html"
+					end: Object {
+						column: 6
+						line: 4
+					}
+					start: Object {
+						column: 1
+						line: 4
+					}
+				}
+			}
+			children: Array []
+			selfClosing: true
+			loc: Object {
+				filename: "attributes/input.html"
+				end: Object {
+					column: 15
+					line: 4
+				}
+				start: Object {
+					column: 0
+					line: 4
+				}
+			}
+			attributes: Array [
+				HTMLAttribute {
+					name: HTMLIdentifier {
+						name: "checked"
+						loc: Object {
+							filename: "attributes/input.html"
+							end: Object {
+								column: 14
+								line: 4
+							}
+							start: Object {
+								column: 7
+								line: 4
+							}
+						}
+					}
+					value: undefined
+					loc: Object {
+						filename: "attributes/input.html"
+						end: Object {
+							column: 14
+							line: 4
+						}
+						start: Object {
+							column: 7
+							line: 4
 						}
 					}
 				}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Rome fails to parse the boolean attribute.

- target.html
```html
<input checked>
```

```
./rome parse target.html
```

I made a PR handle it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
