### PR TITLE
feat(integrations, project): new options for eslint integration

### DIFF
--- a/internal/core/worker/integrations/eslint.ts
+++ b/internal/core/worker/integrations/eslint.ts
@@ -6,20 +6,22 @@ import {Duration, DurationMeasurer} from "@internal/numbers";
 import {Position} from "@internal/parser-core";
 import {WorkerProject} from "../types";
 import Worker from "../Worker";
+import {Consumer} from "@internal/consume";
 
-const eslintLoader = new IntegrationLoader({
+const eslintLoader = new IntegrationLoader<Consumer, "eslint">({
 	name: "eslint",
 	range: "^7.0.0",
-	normalize: (consumer, cwd) => {
+	normalize: ({consumer, cwd, opts}) => {
 		const Factory = consumer.get("ESLint").asFunction();
 		const eslint = Reflect.construct(
 			Factory,
 			[
 				{
 					cwd: cwd.join(),
-					globInputPaths: false,
-					fix: true,
-					rulePaths: [],
+					fix: opts?.fix,
+					rulePaths: opts?.rulePaths,
+					extensions: opts?.extensions,
+					globInputPaths: opts?.globInputPaths,
 				},
 			],
 		);
@@ -49,7 +51,11 @@ export async function maybeRunESLint(
 
 	const diagnostics: Diagnostic[] = [];
 
-	const loader = await eslintLoader.load(project.configPath, project.directory);
+	const loader = await eslintLoader.load(
+		project.configPath,
+		project.directory,
+		project.config.integrations.eslint,
+	);
 
 	const ignored = await eslintLoader.wrap(async () => {
 		const isPathIgnored = loader.module.get("isPathIgnored").asWrappedFunction();

--- a/internal/core/worker/integrations/prettier.ts
+++ b/internal/core/worker/integrations/prettier.ts
@@ -3,11 +3,12 @@ import Worker from "../Worker";
 import {FileReference, WorkerProject} from "@internal/core";
 import {Duration, DurationMeasurer} from "@internal/numbers";
 import {Diagnostic} from "@internal/diagnostics";
+import {Consumer} from "@internal/consume";
 
-const prettierLoader = new IntegrationLoader({
+const prettierLoader = new IntegrationLoader<Consumer, "prettier">({
 	name: "prettier",
 	range: "^2.0.0",
-	normalize: (consumer) => {
+	normalize: ({consumer}) => {
 		return consumer;
 	},
 });

--- a/internal/project/constants.ts
+++ b/internal/project/constants.ts
@@ -8,10 +8,6 @@ import {CONFIG_EXTENSIONS} from "@internal/codec-config";
 export const VCS_IGNORE_FILENAMES = [".gitignore", ".hgignore"];
 
 export const ESLINT_CONFIG_FILENAMES: string[] = [
-	".eslintrc.js",
-	".eslintrc.cjs",
-	".eslintrc.yaml",
-	".eslintrc.yml",
 	".eslintrc.json",
 	".eslintignore",
 ];

--- a/internal/project/integrations/loadEslint.ts
+++ b/internal/project/integrations/loadEslint.ts
@@ -1,0 +1,25 @@
+import {consumeUnknown} from "@internal/consume";
+import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
+import {IntegrationEslintConfig, arrayOfStrings} from "@internal/project";
+import {json} from "@internal/codec-config";
+
+export function loadEslint(file: string): Partial<IntegrationEslintConfig> {
+	const config: Partial<IntegrationEslintConfig> = {};
+	const data = json.parse({input: file});
+	const eslint = consumeUnknown(data, DIAGNOSTIC_CATEGORIES.eslint, "json");
+
+	if (eslint.has("globInputPaths")) {
+		config.globInputPaths = eslint.get("globInputPaths").asBoolean();
+	}
+	if (eslint.has("extensions")) {
+		config.extensions = arrayOfStrings(eslint.get("extensions"));
+	}
+	if (eslint.has("fix")) {
+		config.fix = eslint.get("fix").asBoolean();
+	}
+	if (eslint.has("rulePaths")) {
+		config.rulePaths = arrayOfStrings(eslint.get("rulePaths"));
+	}
+
+	return config;
+}

--- a/internal/project/integrations/loadPrettier.ts
+++ b/internal/project/integrations/loadPrettier.ts
@@ -1,13 +1,13 @@
 import {consumeUnknown} from "@internal/consume";
 import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
-import {PrettierConfig} from "@internal/project";
+import {IntegrationPrettierConfig} from "@internal/project";
 import {json, json5} from "@internal/codec-config";
 
 export function loadPrettier(
 	file: string,
 	extension: string,
-): Partial<PrettierConfig> {
-	const config: Partial<PrettierConfig> = {};
+): Partial<IntegrationPrettierConfig> {
+	const config: Partial<IntegrationPrettierConfig> = {};
 	let data: unknown;
 	// NOTE: we only support json for now
 	if (extension === "json5") {

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -31,6 +31,7 @@ import {CachedFileReader} from "@internal/fs";
 import {parseSemverRange} from "@internal/codec-semver";
 import {descriptions} from "@internal/diagnostics";
 import {
+	ESLINT_CONFIG_FILENAMES,
 	INTEGRATIONS_IGNORE_FILES,
 	PRETTIER_CONFIG_FILESNAMES,
 	PROJECT_CONFIG_PACKAGE_JSON_FIELD,
@@ -41,6 +42,7 @@ import {sha256} from "@internal/string-utils";
 import {resolveBrowsers} from "@internal/codec-browsers";
 import {ParserOptions} from "@internal/parser-core";
 import {loadPrettier} from "@internal/project/integrations/loadPrettier";
+import {loadEslint} from "@internal/project/integrations/loadEslint";
 
 type NormalizedPartial = {
 	partial: PartialProjectConfig;
@@ -127,6 +129,20 @@ export async function loadCompleteProjectConfig(
 			config.integrations.prettier = {
 				...config.integrations.prettier,
 				...prettierConfig,
+			};
+		}
+	}
+
+	// Load extensions configuration of eslint
+	for (const eslintFile of ESLINT_CONFIG_FILENAMES) {
+		const possiblePath = projectDirectory.append(eslintFile);
+		meta.configDependencies.add(possiblePath);
+		if (await possiblePath.exists()) {
+			const file = await reader.readFileText(possiblePath);
+			const eslintConfig = loadEslint(file);
+			config.integrations.eslint = {
+				...config.integrations.eslint,
+				...eslintConfig,
 			};
 		}
 	}

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -103,7 +103,7 @@ export type ProjectConfigObjects = {
 	targets: Map<string, GetBrowserProps[]>;
 };
 
-export type PrettierConfig = {
+export type IntegrationPrettierConfig = {
 	printWidth: number;
 	tabWidth: number;
 	useTabs: boolean;
@@ -111,10 +111,17 @@ export type PrettierConfig = {
 	singleQuote: boolean;
 };
 
+export type IntegrationEslintConfig = {
+	fix: boolean;
+	extensions: string[];
+	rulePaths: string[];
+	globInputPaths: boolean;
+};
+
 export type ProjectConfigIntegrations = {
-	eslint: Enableable;
+	eslint: Enableable & Partial<IntegrationEslintConfig>;
 	typescriptChecker: Enableable;
-	prettier: Enableable & Partial<PrettierConfig>;
+	prettier: Enableable & Partial<IntegrationPrettierConfig>;
 };
 
 export type ProjectConfigCategoriesWithIgnore = "tests" | "lint";
@@ -223,7 +230,7 @@ export type RawUserProjectConfig = DeepPartial<{
 	integrations: {
 		eslint: Enableable;
 		typescriptChecker: Enableable;
-		prettier: Enableable & Partial<PrettierConfig>;
+		prettier: Enableable & Partial<IntegrationPrettierConfig>;
 	};
 }>;
 

--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -134,11 +134,11 @@ If your project uses `.prettierrc` already, Rome will load the configuration and
 Alternatively, you can configure `prettier` inside Rome's configuration. Rome supports only a
 subset of options:
 
-- [printWidth](https://prettier.io/docs/en/options.html#print-width);
-- [tabWidth](https://prettier.io/docs/en/options.html#tab-width);
-- [useTabs](https://prettier.io/docs/en/options.html#tabs);
-- [semi](https://prettier.io/docs/en/options.html#semicolons);
-- [singleQuote](https://prettier.io/docs/en/options.html#quotes);
+- [`printWidth`](https://prettier.io/docs/en/options.html#print-width);
+- [`tabWidth`](https://prettier.io/docs/en/options.html#tab-width);
+- [`useTabs`](https://prettier.io/docs/en/options.html#tabs);
+- [`semi`](https://prettier.io/docs/en/options.html#semicolons);
+- [`singleQuote`](https://prettier.io/docs/en/options.html#quotes);
 
 The rest of options will be ignored and won't be passed to `prettier`.
 
@@ -169,7 +169,56 @@ Ultimately, the configuration will look like this:
 
 ### `integrations.eslint`
 
-MISSING DOCUMENTATION
+You can use Rome to lint your code using eslint. In order to integrate it,
+you have to install `eslint` in your project and enabled the integration via Rome:
+
+```bash
+rome config enable integrations.eslint
+```
+
+> The minimum `eslint`'s version supported is `7.0.0`;
+
+Now, when you run `./rome check --apply`, Rome will use `prettier` to format your code.
+
+If your project uses `.eslint.json` already, Rome will load the configuration and pass it to
+`eslint`.
+
+Alternatively, you can configure `eslint` inside Rome's configuration. Rome supports only a
+subset of options:
+
+- `fix`
+- `extensions`
+- `globInputPaths`
+- `rulePaths`
+
+You can find more information in the [eslint webpage](https://eslint.org/docs/developer-guide/nodejs-api#parameters).
+
+The rest of options will be ignored and won't be passed to `eslint`.
+
+Ultimately, the configuration will look like this:
+
+```json
+{
+	"rome": {
+		"root": true,
+		"name": "fancy-project",
+		"lint": {
+			"enabled": false
+		},
+		"format": {
+			"enabled": false
+		},
+		"integrations": {
+			"eslint": {
+				"fix": true,
+				"extensions": [".js", ".ts", ".jsx"],
+				"globInputPaths": false,
+				"rulePaths":  ["./path/to/rules", "../../path/to/other/rules"]
+			}
+		}
+	}
+}
+```
 
 ### Supported Locations
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #1570 

This PR does two things:
- adds few more options that can be passed to `eslint`;
- possibility to add these options via Rome's configuration file or via `.eslintrc.json`;
- extended the integration loader, by passing a typed `opts` object

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
