### PR TITLE
chore: add .gitblameignore file for ignore revisions from git blame

### DIFF
--- a/.gitblameignore
+++ b/.gitblameignore
@@ -1,0 +1,14 @@
+#
+# This file can be used to ignore certain revisions from git blame results
+#
+# To use it once:
+#   $ git --ignore-revs-file .gitblameignore
+#
+# To use it all the time:
+#   $ git config --local blame.ignoreRevsFile .gitblameignore
+#
+# If you add a commit to this file, please include the message of the commit and a link to its PR
+#
+
+# Switch to hard tabs (https://github.com/rome/tools/pull/443)
+edc8d08272e8d60f175add47d367171857b81a2b


### PR DESCRIPTION
## Summary

This is useful for ignoring commits like "Switch to hard tabs (https://github.com/rome/tools/pull/443)" which are almost never what you are looking for

## Test Plan

```ignore
#
# This file can be used to ignore certain revisions from git blame results
#
# To use it once:
#   $ git --ignore-revs-file .gitblameignore
#
# To use it all the time:
#   $ git config --local blame.ignoreRevsFile .gitblameignore
#
# If you add a commit to this file, please include the message of the commit and a link to its PR
#
```