### PR TITLE
fix: use method instead of type for LSPProgress

### DIFF
--- a/internal/core/server/lsp/LSPProgress.ts
+++ b/internal/core/server/lsp/LSPProgress.ts
@@ -23,7 +23,7 @@ export default class LSPProgress extends ReporterProgressBase {
 		this.lastRenderKey = "";
 
 		transport.write({
-			type: "$/progress",
+			method: "$/progress",
 			params: {
 				token: this.token,
 				value: {
@@ -52,7 +52,7 @@ export default class LSPProgress extends ReporterProgressBase {
 
 		this.lastRenderKey = renderKey;
 		this.transport.write({
-			type: "$/progress",
+			method: "$/progress",
 			params: {
 				token: this.token,
 				value: {
@@ -69,7 +69,7 @@ export default class LSPProgress extends ReporterProgressBase {
 
 	public end() {
 		this.transport.write({
-			type: "$/progress",
+			method: "$/progress",
 			params: {
 				token: this.token,
 				value: {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Rome LSP uses `type` field for LSPProgress which breaks Neovim's builtin LSP client. It should be `method` instead of `type` according to [the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress)

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

I tried to run the test *before* and *after* my PR to make sure I didn't mess up. Some tests are failing after 10s (`Test worker was unresponsive for 10 seconds. We tried to collect some additional metadata but we timed out again trying to fetch it...`), so I don't think they're caused by my changes