### PR TITLE
fix: exit server process when daemon is stopped

### DIFF
--- a/internal/cli/server.ts
+++ b/internal/cli/server.ts
@@ -15,6 +15,7 @@ import setProcessTitle from "./utils/setProcessTitle";
 import net = require("net");
 import {loadUserConfig} from "@internal/core/common/userConfig";
 import {isBridgeEndDiagnosticsError} from "@internal/events";
+import {createResourceFromServer} from "@internal/resources";
 
 export default async function server() {
 	setProcessTitle("server");
@@ -40,6 +41,7 @@ export default async function server() {
 			}),
 		);
 	});
+	server.resources.add(createResourceFromServer(socketServer));
 
 	socketServer.on(
 		"error",

--- a/internal/core/client/Client.ts
+++ b/internal/core/client/Client.ts
@@ -737,6 +737,7 @@ export default class Client {
 					"server",
 					{
 						detached: true,
+						stdio: "ignore",
 					},
 				);
 				proc.unref();

--- a/internal/core/server/commands/stop.ts
+++ b/internal/core/server/commands/stop.ts
@@ -9,6 +9,7 @@ import {ServerRequest} from "@internal/core";
 import {commandCategories} from "../../common/commands";
 import {createServerCommand} from "../commands";
 import {markup} from "@internal/markup";
+import {safeProcessExit} from "@internal/resources";
 
 export default createServerCommand({
 	category: commandCategories.PROCESS_MANAGEMENT,
@@ -20,5 +21,6 @@ export default createServerCommand({
 	},
 	async callback({server}: ServerRequest) {
 		await server.end();
+		await safeProcessExit(0);
 	},
 });

--- a/internal/resources/factories.ts
+++ b/internal/resources/factories.ts
@@ -142,7 +142,7 @@ export function createResourceFromServer(server: net.Server, name: string = "net
     finalize: () => {
       return new Promise((resolve, reject) => {
         server.close((err) => {
-          if (err === undefined) {
+          if (err != null) {
             reject(err);
           } else {
             resolve();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Closes #1528 

  - Adds the socketServer as a resource so that it gets cleaned up when the server ends. 
  - Adds a `safeProcessExit(0)` to the server stop command. (Is this the right approach?)
  - Prevents a started daemon from inheriting stdio from the client.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Manually tested.

`./rome start`
```
ℹ No running daemon found. Starting one...
✔ Connected to daemon
✔ Started daemon!
```
`./rome stop`
```
✔ Connected to daemon
✔ Stopped server.
```
`./rome status`
```
✖ Server not running.
```
