### PR TITLE
fix(lsp): fix malformed window/logMessage messages

### DIFF
--- a/internal/core/server/lsp/LSPServer.ts
+++ b/internal/core/server/lsp/LSPServer.ts
@@ -121,6 +121,7 @@ export default class LSPServer {
 		this.transport.write({
 			method: "window/logMessage",
 			params: {
+				type: 4,
 				uri: `file://${path.join()}`,
 				message,
 			},


### PR DESCRIPTION
The LSP specification requires window/logMessage notifications to
include a "type" key and a "message" key. Rome's LSP server omits the
required "type" key. This protocol violation causes problems with some
LSP clients.

Adhere to the LSP by adding the missing "type" key.

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
