### PR TITLE
feat(cli): add `suppressLogs` flag for `rome test`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,12 @@ And to update snapshots:
 ./rome test --update-snapshots
 ```
 
+To enable logging:
+
+```bash
+./rome test --no-suppress-logs
+```
+
 ### Generated files
 
 If you are adding a new lint rule, or modifying some core code, you might need to regenerate some files. We have generated files to avoid having to write a lot of boilerplate and automate common tasks.

--- a/internal/core/server/commands/ci.ts
+++ b/internal/core/server/commands/ci.ts
@@ -71,6 +71,7 @@ export default createServerCommand({
 								showAllCoverage: false,
 								syncTests: false,
 								sourceMaps: true,
+								suppressLogs: true,
 							},
 						);
 					},

--- a/internal/core/server/commands/test.ts
+++ b/internal/core/server/commands/test.ts
@@ -26,15 +26,41 @@ export default createServerCommand({
 	examples: [],
 	defineFlags(c: Consumer): Flags {
 		return {
-			filter: c.get("filter").asStringOrVoid(),
-			coverage: c.get("coverage").asBoolean(false),
-			showAllCoverage: c.get("showAllCoverage").asBoolean(false),
-			updateSnapshots: c.get("updateSnapshots").asBoolean(false),
-			freezeSnapshots: c.get("freezeSnapshots").asBoolean(false),
-			focusAllowed: c.get("focusAllowed").asBoolean(true),
-			syncTests: c.get("syncTests").asBoolean(false),
-			sourceMaps: c.get("sourceMaps").asBoolean(true),
-			suppressLogs: c.get("suppressLogs").asBoolean(true),
+			filter: c.get(
+				"filter",
+				{description: markup`filter tests using the provided string`},
+			).asStringOrVoid(),
+			coverage: c.get(
+				"coverage",
+				{description: markup`collect code coverage and print it`},
+			).asBoolean(false),
+			showAllCoverage: c.get(
+				"showAllCoverage",
+				{description: markup`show code coverage for all the tests`},
+			).asBoolean(false),
+			updateSnapshots: c.get(
+				"updateSnapshots",
+				{description: markup`update failing snapshots`},
+			).asBoolean(false),
+			freezeSnapshots: c.get(
+				"freezeSnapshots",
+				{description: markup`prevents snapshots from updating`},
+			).asBoolean(false),
+			focusAllowed: c.get(
+				"focusAllowed",
+				{description: markup`prevent tests from being focused`},
+			).asBoolean(true),
+			syncTests: c.get("syncTests", {description: markup`run tests in sync`}).asBoolean(
+				false,
+			),
+			sourceMaps: c.get(
+				"sourceMaps",
+				{description: markup`prevent sourceMaps from being generated`},
+			).asBoolean(true),
+			suppressLogs: c.get(
+				"suppressLogs",
+				{description: markup`print all logs to the console`},
+			).asBoolean(true),
 		};
 	},
 	async callback(req: ServerRequest, commandFlags: Flags): Promise<void> {

--- a/internal/core/server/commands/test.ts
+++ b/internal/core/server/commands/test.ts
@@ -14,7 +14,9 @@ import {JS_EXTENSIONS} from "../../common/file-handlers/javascript";
 import {TestServerRunnerOptions} from "../testing/types";
 import {markup} from "@internal/markup";
 
-type Flags = Omit<TestServerRunnerOptions, "verboseDiagnostics">;
+type Flags = Omit<TestServerRunnerOptions, "verboseDiagnostics"> & {
+	suppressLogs: boolean;
+};
 
 export default createServerCommand({
 	category: commandCategories.CODE_QUALITY,
@@ -32,6 +34,7 @@ export default createServerCommand({
 			focusAllowed: c.get("focusAllowed").asBoolean(true),
 			syncTests: c.get("syncTests").asBoolean(false),
 			sourceMaps: c.get("sourceMaps").asBoolean(true),
+			suppressLogs: c.get("suppressLogs").asBoolean(true),
 		};
 	},
 	async callback(req: ServerRequest, commandFlags: Flags): Promise<void> {

--- a/internal/core/server/testing/types.ts
+++ b/internal/core/server/testing/types.ts
@@ -26,6 +26,7 @@ export type TestServerRunnerOptions = {
 	verboseDiagnostics: DiagnosticsPrinterFlags["verboseDiagnostics"];
 	syncTests: boolean;
 	sourceMaps: boolean;
+	suppressLogs: boolean;
 };
 
 export type CoverageDirectory = {

--- a/internal/core/worker/test/TestWorkerFile.ts
+++ b/internal/core/worker/test/TestWorkerFile.ts
@@ -179,6 +179,10 @@ export default class TestWorkerFile {
 	}
 
 	private createConsole(): Partial<Console> {
+		if (!this.globalOptions.suppressLogs) {
+			return console;
+		}
+
 		const addDiagnostic = (category: DiagnosticLogCategory, args: unknown[]) => {
 			const err = new Error();
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for `--no-suppress-logs` flag for `rome test` so that logs can be viewed in all cases.

Thanks to @sebmck for the help.

## Test Plan

`./rome ci`
`./rome test`
`./rome test --no-suppress-logs`