### PR TITLE
chore: script file to generate prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,3 +180,13 @@ The `category` is one of the category folders inside the `language` folders.
 ```
 
 The created files will be displayed in the console output.
+
+### `compiler-create-prefix`
+
+This is used to generate a new prefix boilerplate
+
+```bash
+./script compiler-create-prefix [prefixName]
+```
+
+Prefix names with dashes are preferable.

--- a/internal/compiler/transforms/compile/css-handler/prefix/index.ts
+++ b/internal/compiler/transforms/compile/css-handler/prefix/index.ts
@@ -1,4 +1,4 @@
-/* GENERATED:START(hash:5fb179e874f73fc64e32026cfd46a65fd59630e1,id:main) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules` to update. */
+/* GENERATED:START(hash:5fb179e874f73fc64e32026cfd46a65fd59630e1,id:main) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/css-prefix` to update. */
 import display from "./prefixes/display";
 import transform from "./prefixes/transform";
 import transition from "./prefixes/transition";

--- a/internal/path/classes/AbsoluteFilePath.ts
+++ b/internal/path/classes/AbsoluteFilePath.ts
@@ -362,12 +362,14 @@ export default class AbsoluteFilePath
 	}
 
 	public async createDirectory(): Promise<void> {
-		await fs.promises.mkdir(
-			this.join(),
-			{
-				recursive: true,
-			},
-		);
+		if (await this.notExists()) {
+			await fs.promises.mkdir(
+				this.join(),
+				{
+					recursive: true,
+				},
+			);
+		}
 	}
 
 	public openFile(

--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -231,17 +231,26 @@ async function formatFile(
 	);
 }
 
