### PR TITLE
fix(scripts): correct daemon socket path in dev-rome

### DIFF
--- a/internal/core/common/constants.ts
+++ b/internal/core/common/constants.ts
@@ -177,6 +177,7 @@ function getRuntimeDirectory(): AbsoluteFilePath {
 
 export const RUNTIME_DIRECTORY = getRuntimeDirectory();
 
+// Keep this in sync with getSocketPath in scripts/dev-rome.cjs
 function createPipePath(name: string): AbsoluteFilePath {
 	let basename = VERSION;
 

--- a/scripts/dev-rome.cjs
+++ b/scripts/dev-rome.cjs
@@ -44,6 +44,18 @@ function unlink(loc) {
 	}
 }
 
+/**
+ * @param version {string}
+ * @returns {string}
+ */
+function getSocketPath(version) {
+	if (process.platform === "win32") {
+		return String.raw`\\.\pipe\rome-${version}-server`;
+	}
+	const basedir = process.env.XDG_RUNTIME_DIR ?? os.tmpdir();
+	return path.join(basedir, "rome", `${version}-server.sock`);
+}
+
 //# Validate Node version
 
 // Format of node.version is "v12.6.0" so we want to slice off the v
@@ -74,7 +86,7 @@ async function isDevDaemonRunning() {
 	// If there is a running daemon then we shouldn't build and just use the existing bundle
 	// We'll log to let the developer know what's going on
 	const version = `${packageJson.version}-dev`;
-	const socketPath = path.join(os.tmpdir(), `rome-${version}.sock`);
+	const socketPath = getSocketPath(version);
 
 	return new Promise((resolve) => {
 		const socket = net.createConnection(

--- a/scripts/dev-rome.cjs
+++ b/scripts/dev-rome.cjs
@@ -45,6 +45,8 @@ function unlink(loc) {
 }
 
 /**
+ * Keep this in sync with createPipePath in internal/core/common/constants.ts
+ * 
  * @param version {string}
  * @returns {string}
  */


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This is an attempt to fix the socket path in dev-rome.cjs so that `./rome` commands can be run without rebuilding trunk if there's a running daemon. I haven't tested this on Windows. (I'll get setup for Windows testing at some point)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

Manually tested on macOS.

` ./rome start`
```
 Building trunk 
ℹ No running daemon found. Starting one...
✔ Connected to daemon
✔ Started daemon!
```

`./rome status`
```
!!!! A dev daemon is currently running. Skipping new build. !!!!
If you want to run new code and stop the daemon you can stop the daemon with:
$ ./rome stop

✔ Connected to daemon
{
  projects: [{id: 0}, {id: 1}]
  workers: [{astCacheSize: 0, heapTotal: 348_872_704, ownedBytes: 0n, ownedFileCount: 0, pid: 16_808, uptime: 6.303427065}]
  server: {heapTotal: 348_872_704, pid: 16_808, uptime: 6.303700889}
}
```
