### PR TITLE
fix(markdown-parser): fix markdown text ending position

### DIFF
--- a/internal/markdown-parser/parser/inline.ts
+++ b/internal/markdown-parser/parser/inline.ts
@@ -95,8 +95,10 @@ export function parseInline(
 			},
 		);
 	}
+	const pos = parser.getPosition();
+	parser.nextToken();
 	return parser.finishNode(
-		parser.getPosition(),
+		pos,
 		{
 			type: "MarkdownText",
 			value: token.value,

--- a/internal/markdown-parser/parser/paragraph.ts
+++ b/internal/markdown-parser/parser/paragraph.ts
@@ -59,12 +59,10 @@ export function parseParagraph(
 					children.push(nodes);
 				}
 
-				parser.nextToken();
 				break;
 			}
 			case "Text": {
 				children.push(parseText(parser));
-				parser.nextToken();
 				break;
 			}
 			case "OpenSquareBracket": {

--- a/internal/markdown-parser/parser/reference.ts
+++ b/internal/markdown-parser/parser/reference.ts
@@ -55,11 +55,6 @@ export function parseReference(
 			);
 			if (inline) {
 				reference.push(inline);
-				// TODO: call nextToken in parseInline()
-				// console.log(inline.type)
-				// if (inline.type === "MarkdownText") {
-				// 	parser.nextToken();
-				// }
 			}
 		}
 	}

--- a/internal/markdown-parser/parser/reference.ts
+++ b/internal/markdown-parser/parser/reference.ts
@@ -10,9 +10,11 @@ import {parseText} from "@internal/markdown-parser/parser/text";
 
 export function parseReference(
 	parser: MarkdownParser,
-): MarkdownReferenceInline | (AnyMarkdownInlineNode[]) {
+): MarkdownReferenceInline | AnyMarkdownInlineNode[] {
+	parser.expectToken("OpenSquareBracket");
+
 	const pos = parser.getPosition();
-	let reference: MarkdownReference | (AnyMarkdownInlineNode[]) = [];
+	let reference: MarkdownReference | AnyMarkdownInlineNode[] = [];
 	let unwantedTokens = false;
 
 	while (!parser.matchToken("EOF")) {
@@ -53,9 +55,13 @@ export function parseReference(
 			);
 			if (inline) {
 				reference.push(inline);
+				// TODO: call nextToken in parseInline()
+				// console.log(inline.type)
+				// if (inline.type === "MarkdownText") {
+				// 	parser.nextToken();
+				// }
 			}
 		}
-		parser.nextToken();
 	}
 
 	return [

--- a/internal/markdown-parser/parser/text.ts
+++ b/internal/markdown-parser/parser/text.ts
@@ -6,6 +6,7 @@ export function parseText(parser: MarkdownParser): MarkdownText {
 	const token = parser.getToken();
 	const pos = parser.getPosition();
 	if (token.type === "Text") {
+		parser.nextToken();
 		return parser.finishNode(
 			pos,
 			{

--- a/internal/markdown-parser/test-fixtures/headings/input.test.md
+++ b/internal/markdown-parser/test-fixtures/headings/input.test.md
@@ -43,7 +43,7 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "####### this will be a paragraph"
-					loc: SourceLocation headings/input.md 7:0-7:0
+					loc: SourceLocation headings/input.md 7:0-7:32
 				}
 			]
 			loc: SourceLocation headings/input.md 7:0-7:32

--- a/internal/markdown-parser/test-fixtures/lists/input.test.md
+++ b/internal/markdown-parser/test-fixtures/lists/input.test.md
@@ -18,7 +18,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "foo"
-									loc: SourceLocation lists/input.md 1:2-1:2
+									loc: SourceLocation lists/input.md 1:2-1:5
 								}
 							]
 							loc: SourceLocation lists/input.md 1:2-1:5
@@ -39,7 +39,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "bar"
-									loc: SourceLocation lists/input.md 2:2-2:2
+									loc: SourceLocation lists/input.md 2:2-2:5
 								}
 							]
 							loc: SourceLocation lists/input.md 2:2-2:5
