### PR TITLE
fix(formatter): handle parentheses around nested unary

### DIFF
--- a/internal/formatter/node/parentheses.ts
+++ b/internal/formatter/node/parentheses.ts
@@ -297,7 +297,7 @@ parens.set(
 	},
 );
 
-function needsParenUnaryExpression(
+function needsParenUnaryLikeExpression(
 	node:
 		| JSUnaryExpression
 		| JSArrowFunctionExpression
@@ -317,9 +317,20 @@ function needsParenUnaryExpression(
 	);
 }
 
-parens.set("JSUnaryExpression", needsParenUnaryExpression);
-parens.set("JSSpreadElement", needsParenUnaryExpression);
-parens.set("JSSpreadProperty", needsParenUnaryExpression);
+parens.set(
+	"JSUnaryExpression",
+	(node: JSUnaryExpression, parent: AnyNode) => {
+		return (
+			((node.operator === "-" || node.operator === "+") &&
+			parent.type === "JSUnaryExpression" &&
+			parent.operator === node.operator) ||
+			needsParenUnaryLikeExpression(node, parent)
+		);
+	},
+);
+
+parens.set("JSSpreadElement", needsParenUnaryLikeExpression);
+parens.set("JSSpreadProperty", needsParenUnaryLikeExpression);
 
 parens.set(
 	"JSFunctionExpression",
@@ -361,7 +372,7 @@ function needsParenConditionalExpression(
 		return true;
 	}
 
-	return needsParenUnaryExpression(node, parent);
+	return needsParenUnaryLikeExpression(node, parent);
 }
 
 parens.set("JSConditionalExpression", needsParenConditionalExpression);

--- a/internal/formatter/test-fixtures/js/parentheses/input.test.md
+++ b/internal/formatter/test-fixtures/js/parentheses/input.test.md
@@ -19,6 +19,7 @@ async () => {
   (await foo)?.();
 }
 (+foo)?.();
++(+foo);
 class Foo extends (+Bar) {}
 class Foo extends (Bar ?? Baz) {}
 const foo = class extends (Bar ?? Baz) {}
@@ -33,6 +34,7 @@ async () => {
 	(await foo)?.();
 };
 (+foo)?.();
++(+foo);
 class Foo extends (+Bar) {}
 class Foo extends (Bar ?? Baz) {}
 const foo = class extends (Bar ?? Baz) {};

--- a/internal/formatter/test-fixtures/js/parentheses/input.ts
+++ b/internal/formatter/test-fixtures/js/parentheses/input.ts
@@ -3,6 +3,7 @@ async () => {
   (await foo)?.();
 }
 (+foo)?.();
++(+foo);
 class Foo extends (+Bar) {}
 class Foo extends (Bar ?? Baz) {}
 const foo = class extends (Bar ?? Baz) {}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Rome formatter remove parentheses around unary in unary..

- target.ts
```ts
+(+foo);
```

```
$ ./rome format target.ts
++foo;
```

It's a pr for handle it.

```
$ ./rome format target.ts
+(+foo);
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
