### PR TITLE
Add `--logs all` and `--logs error`

### DIFF
--- a/internal/cli-reporter/Reporter.ts
+++ b/internal/cli-reporter/Reporter.ts
@@ -225,24 +225,30 @@ export default class Reporter implements ReporterNamespace {
 
 	public attachConditionalStream(
 		stream: ReporterStream,
-		check: () => boolean,
+		check?: () => boolean,
 	): ReporterConditionalStream {
 		let handle: undefined | ReporterStreamHandle;
 
 		const cond: ReporterConditionalStream = {
-			update: () => {
-				if (check()) {
-					if (handle === undefined) {
-						handle = this.addStream(stream);
-					}
-					return true;
-				} else {
-					if (handle !== undefined) {
-						handle.remove();
-						handle = undefined;
-					}
-					return false;
+			enable: () => {
+				if (handle === undefined) {
+					handle = this.addStream(stream);
 				}
+			},
+			disable: () => {
+				if (handle !== undefined) {
+					handle.remove();
+					handle = undefined;
+				}
+			},
+			update: () => {
+				if (check !== undefined && check()) {
+					cond.enable();
+				} else {
+					cond.disable();
+				}
+
+				return handle !== undefined;
 			},
 		};
 

--- a/internal/cli-reporter/types.ts
+++ b/internal/cli-reporter/types.ts
@@ -79,6 +79,8 @@ export interface ReporterNamespace {
 }
 
 export type ReporterConditionalStream = {
+	enable: () => void;
+	disable: () => void;
 	update: () => boolean;
 };
 

--- a/internal/core/client/Client.ts
+++ b/internal/core/client/Client.ts
@@ -330,7 +330,11 @@ export default class Client {
 			});
 
 			return bridge.events.log.subscribe((
-				{origin, chunk, isError}: ServerBridgeLog,
+				{
+					origin,
+					chunk,
+					isError,
+				}: ServerBridgeLog,
 			) => {
 				// We allow multiple calls to bridge.subscribeLogs
 				// Filter the event if necessary if it wasn't requested by this log subscription

--- a/internal/core/client/Client.ts
+++ b/internal/core/client/Client.ts
@@ -7,6 +7,7 @@
 
 import {
 	ClientFlags,
+	ClientLogsLevel,
 	ClientTerminalFeatures,
 	DEFAULT_CLIENT_FLAGS,
 } from "../common/types/client";
@@ -32,7 +33,10 @@ import {Reporter, ReporterDerivedStreams} from "@internal/cli-reporter";
 import prettyFormat from "@internal/pretty-format";
 import {TarWriter} from "@internal/codec-tar";
 import {Profile, Profiler, Trace, TraceEvent} from "@internal/v8";
-import {PartialServerQueryRequest} from "../common/bridges/ServerBridge";
+import {
+	PartialServerQueryRequest,
+	ServerBridgeLog,
+} from "../common/bridges/ServerBridge";
 import {UserConfig, getUserConfigFile} from "../common/userConfig";
 import {createWriteStream, removeFile} from "@internal/fs";
 import {json} from "@internal/codec-config";
@@ -315,18 +319,25 @@ export default class Client {
 	}
 
 	public subscribeLogs(
-		includeWorkerLogs: boolean,
+		level: ClientLogsLevel,
+		includeWorker: boolean,
 		callback: (chunk: string) => void,
 	): Promise<EventSubscription> {
 		return this.onBridge(async ({bridge}) => {
-			if (includeWorkerLogs) {
-				await bridge.events.enableWorkerLogs.call();
-			}
+			await bridge.events.setLogLevel.call({
+				level,
+				includeWorker,
+			});
 
-			return bridge.events.log.subscribe(({origin, chunk}) => {
-				if (origin === "worker" && !includeWorkerLogs) {
-					// We allow multiple calls to bridge.enableWorkerLogs
-					// Filter the event if necessary if it wasn't requested by this log subscription
+			return bridge.events.log.subscribe((
+				{origin, chunk, isError}: ServerBridgeLog,
+			) => {
+				// We allow multiple calls to bridge.subscribeLogs
+				// Filter the event if necessary if it wasn't requested by this log subscription
+				if (origin === "worker" && !includeWorker) {
+					return;
+				}
+				if (!isError && level !== "all") {
 					return;
 				}
 
@@ -421,6 +432,7 @@ export default class Client {
 		let logsHTML = "";
 		let logsPlain = "";
 		await this.subscribeLogs(
+			"all",
 			true,
 			(chunk) => {
 				logsPlain += joinMarkupLines(

--- a/internal/core/common/bridges/ServerBridge.ts
+++ b/internal/core/common/bridges/ServerBridge.ts
@@ -7,7 +7,11 @@
 
 import {Profile} from "@internal/v8";
 import {Diagnostics} from "@internal/diagnostics";
-import {ClientFlags, ClientRequestFlags} from "../types/client";
+import {
+	ClientFlags,
+	ClientLogsLevel,
+	ClientRequestFlags,
+} from "../types/client";
 import {ReporterStream, ReporterStreamState} from "@internal/cli-reporter";
 import {ServerMarker} from "../../server/Server";
 import {TerminalFeatures} from "@internal/cli-environment";
@@ -91,6 +95,12 @@ export type ServerBridgeInfo = {
 	flags: ClientFlags;
 };
 
+export type ServerBridgeLog = {
+	isError: boolean;
+	origin: "server" | "worker";
+	chunk: string;
+};
+
 export default createBridge({
 	debugName: "server",
 
@@ -100,18 +110,18 @@ export default createBridge({
 		getClientInfo: createBridgeEventDeclaration<void, ServerBridgeInfo>(),
 		serverReady: createBridgeEventDeclaration<void, void>(),
 		write: createBridgeEventDeclaration<[string, boolean], void>(),
-		log: createBridgeEventDeclaration<
-			{
-				origin: "server" | "worker";
-				chunk: string;
-			},
-			void
-		>(),
+		log: createBridgeEventDeclaration<ServerBridgeLog, void>(),
 		lspFromServerBuffer: createBridgeEventDeclaration<string, void>(),
 	},
 
 	server: {
-		enableWorkerLogs: createBridgeEventDeclaration<void, void>(),
+		setLogLevel: createBridgeEventDeclaration<
+			{
+				level: undefined | ClientLogsLevel;
+				includeWorker: boolean;
+			},
+			void
+		>(),
 		endServer: createBridgeEventDeclaration<void, void>(),
 		updateFeatures: createBridgeEventDeclaration<TerminalFeatures, void>(),
 		query: createBridgeEventDeclaration<

--- a/internal/core/common/bridges/WorkerBridge.ts
+++ b/internal/core/common/bridges/WorkerBridge.ts
@@ -15,7 +15,7 @@ import {
 	TransformStageName,
 } from "@internal/compiler";
 import {Profile} from "@internal/v8";
-import {ProfilingStartData} from "./ServerBridge";
+import {ProfilingStartData, ServerBridgeLog} from "./ServerBridge";
 import {
 	DiagnosticIntegrity,
 	DiagnosticSuppressions,
@@ -158,11 +158,13 @@ export default createBridge({
 	shared: {},
 
 	server: {
-		log: createBridgeEventDeclaration<string, void>(),
+		log: createBridgeEventDeclaration<Omit<ServerBridgeLog, "origin">, void>(),
 		fatalError: createBridgeEventDeclaration<BridgeErrorResponseDetails, void>(),
 	},
 
 	client: {
+		setLogs: createBridgeEventDeclaration<boolean, void>(),
+
 		updateProjects: createBridgeEventDeclaration<
 			{
 				projects: WorkerProjects;

--- a/internal/core/common/types/client.ts
+++ b/internal/core/common/types/client.ts
@@ -64,3 +64,5 @@ export type ClientFlags = {
 	realCwd: AbsoluteFilePath;
 	silent: boolean;
 };
+
+export type ClientLogsLevel = "all" | "error";

--- a/internal/core/common/utils/Logger.ts
+++ b/internal/core/common/utils/Logger.ts
@@ -5,46 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-	Reporter,
-	ReporterConditionalStream,
-	ReporterOptions,
-} from "@internal/cli-reporter";
-import {DEFAULT_TERMINAL_FEATURES} from "@internal/cli-environment";
+import {Reporter, ReporterOptions} from "@internal/cli-reporter";
 import {AnyMarkup, markup} from "@internal/markup";
 import workerThreads = require("worker_threads");
 
 export default class Logger extends Reporter {
-	constructor(
-		opts: ReporterOptions,
-		{loggerType, write, check}: {
-			check: () => boolean;
-			write: (chunk: string) => void;
-			loggerType: string;
-		},
-	) {
+	constructor(opts: ReporterOptions, loggerType: string) {
 		super(opts);
 		this.loggerType = loggerType;
-
-		this.conditionalStream = this.attachConditionalStream(
-			{
-				format: "markup",
-				features: {
-					...DEFAULT_TERMINAL_FEATURES,
-					columns: undefined,
-				},
-				write,
-			},
-			check,
-		);
 	}
 
-	private conditionalStream: ReporterConditionalStream;
 	private loggerType: string;
-
-	public updateStream() {
-		this.conditionalStream.update();
-	}
 
 	protected getMessagePrefix(): AnyMarkup {
 		const inner = `${this.loggerType} ${process.pid}:${workerThreads.threadId}`;

--- a/internal/core/server/ServerCache.ts
+++ b/internal/core/server/ServerCache.ts
@@ -65,6 +65,7 @@ export default class ServerCache extends Cache {
 
 		if (this.readDisabled) {
 			logger.warn(markup`Read disabled, skipping breaker verification`);
+			return;
 		}
 
 		if (await exists(breakerPath)) {

--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -239,7 +239,8 @@ export default class ServerRequest {
 		this.files = new AbsoluteFilePathMap();
 
 		this.logger = server.logger.namespace(
-			markup`[ServerRequest] Request #${this.id}:`,
+			markup`ServerRequest`,
+			markup`Request #${this.id}`,
 		);
 
 		this.markerEvent = new Event({

--- a/internal/events/utils.ts
+++ b/internal/events/utils.ts
@@ -10,6 +10,10 @@ import {EventSubscription, EventSubscriptions} from "./types";
 export function mergeEventSubscriptions(
 	subs: EventSubscriptions,
 ): EventSubscription {
+	if (subs.length === 1) {
+		return subs[0];
+	}
+
 	return {
 		async unsubscribe() {
 			for (const sub of subs) {

--- a/internal/test-helpers/integration.ts
+++ b/internal/test-helpers/integration.ts
@@ -418,6 +418,7 @@ export function createIntegrationTest(
 			// Capture client logs
 			let logs = "";
 			await client.subscribeLogs(
+				"all",
 				true,
 				(chunk) => {
 					const textChunk = joinMarkupLines(

--- a/website/src/_includes/docs/cli.md
+++ b/website/src/_includes/docs/cli.md
@@ -54,9 +54,13 @@ This is useful as it will benchmark the command after server initialization and 
 
 The amount of iterations to perform when using the `--benchmark` flag. Defaults to `10`.
 
-##### `--logs`
+##### `--logs all`
 
 Enables server logs and outputs them to the console.
+
+##### `--logs error`
+
+Exclude info logs and only include warnings and errors.
 
 ##### `--log-workers`
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR closes #1331. It completely rewrites the way we transport logs across process boundaries. You may not have known before but we do a lot of optimizations to ensure that logs were only sent from workers to the server when necessary. We also skip a lot of markup processing so that when you use an internal logger without a subscriber, it's very cheap so we can use them as we like.

I added some warning and error logs that would be helpful when debugging issues. Previously we just had a bunch of info messages that are verbose but amazing for debugging.

So I split the flag into `--logs all` and `--logs error`. Where `all` will include info and error logs, and `error`... will only include errors.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Ran `./rome ci`