### PR TITLE
fix(css-parser, formatter): rules inside media

### DIFF
--- a/internal/ast/css/media/CSSMediaQueryList.ts
+++ b/internal/ast/css/media/CSSMediaQueryList.ts
@@ -1,9 +1,10 @@
-import {CSSMediaQuery, NodeBaseWithComments} from "@internal/ast";
+import {CSSBlock, CSSMediaQuery, NodeBaseWithComments} from "@internal/ast";
 import {createBuilder} from "../../utils";
 
 export interface CSSMediaQueryList extends NodeBaseWithComments {
 	readonly type: "CSSMediaQueryList";
-	readonly value: CSSMediaQuery[];
+	readonly prelude: CSSMediaQuery[];
+	readonly block: CSSBlock;
 }
 
 export const cssMediaQueryList = createBuilder<CSSMediaQueryList>(
@@ -11,7 +12,8 @@ export const cssMediaQueryList = createBuilder<CSSMediaQueryList>(
 	{
 		bindingKeys: {},
 		visitorKeys: {
-			value: true,
+			prelude: true,
+			block: true,
 		},
 	},
 );

--- a/internal/css-parser/parser/media/index.ts
+++ b/internal/css-parser/parser/media/index.ts
@@ -16,6 +16,7 @@ import {
 import {descriptions} from "@internal/diagnostics";
 import {parseMediaCondition} from "@internal/css-parser/parser/media/comparison";
 import {AND, NOT} from "@internal/css-parser/utils";
+import {parseComplexBlock} from "@internal/css-parser/parser/block";
 
 function tryParseConditionWithoutOr(
 	parser: CSSParser,
@@ -194,10 +195,6 @@ function parseMedia(parser: CSSParser): CSSMediaQuery | undefined {
 		}
 	}
 
-	// } else if (token.type === "LeftParen") {
-
-	// }
-
 	return undefined;
 }
 
@@ -227,12 +224,16 @@ export function parseMediaList(parser: CSSParser): CSSMediaQueryList | undefined
 			list.push(media);
 		}
 	}
-
-	return parser.finishNode(
-		start,
-		{
-			type: "CSSMediaQueryList",
-			value: list,
-		},
-	);
+	const block = parseComplexBlock(parser);
+	if (block) {
+		return parser.finishNode(
+			start,
+			{
+				type: "CSSMediaQueryList",
+				prelude: list,
+				block,
+			},
+		);
+	}
+	return undefined;
 }

--- a/internal/css-parser/parser/rules.ts
+++ b/internal/css-parser/parser/rules.ts
@@ -106,10 +106,8 @@ export function parseAtRule(
 			break;
 		}
 		if (previousToken.value === "media") {
-			const value = parseMediaList(parser);
-			if (value) {
-				prelude.push(value);
-			}
+			block = parseMediaList(parser);
+			break;
 		}
 		if (previousToken.value === "keyframes") {
 			block = parseKeyframe(parser);

--- a/internal/css-parser/test-fixtures/invalid/media/feature-value-missing/input.test.md
+++ b/internal/css-parser/test-fixtures/invalid/media/feature-value-missing/input.test.md
@@ -9,24 +9,23 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation invalid/media/feature-value-missing/input.css 1:7-1:13
-							}
-							loc: SourceLocation invalid/media/feature-value-missing/input.css 1:6-1:31
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation invalid/media/feature-value-missing/input.css 1:7-1:13
 						}
-					]
-					loc: SourceLocation invalid/media/feature-value-missing/input.css 1:6-1:32
+						loc: SourceLocation invalid/media/feature-value-missing/input.css 1:6-1:31
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation invalid/media/feature-value-missing/input.css 1:32-1:34
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation invalid/media/feature-value-missing/input.css 1:32-1:34
+				loc: SourceLocation invalid/media/feature-value-missing/input.css 1:6-1:34
 			}
 			loc: SourceLocation invalid/media/feature-value-missing/input.css 1:0-1:34
 		}

--- a/internal/css-parser/test-fixtures/invalid/media/feature/input.test.md
+++ b/internal/css-parser/test-fixtures/invalid/media/feature/input.test.md
@@ -9,24 +9,23 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation invalid/media/feature/input.css 1:7-1:13
-							}
-							loc: SourceLocation invalid/media/feature/input.css 1:6-1:18
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation invalid/media/feature/input.css 1:7-1:13
 						}
-					]
-					loc: SourceLocation invalid/media/feature/input.css 1:6-1:18
+						loc: SourceLocation invalid/media/feature/input.css 1:6-1:18
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation invalid/media/feature/input.css 1:18-1:20
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation invalid/media/feature/input.css 1:18-1:20
+				loc: SourceLocation invalid/media/feature/input.css 1:6-1:20
 			}
 			loc: SourceLocation invalid/media/feature/input.css 1:0-1:20
 		}

--- a/internal/css-parser/test-fixtures/invalid/media/type/input.test.md
+++ b/internal/css-parser/test-fixtures/invalid/media/type/input.test.md
@@ -9,16 +9,15 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: []
+				block: CSSBlock {
 					value: []
-					loc: SourceLocation invalid/media/type/input.css 1:6-1:11
+					startingTokenValue: "{"
+					loc: SourceLocation invalid/media/type/input.css 1:11-1:13
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation invalid/media/type/input.css 1:11-1:13
+				loc: SourceLocation invalid/media/type/input.css 1:6-1:13
 			}
 			loc: SourceLocation invalid/media/type/input.css 1:0-1:13
 		}

--- a/internal/css-parser/test-fixtures/media/condition/input.css
+++ b/internal/css-parser/test-fixtures/media/condition/input.css
@@ -3,3 +3,11 @@
 @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
 @media not (min-width: 800px) {}
 @media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {}
+@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {
+	a {
+
+	}
+	.style {
+
+	}
+}

