### PR TITLE
fix(lint): check argument length in noAccessStateInSetState

### DIFF
--- a/internal/compiler/lint/rules/react/noAccessStateInSetState.test.md
+++ b/internal/compiler/lint/rules/react/noAccessStateInSetState.test.md
@@ -307,3 +307,21 @@ class MyComponent extends Component {
 }
 
 ```
+
+### `10`
+
+```
+✔ No known problems!
+
+```
+
+### `10: formatted`
+
+```tsx
+class MyComponent extends Component {
+	increment() {
+		this.setState();
+	}
+}
+
+```

--- a/internal/compiler/lint/rules/react/noAccessStateInSetState.test.rjson
+++ b/internal/compiler/lint/rules/react/noAccessStateInSetState.test.rjson
@@ -89,4 +89,11 @@ valid: [
 						}
 					}
 				"
+	"
+					class MyComponent extends Component {
+						increment() {
+							this.setState();
+						}
+					}
+				"
 ]

--- a/internal/compiler/lint/rules/react/noAccessStateInSetState.ts
+++ b/internal/compiler/lint/rules/react/noAccessStateInSetState.ts
@@ -9,8 +9,9 @@ export default createVisitor({
 		const {node} = path;
 		if (
 			node.type === "JSCallExpression" &&
-			doesNodeMatchPattern(node.callee, "this.setState") &&
-			node.arguments[0].type === "JSObjectExpression"
+			node.arguments.length > 0 &&
+			node.arguments[0].type === "JSObjectExpression" &&
+			doesNodeMatchPattern(node.callee, "this.setState")
 		) {
 			const hasThisState = node.arguments[0].properties.some((arg) => {
 				if (arg.type === "JSObjectProperty") {

--- a/website/src/docs/lint/rules/react/noAccessStateInSetState.md
+++ b/website/src/docs/lint/rules/react/noAccessStateInSetState.md
@@ -17,7 +17,7 @@ prevent using `this.state` within a `this.setState`
 **ESLint Equivalent:** [no-access-state-in-setstate](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md)
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:f8d1a76e318fbd04046bce0f9cbd1a89d426ad97,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:ccbaaef978d695e3838d463aa293d0827ee1911f,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
@@ -238,6 +238,11 @@ prevent using `this.state` within a `this.setState`
 {% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">class</span> <span class="token variable">MyComponent</span> <span class="token keyword">extends</span> <span class="token variable">Component</span> <span class="token punctuation">{</span>
 	<span class="token function">increment</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
 		<span class="token keyword">this</span><span class="token punctuation">.</span><span class="token function">setState</span><span class="token punctuation">(</span><span class="token variable">prevState</span> <span class="token operator">=&gt;</span> <span class="token punctuation">(</span><span class="token punctuation">{</span><span class="token variable">value</span><span class="token punctuation">:</span> <span class="token variable">prevState</span><span class="token punctuation">.</span><span class="token variable">value</span> <span class="token operator">+</span> <span class="token number">1</span><span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+	<span class="token punctuation">}</span>
+<span class="token punctuation">}</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text"><span class="token keyword">class</span> <span class="token variable">MyComponent</span> <span class="token keyword">extends</span> <span class="token variable">Component</span> <span class="token punctuation">{</span>
+	<span class="token function">increment</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+		<span class="token keyword">this</span><span class="token punctuation">.</span><span class="token function">setState</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 	<span class="token punctuation">}</span>
 <span class="token punctuation">}</span></code></pre>{% endraw %}
 <!-- GENERATED:END(id:examples) -->


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Rome throws error on below codes

- tagetr.js
```js
class MyComponent extends Component {
	increment() {
		this.setState();
	}
}
```

```
$ ./rome check ./target.js 

✖ Cannot read property 'type' of undefined
```

I add an array length checking logic.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
