### PR TITLE
WIP: fix(core): Display diagnostics if auto-config fails

### DIFF
--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -45,20 +45,11 @@ export default createLocalCommand({
 			return false;
 		}
 
-		const res = await req.client.query(
-			{
-				commandName: "auto-config",
-			},
-			"server",
+		const data = consumeUnknown(
+			result.data,
+			DIAGNOSTIC_CATEGORIES.parse,
+			"json",
 		);
-
-		if (res.type !== "SUCCESS") {
-			reporter.log(
-				markup`Something went wrong during the execution of the command.`,
-			);
-			return true;
-		}
-		const data = consumeUnknown(res.data, DIAGNOSTIC_CATEGORIES.parse, "json");
 
 		if (!data.exists()) {
 			reporter.log(markup`No problems or updates found in you project.`);

--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -3,7 +3,7 @@ import {CommandName, commandCategories} from "@internal/core/common/commands";
 import {markup} from "@internal/markup";
 import ClientRequest from "@internal/core/client/ClientRequest";
 import {consumeUnknown} from "@internal/consume";
-import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
+import {DIAGNOSTIC_CATEGORIES, DiagnosticsError} from "@internal/diagnostics";
 
 interface Flags {
 	allowDirty: boolean;
@@ -42,6 +42,10 @@ export default createLocalCommand({
 		);
 
 		if (result.type !== "SUCCESS") {
+			if (result.type === "DIAGNOSTICS" && result.hasDiagnostics) {
+				throw new DiagnosticsError("Auto-config failed", result.diagnostics);
+			}
+
 			return false;
 		}
 

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -75,42 +75,41 @@ export default createServerCommand<Flags>({
 					});
 				}
 			}
-		} else {
-			// Generate files
-			await reporter.steps([
-				{
-					message: markup`Generating lint config and apply formatting`,
-					async callback() {
-						const checker = new Checker(
-							req,
-							{
-								apply: true,
-							},
-						);
-						const {printer, savedCount} = await checker.runSingle();
-						result.lint = {
-							diagnostics: printer.processor.getDiagnostics(),
-							savedCount,
-						};
-					},
-				},
-				{
-					message: markup`Scanning dependencies their licenses.`,
-					async callback() {
-						for (const def of currentProject.manifests.values()) {
-							const diagnostics = def.manifest.diagnostics.license;
-
-							if (diagnostics && diagnostics.length > 0) {
-								if (!result.licenses) {
-									result.licenses = [];
-								}
-								result.licenses.push(...diagnostics);
-							}
-						}
-					},
-				},
-			]);
 		}
+		// Generate files
+		await reporter.steps([
+			{
+				message: markup`Generating lint config and apply formatting`,
+				async callback() {
+					const checker = new Checker(
+						req,
+						{
+							apply: true,
+						},
+					);
+					const {printer, savedCount} = await checker.runSingle();
+					result.lint = {
+						diagnostics: printer.processor.getDiagnostics(),
+						savedCount,
+					};
+				},
+			},
+			{
+				message: markup`Scanning dependencies their licenses.`,
+				async callback() {
+					for (const def of currentProject.manifests.values()) {
+						const diagnostics = def.manifest.diagnostics.license;
+
+						if (diagnostics && diagnostics.length > 0) {
+							if (!result.licenses) {
+								result.licenses = [];
+							}
+							result.licenses.push(...diagnostics);
+						}
+					}
+				},
+			},
+		]);
 
 		return result;
 	},


### PR DESCRIPTION
## Summary
If `auto-config` was failing there was no output shown to the user. Now it rethrows the necessary diagnostics to the client.
Also, I've refactored the flow of the command so it won't have to be called twice as before.

## Test Plan
```bash
❯ ❯) git commit -m "test"
On branch master
nothing to commit, working tree clean
❯) ../../rome2/rome auto-config
 Building trunk 
! Running compile on ../../rome2/internal/browsers-db/regions.json seems to be taking longer than expected. Have
[1/2] Generating lint config and apply formatting
[2/2] Scanning dependencies their licenses.

 Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ 2 files saved
  ✔ No problems found!

❯ ❯) ls
foo  index.ts  package.json  package-lock.json  tsconfig.json
❯ ❯) git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   foo/bar.js
	modified:   foo/bar.ts

no changes added to commit (use "git add" and/or "git commit -a")
❯ ❯) ../../rome2/rome auto-config
 Building trunk 
! Running compile on ../../rome2/internal/browsers-db/regions.json seems to be taking longer than expected. Have

 cwd:1 commands/auto-config/uncommittedChanges  FATAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Uncommitted changes in repository

    /home/littlewho/projects/rome_testing/test_prj
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  ⚠ This command is destructive and will format and autofix all files within. We recommend committing your
    changes so you can recover them if you don't like the changes.

    git add -A && git commit -m "chore: rome init backup"

  ℹ If you still really want to do this, you can bypass the restriction and auto configurate the project with 
    --allow-dirty:

    rome auto-config --allow-dirty

  ⚠ Rome exited as this error could not be handled and resulted in a fatal error. Please report if necessary.

~/projects/rome_testing/test_prj master *1 !2                                              27s Py base 10:33:06
❯ 
```