--- a/internal/css-parser/test-fixtures/media/condition/input.test.md
+++ b/internal/css-parser/test-fixtures/media/condition/input.test.md
@@ -9,403 +9,529 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaCondition {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeaturePlain {
-												name: CSSMediaFeatureName {
-													value: "min-width"
-													loc: SourceLocation media/condition/input.css 1:8-1:17
-												}
-												value: CSSMediaFeatureValue {
-													value: CSSDimension {
-														value: 800
-														unit: "px"
-														loc: SourceLocation media/condition/input.css 1:19-1:24
-													}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 1:8-1:17
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
 													loc: SourceLocation media/condition/input.css 1:19-1:24
 												}
-												loc: SourceLocation media/condition/input.css 1:8-1:24
+												loc: SourceLocation media/condition/input.css 1:19-1:24
 											}
 											loc: SourceLocation media/condition/input.css 1:8-1:24
 										}
-										loc: SourceLocation media/condition/input.css 1:7-1:25
+										loc: SourceLocation media/condition/input.css 1:8-1:24
 									}
-								]
-								loc: SourceLocation media/condition/input.css 1:7-1:26
-							}
-							loc: SourceLocation media/condition/input.css 1:6-1:26
+									loc: SourceLocation media/condition/input.css 1:7-1:25
+								}
+							]
+							loc: SourceLocation media/condition/input.css 1:7-1:26
 						}
-					]
-					loc: SourceLocation media/condition/input.css 1:6-1:26
+						loc: SourceLocation media/condition/input.css 1:6-1:26
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 1:26-1:28
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/condition/input.css 1:26-1:28
+				loc: SourceLocation media/condition/input.css 1:6-1:28
 			}
 			loc: SourceLocation media/condition/input.css 1:0-1:28
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaCondition {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeaturePlain {
-												name: CSSMediaFeatureName {
-													value: "min-width"
-													loc: SourceLocation media/condition/input.css 2:8-2:17
-												}
-												value: CSSMediaFeatureValue {
-													value: CSSDimension {
-														value: 800
-														unit: "px"
-														loc: SourceLocation media/condition/input.css 2:19-2:24
-													}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 2:8-2:17
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
 													loc: SourceLocation media/condition/input.css 2:19-2:24
 												}
-												loc: SourceLocation media/condition/input.css 2:8-2:24
+												loc: SourceLocation media/condition/input.css 2:19-2:24
 											}
 											loc: SourceLocation media/condition/input.css 2:8-2:24
 										}