+export async function createDirectory(path: AbsoluteFilePath) {
+	await path.createDirectory();
+	reporter.success(markup`Wrote directory <emphasis>${path}</emphasis>`);
+}
+
 export async function writeFile(path: AbsoluteFilePath, sourceText: string) {
-	sourceText = await formatFile(path, sourceText);
+	try {
+		sourceText = await formatFile(path, sourceText);
 
-	// Windows: `content` will always have `\r` stripped so add it back
-	if (process.platform === "win32") {
-		sourceText = sourceText.replace(/\n/g, "\r\n");
+		// Windows: `content` will always have `\r` stripped so add it back
+		if (process.platform === "win32") {
+			sourceText = sourceText.replace(/\n/g, "\r\n");
+		}
+
+		// Write
+		await path.writeFile(sourceText);
+		reporter.success(markup`Wrote <emphasis>${path}</emphasis>`);
+	} catch (e) {
+		reporter.error(e.message);
 	}
-
-	// Write
-	await path.writeFile(sourceText);
-	reporter.success(markup`Wrote <emphasis>${path}</emphasis>`);
 }
 
 export function waitChildProcess(

--- a/scripts/compiler-create-prefix.ts
+++ b/scripts/compiler-create-prefix.ts
@@ -1,0 +1,102 @@
+import {INTERNAL, ROOT, createDirectory, reporter, writeFile} from "./_utils";
+import {dedent} from "@internal/string-utils";
+import {main as generatedPrefixes} from "./generated-files/css-prefix";
+import {markup} from "@internal/markup";
+
+const basePath = INTERNAL.append("compiler", "transforms", "compile");
+const compilerPath = basePath.append("css-handler", "prefix", "prefixes");
+const testPath = basePath.append("test-fixtures", "css-handler", "prefix");
+
+export async function main([prefixName]: string[]): Promise<number> {
+	if (prefixName === undefined) {
+		reporter.error(markup`./script compiler-create-prefix [prefixName]`);
+		return 1;
+	}
+
+	// Write rule
+	await writeFile(
+		compilerPath.append(`${prefixName}.ts`),
+		dedent`
+			import {
+				createPrefixVisitor,
+				prefixCSSProperty,
+			} from "@internal/compiler/transforms/compile/css-handler/prefix/utils";
+
+			export default [
+				createPrefixVisitor({
+					name: "${prefixName}",
+					enter(path) {
+						return prefixCSSProperty({
+							path,
+							propertyName: "${prefixName}",
+							browserFeaturesKey: "",
+						});
+					},
+				}),
+			];
+		`,
+	);
+
+	const fileName = testPath.append(prefixName);
+	await createDirectory(fileName);
+
+	// Write test fixture
+	await writeFile(
+		fileName.append("input.css"),
+		dedent`
+			.style {
+				${prefixName}: none;
+			}
+		`,
+	);
+
+	// Write docs
+	await writeFile(
+		ROOT.append(
+			"website",
+			"src",
+			"docs",
+			"css-handler",
+			"prefix",
+			`${prefixName}.md`,
+		),
+		dedent`
+			---
+			title: Prefix ${prefixName}
+			layout: layouts/prefix.liquid
+			showHero: false
+			description: MISSING DOCUMENTATION
+			eleventyNavigation:
+				key: css-handler/prefix/${prefixName}
+				parent: css-handler
+				title: ${prefixName}
+			---
+
+			# ${prefixName}
+
+			MISSING DOCUMENTATION
+		`,
+	);
+
+	// TODO: check later
+	// Add description
+	// const diagDescriptionsPath = INTERNAL.append(
+	// 	"diagnostics",
+	// 	"descriptions",
+	// 	"lint.ts",
+	// );
+	// let descriptions = await diagDescriptionsPath.readFileText();
+	// let message = "markup`INSERT MESSAGE HERE`";
+	// descriptions = descriptions.replace(
+	// 	"createDiagnosticsCategory({",
+	// 	`createDiagnosticsCategory({\n	${descriptionKey}: {
+	// 		category: DIAGNOSTIC_CATEGORIES["${categoryName}"],
+	// 		message: ${message},
+	// 	},`,
+	// );
+	// await writeFile(diagDescriptionsPath, descriptions);
+
+	await generatedPrefixes();
+
+	return 0;
+}

--- a/scripts/compiler-create-prefix.ts
+++ b/scripts/compiler-create-prefix.ts
@@ -7,15 +7,15 @@ const basePath = INTERNAL.append("compiler", "transforms", "compile");
 const compilerPath = basePath.append("css-handler", "prefix", "prefixes");
 const testPath = basePath.append("test-fixtures", "css-handler", "prefix");
 
-export async function main([prefixName]: string[]): Promise<number> {
-	if (prefixName === undefined) {
+export async function main([propertyName]: string[]): Promise<number> {
+	if (propertyName === undefined) {
 		reporter.error(markup`./script compiler-create-prefix [prefixName]`);
 		return 1;
 	}
 
 	// Write rule
 	await writeFile(
-		compilerPath.append(`${prefixName}.ts`),
+		compilerPath.append(`${propertyName}.ts`),
 		dedent`
 			import {
 				createPrefixVisitor,
@@ -24,11 +24,11 @@ export async function main([prefixName]: string[]): Promise<number> {
 
 			export default [
 				createPrefixVisitor({
-					name: "${prefixName}",
+					name: "${propertyName}",
 					enter(path) {
 						return prefixCSSProperty({
 							path,
-							propertyName: "${prefixName}",
+							propertyName: "${propertyName}",
 							browserFeaturesKey: "",
 						});
 					},
@@ -37,7 +37,7 @@ export async function main([prefixName]: string[]): Promise<number> {
 		`,
 	);
 
-	const fileName = testPath.append(prefixName);
+	const fileName = testPath.append(propertyName);
 	await createDirectory(fileName);
 
 	// Write test fixture
@@ -45,7 +45,7 @@ export async function main([prefixName]: string[]): Promise<number> {
 		fileName.append("input.css"),
 		dedent`
 			.style {
-				${prefixName}: none;
+				${propertyName}: none;
 			}
 		`,
 	);
@@ -58,21 +58,21 @@ export async function main([prefixName]: string[]): Promise<number> {
 			"docs",
 			"css-handler",
 			"prefix",
-			`${prefixName}.md`,
+			`${propertyName}.md`,
 		),
 		dedent`
 			---
-			title: Prefix ${prefixName}
+			title: Prefix ${propertyName}
 			layout: layouts/prefix.liquid
 			showHero: false
 			description: MISSING DOCUMENTATION
 			eleventyNavigation:
-				key: css-handler/prefix/${prefixName}
+				key: css-handler/prefix/${propertyName}
 				parent: css-handler
-				title: ${prefixName}
+				title: ${propertyName}
 			---
 
-			# ${prefixName}
+			# ${propertyName}
 
 			MISSING DOCUMENTATION
 		`,

--- a/scripts/generated-files/css-prefix.ts
+++ b/scripts/generated-files/css-prefix.ts
@@ -1,4 +1,5 @@
 import {INTERNAL, modifyGeneratedFile} from "../_utils";
+import {toCamelCase} from "@internal/string-utils";
 
 const cssPrefixFolder = INTERNAL.append(
 	"compiler",
@@ -36,17 +37,19 @@ export async function main() {
 	await modifyGeneratedFile(
 		{
 			path: cssPrefixFolder.append("index.ts"),
-			scriptName: "generated-files/lint-rules",
+			scriptName: "generated-files/css-prefix",
 		},
 		async () => {
 			let lines = [];
 			for (const {basename} of defs) {
-				lines.push(`import ${basename} from "./prefixes/${basename}";`);
+				lines.push(
+					`import ${toCamelCase(basename)} from "./prefixes/${basename}";`,
+				);
 			}
 			lines.push("");
 			lines.push("export default [");
 			for (const {basename} of defs) {
-				lines.push(`\t...${basename},`);
+				lines.push(`\t...${toCamelCase(basename)},`);
 			}
 			lines.push("];");
 

--- a/scripts/lint-create-rule.ts
+++ b/scripts/lint-create-rule.ts
@@ -7,9 +7,7 @@ const rulesPath = INTERNAL.append("compiler", "lint", "rules");
 
 export async function main([ruleName]: string[]): Promise<number> {
 	if (ruleName === undefined) {
-		reporter.error(
-			markup`./rome run scripts/ast-create-node scripts/lint/add.cjs [ruleName]`,
-		);
+		reporter.error(markup`./scripts lint-create-node [ruleName]`);
 		return 1;
 	}
 

--- a/website/src/_includes/layouts/prefix.liquid
+++ b/website/src/_includes/layouts/prefix.liquid
@@ -1,0 +1,12 @@
+---
+layout: layouts/base.liquid
+social-image: social-logo.png
+---
+
+<main id="main-content" class="content single">
+	<section>
+
+	{{ content | safe }}
+
+	</section>
+</main>

--- a/website/src/docs/css-handler/index.md
+++ b/website/src/docs/css-handler/index.md
@@ -1,0 +1,8 @@
+---
+title: CSS Handler
+layout: layouts/page.liquid
+layout-type: split
+main-class: css-handler
+eleventyNavigation:
+key: css-handler
+---


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR does the following:
- create a new script called `compiler-create-prefix` that creates the main boilerplate of prefix and updates the main entry point `prefix/index.ts`. We don't have documentation yet but I think we should start creating the files, what we need later is to call the compiler and automatically print the result inside the documentation. This has basically two perks: automation and using the compiler for real;
- updates the `CONTRIBUTING.md` file with the new file;
- fixes a small issue around `AbsolutePath.createDirectory` where a folder should be created only when it doesn't exist;
- fixes an existing issue inside `generated-files/css-prefix` where a property should be converted to camel case, in case the file contains a dash, e.g. `box-shadow.ts`
- creates a basic `index.md`, empty, for future documentation


Part of #1423 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Run manually the scripts

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