@@ -59,7 +59,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "foo"
-									loc: SourceLocation lists/input.md 4:3-4:3
+									loc: SourceLocation lists/input.md 4:3-4:6
 								}
 							]
 							loc: SourceLocation lists/input.md 4:3-4:6
@@ -79,7 +79,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "bar"
-									loc: SourceLocation lists/input.md 5:3-5:3
+									loc: SourceLocation lists/input.md 5:3-5:6
 								}
 							]
 							loc: SourceLocation lists/input.md 5:3-5:6
@@ -99,7 +99,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "example"
-									loc: SourceLocation lists/input.md 6:3-6:3
+									loc: SourceLocation lists/input.md 6:3-6:10
 								}
 							]
 							loc: SourceLocation lists/input.md 6:3-6:10
@@ -121,7 +121,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "foo"
-									loc: SourceLocation lists/input.md 8:6-8:6
+									loc: SourceLocation lists/input.md 8:6-8:9
 								}
 							]
 							loc: SourceLocation lists/input.md 8:6-8:9
@@ -143,7 +143,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "bar"
-									loc: SourceLocation lists/input.md 9:6-9:6
+									loc: SourceLocation lists/input.md 9:6-9:9
 								}
 							]
 							loc: SourceLocation lists/input.md 9:6-9:9
@@ -165,7 +165,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "lorem"
-									loc: SourceLocation lists/input.md 10:6-10:6
+									loc: SourceLocation lists/input.md 10:6-10:11
 								}
 							]
 							loc: SourceLocation lists/input.md 10:6-10:11
@@ -187,11 +187,11 @@ MarkdownRoot {
 								MarkdownReferenceInline {
 									value: ""
 									reference: []
-									loc: SourceLocation lists/input.md 11:2-11:4
+									loc: SourceLocation lists/input.md 11:3-11:4
 								}
 								MarkdownText {
 									value: " something"
-									loc: SourceLocation lists/input.md 11:4-11:4
+									loc: SourceLocation lists/input.md 11:4-11:14
 								}
 							]
 							loc: SourceLocation lists/input.md 11:2-11:14

--- a/internal/markdown-parser/test-fixtures/reference/input.test.md
+++ b/internal/markdown-parser/test-fixtures/reference/input.test.md
@@ -14,10 +14,10 @@ MarkdownRoot {
 			reference: [
 				MarkdownText {
 					value: "lorem"
-					loc: SourceLocation reference/input.md 1:1-1:1
+					loc: SourceLocation reference/input.md 1:1-1:6
 				}
 			]
-			loc: SourceLocation reference/input.md 1:0-1:7
+			loc: SourceLocation reference/input.md 1:1-1:7
 		}
 		MarkdownReferenceInline {
 			value: ""
@@ -26,13 +26,13 @@ MarkdownRoot {
 					value: [
 						MarkdownText {
 							value: "lorem"
-							loc: SourceLocation reference/input.md 3:2-3:2
+							loc: SourceLocation reference/input.md 3:2-3:7
 						}
 					]
-					loc: SourceLocation reference/input.md 3:1-3:7
+					loc: SourceLocation reference/input.md 3:1-3:8
 				}
 			]
-			loc: SourceLocation reference/input.md 3:0-3:9
+			loc: SourceLocation reference/input.md 3:1-3:9
 		}
 		MarkdownReferenceInline {
 			value: ""
@@ -41,13 +41,13 @@ MarkdownRoot {
 					value: [
 						MarkdownText {
 							value: "ipsum"
-							loc: SourceLocation reference/input.md 5:3-5:3
+							loc: SourceLocation reference/input.md 5:3-5:8
 						}
 					]
-					loc: SourceLocation reference/input.md 5:1-5:8
+					loc: SourceLocation reference/input.md 5:1-5:10
 				}
 			]