-										loc: SourceLocation media/condition/input.css 2:7-2:25
+										loc: SourceLocation media/condition/input.css 2:8-2:24
 									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 2:31-2:40
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 2:42-2:47
-														}
-														loc: SourceLocation media/condition/input.css 2:42-2:47
-													}
-													loc: SourceLocation media/condition/input.css 2:31-2:47
-												}
-												loc: SourceLocation media/condition/input.css 2:31-2:47
-											}
-											loc: SourceLocation media/condition/input.css 2:30-2:48
-										}
-										loc: SourceLocation media/condition/input.css 2:26-2:48
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 2:54-2:63
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 2:65-2:70
-														}
-														loc: SourceLocation media/condition/input.css 2:65-2:70
-													}
-													loc: SourceLocation media/condition/input.css 2:54-2:70
-												}
-												loc: SourceLocation media/condition/input.css 2:54-2:70
-											}
-											loc: SourceLocation media/condition/input.css 2:53-2:71
-										}
-										loc: SourceLocation media/condition/input.css 2:49-2:71
-									}
-								]
-								loc: SourceLocation media/condition/input.css 2:7-2:72
-							}
-							loc: SourceLocation media/condition/input.css 2:6-2:72
-						}
-					]
-					loc: SourceLocation media/condition/input.css 2:6-2:72
-				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/condition/input.css 2:72-2:74
-			}
-			loc: SourceLocation media/condition/input.css 2:0-2:74
-		}
-		CSSAtRule {
-			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaCondition {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeaturePlain {
-												name: CSSMediaFeatureName {
-													value: "min-width"
-													loc: SourceLocation media/condition/input.css 3:8-3:17
-												}
-												value: CSSMediaFeatureValue {
-													value: CSSDimension {
-														value: 800
-														unit: "px"
-														loc: SourceLocation media/condition/input.css 3:19-3:24
-													}
-													loc: SourceLocation media/condition/input.css 3:19-3:24
-												}
-												loc: SourceLocation media/condition/input.css 3:8-3:24
-											}
-											loc: SourceLocation media/condition/input.css 3:8-3:24
-										}
-										loc: SourceLocation media/condition/input.css 3:7-3:25
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 3:31-3:40
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 3:42-3:47
-														}
-														loc: SourceLocation media/condition/input.css 3:42-3:47
-													}
-													loc: SourceLocation media/condition/input.css 3:31-3:47
-												}
-												loc: SourceLocation media/condition/input.css 3:31-3:47
-											}
-											loc: SourceLocation media/condition/input.css 3:30-3:48
-										}
-										loc: SourceLocation media/condition/input.css 3:26-3:48
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 3:54-3:63
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 3:65-3:70
-														}
-														loc: SourceLocation media/condition/input.css 3:65-3:70
-													}
-													loc: SourceLocation media/condition/input.css 3:54-3:70
-												}
-												loc: SourceLocation media/condition/input.css 3:54-3:70
-											}
-											loc: SourceLocation media/condition/input.css 3:53-3:71
-										}
-										loc: SourceLocation media/condition/input.css 3:49-3:71
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 3:77-3:86
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 3:88-3:93
-														}
-														loc: SourceLocation media/condition/input.css 3:88-3:93
-													}
-													loc: SourceLocation media/condition/input.css 3:77-3:93
-												}
-												loc: SourceLocation media/condition/input.css 3:77-3:93
-											}
-											loc: SourceLocation media/condition/input.css 3:76-3:94
-										}
-										loc: SourceLocation media/condition/input.css 3:72-3:94
-									}
-								]
-								loc: SourceLocation media/condition/input.css 3:7-3:95
-							}
-							loc: SourceLocation media/condition/input.css 3:6-3:95
-						}
-					]
-					loc: SourceLocation media/condition/input.css 3:6-3:95
-				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/condition/input.css 3:95-3:97
-			}
-			loc: SourceLocation media/condition/input.css 3:0-3:97
-		}
-		CSSAtRule {
-			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaCondition {
-								value: CSSMediaNot {
+									loc: SourceLocation media/condition/input.css 2:7-2:25
+								}
+								CSSMediaAnd {
 									value: CSSMediaInParens {
 										value: CSSMediaFeature {
 											value: CSSMediaFeaturePlain {
 												name: CSSMediaFeatureName {
 													value: "min-width"
-													loc: SourceLocation media/condition/input.css 4:12-4:21
+													loc: SourceLocation media/condition/input.css 2:31-2:40
 												}
 												value: CSSMediaFeatureValue {
 													value: CSSDimension {
 														value: 800
 														unit: "px"
-														loc: SourceLocation media/condition/input.css 4:23-4:28
+														loc: SourceLocation media/condition/input.css 2:42-2:47
 													}
+													loc: SourceLocation media/condition/input.css 2:42-2:47
+												}
+												loc: SourceLocation media/condition/input.css 2:31-2:47
+											}
+											loc: SourceLocation media/condition/input.css 2:31-2:47
+										}
+										loc: SourceLocation media/condition/input.css 2:30-2:48
+									}
+									loc: SourceLocation media/condition/input.css 2:26-2:48
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 2:54-2:63
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 2:65-2:70
+													}
+													loc: SourceLocation media/condition/input.css 2:65-2:70
+												}
+												loc: SourceLocation media/condition/input.css 2:54-2:70
+											}
+											loc: SourceLocation media/condition/input.css 2:54-2:70
+										}
+										loc: SourceLocation media/condition/input.css 2:53-2:71
+									}
+									loc: SourceLocation media/condition/input.css 2:49-2:71
+								}
+							]
+							loc: SourceLocation media/condition/input.css 2:7-2:72
+						}
+						loc: SourceLocation media/condition/input.css 2:6-2:72
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 2:72-2:74
+				}
+				loc: SourceLocation media/condition/input.css 2:6-2:74
+			}
+			loc: SourceLocation media/condition/input.css 2:0-2:74
+		}
+		CSSAtRule {
+			name: "media"
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 3:8-3:17
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
+													loc: SourceLocation media/condition/input.css 3:19-3:24
+												}
+												loc: SourceLocation media/condition/input.css 3:19-3:24
+											}
+											loc: SourceLocation media/condition/input.css 3:8-3:24
+										}
+										loc: SourceLocation media/condition/input.css 3:8-3:24
+									}
+									loc: SourceLocation media/condition/input.css 3:7-3:25
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 3:31-3:40
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 3:42-3:47
+													}
+													loc: SourceLocation media/condition/input.css 3:42-3:47
+												}
+												loc: SourceLocation media/condition/input.css 3:31-3:47
+											}
+											loc: SourceLocation media/condition/input.css 3:31-3:47
+										}
+										loc: SourceLocation media/condition/input.css 3:30-3:48
+									}
+									loc: SourceLocation media/condition/input.css 3:26-3:48
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 3:54-3:63
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 3:65-3:70
+													}
+													loc: SourceLocation media/condition/input.css 3:65-3:70
+												}
+												loc: SourceLocation media/condition/input.css 3:54-3:70
+											}
+											loc: SourceLocation media/condition/input.css 3:54-3:70
+										}
+										loc: SourceLocation media/condition/input.css 3:53-3:71
+									}
+									loc: SourceLocation media/condition/input.css 3:49-3:71
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 3:77-3:86
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 3:88-3:93
+													}
+													loc: SourceLocation media/condition/input.css 3:88-3:93
+												}
+												loc: SourceLocation media/condition/input.css 3:77-3:93
+											}
+											loc: SourceLocation media/condition/input.css 3:77-3:93
+										}
+										loc: SourceLocation media/condition/input.css 3:76-3:94
+									}
+									loc: SourceLocation media/condition/input.css 3:72-3:94
+								}
+							]
+							loc: SourceLocation media/condition/input.css 3:7-3:95
+						}
+						loc: SourceLocation media/condition/input.css 3:6-3:95
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 3:95-3:97
+				}
+				loc: SourceLocation media/condition/input.css 3:6-3:97
+			}
+			loc: SourceLocation media/condition/input.css 3:0-3:97
+		}
+		CSSAtRule {
+			name: "media"
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: CSSMediaNot {
+								value: CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 4:12-4:21
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
 													loc: SourceLocation media/condition/input.css 4:23-4:28
 												}
-												loc: SourceLocation media/condition/input.css 4:12-4:28
+												loc: SourceLocation media/condition/input.css 4:23-4:28
 											}
 											loc: SourceLocation media/condition/input.css 4:12-4:28
 										}
-										loc: SourceLocation media/condition/input.css 4:11-4:29
+										loc: SourceLocation media/condition/input.css 4:12-4:28
 									}
-									loc: SourceLocation media/condition/input.css 4:6-4:29
+									loc: SourceLocation media/condition/input.css 4:11-4:29
 								}
 								loc: SourceLocation media/condition/input.css 4:6-4:29
 							}
 							loc: SourceLocation media/condition/input.css 4:6-4:29
 						}
-					]
-					loc: SourceLocation media/condition/input.css 4:6-4:30
+						loc: SourceLocation media/condition/input.css 4:6-4:29
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 4:30-4:32
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/condition/input.css 4:30-4:32
+				loc: SourceLocation media/condition/input.css 4:6-4:32
 			}
 			loc: SourceLocation media/condition/input.css 4:0-4:32
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaCondition {
-								value: [
-									CSSMediaInParens {
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 5:8-5:17
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
+													loc: SourceLocation media/condition/input.css 5:19-5:24
+												}
+												loc: SourceLocation media/condition/input.css 5:19-5:24
+											}
+											loc: SourceLocation media/condition/input.css 5:8-5:24
+										}
+										loc: SourceLocation media/condition/input.css 5:8-5:24
+									}
+									loc: SourceLocation media/condition/input.css 5:7-5:25
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
 										value: CSSMediaFeature {
 											value: CSSMediaFeaturePlain {
 												name: CSSMediaFeatureName {
 													value: "min-width"
-													loc: SourceLocation media/condition/input.css 5:8-5:17
+													loc: SourceLocation media/condition/input.css 5:31-5:40
 												}
 												value: CSSMediaFeatureValue {
 													value: CSSDimension {
 														value: 800
 														unit: "px"
-														loc: SourceLocation media/condition/input.css 5:19-5:24
-													}
-													loc: SourceLocation media/condition/input.css 5:19-5:24
-												}
-												loc: SourceLocation media/condition/input.css 5:8-5:24
-											}
-											loc: SourceLocation media/condition/input.css 5:8-5:24
-										}
-										loc: SourceLocation media/condition/input.css 5:7-5:25
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 5:31-5:40
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 5:42-5:47
-														}
 														loc: SourceLocation media/condition/input.css 5:42-5:47
 													}
