### PR TITLE
chore: update usages of chained consumer get to getPath

### DIFF
--- a/internal/browser-features/Browser.ts
+++ b/internal/browser-features/Browser.ts
@@ -28,7 +28,7 @@ export abstract class Browser {
 	}
 
 	protected getAgentConsumer(): Consumer {
-		return this.getDataConsumer().get("agents").get(this.getId());
+		return this.getDataConsumer().getPath(["agents", this.getId()]);
 	}
 
 	protected getVersionConsumer(): Consumer {
@@ -111,9 +111,13 @@ export abstract class Browser {
 			return this.cssFeatureCache.get(feature)!;
 		}
 
-		const value = this.getDataConsumer().get("data").get(feature).get("s").get(
+		const value = this.getDataConsumer().getPath([
+			"data",
+			feature,
+			"s",
 			this.getId(),
-		).get(this.getVersion().toString()).asBoolean(false);
+			this.getVersion().toString(),
+		]).asBoolean(false);
 		this.cssFeatureCache.set(feature, value);
 		return value;
 	}
@@ -124,9 +128,12 @@ export abstract class Browser {
 	 * @param region check internal/browsers-db/README.md for more info
 	 */
 	public getRegionUsage(region: string): number | undefined {
-		return consumeUnknown(regions, DIAGNOSTIC_CATEGORIES.parse).get(region).get(
+		return consumeUnknown(regions, DIAGNOSTIC_CATEGORIES.parse).getPath([
+			region,
 			"data",
-		).get(this.getId()).get(this.getVersion().toString()).asNumberOrVoid();
+			this.getId(),
+			this.getVersion().toString(),
+		]).asNumberOrVoid();
 	}
 }
 

