### PR TITLE
fix(markdown-parser): handle text with single newline as same paragraph

### DIFF
--- a/internal/markdown-parser/index.ts
+++ b/internal/markdown-parser/index.ts
@@ -70,40 +70,6 @@ const markdownParser = createParser<MarkdownParserTypes>({
 			if (char === "#") {
 				return [state, consumeHeading(parser, index)];
 			}
-			if (char === "\n") {
-				const nextChar = parser.getInputCharOnly(index.increment());
-				if (nextChar === "#") {
-					return [state, consumeHeading(parser, index.add(1))];
-				}
-
-				if (nextChar === "`") {
-					const token = consumeCode(parser, index.add(1));
-					if (token) {
-						return [state, token];
-					}
-				}
-
-				if (isDigit(nextChar)) {
-					const token = tokenizeListItem(parser, index);
-					if (token) {
-						return [
-							{
-								isParagraph: true,
-								isListItem: true,
-							},
-							token,
-						];
-					}
-				}
-
-				return [
-					{
-						isParagraph: false,
-						isListItem: false,
-					},
-					parser.finishToken("NewLine"),
-				];
-			}
 
 			if (char === "-") {
 				const block = tokenizeBlock(parser, "-", index, char);

--- a/internal/markdown-parser/parser/paragraph.ts
+++ b/internal/markdown-parser/parser/paragraph.ts
@@ -11,7 +11,11 @@ export function parseParagraph(
 ): MarkdownParagraph {
 	const start = parser.getPosition();
 	const children: AnyMarkdownInlineNode[] = [];
-	while (!(parser.matchToken("EOF") || isBlockToken(parser.getToken()) || isBreakingNewLine(parser))) {
+	while (
+		!(parser.matchToken("EOF") ||
+		isBlockToken(parser.getToken()) ||
+		isBreakingNewLine(parser))
+	) {
 		const token = parser.getToken();
 
 		if (isList && token.type === "NewLine") {
@@ -73,7 +77,7 @@ export function parseParagraph(
 				// TODO: to remove once all cases are handled
 				parser.unexpectedDiagnostic({
 					description: descriptions.MARKDOWN_PARSER.INVALID_SEQUENCE,
-					token: token,
+					token,
 				});
 				parser.nextToken();
 			}
@@ -91,5 +95,10 @@ export function parseParagraph(
 
 function isBreakingNewLine(parser: MarkdownParser) {
 	const nextToken = parser.lookaheadToken();
-	return parser.matchToken("NewLine") && (nextToken.type === "NewLine" || nextToken.type === "EOF" || isBlockToken(nextToken))
+	return (
+		parser.matchToken("NewLine") &&
+		(nextToken.type === "NewLine" ||
+		nextToken.type === "EOF" ||
+		isBlockToken(nextToken))
+	);
 }

--- a/internal/markdown-parser/parser/paragraph.ts
+++ b/internal/markdown-parser/parser/paragraph.ts
@@ -18,8 +18,26 @@ export function parseParagraph(
 	) {
 		const token = parser.getToken();
 
-		if (isList && token.type === "NewLine") {
-			break;
+		if (token.type === "NewLine") {
+			if (isList) {
+				break;
+			}
+			const currentPos = parser.getPosition();
+			const next = parser.nextToken();
+			if (next.type === "NewLine" || next.type === "EOF" || isBlockToken(next)) {
+				break;
+			} else {
+				children.push(
+					parser.finishNode(
+						currentPos,
+						{
+							type: "MarkdownText",
+							value: "\n",
+						},
+					),
+				);
+				continue;
+			}
 		}
 
 		switch (token.type) {
@@ -47,20 +65,6 @@ export function parseParagraph(
 			case "Text": {
 				children.push(parseText(parser));
 				parser.nextToken();
-				break;
-			}
-			case "NewLine": {
-				const pos = parser.getPosition();
-				parser.nextToken();
-				children.push(
-					parser.finishNode(
-						pos,
-						{
-							type: "MarkdownText",
-							value: "\n",
-						},
-					),
-				);
 				break;
 			}
 			case "OpenSquareBracket": {

--- a/internal/markdown-parser/test-fixtures/smoke/input.md
+++ b/internal/markdown-parser/test-fixtures/smoke/input.md
@@ -28,3 +28,6 @@ Lorem *ipsum dolor sit* amet, _consectetur adipiscing elit_.
 Lorem __ipsum dolor__ sit amet, **consectetur adipiscing** elit.
 
 Lorem ipsum __**dolor sit amet, consectetur**__ adipiscing elit.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Lorem **ipsum** dolor sit amet, consectetur adipiscing elit.

--- a/internal/markdown-parser/test-fixtures/smoke/input.test.md
+++ b/internal/markdown-parser/test-fixtures/smoke/input.test.md
@@ -12,7 +12,7 @@ MarkdownRoot {
 	corrupt: false
 	diagnostics: Array []
 	integrity: undefined
-	loc: SourceLocation smoke/input.md 1:0-30:64
+	loc: SourceLocation smoke/input.md 1:0-33:60
 	path: UIDPath<smoke/input.md>
 	body: Array [
 		MarkdownHeadingBlock {
@@ -321,6 +321,36 @@ MarkdownRoot {
 				MarkdownText {
 					value: " adipiscing elit."
 					loc: SourceLocation smoke/input.md 30:47-30:47
+				}
+			]
+		}
+		MarkdownParagraph {
+			loc: SourceLocation smoke/input.md 32:0-33:60
+			children: Array [
+				MarkdownText {
+					value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+					loc: SourceLocation smoke/input.md 32:0-32:0
+				}
+				MarkdownText {
+					value: "\n"
+					loc: SourceLocation smoke/input.md 32:56-33:0
+				}
+				MarkdownText {
+					value: "Lorem "
+					loc: SourceLocation smoke/input.md 33:0-33:0
+				}
+				MarkdownEmphasisInline {
+					value: Array [
+						MarkdownText {
+							value: "ipsum"
+							loc: SourceLocation smoke/input.md 33:8-33:8
+						}
+					]
+					loc: SourceLocation smoke/input.md 33:6-33:13
+				}
+				MarkdownText {
+					value: " dolor sit amet, consectetur adipiscing elit."
+					loc: SourceLocation smoke/input.md 33:15-33:15
 				}
 			]
 		}

--- a/internal/markdown-parser/utils.ts
+++ b/internal/markdown-parser/utils.ts
@@ -1,8 +1,7 @@
-import { Tokens } from './types';
-import { TokenValues } from '@internal/parser-core';
+import {Tokens} from "./types";
+import {TokenValues, isDigit} from "@internal/parser-core";
 import {ZeroIndexed} from "@internal/math";
 import {MarkdownParser} from "@internal/markdown-parser/index";
-import {isDigit} from "@internal/parser-core";
 
 const THEMATIC_BREAKS = new Set(["***", "---", "___"]);
 

--- a/internal/markdown-parser/utils.ts
+++ b/internal/markdown-parser/utils.ts
@@ -1,3 +1,5 @@
+import { Tokens } from './types';
+import { TokenValues } from '@internal/parser-core';
 import {ZeroIndexed} from "@internal/math";
 import {MarkdownParser} from "@internal/markdown-parser/index";
 import {isDigit} from "@internal/parser-core";
@@ -106,13 +108,12 @@ export function isntInlineCharacter(char: string) {
 	return !INLINE_HOT_CHARACTERS.has(char);
 }
 
-export function isBlockToken(parser: MarkdownParser) {
+export function isBlockToken(token: TokenValues<Tokens>) {
 	return (
-		parser.matchToken("NewLine") ||
-		parser.matchToken("Code") ||
-		parser.matchToken("Break") ||
-		parser.matchToken("HeadingLevel") ||
-		parser.matchToken("ListItem")
+		token.type === "Code" ||
+		token.type === "Break" ||
+		token.type === "HeadingLevel" ||
+		token.type === "ListItem"
 	);
 }
 
@@ -164,4 +165,11 @@ export function isBlock(
 
 export function readUntilEndOfParagraph(char: string): boolean {
 	return char !== "\n";
+}
+
+export function isBeginningOfLine(parser: MarkdownParser): boolean {
+	return (
+		parser.getCurrentToken().type === "NewLine" ||
+		parser.getCurrentToken().type === "SOF"
+	);
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Currently, text with a single newline is handled as separated paragraphs. This PR makes them handled as same paragraph with `\n` text.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

**input**
```markdown
first line
second line
```

**main branch**
```
MarkdownRoot {
  comments: Array []
  corrupt: false
  diagnostics: Array []
  integrity: Object {hash: "73621482ff083eca9ea88880393298f7d3f53402200780b0c16354a9beb0535a"}
  path: UIDPath<project-rome/test.md>
  body: Array [
    MarkdownParagraph {children: Array [MarkdownText {value: "first line"}]}
    MarkdownParagraph {children: Array [MarkdownText {value: "second line"}]}
  ]
}
```

**This PR**
```
MarkdownRoot {
  comments: Array []
  corrupt: false
  diagnostics: Array []
  integrity: Object {hash: "73621482ff083eca9ea88880393298f7d3f53402200780b0c16354a9beb0535a"}
  path: UIDPath<project-rome/test.md>
  body: Array [
    MarkdownParagraph {
      children: Array [
        MarkdownText {value: "first line"}
        MarkdownText {value: "\n"}
        MarkdownText {value: "second line"}
      ]
    }
  ]
}
```
