### PR TITLE
fix(cli-flags): fix shell completions

### DIFF
--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -807,7 +807,9 @@ export default class Parser<T> {
 			// add command description if exists
 			let description = "";
 			if (meta.description) {
-				description += ` -d '${joinMarkupLines(markupToPlainText(meta.description))}'`;
+				description += ` -d '${joinMarkupLines(
+					markupToPlainText(meta.description),
+				)}'`;
 			}
 
 			script += `${scriptPre} -n '__fish_use_subcommand' -a '${subcmd}'${description}\n`;

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -29,6 +29,7 @@ import {
 	concatMarkup,
 	markup,
 	readMarkup,
+	joinMarkupLines,
 } from "@internal/markup";
 import {
 	Diagnostic,
@@ -40,6 +41,7 @@ import {prettyFormatEager} from "@internal/pretty-format";
 import highlightShell from "@internal/markup-syntax-highlight/highlightShell";
 import {RSERObject} from "@internal/codec-binary-serial";
 import {ExtendedMap} from "@internal/collections";
+import {markupToPlainText} from "@internal/cli-layout";
 
 export type Examples = {
 	description: StaticMarkup;
@@ -805,7 +807,7 @@ export default class Parser<T> {
 			// add command description if exists
 			let description = "";
 			if (meta.description) {
-				description += ` -d '${readMarkup(meta.description)}'`;
+				description += ` -d '${joinMarkupLines(markupToPlainText(meta.description))}'`;
 			}
 
 			script += `${scriptPre} -n '__fish_use_subcommand' -a '${subcmd}'${description}\n`;

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -27,9 +27,9 @@ import {
 	AnyMarkups,
 	StaticMarkup,
 	concatMarkup,
+	joinMarkupLines,
 	markup,
 	readMarkup,
-	joinMarkupLines,
 } from "@internal/markup";
 import {
 	Diagnostic,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Some of the fish shell completions were emitting descriptions of `[object Object]` due to using the wrong markup functions.

```fish
complete -c rome -n '__fish_use_subcommand' -a 'start' -d '[object Object]'
```

[![Discord transcript](https://user-images.githubusercontent.com/7608555/103423965-ad36f080-4b5e-11eb-9c19-81471cc939a7.png)](https://discord.com/channels/678763474494423051/714237988145594428/794284536082202641)

## Test Plan

I just used the `rome --write-shell-completions` command to emit new completions and observed the output by hand.
Unit tests should be written to prevent regressions.

After the changes the command is now producing the expected output

```fish
complete -c rome -n '__fish_use_subcommand' -a 'start' -d 'start daemon (if none running)'
```