### PR TITLE
fix(cli): init command

### DIFF
--- a/internal/core/client/commands/init.ts
+++ b/internal/core/client/commands/init.ts
@@ -40,7 +40,7 @@ export default createLocalCommand({
 		if (hasProject.type !== "SUCCESS") {
 			return true;
 		}
-		if (hasProject.data === false) {
+		if (hasProject.data === true) {
 			client.reporter.warn(
 				markup`Rome has been already configured inside this project.`,
 			);
@@ -91,14 +91,19 @@ export default createLocalCommand({
 			markup`Please choose the size of the indentation (default 2)`,
 		);
 
-		const identSizeAsNumber = Number(indentSize);
-		if (isNaN(identSizeAsNumber) || identSizeAsNumber > 10) {
+		let identSizeAsNumber = Number(indentSize);
+		if (
+			isNaN(identSizeAsNumber) ||
+			identSizeAsNumber === 0 ||
+			identSizeAsNumber > 10
+		) {
 			client.reporter.warn(
 				markup`You inserted a value that is not a number o is greater than 10. Rome will fallback to the default value (1).`,
 			);
 			client.reporter.info(
 				markup`You can change this value later when this command is finished.`,
 			);
+			identSizeAsNumber = 1;
 		}
 
 		await client.query(

--- a/internal/core/common/file-handlers/index.ts
+++ b/internal/core/common/file-handlers/index.ts
@@ -90,6 +90,29 @@ export function getFileHandlerFromPath(
 	return {ext, handler};
 }
 
+/**
+ * Given an extension, it retrieves its relative file handler.
+ *
+ * If it doesn't exists, an error is thrown
+ * @param ext
+ * @param path
+ */
+export function getFileHandlerFromExtension(
+	ext: string,
+	path: Path,
+): Required<GetFileHandlerResult> {
+	const handler = DEFAULT_HANDLERS.get(ext);
+	if (!handler) {
+		throw createSingleDiagnosticsError({
+			description: descriptions.FILES.NO_FILE_HANLDER_EXTENSION(ext),
+			location: {
+				path,
+			},
+		});
+	}
+	return {handler, ext};
+}
+
 export function getFileHandlerFromPathAssert(
 	path: Path,
 	projectConfig: undefined | ProjectConfig,

--- a/internal/diagnostics/descriptions/files.ts
+++ b/internal/diagnostics/descriptions/files.ts
@@ -5,6 +5,11 @@ import {DiagnosticAdvice} from "../types";
 import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
 
 export const files = createDiagnosticsCategory({
+	NO_FILE_HANLDER_EXTENSION: (ext: string) => ({
+		category: DIAGNOSTIC_CATEGORIES["files/missingHandler"],
+		message: markup`Can't file a file handler for the extension <emphasis>${ext}</emphasis>`,
+	}),
+
 	NO_FILE_HANDLER: (path: Path) => {
 		let advice: DiagnosticAdvice[] = [];
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #1515 

There were few issues that I fixed here:
- the check on arguments is now dropped, because it's not needed;
- fixed the check `hasProject.data`;
- handled the case where the user inserts `0` as value for the tab size;
- add manually the project to the `ProjectManager`;
- changed the way the manifest of the project is retrieved. Before, we were interrogating the file system, although now we can't retrieve anymore from there (probably it changed recently). We now retrieve the manifest manually as we already have all the information we need;
- defaulting some values inside the `.editorconfig`. This fixes the case where we have empty a project with no files at all, Rome would create an empty file, which is not what we want. So, in case we don't have any extension, we set some defaults.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually checked

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
