### PR TITLE
Strongly type command names

### DIFF
--- a/internal/cli/cli.ts
+++ b/internal/cli/cli.ts
@@ -28,7 +28,7 @@ import {
 	ClientProfileOptions,
 	getFilenameTimestamp,
 } from "@internal/core/client/Client";
-import {commandCategories, CommandName} from "@internal/core/common/commands";
+import {CommandName, commandCategories} from "@internal/core/common/commands";
 import {FSWriteStream, createWriteStream, writeFile} from "@internal/fs";
 import {markupToPlainText} from "@internal/cli-layout";
 import {

--- a/internal/cli/cli.ts
+++ b/internal/cli/cli.ts
@@ -28,7 +28,7 @@ import {
 	ClientProfileOptions,
 	getFilenameTimestamp,
 } from "@internal/core/client/Client";
-import {commandCategories} from "@internal/core/common/commands";
+import {commandCategories, CommandName} from "@internal/core/common/commands";
 import {FSWriteStream, createWriteStream, writeFile} from "@internal/fs";
 import {markupToPlainText} from "@internal/cli-layout";
 import {
@@ -340,7 +340,7 @@ export default async function cli() {
 		},
 	});
 
-	let command = "";
+	let command: CommandName = "noop";
 	let overrideCLIFlags: Partial<CLIFlags> = {};
 	let commandFlags: RSERObject = {};
 	let args: string[] = [];

--- a/internal/core/client/commands.ts
+++ b/internal/core/client/commands.ts
@@ -16,7 +16,7 @@ import lsp from "./commands/lsp";
 //
 import {UnknownObject} from "@internal/typescript-helpers";
 import ClientRequest from "./ClientRequest";
-import {SharedCommand} from "../common/commands";
+import {CommandName, SharedCommand} from "../common/commands";
 import {ServerQueryResponse} from "@internal/core";
 
 export type LocalCommand<Flags extends UnknownObject> = SharedCommand<
@@ -32,7 +32,7 @@ export function createLocalCommand<Flags extends UnknownObject>(
 }
 
 // rome-ignore lint/ts/noExplicitAny: future cleanup
-export const localCommands: Map<string, LocalCommand<any>> = new Map();
+export const localCommands: Map<CommandName, LocalCommand<any>> = new Map();
 localCommands.set("start", start);
 localCommands.set("develop", develop);
 localCommands.set("stop", stop);

--- a/internal/core/common/bridges/ServerBridge.ts
+++ b/internal/core/common/bridges/ServerBridge.ts
@@ -19,12 +19,13 @@ import {Dict} from "@internal/typescript-helpers";
 import {RecoverySaveFile} from "@internal/core/server/fs/RecoveryStore";
 import {RSERObject, RSERValue} from "@internal/codec-binary-serial";
 import createBridge, {createBridgeEventDeclaration} from "@internal/events/createBridge";
