### PR TITLE
fix(formatter): add space to multiple declarations

### DIFF
--- a/internal/formatter/builders/css/core/CSSDeclaration.ts
+++ b/internal/formatter/builders/css/core/CSSDeclaration.ts
@@ -9,8 +9,11 @@ export default function CSSDeclaration(
 
 	tokens.push(node.name);
 	tokens.push(":");
-	tokens.push(space);
-	tokens.push(...node.value.map((value) => builder.tokenize(value, node)));
+	tokens.push(
+		...node.value.map((value) => {
+			return concat([space, builder.tokenize(value, node)]);
+		}),
+	);
 	if (node.important) {
 		tokens.push(space);
 		tokens.push("!important");

--- a/internal/formatter/test-fixtures/css/basic/input.css
+++ b/internal/formatter/test-fixtures/css/basic/input.css
@@ -13,3 +13,7 @@ span.something {
 h1::before  {
   content: " content ";
 }
+
+a {
+	transition: background-color 0.3s ease-in-out;
+}

--- a/internal/formatter/test-fixtures/css/basic/input.test.md
+++ b/internal/formatter/test-fixtures/css/basic/input.test.md
@@ -30,6 +30,10 @@ h1::before  {
   content: " content ";
 }
 
+a {
+	transition: background-color 0.3s ease-in-out;
+}
+
 ```
 
 ### `Output`
@@ -49,6 +53,10 @@ span.something {
 
 h1::before {
 	content: " content ";
+}
+
+a {
+	transition: background-color 0.3s ease-in-out;
 }
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Current CSS 

```css
a {
	transition: background-color 0.3s ease-in-out;
}
```

Was formatted like this

```css
a {
	transition: background-color0.3sease-in-out;
}
```

This PR fixes the issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new example to the current test fixtures

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