-			loc: SourceLocation reference/input.md 5:0-5:11
+			loc: SourceLocation reference/input.md 5:1-5:11
 		}
 		MarkdownReferenceInline {
 			value: ""
@@ -56,13 +56,13 @@ MarkdownRoot {
 					value: [
 						MarkdownText {
 							value: "lorem"
-							loc: SourceLocation reference/input.md 7:3-7:3
+							loc: SourceLocation reference/input.md 7:3-7:8
 						}
 					]
-					loc: SourceLocation reference/input.md 7:1-7:8
+					loc: SourceLocation reference/input.md 7:1-7:10
 				}
 			]
-			loc: SourceLocation reference/input.md 7:0-7:11
+			loc: SourceLocation reference/input.md 7:1-7:11
 		}
 		MarkdownReferenceInline {
 			value: ""
@@ -71,57 +71,57 @@ MarkdownRoot {
 					value: [
 						MarkdownText {
 							value: "lorem"
-							loc: SourceLocation reference/input.md 9:2-9:2
+							loc: SourceLocation reference/input.md 9:2-9:7
 						}
 					]
-					loc: SourceLocation reference/input.md 9:1-9:7
+					loc: SourceLocation reference/input.md 9:1-9:8
 				}
 			]
-			loc: SourceLocation reference/input.md 9:0-9:9
+			loc: SourceLocation reference/input.md 9:1-9:9
 		}
 		MarkdownReferenceInline {
 			value: ""
 			reference: [
 				MarkdownText {
 					value: "lorem"
-					loc: SourceLocation reference/input.md 11:1-11:1
+					loc: SourceLocation reference/input.md 11:1-11:6
 				}
 				MarkdownText {
 					value: "*"
-					loc: SourceLocation reference/input.md 11:6-11:6
+					loc: SourceLocation reference/input.md 11:6-11:7
 				}
 				MarkdownText {
 					value: " ipsum"
-					loc: SourceLocation reference/input.md 11:7-11:7
+					loc: SourceLocation reference/input.md 11:7-11:13
 				}
 				MarkdownText {
 					value: "**"
-					loc: SourceLocation reference/input.md 11:13-11:13
+					loc: SourceLocation reference/input.md 11:13-11:15
 				}
 			]
-			loc: SourceLocation reference/input.md 11:0-11:16
+			loc: SourceLocation reference/input.md 11:1-11:16
 		}
 		MarkdownReferenceInline {
 			value: ""
 			reference: [
 				MarkdownText {
 					value: "*"
-					loc: SourceLocation reference/input.md 13:1-13:1
+					loc: SourceLocation reference/input.md 13:1-13:2
 				}
 				MarkdownText {
 					value: "lorem "
-					loc: SourceLocation reference/input.md 13:2-13:2
+					loc: SourceLocation reference/input.md 13:2-13:8
 				}
 				MarkdownText {
 					value: "**"
-					loc: SourceLocation reference/input.md 13:8-13:8
+					loc: SourceLocation reference/input.md 13:8-13:10
 				}
 				MarkdownText {
 					value: "ipsum"
-					loc: SourceLocation reference/input.md 13:10-13:10
+					loc: SourceLocation reference/input.md 13:10-13:15
 				}
 			]
-			loc: SourceLocation reference/input.md 13:0-13:16
+			loc: SourceLocation reference/input.md 13:1-13:16
 		}
 	]
 	comments: []

--- a/internal/markdown-parser/test-fixtures/smoke/input.test.md
+++ b/internal/markdown-parser/test-fixtures/smoke/input.test.md
@@ -43,7 +43,7 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "####### this will be a paragraph"
-					loc: SourceLocation smoke/input.md 7:0-7:0
+					loc: SourceLocation smoke/input.md 7:0-7:32
 				}
 			]
 			loc: SourceLocation smoke/input.md 7:0-7:32
@@ -65,7 +65,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "first item"
-									loc: SourceLocation smoke/input.md 15:3-15:3
+									loc: SourceLocation smoke/input.md 15:3-15:13
 								}
 							]
 							loc: SourceLocation smoke/input.md 15:3-15:13
