### PR TITLE
fix: await refreshFileEvent when adding new files

### DIFF
--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -1063,7 +1063,7 @@ export default class MemoryFileSystem {
 		}
 
 		if (isNew) {
-			this.server.refreshFileEvent.push({type: "CREATED", path});
+			await this.server.refreshFileEvent.push({type: "CREATED", path});
 		}
 
 		return true;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #1437

Awaiting the `refreshFileEvent` push allows paths to be batched [in this subscription](https://github.com/rome/tools/blob/0c870f6fb6bf4f35033afabc4dbd44eeafdc2e97/internal/core/server/fs/glob.ts#L252) before this [promise](https://github.com/rome/tools/blob/0c870f6fb6bf4f35033afabc4dbd44eeafdc2e97/internal/core/server/fs/glob.ts#L283) resolves, preventing an initial checker run with zero paths.

Previously, the `newFileEvent` push had been awaited there. Was that await intentionally removed, or was that just a mistake?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->