### PR TITLE
feat(cli): interactive yes/no and suggestion selection for cli commands

### DIFF
--- a/internal/cli-flags/Parser.test.md
+++ b/internal/cli-flags/Parser.test.md
@@ -164,7 +164,67 @@
 
 ```
 
-## `command required with wrong command`
+## `command required with wrong command but multiple generated suggestions`
+
+### `flags`
+
+```javascript
+{}
+```
+
+### `help`
+
+```
+
+ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  test foo1 [flags]
+
+ Global Flags ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ℹ To view global flags run
+  $ rome --help
+
+
+```
+
+### `output`
+
+```
+
+```
+
+## `command required with wrong command but only one generated suggestion`
+
+### `flags`
+
+```javascript
+{}
+```
+
+### `help`
+
+```
+
+ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  test foobar [flags]
+
+ Global Flags ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ℹ To view global flags run
+  $ rome --help
+
+
+```
+
+### `output`
+
+```
+
+```
+
+## `command required with wrong command but provided suggestion`
 
 ### `help`
 
@@ -184,8 +244,6 @@
 
  Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  - foobar
-
   ℹ To view help for a specific command run
   $ test command_name --help
 
@@ -198,62 +256,12 @@
 
  argv:1:5 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Unknown command foo
+  ✖ Unknown command losg
 
-    test foo
-         ^^^
+    test losg
+         ^^^^
 
-  ℹ Did you mean foobar instead?
-
-    test foobar
-
-  ℹ To see all available commands run
-
-    test --help
-
-
-```
-
-## `command required with wrong command and suggestion`
-
-### `help`
-
-```
-
- Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  test [flags]
-
- Global Flags ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-                         --help, -h Show this help screen
-    --log-shell-completions <shell> Generate shell completion commands - values "fish" "bash"
-                                    "zsh")
-  --write-shell-completions <shell> Write shell completion commands - values "fish" "bash" "zsh"
-                                    )
-
- Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ℹ To view help for a specific command run
-  $ test command_name --help
-
-
-```
-
-### `output`
-
-```
-
- argv:1:5 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ Unknown command foo
-
-    test foo
-         ^^^
-
-  ℹ Did you mean foobar instead? A much cooler command
-
-    test foobar
+  ℹ Did you mean logs instead? A much cooler command
 
   ℹ To see all available commands run
 

--- a/internal/cli-reporter/Reporter.ts
+++ b/internal/cli-reporter/Reporter.ts
@@ -154,6 +154,7 @@ export default class Reporter implements ReporterNamespace {
 					cwd: CWD_PATH,
 					home: HOME_PATH,
 				},
+				stdin: process.stdin,
 			},
 		);
 

--- a/internal/string-utils/findClosesMatchingStrings.test.ts
+++ b/internal/string-utils/findClosesMatchingStrings.test.ts
@@ -1,0 +1,42 @@
+import {test} from "rome";
+import {findClosestMatchingStrings} from "./findClosestMatchingStrings";
+
+test(
+	"findClosestMatchingStrings",
+	(t) => {
+		t.looksLike(
+			findClosestMatchingStrings("french", ["quebec", "123", "france", "frenc"]),
+			["frenc"],
+		);
+		t.looksLike(
+			findClosestMatchingStrings("iphone", ["ipod", "iphone 5s", "iphones x"]),
+			["iphone 5s", "iphones x"],
+		);
+
+		t.looksLike(
+			findClosestMatchingStrings(
+				"iphone",
+				["ipod", "iphone 5s", "iphones x"],
+				0.9,
+			),
+			[],
+		);
+
+		t.looksLike(
+			findClosestMatchingStrings(
+				"french",
+				["quebec", "123", "france", "frenc"],
+				0.9,
+			),
+			[],
+		);
+		t.looksLike(
+			findClosestMatchingStrings(
+				"iphone",
+				["ipod", "iphone 5s", "iphones x"],
+				0.9,
+			),
+			[],
+		);
+	},
+);

--- a/internal/string-utils/findClosestMatchingStrings.ts
+++ b/internal/string-utils/findClosestMatchingStrings.ts
@@ -1,0 +1,19 @@
+import {orderBySimilarity} from "./orderBySimilarity";
+
+export function findClosestMatchingStrings(
+	name: string,
+	matches: string[],
+	minRating: number = 0.8,
+): string[] {
+	if (matches.length === 0) {
+		return [];
+	}
+
+	if (matches.length === 1) {
+		return matches;
+	}
+
+	return orderBySimilarity(name, matches).filter((match) =>
+		match.rating >= minRating
+	).map((match) => match.target);
+}

--- a/internal/string-utils/findClosestStringMatch.ts
+++ b/internal/string-utils/findClosestStringMatch.ts
@@ -5,27 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {orderBySimilarity} from "./orderBySimilarity";
+import {findClosestMatchingStrings} from "./findClosestMatchingStrings";
 
 export function findClosestStringMatch(
 	name: string,
 	matches: string[],
 	minRating: number = 0.8,
 ): undefined | string {
-	if (matches.length === 0) {
+	const ratings = findClosestMatchingStrings(name, matches, minRating);
+	if (ratings.length === 0) {
 		return undefined;
 	}
 
-	if (matches.length === 1) {
-		return matches[0];
+	if (ratings.length === 1) {
+		return ratings[0];
 	}
 
-	const ratings = orderBySimilarity(name, matches);
-	const bestMatch = ratings[0];
-
-	if (bestMatch.rating >= minRating) {
-		return bestMatch.target;
-	} else {
-		return undefined;
-	}
+	return ratings[0];
 }


### PR DESCRIPTION
## Summary
This pr resolves #974. 

## Test Plan

1. `rome chekc` suggests the following and the user can interactively select one
```
❯ Unknown command. Found matching commands: 
ℹ Use arrow keys and then enter to select an option
  ◉ check
  ◯ cache dir
  ◯ cache clear
```

2. `rome losg` suggests `rome logs` and the user can choose to execute `rome logs` or not
```
❯ Did you mean logs
ℹ Use arrow keys and then enter to select an option
  ◉ No (shortcut n)
  ◯ Yes (shortcut y)
```

3. throws error if it can't find a relevant match.

```
argv:1:9 flags/invalid  FATAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Unknown command kjsahdaslkjdlkasjdlksajldjkaslkdjalskjda

    dev-rome kjsahdaslkjdlkasjdlksajldjkaslkdjalskjda
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  ℹ To see all available commands run

    dev-rome --help

  ⚠ Rome exited as this error could not be handled and resulted in a fatal error. Please report if necessary.

```