### PR TITLE
feat(core): add support for `node:` prefix for externals

### DIFF
--- a/internal/core/server/dependencies/DependencyGraph.ts
+++ b/internal/core/server/dependencies/DependencyGraph.ts
@@ -91,6 +91,8 @@ const NODE_BUILTINS = [
 	"inspector",
 ];
 
+const NODE_PROTOCOL_BUILTINS = NODE_BUILTINS.map((n) => `node:${n}`);
+
 type SeedQueueItem = {
 	all: boolean;
 	async: boolean;
@@ -137,7 +139,8 @@ export default class DependencyGraph {
 		const project = this.server.projectManager.assertProjectExisting(path);
 		return (
 			project.config.bundler.externals.includes(source) ||
-			NODE_BUILTINS.includes(source)
+			NODE_BUILTINS.includes(source) ||
+			NODE_PROTOCOL_BUILTINS.includes(source)
 		);
 	}
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

From node 15/16 is now possible to use the `node:` prefix to import node internals. For example `require("node:fs")` should now be accepted.

I am not sure if we should check also against the current node version where the application is running. 


UPDATE

Node check not needed, this feature has been added also to previous node versions:

> Added in: v14.13.1, v12.20.0

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually checked

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
