### PR TITLE
fix(compiler): correct return in getOptional

### DIFF
--- a/internal/compiler/lib/VisitorState.ts
+++ b/internal/compiler/lib/VisitorState.ts
@@ -72,10 +72,9 @@ export default class VisitorState<State extends UnknownObject>
 	public getOptional(find?: FindState<State>): undefined | State {
 		const index = this.getIndex(find);
 		if (index === -1) {
-			throw new Error("VisitorState: Could not find stack");
-		} else {
-			return this.stack[index][0];
+			return undefined;
 		}
+		return this.stack[index][0];
 	}
 
 	public get(find?: FindState<State>): State {


### PR DESCRIPTION
## Summary
`getOptional` was throwing an error instead of returning `undefined`.

## Test Plan
`./rome ci`