### PR TITLE
fix(diagnostic): compare diagnostic filter category by contents

### DIFF
--- a/internal/diagnostics/DiagnosticsProcessor.ts
+++ b/internal/diagnostics/DiagnosticsProcessor.ts
@@ -15,6 +15,7 @@ import {DiagnosticsError} from "./error-wrappers";
 import {
 	DIAGNOSTIC_CATEGORIES_SUPPRESS_DEPENDENCIES,
 	DiagnosticCategoryPrefix,
+	equalCategoryNames,
 } from "./categories";
 import {descriptions} from "./descriptions";
 import {matchesSuppression} from "@internal/compiler";
@@ -308,7 +309,7 @@ export default class DiagnosticsProcessor {
 
 			if (
 				filter.category !== undefined &&
-				filter.category !== diag.description.category
+				!equalCategoryNames(filter.category, diag.description.category)
 			) {
 				continue;
 			}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Diagnostic categories can be serialized over the bridge, so they should be compared by their contents not their identity. This was preventing the elimination filter in the LSP server from working.