### PR TITLE
fix(css-parser): handle optional semi

### DIFF
--- a/internal/css-parser/test-fixtures/values/input.css
+++ b/internal/css-parser/test-fixtures/values/input.css
@@ -8,3 +8,12 @@ p::before {
 	width: 20%;
 	margin-top: -5%;
 }
+
+foo {
+	color: yellow
+}
+
+bar {
+	color: yellow;
+	background: none
+}

--- a/internal/css-parser/test-fixtures/values/input.test.md
+++ b/internal/css-parser/test-fixtures/values/input.test.md
@@ -15,7 +15,7 @@ CSSRoot {
 		filename: "values/input.css"
 		end: Object {
 			column: 1
-			line: 10
+			line: 19
 		}
 		start: Object {
 			column: 0
@@ -310,6 +310,219 @@ CSSRoot {
 					start: Object {
 						column: 8
 						line: 5
+					}
+				}
+			}
+		}
+		CSSRule {
+			loc: Object {
+				filename: "values/input.css"
+				end: Object {
+					column: 1
+					line: 14
+				}
+				start: Object {
+					column: 0
+					line: 12
+				}
+			}
+			prelude: Array [
+				CSSSelector {
+					loc: Object {
+						filename: "values/input.css"
+						end: Object {
+							column: 4
+							line: 12
+						}
+						start: Object {
+							column: 0
+							line: 12
+						}
+					}
+					patterns: Array [
+						CSSTypeSelector {
+							value: "foo"
+							loc: Object {
+								filename: "values/input.css"
+								end: Object {
+									column: 3
+									line: 12
+								}
+								start: Object {
+									column: 0
+									line: 12
+								}
+							}
+						}
+					]
+				}
+			]
+			block: CSSBlock {
+				value: Array [
+					CSSDeclaration {
+						name: "color"
+						value: Array [
+							CSSIdentifier {
+								value: "yellow"
+								loc: Object {
+									filename: "values/input.css"
+									end: Object {
+										column: 14
+										line: 13
+									}
+									start: Object {
+										column: 8
+										line: 13
+									}
+								}
+							}
+						]
+						important: false
+						loc: Object {
+							filename: "values/input.css"
+							end: Object {
+								column: 0
+								line: 14
+							}
+							start: Object {
+								column: 1
+								line: 13
+							}
+						}
+					}
+				]
+				startingTokenValue: "{"
+				loc: Object {
+					filename: "values/input.css"
+					end: Object {
+						column: 1
+						line: 14
+					}
+					start: Object {
+						column: 4
+						line: 12
+					}
+				}
+			}
+		}
+		CSSRule {
+			loc: Object {
+				filename: "values/input.css"
+				end: Object {
+					column: 1
+					line: 19
+				}
+				start: Object {
+					column: 0
+					line: 16
+				}
+			}
+			prelude: Array [
+				CSSSelector {
+					loc: Object {
+						filename: "values/input.css"
+						end: Object {
+							column: 4
+							line: 16
+						}
+						start: Object {
+							column: 0
+							line: 16
+						}
+					}
+					patterns: Array [
+						CSSTypeSelector {
+							value: "bar"
+							loc: Object {
+								filename: "values/input.css"
+								end: Object {
+									column: 3
+									line: 16
+								}
+								start: Object {
+									column: 0
+									line: 16
+								}
+							}
+						}
+					]
+				}
+			]
+			block: CSSBlock {
+				value: Array [
+					CSSDeclaration {
+						name: "color"
+						value: Array [
+							CSSIdentifier {
+								value: "yellow"
+								loc: Object {
+									filename: "values/input.css"
+									end: Object {
+										column: 14
+										line: 17
+									}
+									start: Object {
+										column: 8
+										line: 17
+									}
+								}
+							}
+						]
+						important: false
+						loc: Object {
+							filename: "values/input.css"
+							end: Object {
+								column: 14
+								line: 17
+							}
+							start: Object {
+								column: 1
+								line: 17
+							}
+						}
+					}
+					CSSDeclaration {
+						name: "background"
+						value: Array [
+							CSSIdentifier {
+								value: "none"
+								loc: Object {
+									filename: "values/input.css"
+									end: Object {
+										column: 17
+										line: 18
+									}
+									start: Object {
+										column: 13
+										line: 18
+									}
+								}
+							}
+						]
+						important: false
+						loc: Object {
+							filename: "values/input.css"
+							end: Object {
+								column: 0
+								line: 19
+							}
+							start: Object {
+								column: 1
+								line: 18
+							}
+						}
+					}
+				]
+				startingTokenValue: "{"
+				loc: Object {
+					filename: "values/input.css"
+					end: Object {
+						column: 1
+						line: 19
+					}
+					start: Object {
+						column: 4
+						line: 16
 					}
 				}
 			}

--- a/internal/formatter/test-fixtures/css/values/input.css
+++ b/internal/formatter/test-fixtures/css/values/input.css
@@ -4,3 +4,12 @@
 	width: 20%;
 	margin-top: -5%;
 }
+
+foo {
+	color: yellow
+}
+
+bar {
+	color: yellow;
+	background: none
+}

--- a/internal/formatter/test-fixtures/css/values/input.test.md
+++ b/internal/formatter/test-fixtures/css/values/input.test.md
@@ -21,6 +21,15 @@
 	margin-top: -5%;
 }
 
+foo {
+	color: yellow
+}
+
+bar {
+	color: yellow;
+	background: none
+}
+
 ```
 
 ### `Output`
@@ -31,6 +40,15 @@
 	line-height: 0.2;
 	width: 20%;
 	margin-top: -5%;
+}
+
+foo {
+	color: yellow;
+}
+
+bar {
+	color: yellow;
+	background: none;
 }
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

In CSS, The final semicolon in a set of statements is optional. 
But current parser did not handle it well

- test.css
```css
h1 {
	color: red
}
```
```
$ ./rome parse ./test.css
  ✖ AST diagnostics aren't allowed

     project-rome/test.css:3:1 parse(css)  OUTDATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

      ✖ Invalid declaration

      ⚠ This file has been changed since the diagnostic was produced and may be out of date
```

This PR will handle it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test cases
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
