### PR TITLE
fix(js-parser): handle JSXEmptyExpression position

### DIFF
--- a/internal/compiler/lint/rules/jsx/noCommentText.test.md
+++ b/internal/compiler/lint/rules/jsx/noCommentText.test.md
@@ -107,7 +107,7 @@ const a = <div>
 
 ```tsx
 const a = <div>
-	{} /* comment */
+	{/* comment */}
 </div>;
 
 ```
@@ -122,7 +122,7 @@ const a = <div>
 
 ```tsx
 const a = <div>
-	{} /** comment*/
+	{/** comment*/}
 </div>;
 
 ```

--- a/internal/js-parser/parser/jsx.ts
+++ b/internal/js-parser/parser/jsx.ts
@@ -200,18 +200,6 @@ function parseJSXAttributeValue(
 	}
 }
 
-// JSXEmptyExpression is unique type since it doesn't actually parse anything,
-// and so it should start at the end of last read token (left brace) and finish
-// at the beginning of the next one (right brace).
-function parseJSXEmptyExpression(parser: JSParser): JSXEmptyExpression {
-	return parser.finishNode(
-		parser.state.lastEndPos,
-		{
-			type: "JSXEmptyExpression",
-		},
-	);
-}
-
 // Parse JSX spread child
 function parseJSXSpreadChild(parser: JSParser): JSXSpreadChild {
 	const start = parser.getPosition();
@@ -244,8 +232,15 @@ function parseJSXExpressionContainer(parser: JSParser): JSXExpressionContainer {
 		"jsx expression container",
 	);
 	let expression;
+	const beforeBraceR = parser.getPosition();
 	if (match(parser, tt.braceR)) {
-		expression = parseJSXEmptyExpression(parser);
+		expression = parser.finishNodeAt<JSXEmptyExpression>(
+			start,
+			beforeBraceR,
+			{
+				type: "JSXEmptyExpression",
+			},
+		);
 	} else {
 		expression = parseExpression(parser, "jsx inner expression container");
 	}

--- a/internal/js-parser/test-fixtures/jsx/basic/10/input.test.md
+++ b/internal/js-parser/test-fixtures/jsx/basic/10/input.test.md
@@ -15,8 +15,9 @@ JSRoot {
 				children: [
 					JSXExpressionContainer {
 						expression: JSXEmptyExpression {
-							trailingComments: ["1"]
-							loc: SourceLocation jsx/basic/10/input.jsx 1:4-1:4
+							innerComments: ["1"]
+							trailingComments: []
+							loc: SourceLocation jsx/basic/10/input.jsx 1:3-1:27
 						}
 						loc: SourceLocation jsx/basic/10/input.jsx 1:3-1:28
 					}

--- a/internal/js-parser/test-fixtures/jsx/basic/empty-expression-container/input.test.md
+++ b/internal/js-parser/test-fixtures/jsx/basic/empty-expression-container/input.test.md
@@ -15,7 +15,7 @@ JSRoot {
 				children: [
 					JSXExpressionContainer {
 						expression: JSXEmptyExpression {
-							loc: SourceLocation jsx/basic/empty-expression-container/input.jsx 1:4-1:4
+							loc: SourceLocation jsx/basic/empty-expression-container/input.jsx 1:3-1:4
 						}
 						loc: SourceLocation jsx/basic/empty-expression-container/input.jsx 1:3-1:5
 					}

--- a/internal/js-parser/test-fixtures/jsx/errors/attribute-empty-expression/input.test.md
+++ b/internal/js-parser/test-fixtures/jsx/errors/attribute-empty-expression/input.test.md
@@ -19,7 +19,7 @@ JSRoot {
 						}
 						value: JSXExpressionContainer {
 							expression: JSXEmptyExpression {
-								loc: SourceLocation jsx/errors/attribute-empty-expression/input.jsx 1:10-1:10
+								loc: SourceLocation jsx/errors/attribute-empty-expression/input.jsx 1:9-1:10
 							}
 							loc: SourceLocation jsx/errors/attribute-empty-expression/input.jsx 1:9-1:11
 						}

--- a/internal/js-parser/test-fixtures/jsx/errors/unclosed-jsx-element/input.test.md
+++ b/internal/js-parser/test-fixtures/jsx/errors/unclosed-jsx-element/input.test.md
@@ -19,7 +19,7 @@ JSRoot {
 					}
 					JSXExpressionContainer {
 						expression: JSXEmptyExpression {
-							loc: SourceLocation jsx/errors/unclosed-jsx-element/input.jsx 1:12-1:12
+							loc: SourceLocation jsx/errors/unclosed-jsx-element/input.jsx 1:11-1:12
 						}
 						loc: SourceLocation jsx/errors/unclosed-jsx-element/input.jsx 1:11-1:13
 					}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Rome parser does not properly handle the JSXEmptyExpresssion's position. So the comments in JSXExptyExpression attached in `trailingComments`. (But I think it should be in `innerComments`).

- test.jsx
```js
const Foo = () => {
	return <>
		{/* comment */}
	</>
}
```
 - AST (`rome parse test.jsx`)
 
```text
// ...
  JSXExpressionContainer {
                          expression: JSXEmptyExpression {trailingComments: ["1"]}
                        }
//...
```

It's the reason why #1484 occured. The Formatter prints comment at the outside of JSXContainer (`{..}`). 
```
const Foo = () => {
        return <>
                {} /* comment */
        </>;
};
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

There was already test case (wrong, but will be fixed in this PR). see [internal/compiler/lint/rules/jsx/noCommentText.test.md](https://github.com/rome/tools/blob/main/internal/compiler/lint/rules/jsx/noCommentText.test.md#4-formatted)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