--- a/internal/browser-features/index.ts
+++ b/internal/browser-features/index.ts
@@ -57,11 +57,11 @@ function loadAliases(): Map<string, BrowserIds> {
 	const abbr = new Map<string, BrowserIds>();
 	for (const key in agents.asUnknownObject()) {
 		abbr.set(
-			agents.get(key).get("a").asString().toLowerCase(),
+			agents.getPath([key, "a"]).asString().toLowerCase(),
 			key as BrowserIds,
 		);
 		abbr.set(
-			agents.get(key).get("b").asString().toLowerCase(),
+			agents.getPath([key, "b"]).asString().toLowerCase(),
 			key as BrowserIds,
 		);
 	}

--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -171,7 +171,7 @@ async function globUnmatched(
 				await req.server.projectManager.assertProject(path, location),
 				(consumer) =>
 					consumer.has(configCategory) &&
-					consumer.get(configCategory).get("ignore")
+					consumer.getPath([configCategory, "ignore"])
 				,
 			);
 

--- a/internal/core/server/lsp/LSPServer.test.ts
+++ b/internal/core/server/lsp/LSPServer.test.ts
@@ -163,7 +163,7 @@ test(
 				},
 				(msg, resolve) => {
 					if (msg.get("method").asStringOrVoid() === "workspace/applyEdit") {
-						const edits = msg.get("params").get("edit").get("documentChanges").getIndex(
+						const edits = msg.getPath(["params", "edit", "documentChanges"]).getIndex(
 							0,
 						).get("edits").asJSONArray();
 						t.namedSnapshot("edits", edits);

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -468,7 +468,7 @@ export default class ProjectManager {
 				consumer,
 			} = this.findProjectConfigConsumer(
 				project,
-				(consumer) => consumer.has("vsc") && consumer.get("vsc").get("root"),
+				(consumer) => consumer.has("vsc") && consumer.getPath(["vsc", "root"]),
 			);
 
 			const rootConfigLocation: undefined | DiagnosticLocation =

--- a/internal/v8/InspectorClient.ts
+++ b/internal/v8/InspectorClient.ts
@@ -86,7 +86,7 @@ export default class InspectorClient {
 				const handler = this.callbacks.get(id);
 				if (handler !== undefined) {
 					if (data.has("error")) {
-						const errorMessage = data.get("error").get("message").asString();
+						const errorMessage = data.getPath(["error", "message"]).asString();
 						handler.reject(new Error(errorMessage));
 					} else {
 						handler.resolve(data.get("result"));

--- a/scripts/generated-files/browsers-db.ts
+++ b/scripts/generated-files/browsers-db.ts
@@ -394,19 +394,17 @@ function generateDataAgents(rawData: Consumer) {
 		}
 
 		const vs = generateDataAgentsVersions(
-			rawData.get("agents").get(agent).get("version_list").asImplicitArray(),
+			rawData.getPath(["agents", agent, "version_list"]).asImplicitArray(),
 		);
-		const currentVersion = rawData.get("agents").get(agent).get(
-			"current_version",
-		).asString();
+		const currentVersion = rawData.getPath(["agents", agent, "current_version"]).asString();
 
 		agents.set(
 			agent,
 			{
-				b: rawData.get("agents").get(agent).get("browser").asString(),
-				a: rawData.get("agents").get(agent).get("abbr").asString(),
-				p: rawData.get("agents").get(agent).get("prefix").asString(),
-				t: rawData.get("agents").get(agent).get("type").asString(),
+				b: rawData.getPath(["agents", agent, "browser"]).asString(),
+				a: rawData.getPath(["agents", agent, "abbr"]).asString(),
+				p: rawData.getPath(["agents", agent, "prefix"]).asString(),
+				t: rawData.getPath(["agents", agent, "type"]).asString(),
 				vs,
 				cv: isNaN(parseFloat(currentVersion))
 					? vs[vs.length - 1].v
@@ -465,10 +463,10 @@ function generateDataData(rawData: Consumer) {
 	for (const feature in rawData.get("data").asUnknownObject()) {
 		// Skip non CSS features for the time being
 		if (
-			!rawData.get("cats").get("CSS").asMappedArray((c) => c.asString()).some((
+			!rawData.getPath(["cats", "CSS"]).asMappedArray((c) => c.asString()).some((
 				c,
 			) =>
-				rawData.get("data").get(feature).get("categories").asMappedArray((c) =>
+				rawData.getPath(["data", feature, "categories"]).asMappedArray((c) =>
 					c.asString()
 				).includes(c)
 			)
@@ -478,16 +476,16 @@ function generateDataData(rawData: Consumer) {
 
 		const stats = new Map<string, Map<number, boolean>>();
 
-		for (const agent in rawData.get("data").get(feature).get("stats").asUnknownObject()) {
+		for (const agent in rawData.getPath(["data", feature, "stats"]).asUnknownObject()) {
 			if (agent === "ie" || agent === "ie_mob") {
 				continue;
 			}
 
 			const featureAgents = new Map<number, boolean>();
 
-			for (const v in rawData.get("data").get(feature).get("stats").get(agent).asUnknownObject()) {
+			for (const v in rawData.getPath(["data", feature, "stats", agent]).asUnknownObject()) {
 				if (
-					rawData.get("data").get(feature).get("stats").get(agent).get(v).asString().includes(
+					rawData.getPath(["data", feature, "stats", agent, v]).asString().includes(
 						"x",
 					)
 				) {
@@ -511,7 +509,7 @@ function generateDataData(rawData: Consumer) {
 			feature,
 			{
 				s: stats,
-				c: rawData.get("data").get(feature).get("categories").asMappedArray((c) =>
+				c: rawData.getPath(["data", feature, "categories"]).asMappedArray((c) =>
 					c.asString()
 				),
 			},
@@ -564,26 +562,26 @@ function generateRegionsData(rawRegionUsage: Consumer) {
 
 		const usageAgent = new Map<number, number>();
 
-		for (const v in rawRegionUsage.get("data").get(agent).asUnknownObject()) {
+		for (const v in rawRegionUsage.getPath(["data", agent]).asUnknownObject()) {
 			if (
-				rawRegionUsage.get("data").get(agent).get(v).asNumberOrVoid() != null &&
-				rawRegionUsage.get("data").get(agent).get(v).asNumber() > 0
+				rawRegionUsage.getPath(["data", agent, v]).asNumberOrVoid() != null &&
+				rawRegionUsage.getPath(["data", agent, v]).asNumber() > 0
 			) {
 				// Could be optimized but copying 3 times works
 				// Converts versions like `12-20` into 2 versions 12 and 20
 				if (v.includes("-")) {
 					usageAgent.set(
 						parseFloat(v.split("-")[0]),
-						rawRegionUsage.get("data").get(agent).get(v).asNumber(),
+						rawRegionUsage.getPath(["data", agent, v]).asNumber(),
 					);
 					usageAgent.set(
 						parseFloat(v.split("-")[1]),
-						rawRegionUsage.get("data").get(agent).get(v).asNumber(),
+						rawRegionUsage.getPath(["data", agent, v]).asNumber(),
 					);
 				} else {
 					usageAgent.set(
 						parseFloat(v),
-						rawRegionUsage.get("data").get(agent).get(v).asNumber(),
+						rawRegionUsage.getPath(["data", agent, v]).asNumber(),
 					);
 				}
 			}


### PR DESCRIPTION
## Summary
Replaces `consumer.get("one").get("two")` calls to `consumer.getPath(["one", "two"])`.

## Test Plan
CI
