### PR TITLE
Add integrations.eslint.enabled project config option

### DIFF
--- a/internal/ast-utils/removeLoc.ts
+++ b/internal/ast-utils/removeLoc.ts
@@ -54,7 +54,7 @@ export function removeLoc(ast: AnyNode): AnyNodes {
 	const context = new CompilerContext({
 		ast: MOCK_PROGRAM,
 		project: {
-			configHashes: [],
+			configCacheKeys: [],
 			directory: undefined,
 			config: createDefaultProjectConfig(),
 		},

--- a/internal/ast-utils/removeLoc.ts
+++ b/internal/ast-utils/removeLoc.ts
@@ -11,7 +11,6 @@ import {
 	MOCK_PROGRAM,
 	NodeBaseWithComments,
 } from "@internal/ast";
-import {createDefaultProjectConfig} from "@internal/project";
 import {AnyVisitors, CompilerContext, Path, signals} from "@internal/compiler";
 import {SourceLocation} from "@internal/parser-core";
 
@@ -53,11 +52,6 @@ const removeLocTransform: AnyVisitors = [
 export function removeLoc(ast: AnyNode): AnyNodes {
 	const context = new CompilerContext({
 		ast: MOCK_PROGRAM,
-		project: {
-			configCacheKeys: [],
-			directory: undefined,
-			config: createDefaultProjectConfig(),
-		},
 	});
 	return context.reduce(ast, removeLocTransform);
 }

--- a/internal/codec-binary-serial/RSERBufferParser.ts
+++ b/internal/codec-binary-serial/RSERBufferParser.ts
@@ -7,7 +7,7 @@ import {
 	RSERObject,
 	RSERSet,
 	RSERValue,
-	RSERValueObject,
+	RSERValueReferenceable,
 } from "./types";
 import {
 	FILE_CODES,
@@ -48,7 +48,7 @@ export default class RSERBufferParser {
 		this.references = new ExtendedMap("references");
 	}
 
-	private references: ExtendedMap<number, RSERValueObject>;
+	private references: ExtendedMap<number, RSERValueReferenceable>;
 	private view: DataView;
 	private bytes: Uint8Array;
 	public readOffset: number;
@@ -199,7 +199,7 @@ export default class RSERBufferParser {
 		return undefined;
 	}
 
-	public decodeDeclareReference(): RSERValueObject {
+	public decodeDeclareReference(): RSERValueReferenceable {
 		this.expectCode(VALUE_CODES.DECLARE_REFERENCE);
 		const id = this.decodeNumber();
 		const code = this.peekCode();
@@ -248,8 +248,13 @@ export default class RSERBufferParser {
 		}
 
 		// These can never refer to itself
-		let val: RSERValueObject;
+		let val: RSERValueReferenceable;
 		switch (code) {
+			case VALUE_CODES.STRING: {
+				val = this.decodeString();
+				break;
+			}
+
 			case VALUE_CODES.REGEXP: {
 				val = this.decodeRegExp();
 				break;
@@ -304,7 +309,7 @@ export default class RSERBufferParser {
 		return val;
 	}
 
-	public decodeReference(): RSERValueObject {
+	public decodeReference(): RSERValueReferenceable {
 		this.expectCode(VALUE_CODES.REFERENCE);
 		const id = this.decodeNumber();
 		return this.references.assert(id);

--- a/internal/codec-binary-serial/constants.ts
+++ b/internal/codec-binary-serial/constants.ts
@@ -36,38 +36,52 @@ export function formatCode(code: number): string {
 export enum VALUE_CODES {
 	STREAM_HEADER,
 	MESSAGE_HEADER,
+
 	STRING,
-	ARRAY,
-	SET,
-	MAP,
-	OBJECT,
-	SYMBOL,
-	DATE,
 	TRUE,
 	FALSE,
 	NULL,
 	UNDEFINED,
+
+	SYMBOL,
+	DATE,
+	ERROR,
+	REGEXP,
+
+	ARRAY,
+	SET,
+	MAP,
+	OBJECT,
+	TEMPLATED_OBJECT_ARRAY,
+
 	INT8,
 	INT16,
 	INT32,
 	INT64,
 	FLOAT,
 	NAN,
+
 	POSITIVE_INFINITY,
 	NEGATIVE_INFINITY,
 	NEGATIVE_ZERO,
+
 	FILE_PATH,
 	FILE_PATH_SET,
 	FILE_PATH_MAP,
-	ERROR,
-	REGEXP,
-	TEMPLATED_OBJECT_ARRAY,
+
 	REFERENCE,
 	DECLARE_REFERENCE,
+
 	ARRAY_BUFFER,
 	ARRAY_BUFFER_VIEW,
+
 	POSITION,
 	SOURCE_LOCATION,
+
+	// These save a single byte having to specify an Int8...
+	NEGATIVE_ONE,
+	POSITIVE_ZERO,
+	POSITIVE_ONE,
 }
 
 export function validateValueCode(code: number): VALUE_CODES {
@@ -107,6 +121,9 @@ export function validateValueCode(code: number): VALUE_CODES {
 		case VALUE_CODES.STREAM_HEADER:
 		case VALUE_CODES.POSITION:
 		case VALUE_CODES.SOURCE_LOCATION:
+		case VALUE_CODES.NEGATIVE_ONE:
+		case VALUE_CODES.POSITIVE_ZERO:
+		case VALUE_CODES.POSITIVE_ONE:
 			return code;
 
 		default:

--- a/internal/codec-binary-serial/types.ts
+++ b/internal/codec-binary-serial/types.ts
@@ -6,7 +6,7 @@ import {
 	UnknownPathMap,
 } from "@internal/path";
 
-export type IntSize = 1 | 2 | 4 | 8;
+export type IntSize = 0 | 1 | 2 | 4 | 8;
 
 export type EqualShapeObjects<Value> = {[key in keyof Value]: Value[key]};
 
@@ -64,5 +64,3 @@ export type RSERObject = {
 export type RSERArray = RSERValue[];
 
 export type RSERValueObject = Extract<RSERValue, object>;
-
-export type RSERValueReferenceable = RSERValueObject | string;

--- a/internal/codec-binary-serial/types.ts
+++ b/internal/codec-binary-serial/types.ts
@@ -64,3 +64,5 @@ export type RSERObject = {
 export type RSERArray = RSERValue[];
 
 export type RSERValueObject = Extract<RSERValue, object>;
+
+export type RSERValueReferenceable = RSERValueObject | string;

--- a/internal/compiler/api/analyzeDependencies.test.ts
+++ b/internal/compiler/api/analyzeDependencies.test.ts
@@ -19,7 +19,7 @@ async function testAnalyzeDeps(input: string, sourceType: ConstJSSourceType) {
 		ast: parseJS({input, sourceType, path: createUnknownPath("unknown")}),
 		sourceText: input,
 		project: {
-			configHashes: [],
+			configCacheKeys: [],
 			directory: undefined,
 			config: createDefaultProjectConfig(),
 		},

--- a/internal/compiler/api/analyzeDependencies.test.ts
+++ b/internal/compiler/api/analyzeDependencies.test.ts
@@ -6,7 +6,6 @@
  */
 
 import analyzeDependencies from "./analyzeDependencies";
-import {createDefaultProjectConfig} from "@internal/project";
 import {test} from "rome";
 import {parseJS} from "@internal/js-parser";
 import {ConstJSSourceType} from "@internal/ast";
@@ -18,11 +17,6 @@ async function testAnalyzeDeps(input: string, sourceType: ConstJSSourceType) {
 		options: {},
 		ast: parseJS({input, sourceType, path: createUnknownPath("unknown")}),
 		sourceText: input,
-		project: {
-			configCacheKeys: [],
-			directory: undefined,
-			config: createDefaultProjectConfig(),
-		},
 	});
 }
 

--- a/internal/compiler/api/compile.ts
+++ b/internal/compiler/api/compile.ts
@@ -44,7 +44,7 @@ export default async function compile(
 	const formatted = formatAST(
 		transformedAst,
 		{
-			projectConfig: project.config,
+			projectConfig: project?.config,
 			typeAnnotations: false,
 			indent: req.stage === "compileForBundle" ? 1 : 0,
 			sourceMaps: true,

--- a/internal/compiler/lib/Cache.ts
+++ b/internal/compiler/lib/Cache.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {TransformProjectDefinition, TransformRequest} from "../types";
+import {CompilerProject, TransformRequest} from "../types";
 import {AnyRoot} from "@internal/ast";
 import {JSONObject} from "@internal/codec-config";
 
@@ -15,7 +15,7 @@ type CacheQuery = {
 };
 
 let projectIdCounter = 0;
-const projectToId: WeakMap<TransformProjectDefinition, number> = new WeakMap();
+const projectToId: WeakMap<CompilerProject, number> = new WeakMap();
 
 export default class Cache<Result> {
 	constructor() {
@@ -31,14 +31,16 @@ export default class Cache<Result> {
 		const {ast, project, options} = req;
 		const keyParts: string[] = [];
 
-		let projectId = projectToId.get(project);
-		if (projectId === undefined) {
-			projectId = projectIdCounter++;
-			projectToId.set(project, projectId);
-		}
+		if (project !== undefined) {
+			let projectId = projectToId.get(project);
+			if (projectId === undefined) {
+				projectId = projectIdCounter++;
+				projectToId.set(project, projectId);
+			}
 
-		// Add project config cache counter
-		keyParts.push(String(projectId));
+			// Add project config cache counter
+			keyParts.push(String(projectId));
+		}
 
 		// Add options if they exist
 		const extra = {

--- a/internal/compiler/lib/CompilerContext.ts
+++ b/internal/compiler/lib/CompilerContext.ts
@@ -98,7 +98,7 @@ export default class CompilerContext {
 			frozen = false,
 			options = {},
 			project = {
-				configHashes: [],
+				configCacheKeys: [],
 				directory: undefined,
 				config: createDefaultProjectConfig(),
 			},

--- a/internal/compiler/lib/CompilerContext.ts
+++ b/internal/compiler/lib/CompilerContext.ts
@@ -154,8 +154,10 @@ export default class CompilerContext {
 	public frozen: boolean;
 	private origin: undefined | DiagnosticOrigin;
 	public options: CompilerOptions;
-	
-	public static normalizeProject(project: undefined | CompilerProject): CompilerProject {
+
+	public static normalizeProject(
+		project: undefined | CompilerProject,
+	): CompilerProject {
 		if (project === undefined) {
 			return {
 				config: createDefaultProjectConfig(),

--- a/internal/compiler/lib/CompilerContext.ts
+++ b/internal/compiler/lib/CompilerContext.ts
@@ -35,8 +35,8 @@ import {reduceNode} from "../methods/reduce";
 import {UnknownPath, createUnknownPath} from "@internal/path";
 import {
 	AnyVisitor,
+	CompilerProject,
 	LintCompilerOptionsDecision,
-	TransformProjectDefinition,
 	Visitor,
 } from "../types";
 import {createSuppressionsVisitor, matchesSuppression} from "../suppressions";
@@ -63,7 +63,7 @@ export type ContextArg = {
 	ast: AnyRoot;
 	suppressions?: DiagnosticSuppressions;
 	ref?: FileReference;
-	project?: TransformProjectDefinition;
+	project?: CompilerProject;
 	frozen?: boolean;
 	options?: CompilerOptions;
 	origin?: DiagnosticOrigin;
@@ -97,11 +97,7 @@ export default class CompilerContext {
 			ref,
 			frozen = false,
 			options = {},
-			project = {
-				configCacheKeys: [],
-				directory: undefined,
-				config: createDefaultProjectConfig(),
-			},
+			project,
 			suppressions = [],
 		} = arg;
 
@@ -114,7 +110,7 @@ export default class CompilerContext {
 			ref === undefined ? ast.filename : ref.relative.join();
 		this.frozen = frozen;
 		this.integrity = ast.integrity;
-		this.project = project;
+		this.project = CompilerContext.normalizeProject(project);
 		this.options = options;
 		this.origin = origin;
 		this.cacheDependencies = new Set();
@@ -140,7 +136,7 @@ export default class CompilerContext {
 	public filename: string;
 	private integrity: undefined | DiagnosticIntegrity;
 	public path: UnknownPath;
-	public project: TransformProjectDefinition;
+	public project: CompilerProject;
 	public language: DiagnosticLanguage;
 	private sourceTypeJS: undefined | ConstJSSourceType;
 	private reducedRoot: boolean;
@@ -158,6 +154,16 @@ export default class CompilerContext {
 	public frozen: boolean;
 	private origin: undefined | DiagnosticOrigin;
 	public options: CompilerOptions;
+	
+	public static normalizeProject(project: undefined | CompilerProject): CompilerProject {
+		if (project === undefined) {
+			return {
+				config: createDefaultProjectConfig(),
+			};
+		} else {
+			return project;
+		}
+	}
 
 	public getVisitorState<State extends UnknownObject>(
 		visitor: Visitor<State>,

--- a/internal/compiler/lint/decisions.test.ts
+++ b/internal/compiler/lint/decisions.test.ts
@@ -4,7 +4,6 @@ import {parseDecisionStrings} from "@internal/compiler";
 import {createAbsoluteFilePath} from "@internal/path";
 import lint from "./index";
 import {parseJS} from "@internal/js-parser";
-import {createDefaultProjectConfig} from "@internal/project";
 import {ob1Number0, ob1Number1} from "@internal/ob1";
 
 test(
@@ -30,11 +29,6 @@ test(
 
 		const res = await lint({
 			applySafeFixes: true,
-			project: {
-				configCacheKeys: [],
-				directory: undefined,
-				config: createDefaultProjectConfig(),
-			},
 			options: {
 				lint: compilerOptions,
 			},

--- a/internal/compiler/lint/decisions.test.ts
+++ b/internal/compiler/lint/decisions.test.ts
@@ -31,7 +31,7 @@ test(
 		const res = await lint({
 			applySafeFixes: true,
 			project: {
-				configHashes: [],
+				configCacheKeys: [],
 				directory: undefined,
 				config: createDefaultProjectConfig(),
 			},

--- a/internal/compiler/lint/index.test.ts
+++ b/internal/compiler/lint/index.test.ts
@@ -18,7 +18,7 @@ function createLintTransformOptions(
 		}),
 		options: {},
 		project: {
-			configHashes: [],
+			configCacheKeys: [],
 			config: mutateConfig(createDefaultProjectConfig()),
 			directory: undefined,
 		},
@@ -50,7 +50,7 @@ function createLintTransformSuppressions(
 			},
 		},
 		project: {
-			configHashes: [],
+			configCacheKeys: [],
 			config: mutateConfig(createDefaultProjectConfig()),
 			directory: undefined,
 		},

--- a/internal/compiler/lint/index.test.ts
+++ b/internal/compiler/lint/index.test.ts
@@ -18,9 +18,7 @@ function createLintTransformOptions(
 		}),
 		options: {},
 		project: {
-			configCacheKeys: [],
 			config: mutateConfig(createDefaultProjectConfig()),
-			directory: undefined,
 		},
 	};
 }
@@ -50,9 +48,7 @@ function createLintTransformSuppressions(
 			},
 		},
 		project: {
-			configCacheKeys: [],
 			config: mutateConfig(createDefaultProjectConfig()),
-			directory: undefined,
 		},
 	};
 }

--- a/internal/compiler/lint/index.ts
+++ b/internal/compiler/lint/index.ts
@@ -51,7 +51,8 @@ function getVisitors(config: ProjectConfig): AnyVisitor[] {
 const lintCache: Cache<LintResult> = new Cache();
 
 export default async function lint(req: LintRequest): Promise<LintResult> {
-	const {ast, project, applySafeFixes, options, suppressionExplanation} = req;
+	const {ast, applySafeFixes, options, suppressionExplanation} = req;
+	const project = CompilerContext.normalizeProject(req.project);
 
 	const query = Cache.buildQuery(req, {applySafeFixes, suppressionExplanation});
 	const cached = lintCache.get(query);

--- a/internal/compiler/methods/transform.ts
+++ b/internal/compiler/methods/transform.ts
@@ -67,7 +67,7 @@ export default async function transform(
 	});
 
 	const transformFactory = stageTransforms[stage];
-	const transforms = transformFactory(project.config, options);
+	const transforms = transformFactory(context.project.config, options);
 
 	let visitors: AnyVisitors = await context.normalizeTransforms(transforms);
 

--- a/internal/compiler/types.ts
+++ b/internal/compiler/types.ts
@@ -17,6 +17,11 @@ import {Dict, UnknownObject} from "@internal/typescript-helpers";
 import {DiagnosticCategory} from "@internal/diagnostics";
 import {VisitorStateEnter, VisitorStateExit} from "./lib/VisitorState";
 
+export type CompilerProject = {
+	config: ProjectConfig;
+	directory?: undefined | AbsoluteFilePath;
+};
+
 //
 export type TransformStageName = "pre" | "compile" | "compileForBundle";
 
@@ -56,18 +61,12 @@ export type LintRequest = TransformRequest & {
 	suppressionExplanation?: string;
 };
 
-export type TransformProjectDefinition = {
-	configCacheKeys: string[];
-	config: ProjectConfig;
-	directory: undefined | AbsoluteFilePath;
-};
-
 export type TransformRequest = {
-	ref?: FileReference;
 	sourceText: string;
 	ast: AnyRoot;
-	project: TransformProjectDefinition;
 	options: CompilerOptions;
+	ref?: FileReference;
+	project?: CompilerProject;
 	stage?: TransformStageName;
 };
 

--- a/internal/compiler/types.ts
+++ b/internal/compiler/types.ts
@@ -57,7 +57,7 @@ export type LintRequest = TransformRequest & {
 };
 
 export type TransformProjectDefinition = {
-	configHashes: string[];
+	configCacheKeys: string[];
 	config: ProjectConfig;
 	directory: undefined | AbsoluteFilePath;
 };

--- a/internal/core/common/bridges/WorkerBridge.ts
+++ b/internal/core/common/bridges/WorkerBridge.ts
@@ -34,7 +34,7 @@ import {RecoverySaveFile} from "@internal/core/server/fs/RecoveryStore";
 import {WorkerBuffer} from "@internal/core/worker/Worker";
 import {createBridgeEventDeclaration} from "@internal/events/createBridge";
 import {FileNotFound} from "@internal/fs";
-import { Dict } from "@internal/typescript-helpers";
+import {Dict} from "@internal/typescript-helpers";
 
 export type WorkerProject = CompilerProject & {
 	configCacheKeys: Dict<string>;
@@ -167,10 +167,7 @@ export default createBridge({
 
 		evictProject: createBridgeEventDeclaration<number, void>(),
 
-		updateProjects: createBridgeEventDeclaration<
-			WorkerProjects,
-			void
-		>(),
+		updateProjects: createBridgeEventDeclaration<WorkerProjects, void>(),
 
 		updateManifests: createBridgeEventDeclaration<
 			{

--- a/internal/core/common/bridges/WorkerBridge.ts
+++ b/internal/core/common/bridges/WorkerBridge.ts
@@ -11,6 +11,7 @@ import {AnyRoot, ConstJSSourceType} from "@internal/ast";
 import {
 	BundleCompileOptions,
 	CompileResult,
+	CompilerProject,
 	LintCompilerOptions,
 	TransformStageName,
 } from "@internal/compiler";
@@ -30,17 +31,16 @@ import {AbsoluteFilePath, createAbsoluteFilePath} from "@internal/path";
 import {Number0} from "@internal/ob1";
 import {FormatterOptions} from "@internal/formatter";
 import {RecoverySaveFile} from "@internal/core/server/fs/RecoveryStore";
-import {ProjectConfig} from "@internal/project";
 import {WorkerBuffer} from "@internal/core/worker/Worker";
 import {createBridgeEventDeclaration} from "@internal/events/createBridge";
 import {FileNotFound} from "@internal/fs";
+import { Dict } from "@internal/typescript-helpers";
 
-export type WorkerProjects = {
-	id: number;
-	directory: AbsoluteFilePath;
-	configHashes: string[];
-	config: undefined | ProjectConfig;
-}[];
+export type WorkerProject = CompilerProject & {
+	configCacheKeys: Dict<string>;
+};
+
+export type WorkerProjects = Map<number, WorkerProject>;
 
 export type WorkerPartialManifest = {
 	path: AbsoluteFilePath;
@@ -165,10 +165,10 @@ export default createBridge({
 	client: {
 		setLogs: createBridgeEventDeclaration<boolean, void>(),
 
+		evictProject: createBridgeEventDeclaration<number, void>(),
+
 		updateProjects: createBridgeEventDeclaration<
-			{
-				projects: WorkerProjects;
-			},
+			WorkerProjects,
 			void
 		>(),
 

--- a/internal/core/common/file-handlers/types.ts
+++ b/internal/core/common/file-handlers/types.ts
@@ -6,7 +6,7 @@
  */
 
 import {FileReference} from "@internal/core";
-import {WorkerParseOptions} from "../bridges/WorkerBridge";
+import {WorkerParseOptions, WorkerProject} from "../bridges/WorkerBridge";
 import Worker from "../../worker/Worker";
 import {
 	DiagnosticIntegrity,
@@ -14,7 +14,6 @@ import {
 	DiagnosticSuppressions,
 	Diagnostics,
 } from "@internal/diagnostics";
-import * as compiler from "@internal/compiler";
 import {AnyRoot, ConstJSSourceType} from "@internal/ast";
 import {UnknownPath} from "@internal/path";
 
@@ -31,7 +30,7 @@ export type ExtensionHandlerMethodInfo = {
 	mtimeNs: bigint;
 	integrity: undefined | DiagnosticIntegrity;
 	file: FileReference;
-	project: compiler.TransformProjectDefinition;
+	project: WorkerProject;
 	worker: Worker;
 };
 

--- a/internal/core/server/WorkerQueue.ts
+++ b/internal/core/server/WorkerQueue.ts
@@ -8,7 +8,7 @@
 import {WorkerContainer} from "./WorkerManager";
 import Server from "./Server";
 import {AbsoluteFilePath} from "@internal/path";
-import {FileNotFound} from "@internal/fs/FileNotFound";
+import {FileNotFound} from "@internal/fs";
 import {Queue, QueueOptions} from "@internal/async";
 
 export type WorkerQueueOptions<M> = QueueOptions<

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -154,6 +154,7 @@ async function runCommand(
 			const project = await req.assertClientCwdProject();
 			const meta = assertHardMeta(project.meta);
 			const {configPath, configSourceSubKey} = meta;
+			const rootProject = project.root ?? project;
 
 			await handleConfig(
 				configPath,
@@ -161,9 +162,12 @@ async function runCommand(
 				async (res, stringified) => {
 					await normalizeProjectConfig(
 						res,
-						meta.configPath,
-						stringified,
-						meta.projectDirectory,
+						{
+							configPath: meta.configPath,
+							configFile: stringified,
+							projectDirectory: project.directory,
+							rootProjectDirectory: rootProject.directory,
+						},
 					);
 				},
 			);

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -19,7 +19,7 @@ import {
 	json,
 	stringifyConfig,
 } from "@internal/codec-config";
-import {readFileText, writeFile} from "@internal/fs";
+import {CachedFileReader, readFileText, writeFile} from "@internal/fs";
 import {
 	loadUserConfig,
 	normalizeUserConfig,
@@ -159,12 +159,12 @@ async function runCommand(
 			await handleConfig(
 				configPath,
 				configSourceSubKey,
-				async (res, stringified) => {
+				async (res) => {
 					await normalizeProjectConfig(
 						res,
 						{
+							reader: new CachedFileReader(),
 							configPath: meta.configPath,
-							configFile: stringified,
 							projectDirectory: project.directory,
 							rootProjectDirectory: rootProject.directory,
 						},

--- a/internal/core/server/dependencies/DependencyGraph.ts
+++ b/internal/core/server/dependencies/DependencyGraph.ts
@@ -26,9 +26,8 @@ import {
 	AbsoluteFilePathMap,
 	createUnknownPath,
 } from "@internal/path";
-
 import {markup} from "@internal/markup";
-import {FileNotFound, MissingFileReturn} from "@internal/fs/FileNotFound";
+import FileNotFound, {MissingFileReturn} from "@internal/fs/FileNotFound";
 
 export type DependencyGraphSeedResult = {
 	node: DependencyNode;

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -36,11 +36,11 @@ import {
 	exists,
 	lstat,
 	readDirectory,
-	readFileText,
 	watch,
+	CachedFileReader,
 } from "@internal/fs";
 import crypto = require("crypto");
-import {FileNotFound} from "@internal/fs/FileNotFound";
+import {FileNotFound} from "@internal/fs";
 import {markup} from "@internal/markup";
 import {ReporterNamespace} from "@internal/cli-reporter";
 import {GlobOptions, Globber} from "./glob";
@@ -103,11 +103,12 @@ type DeclareManifestOpts = {
 	dirname: AbsoluteFilePath;
 	path: AbsoluteFilePath;
 	isPartialProject: boolean;
-	content: undefined | string;
+	reader: CachedFileReader;
 };
 
 type CrawlOptions = {
 	reason: "watch" | "initial";
+	reader: CachedFileReader;
 	watcherId?: number;
 	partialAllowlist?: AbsoluteFilePath[];
 	diagnostics: DiagnosticsProcessor;
@@ -210,21 +211,23 @@ export default class MemoryFileSystem {
 	// Inject virtual modules so they are discoverable
 	private async injectVirtualModules() {
 		const files = this.server.virtualModules.getStatMap();
+		const reader = new CachedFileReader();
 
 		for (const [path, {stats, content}] of files) {
 			if (stats.isDirectory()) {
 				this.directories.set(path, toSimpleStats(stats));
 			} else {
+				reader.cache(path, Buffer.from(content ?? ""));
 				this.files.set(path, toSimpleStats(stats));
 				this.addFileToDirectoryListing(path);
 
 				if (isValidManifest(path)) {
 					await this.declareManifest({
 						isPartialProject: false,
-						content,
 						diagnostics: this.server.createDisconnectedDiagnosticsProcessor([]),
 						dirname: path.getParent(),
 						path,
+						reader,
 					});
 				}
 			}
@@ -328,6 +331,7 @@ export default class MemoryFileSystem {
 					diagnostics,
 					onFoundDirectory,
 					reason: "initial",
+					reader: new CachedFileReader(),
 				},
 			);
 			const took = Date.now() - start;
@@ -680,12 +684,12 @@ export default class MemoryFileSystem {
 		{
 			path,
 			diagnostics,
-			content,
 			isPartialProject,
+			reader,
 		}: DeclareManifestOpts,
 	): Promise<void> {
 		// Fetch the manifest
-		const manifestRaw = content ?? (await readFileText(path));
+		const manifestRaw = await reader.readFileText(path);
 		const hash = crypto.createHash("sha256").update(manifestRaw).digest("hex");
 
 		const consumer = json.consumeValue({
@@ -741,6 +745,7 @@ export default class MemoryFileSystem {
 
 		if (isProjectPackage && consumer.has(PROJECT_CONFIG_PACKAGE_JSON_FIELD)) {
 			await projectManager.addDiskProject({
+				reader,
 				projectDirectory: directory,
 				configPath: path,
 				isPartial: isPartialProject,
@@ -954,6 +959,7 @@ export default class MemoryFileSystem {
 		const crawlOpts: CrawlOptions = {
 			reason: "watch",
 			diagnostics,
+			reader: new CachedFileReader(),
 			...customCrawlOpts,
 		};
 
@@ -1040,6 +1046,7 @@ export default class MemoryFileSystem {
 			}
 
 			await projectManager.addDiskProject({
+				reader: opts.reader,
 				isPartial: opts.partialAllowlist !== undefined,
 				// Get the directory above .config
 				projectDirectory: dirname.getParent(),
@@ -1049,8 +1056,8 @@ export default class MemoryFileSystem {
 
 		if (isValidManifest(path)) {
 			await this.declareManifest({
+				reader: opts.reader,
 				isPartialProject: opts.partialAllowlist !== undefined,
-				content: undefined,
 				diagnostics: opts.diagnostics,
 				dirname,
 				path,

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -31,16 +31,17 @@ import {
 	AbsoluteFilePathSet,
 } from "@internal/path";
 import {
+	CachedFileReader,
 	FSStats,
 	FSWatcher,
+	FileNotFound,
 	exists,
 	lstat,
 	readDirectory,
 	watch,
-	CachedFileReader,
 } from "@internal/fs";
 import crypto = require("crypto");
-import {FileNotFound} from "@internal/fs";
+
 import {markup} from "@internal/markup";
 import {ReporterNamespace} from "@internal/cli-reporter";
 import {GlobOptions, Globber} from "./glob";

--- a/internal/core/server/linter/Linter.ts
+++ b/internal/core/server/linter/Linter.ts
@@ -32,7 +32,7 @@ import {
 } from "@internal/compiler";
 import {markup} from "@internal/markup";
 import {Dict, VoidCallback} from "@internal/typescript-helpers";
-import {FileNotFound} from "@internal/fs/FileNotFound";
+import {FileNotFound} from "@internal/fs";
 import {WatchFilesEvent} from "../fs/glob";
 
 type LintWatchChanges = {

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -619,8 +619,12 @@ export default class ProjectManager {
 			}
 		}
 
-		// Declare the project
 		const parentProject = this.findLoadedProject(projectDirectory.getParent());
+
+		// The root project is the highest reachable project. The `root` project will not have the `root` property visible.
+		const rootProject = parentProject === undefined ? undefined : parentProject.root ?? parentProject;
+
+		// Declare the project
 		const project: ProjectDefinition = {
 			config,
 			meta,
@@ -628,6 +632,7 @@ export default class ProjectManager {
 			id: this.projectIdCounter++,
 			packages: new Map(),
 			manifests: new Map(),
+			root: rootProject,
 			parent: parentProject,
 			children: new Set(),
 			initialized: false,
@@ -718,7 +723,7 @@ export default class ProjectManager {
 		const projectsSerial: WorkerProjects = [];
 		for (const project of projects) {
 			projectsSerial.push({
-				configHashes: project.meta.configHashes,
+				configHashes: project.meta.configCacheKeys,
 				config: project.config,
 				id: project.id,
 				directory: project.directory,

--- a/internal/core/worker/Worker.ts
+++ b/internal/core/worker/Worker.ts
@@ -12,6 +12,7 @@ import WorkerBridge, {
 	WorkerParseOptions,
 	WorkerPartialManifest,
 	WorkerPartialManifests,
+	WorkerProject,
 	WorkerProjects,
 } from "../common/bridges/WorkerBridge";
 import {AnyRoot, ConstJSSourceType, JSRoot} from "@internal/ast";
@@ -34,7 +35,7 @@ import {
 } from "@internal/fs";
 import {FileReference} from "../common/types/files";
 import {getFileHandlerFromPathAssert} from "../common/file-handlers/index";
-import {TransformProjectDefinition} from "@internal/compiler";
+import {CompilerProject} from "@internal/compiler";
 import WorkerAPI from "./WorkerAPI";
 import {applyWorkerBufferPatch} from "./utils/applyWorkerBufferPatch";
 import VirtualModules from "../common/VirtualModules";
@@ -51,7 +52,7 @@ export type ParseResult = {
 	ast: AnyRoot;
 	integrity: undefined | DiagnosticIntegrity;
 	mtimeNs: bigint;
-	project: TransformProjectDefinition;
+	project: CompilerProject;
 	path: AbsoluteFilePath;
 	lastAccessed: number;
 	sourceText: string;
@@ -148,7 +149,7 @@ export default class Worker {
 	private cache: WorkerCache;
 	private bridge: BridgeClient<typeof WorkerBridge>;
 	private partialManifests: ExtendedMap<number, WorkerPartialManifest>;
-	private projects: Map<number, TransformProjectDefinition>;
+	private projects: WorkerProjects;
 	private astCache: AbsoluteFilePathMap<ParseResult>;
 	private moduleSignatureCache: UnknownPathMap<ModuleSignature>;
 	private buffers: AbsoluteFilePathMap<WorkerBuffer>;
@@ -234,8 +235,12 @@ export default class Worker {
 			return this.api.moduleSignatureJS(payload.ref, payload.parseOptions);
 		});
 
-		bridge.events.updateProjects.subscribe((payload) => {
-			return this.updateProjects(payload.projects);
+		bridge.events.evictProject.subscribe((id) => {
+			return this.evictProject(id);
+		});
+
+		bridge.events.updateProjects.subscribe((projects) => {
+			return this.updateProjects(projects);
 		});
 
 		bridge.events.setLogs.subscribe((enabled) => {
@@ -578,7 +583,7 @@ export default class Worker {
 		return res;
 	}
 
-	public getProject(id: number): TransformProjectDefinition {
+	public getProject(id: number): WorkerProject {
 		const config = this.projects.get(id);
 		if (config === undefined) {
 			throw new Error(
@@ -610,20 +615,13 @@ export default class Worker {
 		}
 	}
 
+	public evictProject(projectId: number) {
+		this.projects.delete(projectId);
+	}
+
 	public updateProjects(projects: WorkerProjects) {
-		for (const {config, directory, configHashes, id} of projects) {
-			if (config === undefined) {
-				this.projects.delete(id);
-			} else {
-				this.projects.set(
-					id,
-					{
-						directory,
-						configCacheKeys: configHashes,
-						config,
-					},
-				);
-			}
+		for (const [id, project] of projects) {
+			this.projects.set(id, project);
 		}
 	}
 }

--- a/internal/core/worker/Worker.ts
+++ b/internal/core/worker/Worker.ts
@@ -619,7 +619,7 @@ export default class Worker {
 					id,
 					{
 						directory,
-						configHashes,
+						configCacheKeys: configHashes,
 						config,
 					},
 				);

--- a/internal/core/worker/WorkerCache.ts
+++ b/internal/core/worker/WorkerCache.ts
@@ -312,18 +312,18 @@ class CacheFile {
 	private async createFreshPortableMetadata(): Promise<PortableCacheMetadataHashless> {
 		const {ref} = this;
 		const project = this.worker.getProject(ref.project);
-		const configHashes = [...project.configHashes];
+		const configCacheKeys = [...project.configCacheKeys];
 
 		if (ref.manifest !== undefined) {
 			const manifest = this.worker.getPartialManifest(ref.manifest);
-			configHashes.push(manifest.hash);
+			configCacheKeys.push(`manifest:${manifest.hash}`);
 		}
 
 		const stats = await this.getStats();
 
 		return {
 			version: VERSION,
-			cacheKey: configHashes.join(";"),
+			cacheKey: configCacheKeys.join(";"),
 			size: stats.size,
 		};
 	}

--- a/internal/core/worker/WorkerCache.ts
+++ b/internal/core/worker/WorkerCache.ts
@@ -312,7 +312,11 @@ class CacheFile {
 	private async createFreshPortableMetadata(): Promise<PortableCacheMetadataHashless> {
 		const {ref} = this;
 		const project = this.worker.getProject(ref.project);
-		const configCacheKeys = [...project.configCacheKeys];
+		const configCacheKeys: Array<string> = [];
+
+		for (const key of Object.keys(project.configCacheKeys).sort()) {
+			configCacheKeys.push(`${key}:${project.configCacheKeys[key]}`);
+		}
 
 		if (ref.manifest !== undefined) {
 			const manifest = this.worker.getPartialManifest(ref.manifest);

--- a/internal/core/worker/WorkerCache.ts
+++ b/internal/core/worker/WorkerCache.ts
@@ -312,7 +312,7 @@ class CacheFile {
 	private async createFreshPortableMetadata(): Promise<PortableCacheMetadataHashless> {
 		const {ref} = this;
 		const project = this.worker.getProject(ref.project);
-		const configCacheKeys: Array<string> = [];
+		const configCacheKeys: string[] = [];
 
 		for (const key of Object.keys(project.configCacheKeys).sort()) {
 			configCacheKeys.push(`${key}:${project.configCacheKeys[key]}`);

--- a/internal/fs/CachedFileReader.ts
+++ b/internal/fs/CachedFileReader.ts
@@ -1,0 +1,32 @@
+import { AbsoluteFilePath, AbsoluteFilePathMap } from "@internal/path";
+import {readFile} from "./index";
+
+export default class CachedFileReader {
+  constructor() {
+    this.cached = new AbsoluteFilePathMap();
+  }
+
+  private cached: AbsoluteFilePathMap<Buffer | Promise<Buffer>>;
+
+  cache(path: AbsoluteFilePath, buffer: Buffer) {
+    this.cached.set(path, buffer);
+  }
+
+  async readFile(path: AbsoluteFilePath): Promise<Buffer> {
+    const cached = this.cached.get(path);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const promise = readFile(path);
+    this.cached.set(path, promise);
+
+    const buff = await promise;
+    this.cache(path, buff);
+    return buff;
+  }
+
+  readFileText(path: AbsoluteFilePath): Promise<string> {
+    return this.readFile(path).then(buff => buff.toString());
+  }
+}

--- a/internal/fs/CachedFileReader.ts
+++ b/internal/fs/CachedFileReader.ts
@@ -1,32 +1,32 @@
-import { AbsoluteFilePath, AbsoluteFilePathMap } from "@internal/path";
+import {AbsoluteFilePath, AbsoluteFilePathMap} from "@internal/path";
 import {readFile} from "./index";
 
 export default class CachedFileReader {
-  constructor() {
-    this.cached = new AbsoluteFilePathMap();
-  }
+	constructor() {
+		this.cached = new AbsoluteFilePathMap();
+	}
 
-  private cached: AbsoluteFilePathMap<Buffer | Promise<Buffer>>;
+	private cached: AbsoluteFilePathMap<Buffer | Promise<Buffer>>;
 
-  cache(path: AbsoluteFilePath, buffer: Buffer) {
-    this.cached.set(path, buffer);
-  }
+	cache(path: AbsoluteFilePath, buffer: Buffer) {
+		this.cached.set(path, buffer);
+	}
 
-  async readFile(path: AbsoluteFilePath): Promise<Buffer> {
-    const cached = this.cached.get(path);
-    if (cached !== undefined) {
-      return cached;
-    }
+	async readFile(path: AbsoluteFilePath): Promise<Buffer> {
+		const cached = this.cached.get(path);
+		if (cached !== undefined) {
+			return cached;
+		}
 
-    const promise = readFile(path);
-    this.cached.set(path, promise);
+		const promise = readFile(path);
+		this.cached.set(path, promise);
 
-    const buff = await promise;
-    this.cache(path, buff);
-    return buff;
-  }
+		const buff = await promise;
+		this.cache(path, buff);
+		return buff;
+	}
 
-  readFileText(path: AbsoluteFilePath): Promise<string> {
-    return this.readFile(path).then(buff => buff.toString());
-  }
+	readFileText(path: AbsoluteFilePath): Promise<string> {
+		return this.readFile(path).then((buff) => buff.toString());
+	}
 }

--- a/internal/fs/FileNotFound.ts
+++ b/internal/fs/FileNotFound.ts
@@ -11,7 +11,7 @@ export type MissingFileReturn<T> =
 			value: undefined;
 		};
 
-export class FileNotFound extends Error implements NodeSystemError {
+export default class FileNotFound extends Error implements NodeSystemError {
 	constructor(path: AbsoluteFilePath, suffixMessage?: string) {
 		super(
 			suffixMessage === undefined

--- a/internal/fs/index.ts
+++ b/internal/fs/index.ts
@@ -21,7 +21,7 @@ import {
 	setNodeErrorProps,
 } from "@internal/v8";
 import fs = require("fs");
-import {FileNotFound} from "@internal/fs/FileNotFound";
+import {FileNotFound} from "@internal/fs";
 
 // Most fs errors don't have a stack trace. This is due to the way that node queues file operations.
 // Capturing a stacktrace would be very expensive.
@@ -54,7 +54,8 @@ function wrapReject<T>(promise: Promise<T>, addFrames: number): Promise<T> {
 	});
 }
 
-export {FileNotFound} from "./FileNotFound";
+export {default as FileNotFound} from "./FileNotFound";
+export {default as CachedFileReader} from "./CachedFileReader";
 
 // Reexported types: Only file that ever imports the fs module is this one
 export type FSHandle = fs.promises.FileHandle;

--- a/internal/js-analysis/Hub.ts
+++ b/internal/js-analysis/Hub.ts
@@ -6,7 +6,7 @@
  */
 
 import T from "./types/T";
-import {CompilerContext, TransformProjectDefinition} from "@internal/compiler";
+import {CompilerContext, CompilerProject} from "@internal/compiler";
 import {JSRoot} from "@internal/ast";
 import Graph from "./Graph";
 import Evaluator from "./Evaluator";
@@ -21,7 +21,7 @@ const statuses = {
 type HubStatus = number;
 
 export default class Hub {
-	constructor(ast: JSRoot, project: TransformProjectDefinition) {
+	constructor(ast: JSRoot, project?: CompilerProject) {
 		this.context = new CompilerContext({
 			ast,
 			project,

--- a/internal/js-analysis/api/buildGraph.ts
+++ b/internal/js-analysis/api/buildGraph.ts
@@ -9,12 +9,12 @@ import {AnyJSStatement, JSRoot} from "@internal/ast";
 import {CheckProvider} from "../types";
 import {ModuleSignatureManager} from "../Evaluator";
 import Hub from "../Hub";
-import {TransformProjectDefinition} from "@internal/compiler";
+import {CompilerProject} from "@internal/compiler";
 
 export default async function buildGraph(
 	opts: {
 		ast: JSRoot;
-		project: TransformProjectDefinition;
+		project?: CompilerProject;
 		connected: boolean;
 		provider: CheckProvider;
 	},

--- a/internal/js-analysis/api/check.ts
+++ b/internal/js-analysis/api/check.ts
@@ -17,12 +17,12 @@ import E from "../types/errors/E";
 import T from "../types/T";
 import OpenT from "../types/OpenT";
 import buildGraph from "./buildGraph";
-import {TransformProjectDefinition} from "@internal/compiler";
+import {CompilerProject} from "@internal/compiler";
 
 export default async function check(
 	opts: {
 		ast: JSRoot;
-		project: TransformProjectDefinition;
+		project?: CompilerProject;
 		provider: CheckProvider;
 	},
 ): Promise<Diagnostics> {

--- a/internal/js-analysis/api/getModuleSignature.ts
+++ b/internal/js-analysis/api/getModuleSignature.ts
@@ -15,7 +15,7 @@ import {JSRoot} from "@internal/ast";
 import buildGraph from "./buildGraph";
 import T from "../types/T";
 import E from "../types/errors/E";
-import {TransformProjectDefinition} from "@internal/compiler";
+import {CompilerProject} from "@internal/compiler";
 import {Dict} from "@internal/typescript-helpers";
 
 const exportsCache: WeakMap<JSRoot, ModuleSignature> = new WeakMap();
@@ -23,7 +23,7 @@ const exportsCache: WeakMap<JSRoot, ModuleSignature> = new WeakMap();
 export default async function getModuleSignature(
 	opts: {
 		ast: JSRoot;
-		project: TransformProjectDefinition;
+		project: CompilerProject;
 		provider: CheckProvider;
 	},
 ): Promise<ModuleSignature> {

--- a/internal/js-analysis/tests/basic.test.ts
+++ b/internal/js-analysis/tests/basic.test.ts
@@ -22,7 +22,7 @@ async function testCheck(code: string): Promise<Diagnostics> {
 	return check({
 		ast,
 		project: {
-			configHashes: [],
+			configCacheKeys: [],
 			directory: undefined,
 			config: createDefaultProjectConfig(),
 		},

--- a/internal/js-analysis/tests/basic.test.ts
+++ b/internal/js-analysis/tests/basic.test.ts
@@ -6,7 +6,6 @@
  */
 
 import {Diagnostics} from "@internal/diagnostics";
-import {createDefaultProjectConfig} from "@internal/project";
 import {test} from "rome";
 import {check} from "@internal/js-analysis";
 import {parseJS} from "@internal/js-parser";
@@ -21,11 +20,6 @@ async function testCheck(code: string): Promise<Diagnostics> {
 
 	return check({
 		ast,
-		project: {
-			configCacheKeys: [],
-			directory: undefined,
-			config: createDefaultProjectConfig(),
-		},
 		provider: {
 			getExportTypes() {
 				return Promise.reject("unsupported");

--- a/internal/js-ast-utils/renameBindings.test.ts
+++ b/internal/js-ast-utils/renameBindings.test.ts
@@ -11,7 +11,6 @@ import {
 	jsReferenceIdentifier,
 	jsStaticMemberProperty,
 } from "@internal/ast";
-import {createDefaultProjectConfig} from "@internal/project";
 
 test(
 	"should rename biding",
@@ -41,11 +40,6 @@ test(
 
 		const context = new CompilerContext({
 			ast: MOCK_PROGRAM,
-			project: {
-				configCacheKeys: [],
-				directory: undefined,
-				config: createDefaultProjectConfig(),
-			},
 		});
 
 		const path = new Path(js, context, {});

--- a/internal/js-ast-utils/renameBindings.test.ts
+++ b/internal/js-ast-utils/renameBindings.test.ts
@@ -42,7 +42,7 @@ test(
 		const context = new CompilerContext({
 			ast: MOCK_PROGRAM,
 			project: {
-				configHashes: [],
+				configCacheKeys: [],
 				directory: undefined,
 				config: createDefaultProjectConfig(),
 			},

--- a/internal/path/collections.ts
+++ b/internal/path/collections.ts
@@ -15,6 +15,14 @@ import {
 	createUnknownPath,
 } from "./index";
 
+function concat<FilePath extends AnyFilePath>(items: Array<Iterable<FilePath>>): Array<FilePath> {
+	let paths: Array<FilePath> = [];
+	for (const iterable of items) {
+		paths = paths.concat(Array.from(iterable));
+	}
+	return paths;
+}
+
 // Sometimes we don't want to have to deal with what a FilePath serializes into
 // For those purposes we have these wrappers around Map and Set. Here we can add some custom logic
 // to speed up the usage of FilePaths in these scenarios.
@@ -224,6 +232,10 @@ export class AbsoluteFilePathSet
 	createMap(): AbsoluteFilePathMap<void> {
 		return new AbsoluteFilePathMap();
 	}
+
+	public concat(...items: Array<Iterable<AbsoluteFilePath>>): AbsoluteFilePathSet {
+		return new AbsoluteFilePathSet(concat(items));
+	}
 }
 
 export class RelativeFilePathSet
@@ -233,6 +245,10 @@ export class RelativeFilePathSet
 	createMap(): RelativeFilePathMap<void> {
 		return new RelativeFilePathMap();
 	}
+
+	public concat(...items: Array<Iterable<RelativeFilePath>>): RelativeFilePathSet {
+		return new RelativeFilePathSet(concat(items));
+	}
 }
 
 export class UnknownPathSet
@@ -241,6 +257,10 @@ export class UnknownPathSet
 
 	createMap(): UnknownPathMap<void> {
 		return new UnknownPathMap();
+	}
+
+	public concat(...items: Array<Iterable<AnyFilePath>>): UnknownPathSet {
+		return new UnknownPathSet(concat(items));
 	}
 }
 

--- a/internal/path/collections.ts
+++ b/internal/path/collections.ts
@@ -15,8 +15,10 @@ import {
 	createUnknownPath,
 } from "./index";
 
-function concat<FilePath extends AnyFilePath>(items: Array<Iterable<FilePath>>): Array<FilePath> {
-	let paths: Array<FilePath> = [];
+function concat<FilePath extends AnyFilePath>(
+	items: Iterable<FilePath>[],
+): FilePath[] {
+	let paths: FilePath[] = [];
 	for (const iterable of items) {
 		paths = paths.concat(Array.from(iterable));
 	}
@@ -233,7 +235,7 @@ export class AbsoluteFilePathSet
 		return new AbsoluteFilePathMap();
 	}
 
-	public concat(...items: Array<Iterable<AbsoluteFilePath>>): AbsoluteFilePathSet {
+	public concat(...items: Iterable<AbsoluteFilePath>[]): AbsoluteFilePathSet {
 		return new AbsoluteFilePathSet(concat(items));
 	}
 }
@@ -246,7 +248,7 @@ export class RelativeFilePathSet
 		return new RelativeFilePathMap();
 	}
 
-	public concat(...items: Array<Iterable<RelativeFilePath>>): RelativeFilePathSet {
+	public concat(...items: Iterable<RelativeFilePath>[]): RelativeFilePathSet {
 		return new RelativeFilePathSet(concat(items));
 	}
 }
@@ -259,7 +261,7 @@ export class UnknownPathSet
 		return new UnknownPathMap();
 	}
 
-	public concat(...items: Array<Iterable<AnyFilePath>>): UnknownPathSet {
+	public concat(...items: Iterable<AnyFilePath>[]): UnknownPathSet {
 		return new UnknownPathSet(concat(items));
 	}
 }

--- a/internal/project/constants.ts
+++ b/internal/project/constants.ts
@@ -7,7 +7,7 @@ import {CONFIG_EXTENSIONS} from "@internal/codec-config";
 
 export const VCS_IGNORE_FILENAMES = [".gitignore", ".hgignore"];
 
-export const ESLINT_CONFIG_FILENAMES: Array<string> = [
+export const ESLINT_CONFIG_FILENAMES: string[] = [
 	".eslintrc.js",
 	".eslintrc.cjs",
 	".eslintrc.yaml",

--- a/internal/project/constants.ts
+++ b/internal/project/constants.ts
@@ -5,6 +5,17 @@ import {
 } from "@internal/path";
 import {CONFIG_EXTENSIONS} from "@internal/codec-config";
 
+export const VCS_IGNORE_FILENAMES = [".gitignore", ".hgignore"];
+
+export const ESLINT_CONFIG_FILENAMES: Array<string> = [
+	".eslintrc.js",
+	".eslintrc.cjs",
+	".eslintrc.yaml",
+	".eslintrc.yml",
+	".eslintrc.json",
+	".eslintignore",
+];
+
 export const PROJECT_CONFIG_PACKAGE_JSON_FIELD = "rome";
 export const PROJECT_CONFIG_DIRECTORY = ".config";
 export const PROJECT_CONFIG_FILENAMES: string[] = [];

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -112,6 +112,8 @@ export async function loadCompleteProjectConfig(
 		}
 	}
 
+	meta.configDependencies = meta.configDependencies.concat(getParentConfigDependencies(projectDirectory, config));
+
 	return {
 		config,
 		meta,
@@ -183,7 +185,7 @@ export async function normalizeProjectConfig(
 		consumersChain: [consumer],
 		configHashes: [hash],
 		configSourceSubKey,
-		configDependencies: getParentConfigDependencies(projectDirectory),
+		configDependencies: new AbsoluteFilePathSet(),
 	};
 
 	// We never use `name` here but it's used in `loadCompleteProjectConfig`
@@ -236,11 +238,10 @@ export async function normalizeProjectConfig(
 				typeChecking.get("libs"),
 			);
 			config.typeCheck.libs = libs.files;
-			meta.configDependencies = new AbsoluteFilePathSet([
-				...meta.configDependencies,
-				...libs.directories,
-				...libs.files,
-			]);
+			meta.configDependencies = meta.configDependencies.concat(
+				libs.directories,
+				libs.files,
+			);
 		}
 	}
 
@@ -537,11 +538,10 @@ async function extendProjectConfig(
 		meta: {
 			...meta,
 			consumersChain: [...meta.consumersChain, ...extendsMeta.consumersChain],
-			configDependencies: new AbsoluteFilePathSet([
-				...meta.configDependencies,
-				...extendsMeta.configDependencies,
-				extendsPath,
-			]),
+			configDependencies: meta.configDependencies.concat(
+				extendsMeta.configDependencies,
+				[extendsPath],
+			),
 			configHashes: [...meta.configHashes, ...extendsMeta.configHashes],
 		},
 	};

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -167,6 +167,9 @@ export async function normalizeProjectConfig(
 		vcs: {},
 		dependencies: {},
 		targets: new Map(),
+		integrations: {
+			eslint: {},
+		},
 	};
 
 	if (name !== undefined) {
@@ -385,6 +388,16 @@ export async function normalizeProjectConfig(
 		}
 	}
 
+	const integrations = consumer.get("integrations");
+	if (integrations.exists()) {
+		const eslint = integrations.get("eslint");
+		if (categoryExists(eslint)) {
+			if (eslint.has("enabled")) {
+				config.integrations.eslint.enabled = eslint.get("enabled").asBoolean();
+			}
+		}
+	}
+
 	// Need to get this before enforceUsedProperties so it will be flagged
 	const _extends = consumer.get("extends");
 
@@ -537,7 +550,7 @@ async function extendProjectConfig(
 type MergedPartialConfig<
 	A extends PartialProjectConfig,
 	B extends PartialProjectConfig
-> = {[Key in keyof ProjectConfigObjects]: A[Key] & B[Key]};
+> = {[Key in keyof ProjectConfigObjects]: A[Key] & B[Key]} & {integrations: A["integrations"] & B["integrations"]};
 
 function mergePartialConfig<
 	A extends PartialProjectConfig,
@@ -594,5 +607,13 @@ function mergePartialConfig<
 			...b.vcs,
 		},
 		targets: new Map([...a.targets.entries(), ...b.targets.entries()]),
+		integrations: {
+			...a.integrations,
+			...b.integrations,
+			eslint: {
+				...a.integrations.eslint,
+				...b.integrations.eslint,
+			},
+		},
 	};
 }

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -14,7 +14,7 @@ import {
 	createAbsoluteFilePath,
 } from "@internal/path";
 import {Consumer} from "@internal/consume";
-import {RequiredProps} from "@internal/typescript-helpers";
+import {Dict, RequiredProps} from "@internal/typescript-helpers";
 import {SemverRangeNode} from "@internal/codec-semver";
 import {LintRuleName} from "@internal/compiler";
 
@@ -132,7 +132,7 @@ type PartialProjectValue<Type> = Type extends Map<string, any>
 export type ProjectConfigMeta = {
 	projectDirectory: undefined | AbsoluteFilePath;
 	configPath: undefined | AbsoluteFilePath;
-	configCacheKeys: string[];
+	configCacheKeys: Dict<string>;
 	configDependencies: AbsoluteFilePathSet;
 	consumer: undefined | Consumer;
 	configSourceSubKey: undefined | string;
@@ -216,7 +216,7 @@ export function createDefaultProjectConfigMeta(): ProjectConfigMeta {
 	return {
 		projectDirectory: undefined,
 		configPath: undefined,
-		configCacheKeys: [],
+		configCacheKeys: {},
 		configDependencies: new AbsoluteFilePathSet(),
 		consumer: undefined,
 		configSourceSubKey: undefined,

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -27,6 +27,7 @@ export type ProjectDefinition = {
 	packages: Map<string, ManifestDefinition>;
 	manifests: Map<number, ManifestDefinition>;
 	children: Set<ProjectDefinition>;
+	root: undefined | ProjectDefinition;
 	parent: undefined | ProjectDefinition;
 	initialized: boolean;
 	partial: boolean;
@@ -131,7 +132,7 @@ type PartialProjectValue<Type> = Type extends Map<string, any>
 export type ProjectConfigMeta = {
 	projectDirectory: undefined | AbsoluteFilePath;
 	configPath: undefined | AbsoluteFilePath;
-	configHashes: string[];
+	configCacheKeys: string[];
 	configDependencies: AbsoluteFilePathSet;
 	consumer: undefined | Consumer;
 	configSourceSubKey: undefined | string;
@@ -148,11 +149,74 @@ export type ProjectConfig = ProjectConfigBase & ProjectConfigObjects & {
 	integrations: ProjectConfigIntegrations;
 };
 
+// The actual type that we allow users to specify their configuration
+// Types are deliberately wider than they need to be to more accurately represent how they will be provided. ie. `string` rather than string literals
+export type RawUserProjectConfig = {
+	name?: string;
+	version?: string;
+	root?: boolean;
+	extends?: boolean;
+	cache?: {};
+	resolver?: {};
+	compiler?: {};
+	bundler?: {
+		externals?: Array<string>;
+	};
+	typeChecking?: {
+		enabled?: boolean;
+		libs?: Array<string>;
+	};
+	dependencies?: {
+		enabled?: boolean;
+		exceptions?: {
+			invalidLicenses?: {
+				[key: string]: Array<string>;
+			};
+		};
+	};
+	lint?: {
+		ignore?: Array<string>;
+		globals?: Array<string>;
+		disabledRules?: Array<string>;
+		requireSuppressionExplanations?: boolean;
+	};
+	format: {
+		enabled?: boolean;
+		indentStyle?: string;
+		indentSize?: number;
+	};
+	tests?: {
+		ignore?: Array<string>;
+	};
+	develop?: {
+		serveStatic?: boolean;
+	};
+	files?: {
+		vendorPath?: string;
+		maxSize?: number;
+		maxSizeIgnore?: Array<string>;
+		assetExtensions?: Array<string>;
+	};
+	vcs?: {
+		root?: string;
+	};
+	targets?: {
+		[key: string]: {
+			constraints?: Array<string>;
+		};
+	};
+	integrations?: {
+		eslint?: {
+			enabled?: boolean;
+		};
+	};
+};
+
 export function createDefaultProjectConfigMeta(): ProjectConfigMeta {
 	return {
 		projectDirectory: undefined,
 		configPath: undefined,
-		configHashes: [],
+		configCacheKeys: [],
 		configDependencies: new AbsoluteFilePathSet(),
 		consumer: undefined,
 		configSourceSubKey: undefined,

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -91,6 +91,12 @@ export type ProjectConfigObjects = {
 	targets: Map<string, ProjectConfigTarget>;
 };
 
+export type ProjectConfigIntegrations = {
+	eslint: {
+		enabled: boolean;
+	};
+};
+
 export type ProjectConfigCategoriesWithIgnore = "tests" | "lint";
 
 export type ProjectConfigTarget = {
@@ -109,6 +115,12 @@ export type PartialProjectConfig = Partial<ProjectConfigBase> & {
 	[Key in keyof ProjectConfigObjects]: PartialProjectValue<
 		ProjectConfigObjects[Key]
 	>
+} & {
+	integrations: {
+		[Key in keyof ProjectConfigIntegrations]: PartialProjectValue<
+		ProjectConfigIntegrations[Key]
+		>
+	},
 };
 
 // rome-ignore lint/ts/noExplicitAny: future cleanup
@@ -132,7 +144,9 @@ export type ProjectConfigMetaHard = RequiredProps<
 >;
 
 // Final project config
-export type ProjectConfig = ProjectConfigBase & ProjectConfigObjects;
+export type ProjectConfig = ProjectConfigBase & ProjectConfigObjects & {
+	integrations: ProjectConfigIntegrations;
+};
 
 export function createDefaultProjectConfigMeta(): ProjectConfigMeta {
 	return {
@@ -196,5 +210,10 @@ export function createDefaultProjectConfig(): ProjectConfig {
 			maxSize: 40_000_000, // 40 megabytes
 		},
 		targets: new Map(),
+		integrations: {
+			eslint: {
+				enabled: false,
+			},
+		},
 	};
 }

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -119,9 +119,9 @@ export type PartialProjectConfig = Partial<ProjectConfigBase> & {
 } & {
 	integrations: {
 		[Key in keyof ProjectConfigIntegrations]: PartialProjectValue<
-		ProjectConfigIntegrations[Key]
+			ProjectConfigIntegrations[Key]
 		>
-	},
+	};
 };
 
 // rome-ignore lint/ts/noExplicitAny: future cleanup
@@ -145,9 +145,10 @@ export type ProjectConfigMetaHard = RequiredProps<
 >;
 
 // Final project config
-export type ProjectConfig = ProjectConfigBase & ProjectConfigObjects & {
-	integrations: ProjectConfigIntegrations;
-};
+export type ProjectConfig = ProjectConfigBase &
+	ProjectConfigObjects & {
+		integrations: ProjectConfigIntegrations;
+	};
 
 // The actual type that we allow users to specify their configuration
 // Types are deliberately wider than they need to be to more accurately represent how they will be provided. ie. `string` rather than string literals
@@ -160,24 +161,24 @@ export type RawUserProjectConfig = {
 	resolver?: {};
 	compiler?: {};
 	bundler?: {
-		externals?: Array<string>;
+		externals?: string[];
 	};
 	typeChecking?: {
 		enabled?: boolean;
-		libs?: Array<string>;
+		libs?: string[];
 	};
 	dependencies?: {
 		enabled?: boolean;
 		exceptions?: {
 			invalidLicenses?: {
-				[key: string]: Array<string>;
+				[key: string]: string[];
 			};
 		};
 	};
 	lint?: {
-		ignore?: Array<string>;
-		globals?: Array<string>;
-		disabledRules?: Array<string>;
+		ignore?: string[];
+		globals?: string[];
+		disabledRules?: string[];
 		requireSuppressionExplanations?: boolean;
 	};
 	format: {
@@ -186,7 +187,7 @@ export type RawUserProjectConfig = {
 		indentSize?: number;
 	};
 	tests?: {
-		ignore?: Array<string>;
+		ignore?: string[];
 	};
 	develop?: {
 		serveStatic?: boolean;
@@ -194,15 +195,15 @@ export type RawUserProjectConfig = {
 	files?: {
 		vendorPath?: string;
 		maxSize?: number;
-		maxSizeIgnore?: Array<string>;
-		assetExtensions?: Array<string>;
+		maxSizeIgnore?: string[];
+		assetExtensions?: string[];
 	};
 	vcs?: {
 		root?: string;
 	};
 	targets?: {
 		[key: string]: {
-			constraints?: Array<string>;
+			constraints?: string[];
 		};
 	};
 	integrations?: {

--- a/internal/project/utils.ts
+++ b/internal/project/utils.ts
@@ -8,8 +8,16 @@
 import {Consumer} from "@internal/consume";
 import {PathPatterns, parsePathPattern} from "@internal/path-match";
 import {AbsoluteFilePath, AbsoluteFilePathSet} from "@internal/path";
-import {PartialProjectConfig, ProjectConfigMeta, ProjectConfigMetaHard} from "./types";
-import {ESLINT_CONFIG_FILENAMES, PROJECT_CONFIG_FILENAMES, VCS_IGNORE_FILENAMES} from "./constants";
+import {
+	PartialProjectConfig,
+	ProjectConfigMeta,
+	ProjectConfigMetaHard,
+} from "./types";
+import {
+	ESLINT_CONFIG_FILENAMES,
+	PROJECT_CONFIG_FILENAMES,
+	VCS_IGNORE_FILENAMES,
+} from "./constants";
 
 export function assertHardMeta(meta: ProjectConfigMeta): ProjectConfigMetaHard {
 	const {configPath, projectDirectory: directory, consumer} = meta;
@@ -79,11 +87,13 @@ export function mergeAbsoluteFilePathSets(
 }
 
 // Get an array of possible files in parent directories that will cause a project cache invalidation
-export function getParentConfigDependencies({projectDirectory, rootProjectDirectory, partialConfig}: {
-	projectDirectory: AbsoluteFilePath,
-	rootProjectDirectory: AbsoluteFilePath,
-	partialConfig: PartialProjectConfig,
-}): AbsoluteFilePathSet {
+export function getParentConfigDependencies(
+	{projectDirectory, rootProjectDirectory, partialConfig}: {
+		projectDirectory: AbsoluteFilePath;
+		rootProjectDirectory: AbsoluteFilePath;
+		partialConfig: PartialProjectConfig;
+	},
+): AbsoluteFilePathSet {
 	const deps: AbsoluteFilePathSet = new AbsoluteFilePathSet();
 
 	for (const directory of projectDirectory.getChain()) {
@@ -94,16 +104,17 @@ export function getParentConfigDependencies({projectDirectory, rootProjectDirect
 			break;
 		}
 
-		let basenames: Array<string> = [
-			"package.json",
-		];
+		let basenames: string[] = ["package.json"];
 
 		// If eslint integration is enabled then eslint config changes should cause invalid cache files
 		if (partialConfig.integrations.eslint.enabled) {
 			basenames = basenames.concat(ESLINT_CONFIG_FILENAMES);
 		}
 
-		if (partialConfig.vcs.root !== undefined && partialConfig.vcs.root.equal(directory)) {
+		if (
+			partialConfig.vcs.root !== undefined &&
+			partialConfig.vcs.root.equal(directory)
+		) {
 			basenames = basenames.concat(VCS_IGNORE_FILENAMES);
 		}
 

--- a/internal/project/utils.ts
+++ b/internal/project/utils.ts
@@ -9,7 +9,7 @@ import {Consumer} from "@internal/consume";
 import {PathPatterns, parsePathPattern} from "@internal/path-match";
 import {AbsoluteFilePath, AbsoluteFilePathSet} from "@internal/path";
 import {PartialProjectConfig, ProjectConfigMeta, ProjectConfigMetaHard} from "./types";
-import {PROJECT_CONFIG_FILENAMES} from "./constants";
+import {ESLINT_CONFIG_FILENAMES, PROJECT_CONFIG_FILENAMES, VCS_IGNORE_FILENAMES} from "./constants";
 
 export function assertHardMeta(meta: ProjectConfigMeta): ProjectConfigMetaHard {
 	const {configPath, projectDirectory: directory, consumer} = meta;
@@ -78,15 +78,6 @@ export function mergeAbsoluteFilePathSets(
 	return new AbsoluteFilePathSet([...a, ...b]);
 }
 
-const ESLINT_CONFIG_FILENAMES: Array<string> = [
-	".eslintrc.js",
-	".eslintrc.cjs",
-	".eslintrc.yaml",
-	".eslintrc.yml",
-	".eslintrc.json",
-	".eslintignore",
-];
-
 // Get an array of possible files in parent directories that will cause a project cache invalidation
 export function getParentConfigDependencies({projectDirectory, rootProjectDirectory, partialConfig}: {
 	projectDirectory: AbsoluteFilePath,
@@ -110,6 +101,10 @@ export function getParentConfigDependencies({projectDirectory, rootProjectDirect
 		// If eslint integration is enabled then eslint config changes should cause invalid cache files
 		if (partialConfig.integrations.eslint.enabled) {
 			basenames = basenames.concat(ESLINT_CONFIG_FILENAMES);
+		}
+
+		if (partialConfig.vcs.root !== undefined && partialConfig.vcs.root.equal(directory)) {
+			basenames = basenames.concat(VCS_IGNORE_FILENAMES);
 		}
 
 		for (const configFilename of PROJECT_CONFIG_FILENAMES) {

--- a/internal/string-utils/sha256.ts
+++ b/internal/string-utils/sha256.ts
@@ -2,7 +2,7 @@ import stream = require("stream");
 import crypto = require("crypto");
 
 export const sha256 = {
-	sync(str: string): string {
+	sync(str: crypto.BinaryLike): string {
 		return crypto.createHash("sha256").update(str).digest("hex");
 	},
 

--- a/internal/test-helpers/integration.ts
+++ b/internal/test-helpers/integration.ts
@@ -220,16 +220,18 @@ export function createMockWorker(force: boolean = false): IntegrationWorker {
 
 	function addProject(config: ProjectConfig): number {
 		let id = projectIdCounter++;
-		worker.updateProjects(new Map([
-			[
-				id, 
-				{
-					config,
-					configCacheKeys: {},
-					directory: createAbsoluteFilePath(`/project-${id}`),
-				},
-			],
-		]));
+		worker.updateProjects(
+			new Map([
+				[
+					id,
+					{
+						config,
+						configCacheKeys: {},
+						directory: createAbsoluteFilePath(`/project-${id}`),
+					},
+				],
+			]),
+		);
 		return id;
 	}
 

--- a/internal/test-helpers/integration.ts
+++ b/internal/test-helpers/integration.ts
@@ -220,14 +220,16 @@ export function createMockWorker(force: boolean = false): IntegrationWorker {
 
 	function addProject(config: ProjectConfig): number {
 		let id = projectIdCounter++;
-		worker.updateProjects([
-			{
-				config,
-				id,
-				configHashes: [],
-				directory: createAbsoluteFilePath(`/project-${id}`),
-			},
-		]);
+		worker.updateProjects(new Map([
+			[
+				id, 
+				{
+					config,
+					configCacheKeys: {},
+					directory: createAbsoluteFilePath(`/project-${id}`),
+				},
+			],
+		]));
 		return id;
 	}
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR adds a new project config option called `integrations.eslint.enabled`:

```
integrations: {
  eslint: {
    enabled: true
  }
}
```

It does not currently do anything, I will implement that functionality in another PR.

The idea will be to use Rome as an ESLint runner. We use our parallellisation and caching, and transparently convert ESLint errors to diagnostics. An ESLint user could use Rome with some simple config and achieve instant benefits.

In the process of this I also cleaned up how we do cache keys and pass project configs to the compiler.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Ran `./rome ci`