### PR TITLE
fix(lsp): adhere to JSON-RPC specification

### DIFF
--- a/internal/core/server/lsp/LSPProgress.ts
+++ b/internal/core/server/lsp/LSPProgress.ts
@@ -23,6 +23,7 @@ export default class LSPProgress extends ReporterProgressBase {
 		this.lastRenderKey = "";
 
 		transport.write({
+			jsonrpc: "2.0",
 			method: "$/progress",
 			params: {
 				token: this.token,
@@ -52,6 +53,7 @@ export default class LSPProgress extends ReporterProgressBase {
 
 		this.lastRenderKey = renderKey;
 		this.transport.write({
+			jsonrpc: "2.0",
 			method: "$/progress",
 			params: {
 				token: this.token,
@@ -69,6 +71,7 @@ export default class LSPProgress extends ReporterProgressBase {
 
 	public end() {
 		this.transport.write({
+			jsonrpc: "2.0",
 			method: "$/progress",
 			params: {
 				token: this.token,

--- a/internal/core/server/lsp/LSPServer.ts
+++ b/internal/core/server/lsp/LSPServer.ts
@@ -119,6 +119,7 @@ export default class LSPServer {
 	private logMessage(path: AbsoluteFilePath, message: string) {
 		this.server.logger.info(markup`[LSPServer] ${message}`);
 		this.transport.write({
+			jsonrpc: "2.0",
 			method: "window/logMessage",
 			params: {
 				uri: `file://${path.join()}`,
@@ -429,6 +430,7 @@ export default class LSPServer {
 					const edits = diffTextEdits(original, saveFile.content);
 
 					await this.transport.request({
+						jsonrpc: "2.0",
 						method: "workspace/applyEdit",
 						params: {
 							label: "Rome Action",

--- a/internal/core/server/lsp/protocol.ts
+++ b/internal/core/server/lsp/protocol.ts
@@ -93,7 +93,7 @@ export class LSPTransport {
 		return new Promise((resolve, reject) => {
 			const id = ++this.requestIdCounter;
 			this.requestCallbacks.set(id, {resolve, reject});
-			this.write({...req, id});
+			this.write({...req, id, jsonrpc: "2.0"});
 		});
 	}
 
@@ -148,12 +148,14 @@ export class LSPTransport {
 					result = await this.requestEvent.call({method, params});
 				}
 				const res: LSPResponseMessage = {
+					jsonrpc: "2.0",
 					id,
 					result,
 				};
 				this.write(res);
 			} catch (err) {
 				const res: LSPResponseMessage = {
+					jsonrpc: "2.0",
 					id,
 					error: {
 						code: -32_603,

--- a/internal/core/server/lsp/types.ts
+++ b/internal/core/server/lsp/types.ts
@@ -9,6 +9,11 @@ import {JSONArray, JSONObject, JSONPropertyValue} from "@internal/codec-config";
 
 export type LSPRequestMessage = {
 	/**
+   * JSON-RPC version number. Must be "2.0".
+   */
+	jsonrpc: "2.0";
+
+	/**
    * The request id.
    */
 	id: number | string;
@@ -25,6 +30,11 @@ export type LSPRequestMessage = {
 };
 
 export type LSPResponseMessage = {
+	/**
+   * JSON-RPC version number. Must be "2.0".
+   */
+	jsonrpc: "2.0";
+
 	/**
    * The request id.
    */
@@ -61,6 +71,11 @@ export type LSPResponseError = {
 };
 
 export type LSPNotificationMessage = {
+	/**
+   * JSON-RPC version number. Must be "2.0".
+   */
+	jsonrpc: "2.0";
+
 	/**
    * The method to be invoked.
    */


### PR DESCRIPTION
LSP is built atop the JSON-RPC specification [1]. This specification
requires messages to have a key "jsonrpc" with a value of "2.0" (as a
string). Rome's LSP server does not include a "jsonrpc" key in its
messages. This protocol violation causes some LSP clients to reject
Rome's messages.

Include the required key, fixing Rome for these clients.

[1] https://www.jsonrpc.org/specification

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
