### PR TITLE
fix(css-parser): handle multiline comments

### DIFF
--- a/internal/css-parser/index.ts
+++ b/internal/css-parser/index.ts
@@ -37,9 +37,9 @@ export const cssParser = createParser<CSSParserTypes>({
 			index = index.add(2);
 			let value = "";
 			while (
-				parser.getInputCharOnly(index) !== "*" &&
-				parser.getInputCharOnly(index.increment()) !== "/" &&
-				!parser.isEOF(index)
+				!((parser.getInputCharOnly(index) === "*" &&
+				parser.getInputCharOnly(index.increment()) === "/") ||
+				parser.isEOF(index))
 			) {
 				value += parser.getInputCharOnly(index);
 				index = index.add(1);

--- a/internal/css-parser/test-fixtures/comment/input.css
+++ b/internal/css-parser/test-fixtures/comment/input.css
@@ -1,3 +1,7 @@
+/*
+ * comments
+ */
+
 a {
 	color: white; /* comment */
 }

--- a/internal/css-parser/test-fixtures/comment/input.test.md
+++ b/internal/css-parser/test-fixtures/comment/input.test.md
@@ -9,65 +9,42 @@ CSSRoot {
 	corrupt: false
 	diagnostics: Array []
 	integrity: undefined
-	loc: SourceLocation comment/input.css 1:0-11:1
+	loc: SourceLocation comment/input.css 1:0-15:1
 	path: RelativePath<comment/input.css>
 	comments: Array [
 		CommentBlock {
 			id: "0"
-			value: " comment "
-			loc: SourceLocation comment/input.css 2:15-2:28
+			value: "\n * comments\n "
+			loc: SourceLocation comment/input.css 1:0-3:3
 		}
 		CommentBlock {
 			id: "1"
 			value: " comment "
-			loc: SourceLocation comment/input.css 6:8-6:21
+			loc: SourceLocation comment/input.css 6:15-6:28
 		}
 		CommentBlock {
 			id: "2"
 			value: " comment "
-			loc: SourceLocation comment/input.css 9:2-9:15
+			loc: SourceLocation comment/input.css 10:8-10:21
+		}
+		CommentBlock {
+			id: "3"
+			value: " comment "
+			loc: SourceLocation comment/input.css 13:2-13:15
 		}
 	]
 	body: Array [
 		CSSRule {
-			loc: SourceLocation comment/input.css 1:0-3:1
-			prelude: Array [
-				CSSSelector {
-					loc: SourceLocation comment/input.css 1:0-1:2
-					patterns: Array [
-						CSSTypeSelector {
-							value: "a"
-							loc: SourceLocation comment/input.css 1:0-1:1
-						}
-					]
-				}
-			]
-			block: CSSBlock {
-				value: Array [
-					CSSDeclaration {
-						name: "color"
-						value: Array [
-							CSSIdentifier {
-								value: "white"
-								loc: SourceLocation comment/input.css 2:8-2:13
-							}
-						]
-						important: false
-						loc: SourceLocation comment/input.css 2:1-2:13
-					}
-				]
-				startingTokenValue: "{"
-				loc: SourceLocation comment/input.css 1:2-3:1
-			}
-		}
-		CSSRule {
+			leadingComments: Array ["0"]
 			loc: SourceLocation comment/input.css 5:0-7:1
 			prelude: Array [
 				CSSSelector {
+					leadingComments: undefined
 					loc: SourceLocation comment/input.css 5:0-5:2
 					patterns: Array [
 						CSSTypeSelector {
 							value: "a"
+							leadingComments: undefined
 							loc: SourceLocation comment/input.css 5:0-5:1
 						}
 					]
@@ -80,12 +57,11 @@ CSSRoot {
 						value: Array [
 							CSSIdentifier {
 								value: "white"
-								leadingComments: Array ["1"]
-								loc: SourceLocation comment/input.css 6:22-6:27
+								loc: SourceLocation comment/input.css 6:8-6:13
 							}
 						]
 						important: false
-						loc: SourceLocation comment/input.css 6:1-6:27
+						loc: SourceLocation comment/input.css 6:1-6:13
 					}
 				]
 				startingTokenValue: "{"
@@ -96,7 +72,7 @@ CSSRoot {
 			loc: SourceLocation comment/input.css 9:0-11:1
 			prelude: Array [
 				CSSSelector {
-					loc: SourceLocation comment/input.css 9:0-9:16
+					loc: SourceLocation comment/input.css 9:0-9:2
 					patterns: Array [
 						CSSTypeSelector {
 							value: "a"
@@ -112,15 +88,47 @@ CSSRoot {
 						value: Array [
 							CSSIdentifier {
 								value: "white"
-								loc: SourceLocation comment/input.css 10:8-10:13
+								leadingComments: Array ["2"]
+								loc: SourceLocation comment/input.css 10:22-10:27
 							}
 						]
 						important: false
-						loc: SourceLocation comment/input.css 10:1-10:13
+						loc: SourceLocation comment/input.css 10:1-10:27
 					}
 				]
 				startingTokenValue: "{"
-				loc: SourceLocation comment/input.css 9:16-11:1
+				loc: SourceLocation comment/input.css 9:2-11:1
+			}
+		}
+		CSSRule {
+			loc: SourceLocation comment/input.css 13:0-15:1
+			prelude: Array [
+				CSSSelector {
+					loc: SourceLocation comment/input.css 13:0-13:16
+					patterns: Array [
+						CSSTypeSelector {
+							value: "a"
+							loc: SourceLocation comment/input.css 13:0-13:1
+						}
+					]
+				}
+			]
+			block: CSSBlock {
+				value: Array [
+					CSSDeclaration {
+						name: "color"
+						value: Array [
+							CSSIdentifier {
+								value: "white"
+								loc: SourceLocation comment/input.css 14:8-14:13
+							}
+						]
+						important: false
+						loc: SourceLocation comment/input.css 14:1-14:13
+					}
+				]
+				startingTokenValue: "{"
+				loc: SourceLocation comment/input.css 13:16-15:1
 			}
 		}
 	]


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

CSS parser fails to parse multiline comments. This PR will fix it

- test.css
```css
/*
 * comments
 */
```

```
./rome parse test.css
```

- result

```
  ✖ Expected a left curly bracket {.

    1 │ /*
    2 │  * comments
  > 3 │  */
      │   ^
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

test cases

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