@@ -85,7 +85,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "second item"
-									loc: SourceLocation smoke/input.md 16:3-16:3
+									loc: SourceLocation smoke/input.md 16:3-16:14
 								}
 							]
 							loc: SourceLocation smoke/input.md 16:3-16:14
@@ -106,7 +106,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "first item"
-									loc: SourceLocation smoke/input.md 17:2-17:2
+									loc: SourceLocation smoke/input.md 17:2-17:12
 								}
 							]
 							loc: SourceLocation smoke/input.md 17:2-17:12
@@ -127,7 +127,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "second item"
-									loc: SourceLocation smoke/input.md 18:2-18:2
+									loc: SourceLocation smoke/input.md 18:2-18:13
 								}
 							]
 							loc: SourceLocation smoke/input.md 18:2-18:13
@@ -148,7 +148,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "first item"
-									loc: SourceLocation smoke/input.md 19:2-19:2
+									loc: SourceLocation smoke/input.md 19:2-19:12
 								}
 							]
 							loc: SourceLocation smoke/input.md 19:2-19:12
@@ -169,7 +169,7 @@ MarkdownRoot {
 							children: [
 								MarkdownText {
 									value: "second item"
-									loc: SourceLocation smoke/input.md 20:2-20:2
+									loc: SourceLocation smoke/input.md 20:2-20:13
 								}
 							]
 							loc: SourceLocation smoke/input.md 20:2-20:13
@@ -185,11 +185,11 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "*"
-					loc: SourceLocation smoke/input.md 21:0-21:0
+					loc: SourceLocation smoke/input.md 21:0-21:1
 				}
 				MarkdownText {
 					value: "paragraph"
-					loc: SourceLocation smoke/input.md 21:1-21:1
+					loc: SourceLocation smoke/input.md 21:1-21:10
 				}
 			]
 			loc: SourceLocation smoke/input.md 21:0-21:10
@@ -202,7 +202,7 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "Paragraph"
-					loc: SourceLocation smoke/input.md 23:0-23:0
+					loc: SourceLocation smoke/input.md 23:0-23:9
 				}
 			]
 			loc: SourceLocation smoke/input.md 23:0-23:9
@@ -215,33 +215,33 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "Lorem "
-					loc: SourceLocation smoke/input.md 26:0-26:0
+					loc: SourceLocation smoke/input.md 26:0-26:6
 				}
 				MarkdownEmphasisInline {
 					value: [
 						MarkdownText {
 							value: "ipsum dolor sit"
-							loc: SourceLocation smoke/input.md 26:7-26:7
+							loc: SourceLocation smoke/input.md 26:7-26:22
 						}
 					]
-					loc: SourceLocation smoke/input.md 26:6-26:22
+					loc: SourceLocation smoke/input.md 26:6-26:23
 				}
 				MarkdownText {
 					value: " amet, "
-					loc: SourceLocation smoke/input.md 26:23-26:23
+					loc: SourceLocation smoke/input.md 26:23-26:30
 				}
 				MarkdownEmphasisInline {
 					value: [
 						MarkdownText {
 							value: "consectetur adipiscing elit"
-							loc: SourceLocation smoke/input.md 26:31-26:31
+							loc: SourceLocation smoke/input.md 26:31-26:58
 						}
 					]
-					loc: SourceLocation smoke/input.md 26:30-26:58
+					loc: SourceLocation smoke/input.md 26:30-26:59
 				}
 				MarkdownText {
 					value: "."
-					loc: SourceLocation smoke/input.md 26:59-26:59
+					loc: SourceLocation smoke/input.md 26:59-26:60
 				}
 			]
 			loc: SourceLocation smoke/input.md 26:0-26:60
