### PR TITLE
feat(lint): Add optional call expression support to preferOptianalChaining linting rule

### DIFF
--- a/internal/child-process/index.ts
+++ b/internal/child-process/index.ts
@@ -31,23 +31,19 @@ export class ChildProcess {
 
 		const {stdout, stderr} = this.process;
 
-		if (stdout != null) {
-			stdout.on(
-				"data",
-				(chunk) => {
-					this.output.push([0, chunk]);
-				},
-			);
-		}
+		stdout?.on(
+			"data",
+			(chunk) => {
+				this.output.push([0, chunk]);
+			},
+		);
 
-		if (stderr != null) {
-			stderr.on(
-				"data",
-				(chunk) => {
-					this.output.push([1, chunk]);
-				},
-			);
-		}
+		stderr?.on(
+			"data",
+			(chunk) => {
+				this.output.push([1, chunk]);
+			},
+		);
 	}
 
 	public process: childProcess.ChildProcess;

--- a/internal/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/internal/cli-diagnostics/DiagnosticsPrinter.ts
@@ -576,7 +576,7 @@ export default class DiagnosticsPrinter extends Error {
 			case "github-actions": {
 				const parts = [];
 
-				if (path !== undefined && path.isAbsolute()) {
+				if (path?.isAbsolute()) {
 					parts.push(`file=${this.cwd.relative(path).join()}`);
 
 					if (start !== undefined) {

--- a/internal/cli-diagnostics/printAdvice.ts
+++ b/internal/cli-diagnostics/printAdvice.ts
@@ -482,8 +482,7 @@ function printStacktrace(
 			// refers to the diagnostic
 			const isImportantStackFrame =
 				path !== undefined &&
-				(path.equal(diagnostic.location.path) ||
-				(item.importantPaths !== undefined && item.importantPaths.has(path)));
+				(path.equal(diagnostic.location.path) || item.importantPaths?.has(path));
 			const shouldShowCodeFrame = isImportantStackFrame || shownCodeFrames < 2;
 
 			if (

--- a/internal/cli-flags/Parser.test.ts
+++ b/internal/cli-flags/Parser.test.ts
@@ -43,14 +43,12 @@ async function testParser<T>(
 	});
 
 	const {diagnostics} = await catchDiagnostics(async () => {
-		if (preInit !== undefined) {
-			preInit(parser);
-		}
+		preInit?.(parser);
+
 		const flags = await parser.init();
 		t.namedSnapshot("flags", flags);
-		if (postInit !== undefined) {
-			postInit(parser, flags);
-		}
+
+		postInit?.(parser, flags);
 	});
 
 	if (diagnostics !== undefined) {

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -940,9 +940,8 @@ export default class Parser<T> {
 			} else {
 				if (commandToFlags.has(meta.command)) {
 					const flags = commandToFlags.get(meta.command);
-					if (flags) {
-						flags.add(meta);
-					}
+
+					flags?.add(meta);
 				} else {
 					const flags: Set<ArgDeclaration> = new Set();
 					flags.add(meta);

--- a/internal/cli-layout/Grid.ts
+++ b/internal/cli-layout/Grid.ts
@@ -1349,9 +1349,7 @@ export default class Grid {
 
 		const subAncestry: Ancestry = [...ancestry, tag];
 
-		if (hook?.before !== undefined) {
-			hook.before(tag, this, ancestry);
-		}
+		hook?.before?.(tag, this, ancestry);
 
 		switch (tag.name) {
 			case "locator": {
@@ -1386,9 +1384,7 @@ export default class Grid {
 			}
 		}
 
-		if (hook?.after !== undefined) {
-			hook.after(tag, this, ancestry);
-		}
+		hook?.after?.(tag, this, ancestry);
 	}
 
 	private drawChild(child: MarkupParsedChild, ancestry: Ancestry) {

--- a/internal/cli-reporter/Reporter.ts
+++ b/internal/cli-reporter/Reporter.ts
@@ -202,15 +202,11 @@ export default class Reporter implements ReporterNamespace {
 			features,
 			write: (chunk, error) => {
 				if (error) {
-					if (stderr !== undefined) {
-						// @ts-ignore
-						stderr.write(chunk);
-					}
+					// @ts-ignore
+					stderr?.write(chunk);
 				} else {
-					if (stdout !== undefined) {
-						// @ts-ignore
-						stdout.write(chunk);
-					}
+					// @ts-ignore
+					stdout?.write(chunk);
 				}
 			},
 		});

--- a/internal/cli/cli.ts
+++ b/internal/cli/cli.ts
@@ -550,9 +550,7 @@ export default async function cli() {
 				fileout = clientFlags.cwd.resolve(cliFlags.logPath).createWriteStream();
 
 				client.endEvent.subscribe(() => {
-					if (fileout !== undefined) {
-						fileout.end();
-					}
+					fileout?.end();
 				});
 			}
 

--- a/internal/compiler/lint/rules/js/preferOptionalChaining.test.md
+++ b/internal/compiler/lint/rules/js/preferOptionalChaining.test.md
@@ -120,12 +120,13 @@ foo?.bar;
 
 ```
 
- lint/js/preferOptionalChaining/reject/5/filename.ts:2 lint/js/preferOptionalChaining  FIXABLE  ━━━━
+ lint/js/preferOptionalChaining/reject/5/filename.ts:3 lint/js/preferOptionalChaining  FIXABLE  ━━━━
 
   ✖ Prefer optional chaining to manual checks.
 
     1 │ let foo = {};
-  > 2 │ foo != null && foo.bar;
+    2 │ // leading binary comment
+  > 3 │ foo != null && foo.bar;
       │ ^^^^^^^^^^^^^^^^^^^^^^
 
   ℹ Safe fix
@@ -140,6 +141,7 @@ foo?.bar;
 
 ```ts
 let foo = {};
+// leading binary comment
 foo?.bar;
 
 ```
@@ -288,12 +290,13 @@ foo?.bar;
 
 ```
 
- lint/js/preferOptionalChaining/reject/11/filename.ts:2 lint/js/preferOptionalChaining  FIXABLE  ━━━
+ lint/js/preferOptionalChaining/reject/11/filename.ts:3 lint/js/preferOptionalChaining  FIXABLE  ━━━
 
   ✖ Prefer optional chaining to manual checks.
 
     1 │ let foo = {};
-  > 2 │ foo ? foo.bar.baz : undefined
+    2 │ // leading ternary comment
+  > 3 │ foo ? foo.bar.baz : undefined
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   ℹ Safe fix
@@ -308,6 +311,7 @@ foo?.bar;
 
 ```ts
 let foo = {};
+// leading ternary comment
 foo?.bar.baz;
 
 ```
@@ -316,15 +320,106 @@ foo?.bar.baz;
 
 ```
 
- lint/js/preferOptionalChaining/reject/12/filename.ts:2:4 lint/js/preferOptionalChaining  FIXABLE  ━
+ lint/js/preferOptionalChaining/reject/12/filename.ts:3 lint/js/preferOptionalChaining  FIXABLE  ━━━
 
   ✖ Prefer optional chaining to manual checks.
 
-    1 │ let foo = {};
-  > 2 │ if (foo != undefined && foo.bar != null) {
-      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │   foo.bar('baz');
-    4 │ }
+    1 │ let foo = {}
+    2 │ // leading binary comment
+  > 3 │ foo && foo()
+      │ ^^^^^^^^^^^^
+
+  ℹ Safe fix
+
+  - foo·&&·foo()
+  + foo?.()
+
+
+```
+
+### `11: formatted`
+
+```ts
+let foo = {};
+// leading binary comment
+foo?.();
+
+```
+
+### `12`
+
+```
+
+ lint/js/preferOptionalChaining/reject/13/filename.ts:3 lint/js/preferOptionalChaining  FIXABLE  ━━━
+
+  ✖ Prefer optional chaining to manual checks.
+
+    1 │ let foo = {}
+    2 │ // leading binary comment
+  > 3 │ foo && foo.bar()
+      │ ^^^^^^^^^^^^^^^^
+
+  ℹ Safe fix
+
+  - foo·&&·foo.bar()
+  + foo?.bar()
+
+
+```
+
+### `12: formatted`
+
+```ts
+let foo = {};
+// leading binary comment
+foo?.bar();
+
+```
+
+### `13`
+
+```
+
+ lint/js/preferOptionalChaining/reject/14/filename.ts:3 lint/js/preferOptionalChaining  FIXABLE  ━━━
+
+  ✖ Prefer optional chaining to manual checks.
+
+    1 │ let foo = {}
+    2 │ // leading ternary comment
+  > 3 │ foo ? foo.bar() : undefined
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  ℹ Safe fix
+
+  - foo·?·foo.bar()·:·undefined
+  + foo?.bar()
+
+
+```
+
+### `13: formatted`
+
+```ts
+let foo = {};
+// leading ternary comment
+foo?.bar();
+
+```
+
+### `14`
+
+```
+
+ lint/js/preferOptionalChaining/reject/15/filename.ts:5:1 lint/js/preferOptionalChaining  FIXABLE  ━
+
+  ✖ Prefer optional chaining to manual checks.
+
+    3 │ if (
+    4 │   // leading if condtion comment
+  > 5 │   foo != undefined && foo.bar != null
+      │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ ) {
+    7 │   // leading call expression comment comment
 
   ℹ Safe fix
 
@@ -334,57 +429,15 @@ foo?.bar.baz;
 
 ```
 
-### `11: formatted`
-
-```ts
-let foo = {};
-if (foo?.bar != null) {
-	foo.bar("baz");
-}
-
-```
-
-### `12`
-
-```
-
-```
-
-### `12: formatted`
-
-```ts
-let foo = {};
-foo?.bar;
-
-```
-
-### `13`
-
-```
-
-```
-
-### `13: formatted`
-
-```ts
-let foo = {};
-let bar = "";
-foo && bar.foo;
-
-```
-
-### `14`
-
-```
-
-```
-
 ### `14: formatted`
 
 ```ts
 let foo = {};
-let bar = "";
-bar in foo && foo.bar;
+// leading if statement comment
+
+// leading if condtion comment
+// leading call expression comment comment
+foo?.bar?.("baz")
 
 ```
 
@@ -398,7 +451,7 @@ bar in foo && foo.bar;
 
 ```ts
 let foo = {};
-foo?.[bar];
+foo?.bar;
 
 ```
 
@@ -412,7 +465,8 @@ foo?.[bar];
 
 ```ts
 let foo = {};
-foo ? foo.bar.baz : null;
+let bar = "";
+foo && bar.foo;
 
 ```
 
@@ -423,6 +477,49 @@ foo ? foo.bar.baz : null;
 ```
 
 ### `17: formatted`
+
+```ts
+let foo = {};
+let bar = "";
+bar in foo && foo.bar;
+
+```
+
+### `18`
+
+```
+
+```
+
+### `18: formatted`
+
+```ts
+let foo = {};
+foo?.[bar];
+
+```
+
+### `19`
+
+```
+
+```
+
+### `19: formatted`
+
+```ts
+let foo = {};
+foo ? foo.bar.baz : null;
+
+```
+
+### `20`
+
+```
+
+```
+
+### `20: formatted`
 
 ```ts
 let foo = {};

--- a/internal/compiler/lint/rules/js/preferOptionalChaining.test.rjson
+++ b/internal/compiler/lint/rules/js/preferOptionalChaining.test.rjson
@@ -18,6 +18,7 @@ invalid: [
 	"
 	"
 		let foo = {};
+		// leading binary comment
 		foo != null && foo.bar;
 	"
 	"
@@ -42,11 +43,32 @@ invalid: [
 	"
 	"
 		let foo = {};
+		// leading ternary comment
 		foo ? foo.bar.baz : undefined
 	"
 	"
+	let foo = {}
+	// leading binary comment
+	foo && foo()
+	"
+	"
+	let foo = {}
+	// leading binary comment
+	foo && foo.bar()
+	"
+	"
+	let foo = {}
+	// leading ternary comment
+	foo ? foo.bar() : undefined
+	"
+	"
 		let foo = {};
-		if (foo != undefined && foo.bar != null) {
+		// leading if statement comment
+		if (
+			// leading if condtion comment
+			foo != undefined && foo.bar != null
+		) {
+			// leading call expression comment comment
 			foo.bar('baz');
 		}
 	"

--- a/internal/compiler/lint/rules/js/preferOptionalChaining.ts
+++ b/internal/compiler/lint/rules/js/preferOptionalChaining.ts
@@ -1,11 +1,14 @@
 import {
 	AnyJSExpression,
+	AnyNode,
 	JSBinaryExpression,
+	JSCallExpression,
 	JSMemberExpression,
 	JSNullLiteral,
 	JSReferenceIdentifier,
 	jsIdentifier,
 	jsMemberExpression,
+	jsOptionalCallExpression,
 	jsStaticMemberProperty,
 } from "@internal/ast";
 import {createVisitor, signals} from "@internal/compiler";
@@ -29,6 +32,11 @@ function isReferenceOrMemberExpression(
 	);
 }
 
+type Output = {
+	name: string;
+	optional?: boolean;
+};
+
 /**
  * Arrayify object to by identifiers
  *
@@ -44,12 +52,6 @@ function isReferenceOrMemberExpression(
  * output
  * `null`
  */
-
-type Output = {
-	name: string;
-	optional?: boolean;
-};
-
 function memberExpressionToArray(
 	arg: JSMemberExpression | JSReferenceIdentifier,
 ): Output[] | null {
@@ -210,16 +212,112 @@ function getVerifiedRight(node: AnyJSExpression): null | VerifiedRight {
 	return null;
 }
 
+function getVerifiedConsequent(node: AnyNode): null | JSCallExpression {
+	if (
+		node.type === "JSExpressionStatement" &&
+		node.expression.type === "JSCallExpression"
+	) {
+		return node.expression;
+	}
+
+	if (
+		node.type === "JSBlockStatement" &&
+		node.body.length === 1 &&
+		node.body[0].type === "JSExpressionStatement" &&
+		node.body[0].expression.type === "JSCallExpression"
+	) {
+		return node.body[0].expression;
+	}
+
+	return null;
+}
+
 export default createVisitor({
 	name: "js/preferOptionalChaining",
 	enter(path) {
 		const {node} = path;
 
 		/**
+		 * Optional call expression
+		 * `if (foo) foo()` --> `foo?.()`
+		 */
+		if (node.type === "JSIfStatement" && node.alternate === undefined) {
+			const consequent = getVerifiedConsequent(node.consequent);
+			const left = getVerifiedLeft(node.test);
+			if (
+				left !== null &&
+				consequent !== null &&
+				isReferenceOrMemberExpression(consequent.callee)
+			) {
+				const newCallee = mergeMemberExpressions(
+					left,
+					consequent.callee,
+					{inclusive: true},
+				);
+				if (newCallee) {
+					const callExpression = {
+						...consequent,
+						callee: newCallee.node,
+					};
+					return path.addFixableDiagnostic(
+						{
+							fixed: signals.replace(
+								newCallee.sameLength
+									? jsOptionalCallExpression.create({
+											...callExpression,
+											optional: true,
+										})
+									: callExpression,
+							),
+						},
+						descriptions.LINT.JS_PREFER_OPTIONAL_CHAINING,
+					);
+				}
+			}
+		}
+
+		/**
+		 * `foo ? foo() : undefined` --> `foo?.()`
 		 * `foo ? foo.bar : undefined` --> `foo?.bar`
 		 */
 		if (node.type === "JSConditionalExpression" && isUndefined(node.alternate)) {
 			const left = getVerifiedLeft(node.test);
+
+			/**
+			 * optional call expr
+			 * `foo ? foo() : undefined` --> `foo?.()`
+			 */
+			if (
+				node.consequent.type === "JSCallExpression" &&
+				isReferenceOrMemberExpression(node.consequent.callee) &&
+				left !== null
+			) {
+				const newCallee = mergeMemberExpressions(
+					left,
+					node.consequent.callee,
+					{inclusive: true},
+				);
+				if (newCallee) {
+					const callExpression = {
+						...node.consequent,
+						callee: newCallee.node,
+					};
+					return path.addFixableDiagnostic(
+						{
+							fixed: signals.replace(
+								newCallee.sameLength
+									? jsOptionalCallExpression.create({
+											...callExpression,
+											optional: true,
+										})
+									: callExpression,
+							),
+						},
+						descriptions.LINT.JS_PREFER_OPTIONAL_CHAINING,
+					);
+				}
+			}
+
 			/**
 			 * optional member expr
 			 * `foo ? foo.bar : undefined` --> `foo?.bar`
@@ -251,11 +349,42 @@ export default createVisitor({
 		/**
 		 * Optional member expression and call expression
 		 * `foo && foo.bar` --> `foo?.bar`
+		 * `foo.bar && foo.bar()` --> `foo.bar?.()
 		 */
 		if (node.type === "JSLogicalExpression" && node.operator === "&&") {
 			const left = getVerifiedLeft(node.left);
 			if (!left) {
 				return signals.retain;
+			}
+
+			if (
+				node.right.type === "JSCallExpression" &&
+				isReferenceOrMemberExpression(node.right.callee)
+			) {
+				const newCallee = mergeMemberExpressions(
+					left,
+					node.right.callee,
+					{inclusive: true},
+				);
+				if (newCallee) {
+					const callExpression = {
+						...node.right,
+						callee: newCallee.node,
+					};
+					return path.addFixableDiagnostic(
+						{
+							fixed: signals.replace(
+								newCallee.sameLength
+									? jsOptionalCallExpression.create({
+											...callExpression,
+											optional: true,
+										})
+									: callExpression,
+							),
+						},
+						descriptions.LINT.JS_PREFER_OPTIONAL_CHAINING,
+					);
+				}
 			}
 
 			const right = getVerifiedRight(node.right);

--- a/internal/compiler/lint/suppressions.ts
+++ b/internal/compiler/lint/suppressions.ts
@@ -62,10 +62,7 @@ export function addSuppressions(
 		const lastComment = context.comments.getCommentsFromIds(
 			node.leadingComments,
 		).pop();
-		if (
-			lastComment !== undefined &&
-			lastComment.value.includes(SUPPRESSION_START)
-		) {
+		if (lastComment?.value.includes(SUPPRESSION_START)) {
 			updateComment = lastComment;
 		}
 		// Insert new comment if there's none to update

--- a/internal/compiler/lint/utils/aria/elementsToConceptsMap.ts
+++ b/internal/compiler/lint/utils/aria/elementsToConceptsMap.ts
@@ -5,32 +5,28 @@ export type MapOfElementsToConcepts = Map<string, Set<ARIARole>>;
 const elementsToConceptsMap: MapOfElementsToConcepts = new Map();
 
 for (const [, attributes] of ariaRolesMap) {
-	if (attributes.baseConcepts) {
-		attributes.baseConcepts.forEach(({module, concept}) => {
-			if (module === "HTML") {
-				if (!elementsToConceptsMap.has(concept.name)) {
-					elementsToConceptsMap.set(
-						concept.name,
-						new Set(attributes.superClassRole),
-					);
-				}
+	attributes.baseConcepts?.forEach(({module, concept}) => {
+		if (module === "HTML") {
+			if (!elementsToConceptsMap.has(concept.name)) {
+				elementsToConceptsMap.set(
+					concept.name,
+					new Set(attributes.superClassRole),
+				);
 			}
-		});
-	}
+		}
+	});
 }
 for (const [, attributes] of ariaRolesMap) {
-	if (attributes.baseConcepts) {
-		attributes.baseConcepts.forEach(({module, concept}) => {
-			if (module === "HTML") {
-				if (!elementsToConceptsMap.has(concept.name)) {
-					elementsToConceptsMap.set(
-						concept.name,
-						new Set(attributes.superClassRole),
-					);
-				}
+	attributes.baseConcepts?.forEach(({module, concept}) => {
+		if (module === "HTML") {
+			if (!elementsToConceptsMap.has(concept.name)) {
+				elementsToConceptsMap.set(
+					concept.name,
+					new Set(attributes.superClassRole),
+				);
 			}
-		});
-	}
+		}
+	});
 }
 
 export default elementsToConceptsMap;

--- a/internal/compiler/scope/evaluators/JSExportLocalDeclaration.ts
+++ b/internal/compiler/scope/evaluators/JSExportLocalDeclaration.ts
@@ -16,9 +16,8 @@ export default createScopeEvaluator({
 		scope.injectEvaluate(node.declaration, node);
 		for (const id of getBindingIdentifiers(node)) {
 			const binding = scope.getBinding(id.name);
-			if (binding !== undefined) {
-				binding.setExported(true);
-			}
+
+			binding?.setExported(true);
 		}
 	},
 });

--- a/internal/compiler/transforms/compile/validation/optimizeImports.ts
+++ b/internal/compiler/transforms/compile/validation/optimizeImports.ts
@@ -157,7 +157,7 @@ export default createVisitor({
 					isIdentifierish(node.object)
 				) {
 					const wildcardInfo = wildcardImports.get(node.object.name);
-					if (wildcardInfo !== undefined && wildcardInfo.references.has(node)) {
+					if (wildcardInfo?.references.has(node)) {
 						const name = getName(node);
 						if (name === undefined) {
 							throw new Error("Expected name");

--- a/internal/core/client/Client.ts
+++ b/internal/core/client/Client.ts
@@ -775,9 +775,7 @@ export default class Client {
 			reporter.error(markup`Failed to connect. Killing daemon.`);
 		}
 
-		if (proc !== undefined) {
-			proc.kill();
-		}
+		proc?.kill();
 
 		return undefined;
 	}

--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -112,7 +112,7 @@ export default createLocalCommand({
 					const description = license.get("description").asMap();
 					if (description.has("advice")) {
 						const advice = description.get("advice");
-						if (advice && advice.exists()) {
+						if (advice?.exists()) {
 							const diags = advice.asImplicitArray();
 							if (diags.length > 0) {
 								const actionDiagnostics = diags.filter((d) =>

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -496,9 +496,8 @@ export default class MemoryFileSystem {
 		// Remove from 'parent directory listing
 		const dirname = path.getParent();
 		const parentListing = this.directoryListings.get(dirname);
-		if (parentListing !== undefined) {
-			parentListing.delete(path);
-		}
+
+		parentListing?.delete(path);
 	}
 
 	private handleDeletedManifest(path: AbsoluteFilePath): void {
@@ -843,16 +842,12 @@ export default class MemoryFileSystem {
 			return false;
 		}
 
-		if (opts.tick !== undefined) {
-			opts.tick(directoryPath);
-		}
+		opts.tick?.(directoryPath);
 
 		this.addFileToDirectoryListing(directoryPath);
 		this.directories.set(directoryPath, stats);
 
-		if (opts.onFoundDirectory !== undefined) {
-			opts.onFoundDirectory(directoryPath);
-		}
+		opts.onFoundDirectory?.(directoryPath);
 
 		// Crawl the directory
 		const paths = await directoryPath.readDirectory();
@@ -1001,9 +996,7 @@ export default class MemoryFileSystem {
 			return false;
 		}
 
-		if (opts.tick !== undefined) {
-			opts.tick(path);
-		}
+		opts.tick?.(path);
 
 		const isNew = !this.files.has(path);
 		this.files.set(path, stats);

--- a/internal/core/server/fs/glob.ts
+++ b/internal/core/server/fs/glob.ts
@@ -262,9 +262,8 @@ class GlobberWatcher {
 		);
 
 		const {request} = this.globber;
-		if (request !== undefined) {
-			request.resources.add(refreshSub);
-		}
+
+		request?.resources.add(refreshSub);
 
 		try {
 			const promises: Promise<unknown>[] = [];

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -585,9 +585,7 @@ export default class ProjectManager {
 		this.projects.set(project.id, project);
 		this.projectDirectoryToProject.set(projectDirectory, project);
 
-		if (parentProject !== undefined) {
-			parentProject.children.add(project);
-		}
+		parentProject?.children.add(project);
 
 		// Add all project config dependencies so changes invalidate the whole project
 		if (meta.configPath !== undefined) {

--- a/internal/css-parser/parser/declaration.ts
+++ b/internal/css-parser/parser/declaration.ts
@@ -99,9 +99,9 @@ export function parseDeclaration(
 			});
 			return undefined;
 		}
-		if (onAtDeclaration) {
-			onAtDeclaration(currentToken, parentAtKeywordToken);
-		}
+
+		onAtDeclaration?.(currentToken, parentAtKeywordToken);
+
 		let name: string | CSSCustomProperty;
 		if (isCustomProperty(currentToken.value)) {
 			name = parser.finishNode(

--- a/internal/diagnostics/DiagnosticsNormalizer.ts
+++ b/internal/diagnostics/DiagnosticsNormalizer.ts
@@ -91,7 +91,7 @@ export default class DiagnosticsNormalizer {
 
 	private hasSourceMaps(): boolean {
 		const {sourceMaps} = this;
-		return sourceMaps !== undefined && sourceMaps.hasAny();
+		return sourceMaps?.hasAny() ?? false;
 	}
 
 	private couldNormalizeMarkup(): boolean {
@@ -214,7 +214,7 @@ export default class DiagnosticsNormalizer {
 		let {marker, path, start, end, integrity} = location;
 		let origPath = path;
 
-		if (sourceMaps !== undefined && sourceMaps.hasAny()) {
+		if (sourceMaps?.hasAny()) {
 			if (start !== undefined) {
 				const resolved = sourceMaps.approxOriginalPositionFor(
 					origPath,

--- a/internal/diagnostics/DiagnosticsProcessor.ts
+++ b/internal/diagnostics/DiagnosticsProcessor.ts
@@ -330,7 +330,7 @@ export default class DiagnosticsProcessor {
 				continue;
 			}
 
-			if (filter.test !== undefined && filter.test(diag)) {
+			if (filter.test?.(diag)) {
 				continue;
 			}
 
@@ -380,9 +380,8 @@ export default class DiagnosticsProcessor {
 						suppression,
 					)
 				) {
-					if (unusedSuppressions !== undefined) {
-						unusedSuppressions.delete(suppression);
-					}
+					unusedSuppressions?.delete(suppression);
+
 					if (!ignoreSuppressionsAndFilter) {
 						visibility.suppressed = true;
 					}
@@ -510,9 +509,8 @@ export default class DiagnosticsProcessor {
 				entry.guaranteedDiagnostics.push(diag);
 				this.setGuaranteedCount(this.guaranteedCount + 1);
 				entry.guaranteedCount++;
-				if (guaranteed !== undefined) {
-					guaranteed.push(diag);
-				}
+
+				guaranteed?.push(diag);
 			} else if (visibility.maybe) {
 				entry.maybeDiagnostics.push(diag);
 			} else if (visibility.suppressed) {

--- a/internal/events/Bridge.ts
+++ b/internal/events/Bridge.ts
@@ -133,9 +133,7 @@ export default class Bridge<
 			this.registerEvent(new BridgeEventBidirectional(name, this));
 		}
 
-		if (def.init !== undefined) {
-			def.init(this);
-		}
+		def.init?.(this);
 	}
 
 	private heartbeatTimeout: undefined | NodeJS.Timeout;

--- a/internal/events/BridgeEvent.ts
+++ b/internal/events/BridgeEvent.ts
@@ -134,9 +134,7 @@ export class BridgeEvent<
 
 		callbacks.resource.release();
 
-		if (callbacks.completed !== undefined) {
-			callbacks.completed();
-		}
+		callbacks.completed?.();
 	}
 
 	public hasSubscriptions(): boolean {

--- a/internal/events/Event.ts
+++ b/internal/events/Event.ts
@@ -39,9 +39,8 @@ export default class Event<Param, Ret = void> {
 
 	private onSubscriptionChange() {
 		const {onSubscriptionChange} = this.options;
-		if (onSubscriptionChange !== undefined) {
-			onSubscriptionChange();
-		}
+
+		onSubscriptionChange?.();
 	}
 
 	public async clear(): Promise<void> {

--- a/internal/project/utils.ts
+++ b/internal/project/utils.ts
@@ -89,10 +89,7 @@ export function getParentConfigDependencies(
 			basenames = basenames.concat(ESLINT_CONFIG_FILENAMES);
 		}
 
-		if (
-			partialConfig.vcs.root !== undefined &&
-			partialConfig.vcs.root.equal(directory)
-		) {
+		if (partialConfig.vcs.root?.equal(directory)) {
 			basenames = basenames.concat(VCS_IGNORE_FILENAMES);
 		}
 

--- a/website/api/server.js
+++ b/website/api/server.js
@@ -513,6 +513,7 @@ app.post(
 );
 
 app.use(function(err, req, res, next) {
+	// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 	if (Sentry !== undefined) {
 		Sentry.captureException(err);
 	}
@@ -536,6 +537,7 @@ async function main() {
 }
 
 main().catch((err) => {
+	// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 	if (Sentry !== undefined) {
 		Sentry.captureException(err);
 	}

--- a/website/src/_includes/scripts/funding.js
+++ b/website/src/_includes/scripts/funding.js
@@ -268,6 +268,7 @@ function openModal(tier) {
 
 	// Remove tier description if one exists
 	const existingTierDescription = document.querySelector(".modal .tier");
+	// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 	if (existingTierDescription != null) {
 		existingTierDescription.remove();
 	}

--- a/website/src/_includes/scripts/index.js
+++ b/website/src/_includes/scripts/index.js
@@ -345,6 +345,7 @@ class Manager {
 			return false;
 		}
 
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (callback !== undefined) {
 			callback();
 		}
@@ -370,11 +371,13 @@ class Manager {
 		const hash = target.getAttribute("href");
 		window.location.hash = hash;
 		this.scrollToHeading(hash);
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (navigator.clipboard !== undefined) {
 			navigator.clipboard.writeText(window.location.href);
 		}
 
 		// Only another copied text can appear here so delete it if it exists
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (target.nextElementSibling != null) {
 			target.nextElementSibling.remove();
 		}
@@ -544,6 +547,7 @@ function toggleColorSchemeSwitch(evt) {
 }
 
 const colorSchemeSwitcher = document.querySelector(".color-scheme-switch");
+// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 if (colorSchemeSwitcher != null) {
 	colorSchemeSwitcher.addEventListener("click", toggleColorSchemeSwitch, false);
 }
@@ -559,6 +563,7 @@ function toggleMobileSidebar() {
 	sidebar.classList.toggle("visible");
 	document.body.classList.toggle("no-scroll");
 }
+// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 if (mobileSidebarHandle != null) {
 	mobileSidebarHandle.addEventListener(
 		"click",
@@ -574,6 +579,7 @@ if (mobileSidebarHandle != null) {
 // Only initialize on focus
 
 const docsearchInput = document.querySelector("#docsearch");
+// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 if (docsearchInput != null) {
 	docsearchInput.addEventListener(
 		"focus",
@@ -690,6 +696,7 @@ for (const scroller of heroScrollers) {
 
 	function addActiveClasses(activeIndex) {
 		const beforeItem = items[activeIndex - 1];
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (beforeItem !== undefined) {
 			beforeItem.classList.add("active-sibling");
 		}
@@ -697,6 +704,7 @@ for (const scroller of heroScrollers) {
 		items[activeIndex].classList.add("active");
 
 		const afterItem = items[activeIndex + 1];
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (afterItem !== undefined) {
 			afterItem.classList.add("active-sibling");
 		}
@@ -704,6 +712,7 @@ for (const scroller of heroScrollers) {
 
 	function removeActiveClasses(activeIndex) {
 		const beforeItem = items[activeIndex - 1];
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (beforeItem !== undefined) {
 			beforeItem.classList.remove("active-sibling");
 		}
@@ -711,6 +720,7 @@ for (const scroller of heroScrollers) {
 		items[activeIndex].classList.remove("active");
 
 		const afterItem = items[activeIndex + 1];
+		// rome-ignore lint/js/preferOptionalChaining: netlify's node version does not support optional call expressions
 		if (afterItem !== undefined) {
 			afterItem.classList.remove("active-sibling");
 		}

--- a/website/src/docs/lint/rules/js/preferOptionalChaining.md
+++ b/website/src/docs/lint/rules/js/preferOptionalChaining.md
@@ -17,7 +17,7 @@ MISSING DOCUMENTATION
 
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:1840185864b23e929cb20ea1063aa9167ca67269,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:f5cb13ffce542bf4fc5c5c4a91f2bde5adecd65e,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
@@ -103,14 +103,16 @@ MISSING DOCUMENTATION
 ---
 
 {% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
+<span class="token comment">// leading binary comment</span>
 <span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token boolean">null</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">;</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:2</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:3</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
 
   <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token boolean">null</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">;</span>
+  <strong>  2</strong><strong> │ </strong><span class="token comment">// leading binary comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 3</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token boolean">null</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">;</span>
      <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
 
   <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
@@ -223,14 +225,16 @@ MISSING DOCUMENTATION
 ---
 
 {% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
+<span class="token comment">// leading ternary comment</span>
 <span class="token variable">foo</span> <span class="token punctuation">?</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">.</span><span class="token variable">baz</span> <span class="token punctuation">:</span> <span class="token variable">undefined</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:2</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:3</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
 
   <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token punctuation">?</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">.</span><span class="token variable">baz</span> <span class="token punctuation">:</span> <span class="token variable">undefined</span>
+  <strong>  2</strong><strong> │ </strong><span class="token comment">// leading ternary comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 3</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token punctuation">?</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span><span class="token punctuation">.</span><span class="token variable">baz</span> <span class="token punctuation">:</span> <span class="token variable">undefined</span>
      <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
 
   <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
@@ -242,20 +246,92 @@ MISSING DOCUMENTATION
 
 ---
 
-{% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
-<span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token variable">undefined</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span> <span class="token operator">!=</span> <span class="token boolean">null</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
-	<span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token string">&apos;baz&apos;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-<span class="token punctuation">}</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+<span class="token comment">// leading binary comment</span>
+<span class="token variable">foo</span> <span class="token operator">&amp;&amp;</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token punctuation">)</span></code></pre>{% endraw %}
 {% raw %}<pre class="language-text"><code class="language-text">
- <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:2:4</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:3</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
 
   <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
 
-  <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
-  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2</strong><strong> │ </strong><span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token variable">undefined</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span> <span class="token operator">!=</span> <span class="token boolean">null</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
-     <strong> │ </strong>    <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
-  <strong>  3</strong><strong> │ </strong>  <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token string">&apos;baz&apos;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-  <strong>  4</strong><strong> │ </strong><span class="token punctuation">}</span>
+  <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+  <strong>  2</strong><strong> │ </strong><span class="token comment">// leading binary comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 3</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token operator">&amp;&amp;</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token punctuation">)</span>
+     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>&amp;&amp;</strong></span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>foo</strong></span><span style="color: Tomato;">()</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span><span style="color: MediumSeaGreen;"><strong>?.</strong></span><span style="color: MediumSeaGreen;">()</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+<span class="token comment">// leading binary comment</span>
+<span class="token variable">foo</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token punctuation">)</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:3</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
+
+  <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+  <strong>  2</strong><strong> │ </strong><span class="token comment">// leading binary comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 3</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token punctuation">)</span>
+     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>&amp;&amp;</strong></span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>foo</strong></span><span style="color: Tomato;">.bar()</span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo</span><span style="color: MediumSeaGreen;"><strong>?</strong></span><span style="color: MediumSeaGreen;">.bar()</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+<span class="token comment">// leading ternary comment</span>
+<span class="token variable">foo</span> <span class="token punctuation">?</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">:</span> <span class="token variable">undefined</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:3</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
+
+  <strong>  1</strong><strong> │ </strong><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span>
+  <strong>  2</strong><strong> │ </strong><span class="token comment">// leading ternary comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 3</strong><strong> │ </strong><span class="token variable">foo</span> <span class="token punctuation">?</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">:</span> <span class="token variable">undefined</span>
+     <strong> │ </strong><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+
+  <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;">foo</span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;">?</span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>foo</strong></span><span style="color: Tomato;">.bar()</span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>:</strong></span><span style="color: Tomato;"><strong><span style="opacity: 0.8;">&middot;</span></strong></span><span style="color: Tomato;"><strong>undefined</strong></span>
+  <span style="color: MediumSeaGreen;">+</span> <span style="color: MediumSeaGreen;">foo?.bar()</span>
+
+</code></pre>{% endraw %}
+
+---
+
+{% raw %}<pre class="language-js"><code class="language-js"><span class="token keyword">let</span> <span class="token variable">foo</span> <span class="token operator">=</span> <span class="token punctuation">{</span><span class="token punctuation">}</span><span class="token punctuation">;</span>
+<span class="token comment">// leading if statement comment</span>
+<span class="token keyword">if</span> <span class="token punctuation">(</span>
+	<span class="token comment">// leading if condtion comment</span>
+	<span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token variable">undefined</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span> <span class="token operator">!=</span> <span class="token boolean">null</span>
+<span class="token punctuation">)</span> <span class="token punctuation">{</span>
+	<span class="token comment">// leading call expression comment comment</span>
+	<span class="token variable">foo</span><span class="token punctuation">.</span><span class="token function">bar</span><span class="token punctuation">(</span><span class="token string">&apos;baz&apos;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+<span class="token punctuation">}</span></code></pre>{% endraw %}
+{% raw %}<pre class="language-text"><code class="language-text">
+ <span style="text-decoration-style: dashed; text-decoration-line: underline;">filename.ts:5:1</span> <strong>lint/js/preferOptionalChaining</strong> <span style="color: #000; background-color: #ddd;"> FIXABLE </span> ━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Prefer optional chaining to manual checks.</span>
+
+  <strong>  3</strong><strong> │ </strong><span class="token keyword">if</span> <span class="token punctuation">(</span>
+  <strong>  4</strong><strong> │ </strong>  <span class="token comment">// leading if condtion comment</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 5</strong><strong> │ </strong>  <span class="token variable">foo</span> <span class="token operator">!=</span> <span class="token variable">undefined</span> <span class="token operator">&amp;&amp;</span> <span class="token variable">foo</span><span class="token punctuation">.</span><span class="token variable">bar</span> <span class="token operator">!=</span> <span class="token boolean">null</span>
+     <strong> │ </strong>  <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
+  <strong>  6</strong><strong> │ </strong><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+  <strong>  7</strong><strong> │ </strong>  <span class="token comment">// leading call expression comment comment</span>
 
   <strong><span style="color: rgb(38, 148, 255);">ℹ </span></strong><span style="color: rgb(38, 148, 255);">Safe fix</span>
 


### PR DESCRIPTION
## Summary

This PR is a follow up to #1143 & #1231. Now the rule also marks the code that can be written using optional call expressions as an error. Besides adding the OCE support I've also improved the auto fix to preserve the leading and trailing comment from the original code for OCE and optional member expressions.

## Test Plan

I've added the test cases for OCE and the once that check that the comment preservation works.

I have not yet pushed the auto fix for discovered `check` problems to see the CI output in GH actions
