### PR TITLE
feat(project): support ignore files for eslint and prettier

### DIFF
--- a/internal/project/constants.ts
+++ b/internal/project/constants.ts
@@ -23,6 +23,11 @@ export const PRETTIER_CONFIG_FILESNAMES: string[] = [
 	".prettierr.json5",
 ];
 
+export const INTEGRATIONS_IGNORE_FILES: string[] = [
+	".prettierignore",
+	".eslintignore",
+];
+
 export const PROJECT_CONFIG_PACKAGE_JSON_FIELD = "rome";
 export const PROJECT_CONFIG_DIRECTORY = ".config";
 export const PROJECT_CONFIG_FILENAMES: string[] = [];


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds support for ignore files from `.eslintignore` and `.prettierignore` sources.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually checked on a project

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