+import {CommandName} from "../commands";
 
 export type ServerQueryRequest = {
 	requestFlags: ClientRequestFlags;
 	commandFlags: RSERObject;
 	args: string[];
-	commandName: string;
+	commandName: CommandName;
 	silent: boolean;
 	noData: boolean;
 	noFileWrites: boolean;
@@ -37,7 +38,7 @@ export type PartialServerQueryRequest = Partial<Omit<
 	"requestFlags" | "commandName"
 >> & {
 	requestFlags?: Partial<ClientRequestFlags>;
-	commandName: string;
+	commandName: CommandName;
 };
 
 type ServerQueryResponseBase = {

--- a/internal/core/common/commands.ts
+++ b/internal/core/common/commands.ts
@@ -10,6 +10,46 @@ import {UnknownObject} from "@internal/typescript-helpers";
 import {StaticMarkup} from "@internal/markup";
 import {Examples} from "@internal/cli-flags";
 
+// List of valid command names, includes both server and client commands
+export type CommandName =
+	| "_evict"
+	| "_moduleSignature"
+	| "_projectDump"
+	| "analyzeDependencies"
+	| "bundle"
+	| "cache dir"
+	| "cache clear"
+	| "check"
+	| "ci"
+	| "compile"
+	| "config location"
+	| "config disable"
+	| "config enable"
+	| "config push"
+	| "config set"
+	| "config set-directory"
+	| "develop"
+	| "format"
+	| "init"
+	| "lsp"
+	| "json"
+	| "noop"
+	| "parse"
+	| "publish"
+	| "resolve"
+	| "restart"
+	| "start"
+	| "run"
+	| "stop"
+	| "status"
+	| "test"
+	| "recover apply"
+	| "recover clear"
+	| "recover diff"
+	| "recover dir"
+	| "recover list"
+	| "recover pop";
+
 export interface SharedCommand<Req, Flags extends UnknownObject, Ret> {
 	category: string;
 	description: StaticMarkup;

--- a/internal/core/index.ts
+++ b/internal/core/index.ts
@@ -12,6 +12,7 @@ export {getFileHandlerFromPath} from "./common/file-handlers/index";
 export {default as Client} from "./client/Client";
 export {localCommands} from "./client/commands";
 
+export {CommandName} from "./common/commands";
 export {default as WorkerBridge} from "./common/bridges/WorkerBridge";
 export {default as ServerBridge} from "./common/bridges/ServerBridge";
 export {

--- a/internal/core/server/commands.ts
+++ b/internal/core/server/commands.ts
@@ -33,7 +33,7 @@ import _projectDump from "./commands/_projectDump";
 //
 import {UnknownObject} from "@internal/typescript-helpers";
 import ServerRequest from "./ServerRequest";
-import {SharedCommand} from "../common/commands";
+import {CommandName, SharedCommand} from "../common/commands";
 import {DiagnosticsPrinter} from "@internal/cli-diagnostics";
 import {StaticMarkup} from "@internal/markup";
 import init from "@internal/core/server/commands/init";
@@ -92,7 +92,7 @@ export async function chainCommands(
 }
 
 // rome-ignore lint/ts/noExplicitAny: future cleanup
-export const serverCommands: Map<string, ServerCommand<any>> = new Map();
+export const serverCommands: Map<CommandName, ServerCommand<any>> = new Map();
 serverCommands.set("_evict", _evict);
 serverCommands.set("_moduleSignature", _moduleSignature);
 serverCommands.set("_projectDump", _projectDump);

--- a/internal/core/server/lsp/LSPServer.ts
+++ b/internal/core/server/lsp/LSPServer.ts
@@ -41,7 +41,7 @@ import {
 import {markup, readMarkup} from "@internal/markup";
 import {LSPCodeAction} from "./types";
 import {Event} from "@internal/events";
-import { CommandName } from "@internal/core/common/commands";
+import {CommandName} from "@internal/core/common/commands";
 
 export default class LSPServer {
 	constructor(request: ServerRequest) {

--- a/internal/core/server/lsp/LSPServer.ts
+++ b/internal/core/server/lsp/LSPServer.ts
@@ -41,6 +41,7 @@ import {
 import {markup, readMarkup} from "@internal/markup";
 import {LSPCodeAction} from "./types";
 import {Event} from "@internal/events";
+import { CommandName } from "@internal/core/common/commands";
 
 export default class LSPServer {
 	constructor(request: ServerRequest) {
@@ -119,7 +120,7 @@ export default class LSPServer {
 	}
 
 	private createFakeServerRequest(
-		commandName: string,
+		commandName: CommandName,
 		args: string[] = [],
 	): ServerRequest {
 		return new ServerRequest({
@@ -168,7 +169,7 @@ export default class LSPServer {
 			return;
 		}
 
-		const req = this.createFakeServerRequest("lsp_project", [path.join()]);
+		const req = this.createFakeServerRequest("noop", [path.join()]);
 		await req.init();
 
 		// This is not awaited so it doesn't delay the initialize response

--- a/internal/diagnostics/descriptions/files.ts
+++ b/internal/diagnostics/descriptions/files.ts
@@ -12,8 +12,8 @@ export const files = createDiagnosticsCategory({
 				type: "action",
 				instruction: markup`You can treat this file extension as a binary asset by running`,
 				noun: markup`Treat this file extension as a binary asset`,
-				command: "config",
-				args: ["push", "files.assetExtensions", path.getDotlessExtensions()],
+				command: "config push",
+				args: ["files.assetExtensions", path.getDotlessExtensions()],
 			});
 		}
 
@@ -48,15 +48,15 @@ export const files = createDiagnosticsCategory({
 					type: "action",
 					instruction: markup`You can ignore this file from linting by running`,
 					noun: markup`Ignore this file from linting`,
-					command: "config",
-					args: ["push", "lint.ignore", relative],
+					command: "config push",
+					args: ["lint.ignore", relative],
 				},
 				{
 					type: "action",
 					instruction: markup`Or can allow this specific file to exceed the size limit with`,
 					noun: markup`Allow only this specific file to exceed the limit`,
-					command: "config",
-					args: ["push", "files.maxSizeIgnore", relative],
+					command: "config push",
+					args: ["files.maxSizeIgnore", relative],
 				},
 				{
 					type: "action",
@@ -64,8 +64,8 @@ export const files = createDiagnosticsCategory({
 						size,
 					)}</filesize>`,
 					noun: markup`Increase project max file size limit`,
-					command: "config",
-					args: ["set", "files.maxSize", String(size)],
+					command: "config set",
+					args: ["files.maxSize", String(size)],
 				},
 			],
 		};

--- a/internal/diagnostics/types.ts
+++ b/internal/diagnostics/types.ts
@@ -12,7 +12,7 @@ import {Number0, Number1} from "@internal/ob1";
 import {JSONPropertyValue} from "@internal/codec-config";
 import {DiagnosticCategory} from "./categories";
 import {Dict} from "@internal/typescript-helpers";
-import {ClientRequestFlags} from "@internal/core";
+import {ClientRequestFlags, CommandName} from "@internal/core";
 import {StaticMarkup} from "@internal/markup";
 
 export type DiagnosticFilter = {
@@ -172,7 +172,7 @@ export type DiagnosticAdviceAction = {
 	shortcut?: string;
 	instruction: StaticMarkup;
 	noun: StaticMarkup;
-	command: string;
+	command: CommandName;
 	commandFlags?: Dict<boolean | string | (string[])>;
 	requestFlags?: ClientRequestFlags;
 	args?: string[];

--- a/internal/test-helpers/integration.ts
+++ b/internal/test-helpers/integration.ts
@@ -478,7 +478,7 @@ export function createIntegrationTest(
 						);
 					},
 					async createRequest(
-						query: PartialServerQueryRequest = {commandName: "unknown"},
+						query: PartialServerQueryRequest = {commandName: "noop"},
 					) {
 						return new ServerRequest({
 							client: serverClient,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR adds a type union of all valid command names and switches all the appropriate callsites that use `string` to it. Thanks @ematipico for flagging in #1334! I put a subcommand name in `args` instead of `command`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Ran TS.