@@ -250,33 +250,33 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "Lorem "
-					loc: SourceLocation smoke/input.md 28:0-28:0
+					loc: SourceLocation smoke/input.md 28:0-28:6
 				}
 				MarkdownEmphasisInline {
 					value: [
 						MarkdownText {
 							value: "ipsum dolor"
-							loc: SourceLocation smoke/input.md 28:8-28:8
+							loc: SourceLocation smoke/input.md 28:8-28:19
 						}
 					]
-					loc: SourceLocation smoke/input.md 28:6-28:19
+					loc: SourceLocation smoke/input.md 28:6-28:21
 				}
 				MarkdownText {
 					value: " sit amet, "
-					loc: SourceLocation smoke/input.md 28:21-28:21
+					loc: SourceLocation smoke/input.md 28:21-28:32
 				}
 				MarkdownEmphasisInline {
 					value: [
 						MarkdownText {
 							value: "consectetur adipiscing"
-							loc: SourceLocation smoke/input.md 28:34-28:34
+							loc: SourceLocation smoke/input.md 28:34-28:56
 						}
 					]
-					loc: SourceLocation smoke/input.md 28:32-28:56
+					loc: SourceLocation smoke/input.md 28:32-28:58
 				}
 				MarkdownText {
 					value: " elit."
-					loc: SourceLocation smoke/input.md 28:58-28:58
+					loc: SourceLocation smoke/input.md 28:58-28:64
 				}
 			]
 			loc: SourceLocation smoke/input.md 28:0-28:64
@@ -285,27 +285,28 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "Lorem ipsum "
-					loc: SourceLocation smoke/input.md 30:0-30:0
+					loc: SourceLocation smoke/input.md 30:0-30:12
 				}
 				MarkdownEmphasisInline {
 					value: []
 					loc: SourceLocation smoke/input.md 30:12-30:14
 				}
-				MarkdownText {
-					value: "dolor sit amet, consectetur"
-					loc: SourceLocation smoke/input.md 30:16-30:16
-				}
-				MarkdownText {
-					value: "**"
-					loc: SourceLocation smoke/input.md 30:43-30:43
+				MarkdownEmphasisInline {
+					value: [
+						MarkdownText {
+							value: "dolor sit amet, consectetur"
+							loc: SourceLocation smoke/input.md 30:16-30:43
+						}
+					]
+					loc: SourceLocation smoke/input.md 30:14-30:45
 				}
 				MarkdownText {
 					value: "__"
-					loc: SourceLocation smoke/input.md 30:45-30:45
+					loc: SourceLocation smoke/input.md 30:45-30:47
 				}
 				MarkdownText {
 					value: " adipiscing elit."
-					loc: SourceLocation smoke/input.md 30:47-30:47
+					loc: SourceLocation smoke/input.md 30:47-30:64
 				}
 			]
 			loc: SourceLocation smoke/input.md 30:0-30:64
@@ -314,7 +315,7 @@ MarkdownRoot {
 			children: [
 				MarkdownText {
 					value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-					loc: SourceLocation smoke/input.md 32:0-32:0
+					loc: SourceLocation smoke/input.md 32:0-32:56
 				}
 				MarkdownText {
 					value: "\n"
@@ -322,20 +323,20 @@ MarkdownRoot {
 				}
 				MarkdownText {
 					value: "Lorem "
-					loc: SourceLocation smoke/input.md 33:0-33:0
+					loc: SourceLocation smoke/input.md 33:0-33:6
 				}
 				MarkdownEmphasisInline {
 					value: [
 						MarkdownText {
 							value: "ipsum"
-							loc: SourceLocation smoke/input.md 33:8-33:8
+							loc: SourceLocation smoke/input.md 33:8-33:13
 						}
 					]
-					loc: SourceLocation smoke/input.md 33:6-33:13
+					loc: SourceLocation smoke/input.md 33:6-33:15
 				}
 				MarkdownText {
 					value: " dolor sit amet, consectetur adipiscing elit."
-					loc: SourceLocation smoke/input.md 33:15-33:15
+					loc: SourceLocation smoke/input.md 33:15-33:60
 				}
 			]
 			loc: SourceLocation smoke/input.md 32:0-33:60


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Currently, `MarkdownText`'s ending position is the same as starting position. This PR fixes it.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

See snapshot


