### PR TITLE
fix(lsp): publish diagnostics from LSP server

### DIFF
--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -264,7 +264,10 @@ export default class ServerRequest {
 		);
 
 		this.reporter = query.silent
-			? new Reporter("ServerRequestSilent")
+			? new Reporter(
+					"ServerRequestSilent",
+					{markupOptions: client.reporter.markupOptions},
+				)
 			: client.reporter.fork();
 		this.resources.add(this.reporter);
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Closes #1540 

There are still problems with the LSP server that I’ll follow up on in separate issues, but this addresses three bugs related to publishing diagnostics.

1. The LSP server only published diagnostics for AbsoluteFilePaths but was receiving UIDPath instances.
2. The LSP server was attempting to mutate an immutable DiagnosticsProcessor.
3. And then the tricky one:


The CheckRunner was adding diagnostics to its processor keyed by UIDPath. When a file changes, it should remove old diagnostics for that path because they’re about to be recomputed. But it was attempting that with an AbsoluteFilePath, which didn’t remove the UIDPath-keyed diagnostics. So diagnostics were accumulating for the lifetime of the CheckRunner, and if you fixed a problem in an open file in VS Code, the diagnostic wouldn’t go away.

A quick fix could have been to attempt to remove old diagnostics using both an AbsoluteFilePath and its converted UIDPath, but there shouldn’t have been any UIDPath-keyed diagnostics on the processor at all. When adding diagnostics to a processor, they’re first mapped with a DiagnosticsNormalizer which can potentially turn UIDPaths into AbsoluteFilePaths, but it doesn’t have that ability built-in. Instead, its `normalizePath` method calls the `normalizePosition` function from its `markupOptions`, and it gets those `markupOptions` based on how the DiagnosticsProcessor is created.

 In the case of the CheckRunner, it uses the `createDiagnosticsProcessor` method on ServerRequest which passes in the `markupOptions` from its Reporter. The ServerRequest reporter is (usually) forked from the ServerClient reporter which in turn gets its `markupOptions` from the Logger instance on the Server. And that has a `normalizePosition` function that turns UIDPaths into AbsoluteFilePaths.

What was happening here is that the LSPServer creates server requests for its lint sessions using the `silent: true` option which causes the ServerRequest to create a new Reporter instead of forking the reporter from the ServerClient. And that new Reporter didn’t have any `markupOptions` and so the DiagnosticsNormalizer wasn’t able to work as intended. 