### PR TITLE
fix: regressions in decisions and review command

### DIFF
--- a/internal/compiler/lib/CompilerPath.ts
+++ b/internal/compiler/lib/CompilerPath.ts
@@ -446,6 +446,7 @@ export default class CompilerPath {
 			{
 				...description,
 				advice,
+				verboseAdvice,
 			},
 			{
 				...diag,

--- a/internal/compiler/lint/suppressions.ts
+++ b/internal/compiler/lint/suppressions.ts
@@ -7,7 +7,7 @@
 
 import {AnyComment, AnyNode, AnyRoot} from "@internal/ast";
 import {CompilerContext, signals} from "@internal/compiler";
-import {OneIndexed} from "@internal/numbers";
+import {IndexedNumberSet, OneIndexed} from "@internal/numbers";
 import CompilerPath from "../lib/CompilerPath";
 import {LintCompilerOptionsDecision} from "../types";
 import {injectComment} from "../transforms/helpers";
@@ -39,7 +39,7 @@ export function addSuppressions(
 		return ast;
 	}
 
-	const visitedLines: Set<OneIndexed> = new Set();
+	const visitedLines = new IndexedNumberSet<OneIndexed>();
 
 	function addComment(
 		path: CompilerPath,

--- a/internal/core/client/review.ts
+++ b/internal/core/client/review.ts
@@ -158,7 +158,7 @@ async function ask(
 
 	if (hasExtraOptions) {
 		if (showMoreOptions) {
-			options.more = {
+			options.less = {
 				label: markup`Less options...`,
 				shortcut: "l",
 			};
@@ -181,6 +181,7 @@ async function ask(
 		wrapErrors: true,
 	});
 	diag = printer.processor.normalizer.normalizeDiagnostic(diag);
+	printer.processor.addDiagnostic(diag);
 	await printer.print({showFooter: false});
 
 	const answer = await reporter.radio(

--- a/internal/numbers/indexed.ts
+++ b/internal/numbers/indexed.ts
@@ -86,7 +86,7 @@ enhanceNodeInspectClass(
 export class IndexedNumberSet<Indexed extends IndexedNumber>
 	extends MappedSet<Indexed, number> {
 	constructor(entries?: Iterable<Indexed>) {
-		super((line) => [line.valueOf(), line], entries);
+		super((num) => [num.valueOf(), num], entries);
 	}
 }
 

--- a/internal/numbers/indexed.ts
+++ b/internal/numbers/indexed.ts
@@ -1,3 +1,4 @@
+import {MappedSet} from "@internal/collections";
 import {enhanceNodeInspectClass} from "@internal/node";
 import {isObject} from "@internal/typescript-helpers";
 
@@ -81,6 +82,15 @@ enhanceNodeInspectClass(
 		return `OneIndexedNumber<${inst.valueOf()}>`;
 	},
 );
+
+export class IndexedNumberSet<Indexed extends IndexedNumber>
+	extends MappedSet<Indexed, number> {
+	constructor(entries?: Iterable<Indexed>) {
+		super((line) => [line.valueOf(), line], entries);
+	}
+}
+
+IndexedNumberSet.prototype[Symbol.toStringTag] = "IndexedNumberSet";
 
 export type IndexedNumber = OneIndexed | ZeroIndexed;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Closes #1579 

- Include `verboseAdvice` options when reviewing diagnostics
- Display the diagnostic that the user is being asked to review
- Fix `less` option so that it toggles back to original options
- Prevent injecting multiple duplicate suppression comments