-													loc: SourceLocation media/condition/input.css 5:31-5:47
+													loc: SourceLocation media/condition/input.css 5:42-5:47
 												}
 												loc: SourceLocation media/condition/input.css 5:31-5:47
 											}
-											loc: SourceLocation media/condition/input.css 5:30-5:48
+											loc: SourceLocation media/condition/input.css 5:31-5:47
 										}
-										loc: SourceLocation media/condition/input.css 5:26-5:48
+										loc: SourceLocation media/condition/input.css 5:30-5:48
 									}
-									CSSMediaOr {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/condition/input.css 5:53-5:62
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/condition/input.css 5:64-5:69
-														}
+									loc: SourceLocation media/condition/input.css 5:26-5:48
+								}
+								CSSMediaOr {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 5:53-5:62
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
 														loc: SourceLocation media/condition/input.css 5:64-5:69
 													}
-													loc: SourceLocation media/condition/input.css 5:53-5:69
+													loc: SourceLocation media/condition/input.css 5:64-5:69
 												}
 												loc: SourceLocation media/condition/input.css 5:53-5:69
 											}
-											loc: SourceLocation media/condition/input.css 5:52-5:70
+											loc: SourceLocation media/condition/input.css 5:53-5:69
 										}
-										loc: SourceLocation media/condition/input.css 5:49-5:70
+										loc: SourceLocation media/condition/input.css 5:52-5:70
 									}
-								]
-								loc: SourceLocation media/condition/input.css 5:7-5:71
-							}
-							loc: SourceLocation media/condition/input.css 5:6-5:71
+									loc: SourceLocation media/condition/input.css 5:49-5:70
+								}
+							]
+							loc: SourceLocation media/condition/input.css 5:7-5:71
 						}
-					]
-					loc: SourceLocation media/condition/input.css 5:6-5:71
+						loc: SourceLocation media/condition/input.css 5:6-5:71
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 5:71-5:73
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/condition/input.css 5:71-5:73
+				loc: SourceLocation media/condition/input.css 5:6-5:73
 			}
 			loc: SourceLocation media/condition/input.css 5:0-5:73
+		}
+		CSSAtRule {
+			name: "media"
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaCondition {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/condition/input.css 6:8-6:17
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
+													loc: SourceLocation media/condition/input.css 6:19-6:24
+												}
+												loc: SourceLocation media/condition/input.css 6:19-6:24
+											}
+											loc: SourceLocation media/condition/input.css 6:8-6:24
+										}
+										loc: SourceLocation media/condition/input.css 6:8-6:24
+									}
+									loc: SourceLocation media/condition/input.css 6:7-6:25
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 6:31-6:40
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 6:42-6:47
+													}
+													loc: SourceLocation media/condition/input.css 6:42-6:47
+												}
+												loc: SourceLocation media/condition/input.css 6:31-6:47
+											}
+											loc: SourceLocation media/condition/input.css 6:31-6:47
+										}
+										loc: SourceLocation media/condition/input.css 6:30-6:48
+									}
+									loc: SourceLocation media/condition/input.css 6:26-6:48
+								}
+								CSSMediaOr {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/condition/input.css 6:53-6:62
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
+														loc: SourceLocation media/condition/input.css 6:64-6:69
+													}
+													loc: SourceLocation media/condition/input.css 6:64-6:69
+												}
+												loc: SourceLocation media/condition/input.css 6:53-6:69
+											}
+											loc: SourceLocation media/condition/input.css 6:53-6:69
+										}
+										loc: SourceLocation media/condition/input.css 6:52-6:70
+									}
+									loc: SourceLocation media/condition/input.css 6:49-6:70
+								}
+							]
+							loc: SourceLocation media/condition/input.css 6:7-6:71
+						}
+						loc: SourceLocation media/condition/input.css 6:6-6:71
+					}
+				]
+				block: CSSBlock {
+					value: [
+						CSSRule {
+							prelude: [
+								CSSSelector {
+									patterns: [
+										CSSTypeSelector {
+											value: "a"
+											loc: SourceLocation media/condition/input.css 7:1-7:2
+										}
+									]
+									loc: SourceLocation media/condition/input.css 7:1-7:3
+								}
+							]
+							block: CSSBlock {
+								value: []
+								startingTokenValue: "{"
+								loc: SourceLocation media/condition/input.css 7:3-9:2
+							}
+							loc: SourceLocation media/condition/input.css 7:1-9:2
+						}
+						CSSRule {
+							prelude: [
+								CSSSelector {
+									patterns: [
+										CSSClassSelector {
+											value: "style"
+											loc: SourceLocation media/condition/input.css 10:1-10:7
+										}
+									]
+									loc: SourceLocation media/condition/input.css 10:1-10:8
+								}
+							]
+							block: CSSBlock {
+								value: []
+								startingTokenValue: "{"
+								loc: SourceLocation media/condition/input.css 10:8-12:2
+							}
+							loc: SourceLocation media/condition/input.css 10:1-12:2
+						}
+					]
+					startingTokenValue: "{"
+					loc: SourceLocation media/condition/input.css 6:71-13:1
+				}
+				loc: SourceLocation media/condition/input.css 6:6-13:1
+			}
+			loc: SourceLocation media/condition/input.css 6:0-13:1
 		}
 	]
 	comments: []
 	corrupt: false
 	diagnostics: []
 	path: RelativePath<media/condition/input.css>
