### PR TITLE
Rome init missing argument

### DIFF
--- a/internal/core/client/commands/init.ts
+++ b/internal/core/client/commands/init.ts
@@ -33,6 +33,7 @@ export default createLocalCommand({
 				commandFlags: {
 					checkProject: true,
 				},
+				args: [], // TODO: What is supposed to be passed in here, if anything.
 			},
 			"server",
 		);

--- a/internal/core/server/commands/init.ts
+++ b/internal/core/server/commands/init.ts
@@ -73,7 +73,7 @@ export default createServerCommand<Flags>({
 		const {configType, indentSize, indentStyle, checkProject} = flags;
 
 		// Warn if provided with arguments
-		if (args.length > 0) {
+		if (args.length > 0) { // TODO: Should this assertion be changed?
 			req.expectArgumentLength(
 				0,
 				0,
@@ -96,7 +96,7 @@ export default createServerCommand<Flags>({
 		// - second part creates a basic configuration file and and the .editorconfig
 		// part of the command where we check if a configuration already exists
 		if (checkProject) {
-			req.expectArgumentLength(1);
+			req.expectArgumentLength(1); // TODO: Does this belong here at all?
 			// Check for sensitive directory
 			if (server.projectManager.isBannedProjectPath(cwd)) {
 				const diagnostic: Diagnostic = {


### PR DESCRIPTION
@ematipico in response to https://github.com/rome/tools/issues/1418#issuecomment-835376565

> Actually, the argument is expected to be passed. One of the most recent refactors broke the passage of arguments between commands using the Rome server.

I'm wondering what you expect this argument to be?