### PR TITLE
fix: match sourceMappingURL to bundler hard-coded output filename

### DIFF
--- a/internal/core/server/bundler/BundleRequest.ts
+++ b/internal/core/server/bundler/BundleRequest.ts
@@ -75,7 +75,7 @@ export default class BundleRequest {
 		this.diagnostics.addAllowedUnusedSuppressionPrefix("lint");
 
 		this.sourceMap = new SourceMapGenerator({
-			path: createPath(this.resolvedEntry.getBasename()),
+			path: createPath("index.js"),
 		});
 
 		this.assets = new RelativePathMap();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Currently when bundling, the sourceMappingURL is incorrect because the bundle filename is hard-coded as 'index.js' but the sourceMappingURL is coming from the name of the entry file. This makes it harder for the debugger to find source maps.

As a temporary quick fix, is it reasonable to hard-code `index.js` here to match?