### PR TITLE
docs(theme): correctly align theme toggle switch

### DIFF
--- a/website/src/styles/_sidebar.scss
+++ b/website/src/styles/_sidebar.scss
@@ -281,6 +281,7 @@
 	line-height: 16px;
 	background-color: var(--color-scheme-switcher-color);
 	border-radius: 15px;
+	padding: 0;
 	flex-shrink: 0;
 	cursor: pointer;
 	display: flex;


### PR DESCRIPTION


## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

The default padding on `button` elements isn't even on all sides, so it makes sense to remove it completely, since it looks like it was meant to be this way.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

look at the website and verify the new alignment.

before|after
---|---
<img width="80" alt="before, light mode" src="https://user-images.githubusercontent.com/6270048/117866059-f6c6e300-b296-11eb-9dfd-efbaffcb9307.png"> | <img width="74" alt="after, light mode" src="https://user-images.githubusercontent.com/6270048/117866062-f75f7980-b296-11eb-92fd-ac33c9e974c0.png">
<img width="75" alt="before, dark mode" src="https://user-images.githubusercontent.com/6270048/117866066-f7f81000-b296-11eb-8247-cd4d8fc6cc24.png"> | <img width="76" alt="after, dark mode" src="https://user-images.githubusercontent.com/6270048/117866065-f7f81000-b296-11eb-919d-f5c2fe0f3a64.png">







