### PR TITLE
chore: Add .rgignore file

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,12 @@
+#
+# This file can be used to ignore certain files from ripgrep/vscode's search
+# results.
+#
+# Before you add anything to this file, keep in mind that it will affect
+# everyone's ability to grep for things. Consider creating your own local
+# `.rgignore` file in your `$HOME` directory.
+#
+
+# Checked-in pre-built version of Rome
+scripts/vendor/rome.cjs
+scripts/vendor/rome.cjs.map


### PR DESCRIPTION

## Summary

```
scripts/vendor/rome.cjs
scripts/vendor/rome.cjs.map
```

These two files show up in almost every search you could make in the rome repo. Adding them to `.rgignore` makes ripgrep (`rg`) ignore them when searching through files. ripgrep is also used by vscode so it cleans up the results you see there as well.

## Test Plan

Search for something in vscode, you shouldn't find anything in these files.


Also note that you can toggle this button to turn the ignore files on/off.

![Screen Shot 2021-05-17 at 4 02 23 PM](https://user-images.githubusercontent.com/952783/118572031-4ba1a800-b734-11eb-99ef-c0a575a531c2.png)