-	loc: SourceLocation media/condition/input.css 1:0-5:73
+	loc: SourceLocation media/condition/input.css 1:0-13:1
 }
 ```

--- a/internal/css-parser/test-fixtures/media/feature/input.test.md
+++ b/internal/css-parser/test-fixtures/media/feature/input.test.md
@@ -9,395 +9,389 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 1:7-1:13
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeatureBoolean {
-												value: "color"
-												loc: SourceLocation media/feature/input.css 1:19-1:24
-											}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 1:7-1:13
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeatureBoolean {
+											value: "color"
 											loc: SourceLocation media/feature/input.css 1:19-1:24
 										}
-										loc: SourceLocation media/feature/input.css 1:18-1:25
+										loc: SourceLocation media/feature/input.css 1:19-1:24
 									}
-								]
-								loc: SourceLocation media/feature/input.css 1:14-1:26
-							}
-							loc: SourceLocation media/feature/input.css 1:6-1:26
+									loc: SourceLocation media/feature/input.css 1:18-1:25
+								}
+							]
+							loc: SourceLocation media/feature/input.css 1:14-1:26
 						}
-					]
-					loc: SourceLocation media/feature/input.css 1:6-1:26
+						loc: SourceLocation media/feature/input.css 1:6-1:26
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 1:26-1:28
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 1:26-1:28
+				loc: SourceLocation media/feature/input.css 1:6-1:28
 			}
 			loc: SourceLocation media/feature/input.css 1:0-1:28
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							condition: "only"
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 2:12-2:18
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeatureBoolean {
-												value: "color"
-												loc: SourceLocation media/feature/input.css 2:24-2:29
-											}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						condition: "only"
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 2:12-2:18
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeatureBoolean {
+											value: "color"
 											loc: SourceLocation media/feature/input.css 2:24-2:29
 										}
-										loc: SourceLocation media/feature/input.css 2:23-2:30
+										loc: SourceLocation media/feature/input.css 2:24-2:29
 									}
-								]
-								loc: SourceLocation media/feature/input.css 2:19-2:31
-							}
-							loc: SourceLocation media/feature/input.css 2:6-2:31
+									loc: SourceLocation media/feature/input.css 2:23-2:30
+								}
+							]
+							loc: SourceLocation media/feature/input.css 2:19-2:31
 						}
-					]
-					loc: SourceLocation media/feature/input.css 2:6-2:31
+						loc: SourceLocation media/feature/input.css 2:6-2:31
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 2:31-2:33
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 2:31-2:33
+				loc: SourceLocation media/feature/input.css 2:6-2:33
 			}
 			loc: SourceLocation media/feature/input.css 2:0-2:33
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							condition: "only"
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 3:12-3:18
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeaturePlain {
-												name: CSSMediaFeatureName {
-													value: "min-width"
-													loc: SourceLocation media/feature/input.css 3:24-3:33
-												}
-												value: CSSMediaFeatureValue {
-													value: CSSDimension {
-														value: 800
-														unit: "px"
-														loc: SourceLocation media/feature/input.css 3:35-3:40
-													}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						condition: "only"
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 3:12-3:18
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/feature/input.css 3:24-3:33
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
 													loc: SourceLocation media/feature/input.css 3:35-3:40
 												}
-												loc: SourceLocation media/feature/input.css 3:24-3:40
+												loc: SourceLocation media/feature/input.css 3:35-3:40
 											}
 											loc: SourceLocation media/feature/input.css 3:24-3:40
 										}
-										loc: SourceLocation media/feature/input.css 3:23-3:41
+										loc: SourceLocation media/feature/input.css 3:24-3:40
 									}
-								]
-								loc: SourceLocation media/feature/input.css 3:19-3:42
-							}
-							loc: SourceLocation media/feature/input.css 3:6-3:42
+									loc: SourceLocation media/feature/input.css 3:23-3:41
+								}
+							]
+							loc: SourceLocation media/feature/input.css 3:19-3:42
 						}
-					]
-					loc: SourceLocation media/feature/input.css 3:6-3:42
+						loc: SourceLocation media/feature/input.css 3:6-3:42
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 3:42-3:44
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 3:42-3:44
+				loc: SourceLocation media/feature/input.css 3:6-3:44
 			}
 			loc: SourceLocation media/feature/input.css 3:0-3:44
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 4:7-4:13
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
-										value: CSSMediaFeature {
-											value: CSSMediaFeaturePlain {
-												name: CSSMediaFeatureName {
-													value: "min-width"
-													loc: SourceLocation media/feature/input.css 4:19-4:35
-												}
-												value: CSSMediaFeatureValue {
-													value: CSSDimension {
-														value: 800
-														unit: "px"
-														loc: SourceLocation media/feature/input.css 4:46-4:51
-													}
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 4:7-4:13
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/feature/input.css 4:19-4:35
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
 													loc: SourceLocation media/feature/input.css 4:46-4:51
 												}
-												loc: SourceLocation media/feature/input.css 4:19-4:51
+												loc: SourceLocation media/feature/input.css 4:46-4:51
 											}
 											loc: SourceLocation media/feature/input.css 4:19-4:51
 										}
-										loc: SourceLocation media/feature/input.css 4:18-4:60
+										loc: SourceLocation media/feature/input.css 4:19-4:51
 									}
-								]
-								loc: SourceLocation media/feature/input.css 4:14-4:61
-							}
-							loc: SourceLocation media/feature/input.css 4:6-4:61
+									loc: SourceLocation media/feature/input.css 4:18-4:60
+								}
+							]
+							loc: SourceLocation media/feature/input.css 4:14-4:61
 						}
-					]
-					loc: SourceLocation media/feature/input.css 4:6-4:61
+						loc: SourceLocation media/feature/input.css 4:6-4:61
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 4:61-4:63
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 4:61-4:63
+				loc: SourceLocation media/feature/input.css 4:6-4:63
 			}
 			loc: SourceLocation media/feature/input.css 4:0-4:63
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 5:7-5:13
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 5:7-5:13
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/feature/input.css 5:19-5:28
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
+													loc: SourceLocation media/feature/input.css 5:30-5:35
+												}
+												loc: SourceLocation media/feature/input.css 5:30-5:35
+											}
+											loc: SourceLocation media/feature/input.css 5:19-5:35
+										}
+										loc: SourceLocation media/feature/input.css 5:19-5:35
+									}
+									loc: SourceLocation media/feature/input.css 5:18-5:36
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
 										value: CSSMediaFeature {
 											value: CSSMediaFeaturePlain {
 												name: CSSMediaFeatureName {
 													value: "min-width"
-													loc: SourceLocation media/feature/input.css 5:19-5:28
+													loc: SourceLocation media/feature/input.css 5:42-5:51
 												}
 												value: CSSMediaFeatureValue {
 													value: CSSDimension {
 														value: 800
 														unit: "px"
-														loc: SourceLocation media/feature/input.css 5:30-5:35
-													}
-													loc: SourceLocation media/feature/input.css 5:30-5:35
-												}
-												loc: SourceLocation media/feature/input.css 5:19-5:35
-											}
-											loc: SourceLocation media/feature/input.css 5:19-5:35
-										}
-										loc: SourceLocation media/feature/input.css 5:18-5:36
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/feature/input.css 5:42-5:51
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/feature/input.css 5:53-5:58
-														}
 														loc: SourceLocation media/feature/input.css 5:53-5:58
 													}
-													loc: SourceLocation media/feature/input.css 5:42-5:58
+													loc: SourceLocation media/feature/input.css 5:53-5:58
 												}
 												loc: SourceLocation media/feature/input.css 5:42-5:58
 											}
-											loc: SourceLocation media/feature/input.css 5:41-5:59
+											loc: SourceLocation media/feature/input.css 5:42-5:58
 										}
-										loc: SourceLocation media/feature/input.css 5:37-5:59
+										loc: SourceLocation media/feature/input.css 5:41-5:59
 									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/feature/input.css 5:65-5:74
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/feature/input.css 5:76-5:81
-														}
+									loc: SourceLocation media/feature/input.css 5:37-5:59
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/feature/input.css 5:65-5:74
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
 														loc: SourceLocation media/feature/input.css 5:76-5:81
 													}
-													loc: SourceLocation media/feature/input.css 5:65-5:81
+													loc: SourceLocation media/feature/input.css 5:76-5:81
 												}
 												loc: SourceLocation media/feature/input.css 5:65-5:81
 											}
-											loc: SourceLocation media/feature/input.css 5:64-5:82
+											loc: SourceLocation media/feature/input.css 5:65-5:81
 										}
-										loc: SourceLocation media/feature/input.css 5:60-5:82
+										loc: SourceLocation media/feature/input.css 5:64-5:82
 									}
-								]
-								loc: SourceLocation media/feature/input.css 5:14-5:83
-							}
-							loc: SourceLocation media/feature/input.css 5:6-5:83
+									loc: SourceLocation media/feature/input.css 5:60-5:82
+								}
+							]
+							loc: SourceLocation media/feature/input.css 5:14-5:83
 						}
-					]
-					loc: SourceLocation media/feature/input.css 5:6-5:83
+						loc: SourceLocation media/feature/input.css 5:6-5:83
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 5:83-5:85
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 5:83-5:85
+				loc: SourceLocation media/feature/input.css 5:6-5:85
 			}
 			loc: SourceLocation media/feature/input.css 5:0-5:85
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/feature/input.css 6:7-6:13
-							}
-							conditionWithoutOr: CSSMediaConditionWithoutOr {
-								value: [
-									CSSMediaInParens {
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/feature/input.css 6:7-6:13
+						}
+						conditionWithoutOr: CSSMediaConditionWithoutOr {
+							value: [
+								CSSMediaInParens {
+									value: CSSMediaFeature {
+										value: CSSMediaFeaturePlain {
+											name: CSSMediaFeatureName {
+												value: "min-width"
+												loc: SourceLocation media/feature/input.css 6:19-6:28
+											}
+											value: CSSMediaFeatureValue {
+												value: CSSDimension {
+													value: 800
+													unit: "px"
+													loc: SourceLocation media/feature/input.css 6:30-6:35
+												}
+												loc: SourceLocation media/feature/input.css 6:30-6:35
+											}
+											loc: SourceLocation media/feature/input.css 6:19-6:35
+										}
+										loc: SourceLocation media/feature/input.css 6:19-6:35
+									}
+									loc: SourceLocation media/feature/input.css 6:18-6:36
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
 										value: CSSMediaFeature {
 											value: CSSMediaFeaturePlain {
 												name: CSSMediaFeatureName {
 													value: "min-width"
-													loc: SourceLocation media/feature/input.css 6:19-6:28
+													loc: SourceLocation media/feature/input.css 6:42-6:51
 												}
 												value: CSSMediaFeatureValue {
 													value: CSSDimension {
 														value: 800
 														unit: "px"
-														loc: SourceLocation media/feature/input.css 6:30-6:35
-													}
-													loc: SourceLocation media/feature/input.css 6:30-6:35
-												}
-												loc: SourceLocation media/feature/input.css 6:19-6:35
-											}
-											loc: SourceLocation media/feature/input.css 6:19-6:35
-										}
-										loc: SourceLocation media/feature/input.css 6:18-6:36
-									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/feature/input.css 6:42-6:51
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/feature/input.css 6:53-6:58
-														}
 														loc: SourceLocation media/feature/input.css 6:53-6:58
 													}
-													loc: SourceLocation media/feature/input.css 6:42-6:58
+													loc: SourceLocation media/feature/input.css 6:53-6:58
 												}
 												loc: SourceLocation media/feature/input.css 6:42-6:58
 											}
-											loc: SourceLocation media/feature/input.css 6:41-6:59
+											loc: SourceLocation media/feature/input.css 6:42-6:58
 										}
-										loc: SourceLocation media/feature/input.css 6:37-6:59
+										loc: SourceLocation media/feature/input.css 6:41-6:59
 									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/feature/input.css 6:65-6:74
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/feature/input.css 6:76-6:81
-														}
+									loc: SourceLocation media/feature/input.css 6:37-6:59
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/feature/input.css 6:65-6:74
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
 														loc: SourceLocation media/feature/input.css 6:76-6:81
 													}
-													loc: SourceLocation media/feature/input.css 6:65-6:81
+													loc: SourceLocation media/feature/input.css 6:76-6:81
 												}
 												loc: SourceLocation media/feature/input.css 6:65-6:81
 											}
-											loc: SourceLocation media/feature/input.css 6:64-6:82
+											loc: SourceLocation media/feature/input.css 6:65-6:81
 										}
-										loc: SourceLocation media/feature/input.css 6:60-6:82
+										loc: SourceLocation media/feature/input.css 6:64-6:82
 									}
-									CSSMediaAnd {
-										value: CSSMediaInParens {
-											value: CSSMediaFeature {
-												value: CSSMediaFeaturePlain {
-													name: CSSMediaFeatureName {
-														value: "min-width"
-														loc: SourceLocation media/feature/input.css 6:88-6:97
-													}
-													value: CSSMediaFeatureValue {
-														value: CSSDimension {
-															value: 800
-															unit: "px"
-															loc: SourceLocation media/feature/input.css 6:99-6:104
-														}
+									loc: SourceLocation media/feature/input.css 6:60-6:82
+								}
+								CSSMediaAnd {
+									value: CSSMediaInParens {
+										value: CSSMediaFeature {
+											value: CSSMediaFeaturePlain {
+												name: CSSMediaFeatureName {
+													value: "min-width"
+													loc: SourceLocation media/feature/input.css 6:88-6:97
+												}
+												value: CSSMediaFeatureValue {
+													value: CSSDimension {
+														value: 800
+														unit: "px"
 														loc: SourceLocation media/feature/input.css 6:99-6:104
 													}
-													loc: SourceLocation media/feature/input.css 6:88-6:104
+													loc: SourceLocation media/feature/input.css 6:99-6:104
 												}
 												loc: SourceLocation media/feature/input.css 6:88-6:104
 											}
-											loc: SourceLocation media/feature/input.css 6:87-6:105
+											loc: SourceLocation media/feature/input.css 6:88-6:104
 										}
-										loc: SourceLocation media/feature/input.css 6:83-6:105
+										loc: SourceLocation media/feature/input.css 6:87-6:105
 									}
-								]
-								loc: SourceLocation media/feature/input.css 6:14-6:105
-							}
-							loc: SourceLocation media/feature/input.css 6:6-6:105
+									loc: SourceLocation media/feature/input.css 6:83-6:105
+								}
+							]
+							loc: SourceLocation media/feature/input.css 6:14-6:105
 						}
-					]
-					loc: SourceLocation media/feature/input.css 6:6-6:105
+						loc: SourceLocation media/feature/input.css 6:6-6:105
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/feature/input.css 6:105-6:107
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/feature/input.css 6:105-6:107
+				loc: SourceLocation media/feature/input.css 6:6-6:107
 			}
 			loc: SourceLocation media/feature/input.css 6:0-6:107
 		}

--- a/internal/css-parser/test-fixtures/media/type/input.test.md
+++ b/internal/css-parser/test-fixtures/media/type/input.test.md
@@ -9,179 +9,173 @@ CSSRoot {
 	body: [
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 1:7-1:13
-							}
-							loc: SourceLocation media/type/input.css 1:6-1:14
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 1:7-1:13
 						}
-					]
-					loc: SourceLocation media/type/input.css 1:6-1:14
+						loc: SourceLocation media/type/input.css 1:6-1:14
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 1:14-1:16
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 1:14-1:16
+				loc: SourceLocation media/type/input.css 1:6-1:16
 			}
 			loc: SourceLocation media/type/input.css 1:0-1:16
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							condition: "not"
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 2:11-2:17
-							}
-							loc: SourceLocation media/type/input.css 2:6-2:18
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						condition: "not"
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 2:11-2:17
 						}
-					]
-					loc: SourceLocation media/type/input.css 2:6-2:18
+						loc: SourceLocation media/type/input.css 2:6-2:18
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 2:18-2:20
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 2:18-2:20
+				loc: SourceLocation media/type/input.css 2:6-2:20
 			}
 			loc: SourceLocation media/type/input.css 2:0-2:20
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							condition: "only"
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 3:12-3:18
-							}
-							loc: SourceLocation media/type/input.css 3:6-3:19
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						condition: "only"
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 3:12-3:18
 						}
-					]
-					loc: SourceLocation media/type/input.css 3:6-3:19
+						loc: SourceLocation media/type/input.css 3:6-3:19
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 3:19-3:21
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 3:19-3:21
+				loc: SourceLocation media/type/input.css 3:6-3:21
 			}
 			loc: SourceLocation media/type/input.css 3:0-3:21
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "print"
-								loc: SourceLocation media/type/input.css 4:7-4:12
-							}
-							loc: SourceLocation media/type/input.css 4:6-4:12
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "print"
+							loc: SourceLocation media/type/input.css 4:7-4:12
 						}
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 4:14-4:20
-							}
-							loc: SourceLocation media/type/input.css 4:14-4:21
+						loc: SourceLocation media/type/input.css 4:6-4:12
+					}
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 4:14-4:20
 						}
-					]
-					loc: SourceLocation media/type/input.css 4:6-4:21
+						loc: SourceLocation media/type/input.css 4:14-4:21
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 4:21-4:23
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 4:21-4:23
+				loc: SourceLocation media/type/input.css 4:6-4:23
 			}
 			loc: SourceLocation media/type/input.css 4:0-4:23
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 5:7-5:13
-							}
-							loc: SourceLocation media/type/input.css 5:6-5:13
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 5:7-5:13
 						}
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "all"
-								loc: SourceLocation media/type/input.css 5:15-5:18
-							}
+						loc: SourceLocation media/type/input.css 5:6-5:13
+					}
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "all"
 							loc: SourceLocation media/type/input.css 5:15-5:18
 						}
-						CSSMediaQuery {
-							value: CSSMediaType {
-								value: "print"
-								loc: SourceLocation media/type/input.css 5:20-5:25
-							}
-							loc: SourceLocation media/type/input.css 5:20-5:26
+						loc: SourceLocation media/type/input.css 5:15-5:18
+					}
+					CSSMediaQuery {
+						value: CSSMediaType {
+							value: "print"
+							loc: SourceLocation media/type/input.css 5:20-5:25
 						}
-					]
-					loc: SourceLocation media/type/input.css 5:6-5:26
+						loc: SourceLocation media/type/input.css 5:20-5:26
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 5:26-5:28
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 5:26-5:28
+				loc: SourceLocation media/type/input.css 5:6-5:28
 			}
 			loc: SourceLocation media/type/input.css 5:0-5:28
 		}
 		CSSAtRule {
 			name: "media"
-			prelude: [
-				CSSMediaQueryList {
-					value: [
-						CSSMediaQuery {
-							condition: "only"
-							value: CSSMediaType {
-								value: "screen"
-								loc: SourceLocation media/type/input.css 6:12-6:18
-							}
-							loc: SourceLocation media/type/input.css 6:6-6:18
+			prelude: []
+			block: CSSMediaQueryList {
+				prelude: [
+					CSSMediaQuery {
+						condition: "only"
+						value: CSSMediaType {
+							value: "screen"
+							loc: SourceLocation media/type/input.css 6:12-6:18
 						}
-						CSSMediaQuery {
-							condition: "not"
-							value: CSSMediaType {
-								value: "all"
-								loc: SourceLocation media/type/input.css 6:24-6:27
-							}
-							loc: SourceLocation media/type/input.css 6:20-6:27
+						loc: SourceLocation media/type/input.css 6:6-6:18
+					}
+					CSSMediaQuery {
+						condition: "not"
+						value: CSSMediaType {
+							value: "all"
+							loc: SourceLocation media/type/input.css 6:24-6:27
 						}
-						CSSMediaQuery {
-							condition: "only"
-							value: CSSMediaType {
-								value: "print"
-								loc: SourceLocation media/type/input.css 6:34-6:39
-							}
-							loc: SourceLocation media/type/input.css 6:29-6:40
+						loc: SourceLocation media/type/input.css 6:20-6:27
+					}
+					CSSMediaQuery {
+						condition: "only"
+						value: CSSMediaType {
+							value: "print"
+							loc: SourceLocation media/type/input.css 6:34-6:39
 						}
-					]
-					loc: SourceLocation media/type/input.css 6:6-6:40
+						loc: SourceLocation media/type/input.css 6:29-6:40
+					}
+				]
+				block: CSSBlock {
+					value: []
+					startingTokenValue: "{"
+					loc: SourceLocation media/type/input.css 6:40-6:42
 				}
-			]
-			block: CSSBlock {
-				value: []
-				startingTokenValue: "{"
-				loc: SourceLocation media/type/input.css 6:40-6:42
+				loc: SourceLocation media/type/input.css 6:6-6:42
 			}
 			loc: SourceLocation media/type/input.css 6:0-6:42
 		}

--- a/internal/formatter/builders/css/media/CSSMediaQueryList.ts
+++ b/internal/formatter/builders/css/media/CSSMediaQueryList.ts
@@ -5,8 +5,10 @@ export default function CSSMediaQueryList(
 	builder: Builder,
 	node: CSSMediaQueryList,
 ): Token {
-	return concat(
-		node.value.map((child, index) => {
+	const tokens: Token[] = [];
+
+	tokens.push(
+		...node.prelude.map((child, index) => {
 			const tokens: Token[] = [];
 			if (index > 0) {
 				tokens.push(",", space);
@@ -15,4 +17,6 @@ export default function CSSMediaQueryList(
 			return concat(tokens);
 		}),
 	);
+	tokens.push(builder.tokenize(node.block, node));
+	return concat(tokens);
 }

--- a/internal/formatter/test-fixtures/css/media/condition/input.css
+++ b/internal/formatter/test-fixtures/css/media/condition/input.css
@@ -3,3 +3,11 @@
 @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
 @media not (min-width: 800px) {}
 @media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {}
+@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {
+	a {
+
+	}
+	.style {
+
+	}
+}

--- a/internal/formatter/test-fixtures/css/media/condition/input.test.md
+++ b/internal/formatter/test-fixtures/css/media/condition/input.test.md
@@ -18,25 +18,40 @@
 @media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {}
 @media not (min-width: 800px) {}
 @media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {}
+@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {
+	a {
+
+	}
+	.style {
+
+	}
+}
 
 ```
 
 ### `Output`
 
 ```css
-@media (min-width: 800px)  {
+@media (min-width: 800px) {
 }
 
-@media (min-width: 800px) and (min-width: 800px) and (min-width: 800px)  {
+@media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {
 }
 
-@media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px)  {
+@media (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {
 }
 
-@media not (min-width: 800px) {
+@media not (min-width: 800px){
 }
 
-@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px)  {
+@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {
+}
+
+@media (min-width: 800px) and (min-width: 800px) or (min-width: 800px) {
+	a {
+	}
+	.style {
+	}
 }
 
 

--- a/internal/formatter/test-fixtures/css/media/features/input.test.md
+++ b/internal/formatter/test-fixtures/css/media/features/input.test.md
@@ -22,7 +22,7 @@
 ### `Output`
 
 ```css
-@media (min-width: 30em) and (orientation: landscape)  {
+@media (min-width: 30em) and (orientation: landscape) {
 }
 
 

--- a/internal/formatter/test-fixtures/css/media/smoke/input.test.md
+++ b/internal/formatter/test-fixtures/css/media/smoke/input.test.md
@@ -44,30 +44,30 @@ screen {
 ### `Output`
 
 ```css
-@media screen {
+@media screen{
 }
 
 
-@media not screen {
+@media not screen{
 }
 
 
-@media screen, not all, only print {
+@media screen, not all, only print{
 }
 
 
-@media only screen and (min-width: 800px) {
+@media only screen and (min-width: 800px){
 }
 
-@media screen and (min-width: 800px) {
-}
-
-
-@media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {
+@media screen and (min-width: 800px){
 }
 
 
-@media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) {
+@media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){
+}
+
+
+@media screen and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px) and (min-width: 800px){
 }
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #1460 

The issue was that I wrongly parsed the block after the media query, assuming they were declarations. Instead, there are supposed to be rules.

Hence, I changed the structure of the media query AST to mimic what we already have: `prelude` and `block`.
- `prelude` is the media query list
- `block` is a list of rules



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

This PR updates existing snapshots and adds new test cases
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
