### PR TITLE
fix(vscode-extension): correct finding rome on windows os

### DIFF
--- a/public-packages/vscode-extension/index.ts
+++ b/public-packages/vscode-extension/index.ts
@@ -18,7 +18,7 @@ function crawl(root: string): Iterable<string> {
 		[Symbol.iterator]() {
 			return {
 				next() {
-					const value = process.platform === 'win32' ? root.slice(1) : root;
+					const value = process.platform === "win32" ? root.slice(1) : root;
 					root = path.dirname(value);
 
 					return {
@@ -41,7 +41,8 @@ async function tryChain(
 		try {
 			await fs.promises.access(possible);
 			return possible;
-		} catch (err) {}
+		} catch (err) {
+		}
 	}
 	return undefined;
 }

--- a/public-packages/vscode-extension/index.ts
+++ b/public-packages/vscode-extension/index.ts
@@ -18,7 +18,7 @@ function crawl(root: string): Iterable<string> {
 		[Symbol.iterator]() {
 			return {
 				next() {
-					const value = root;
+					const value = process.platform === 'win32' ? root.slice(1) : root;
 					root = path.dirname(value);
 
 					return {
@@ -41,8 +41,7 @@ async function tryChain(
 		try {
 			await fs.promises.access(possible);
 			return possible;
-		} catch (err) {
-		}
+		} catch (err) {}
 	}
 	return undefined;
 }

--- a/scripts/run-vscode-extension.ts
+++ b/scripts/run-vscode-extension.ts
@@ -9,8 +9,10 @@ export async function main(args: string[]) {
 	await execDev(["bundle", "vscode-rome", outFolder]);
 
 	reporter.heading(markup`Running VSCode`);
+	const cmd = process.platform === "win32" ? "code.cmd" : "code";
+
 	await exec(
-		"code",
+		cmd,
 		["--extensionDevelopmentPath", outFolder, "--disable-extensions", ...args],
 	);
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #1039
And also fixes execution of `code` in `scripts/run-vscode-extension` on Windows OS
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->