### PR TITLE
fix(lint): add to undeclered vars

### DIFF
--- a/internal/binary-transport/index.ts
+++ b/internal/binary-transport/index.ts
@@ -94,7 +94,7 @@ export function decodeSingleMessageRSERStream(
 					err,
 					{
 						description: {
-							message: markup`An error occured while decoding binary file ${createAbsoluteFilePath(
+							message: markup`An error occurred while decoding binary file ${createAbsoluteFilePath(
 								String(readStream.path),
 							)}`,
 							category: DIAGNOSTIC_CATEGORIES.parse,

--- a/internal/compiler/lint/rules/js/noUndeclaredVariables.test.md
+++ b/internal/compiler/lint/rules/js/noUndeclaredVariables.test.md
@@ -24,3 +24,16 @@
 foobar;
 
 ```
+
+### `1`
+
+```
+
+```
+
+### `1: formatted`
+
+```ts
+let romeTest: ReadonlyArray<string>;
+
+```

--- a/internal/compiler/lint/rules/js/noUndeclaredVariables.test.toml
+++ b/internal/compiler/lint/rules/js/noUndeclaredVariables.test.toml
@@ -2,3 +2,6 @@ filename = "file.ts"
 invalid = [
 	"foobar;",
 ]
+valid = [
+	"let romeTest: ReadonlyArray<string>;",
+]

--- a/internal/compiler/lint/rules/js/noUndeclaredVariables.ts
+++ b/internal/compiler/lint/rules/js/noUndeclaredVariables.ts
@@ -41,6 +41,7 @@ const TS_VARIABLES_SET = new Set([
 	"PromiseLike",
 	"Promise",
 	"ArrayLike",
+	"ReadonlyArray",
 	"Partial",
 	"Required",
 	"Readonly",

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -174,7 +174,7 @@ async function runCommand(
 		}
 	} catch (err) {
 		reporter.warn(
-			markup`Error occured while validating new config. Your changes have not been saved. Listed locations are not accurate.`,
+			markup`Error occurred while validating new config. Your changes have not been saved. Listed locations are not accurate.`,
 		);
 		throw err;
 	}

--- a/internal/core/worker/test/TestWorkerFile.ts
+++ b/internal/core/worker/test/TestWorkerFile.ts
@@ -516,7 +516,7 @@ export default class TestWorkerFile {
 				advice.push({
 					type: "log",
 					category: "info",
-					text: markup`Error occured while executing test file <emphasis>${this.path}</emphasis>`,
+					text: markup`Error occurred while executing test file <emphasis>${this.path}</emphasis>`,
 				});
 				break;
 			}
@@ -541,7 +541,7 @@ export default class TestWorkerFile {
 				advice.push({
 					type: "log",
 					category: "info",
-					text: markup`Error occured while running <emphasis>teardown</emphasis> for test declared at <emphasis>${diagnosticLocationToMarkupFilelink(
+					text: markup`Error occurred while running <emphasis>teardown</emphasis> for test declared at <emphasis>${diagnosticLocationToMarkupFilelink(
 						origin.test.callsiteLocation,
 					)}:</emphasis>`,
 				});

--- a/website/src/docs/lint/rules/js/noUndeclaredVariables.md
+++ b/website/src/docs/lint/rules/js/noUndeclaredVariables.md
@@ -32,7 +32,7 @@ MISSING DOCUMENTATION
 **ESLint Equivalent:** [no-undef](https://eslint.org/docs/rules/no-undef)
 <!-- GENERATED:END(id:description) -->
 
-<!-- GENERATED:START(hash:877efd162cacc4f55983aee4a944695ad95dca04,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
+<!-- GENERATED:START(hash:39d4d2ae29b8010a09b054f1919d400cfe5743a8,id:examples) Everything below is automatically generated. DO NOT MODIFY. Run `./rome run scripts/generated-files/lint-rules-docs` to update. -->
 ## Examples
 
 ### Invalid
@@ -47,4 +47,8 @@ MISSING DOCUMENTATION
     <span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span><span style="color: Tomato;"><strong>^</strong></span>
 
 </code></pre>{% endraw %}
+
+### Valid
+
+{% raw %}<pre class="language-ts"><code class="language-ts"><span class="token keyword">let</span> <span class="token variable">romeTest</span><span class="token punctuation">:</span> <span class="token variable">ReadonlyArray</span><span class="token operator">&lt;</span><span class="token variable">string</span><span class="token operator">&gt;</span><span class="token punctuation">;</span></code></pre>{% endraw %}
 <!-- GENERATED:END(id:examples) -->


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This is a hotfix to add `ReadonlyArray` to the list of variables to exclude from the rule. It's a temporary fix while we come up for a better solution to handle TS global interfaces.

Fixed some grammar too.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
