### PR TITLE
fix: update replace signal after inheriting location

### DIFF
--- a/internal/compiler/lib/CompilerPath.ts
+++ b/internal/compiler/lib/CompilerPath.ts
@@ -482,6 +482,7 @@ export default class CompilerPath {
 					loc: inheritLoc(old),
 				};
 			}
+			fixed = {...fixed, value};
 		}
 
 		return fixed;

--- a/internal/compiler/lint/rules/js/preferOptionalChaining.test.md
+++ b/internal/compiler/lint/rules/js/preferOptionalChaining.test.md
@@ -338,7 +338,6 @@ foo?.bar.baz;
 
 ```ts
 let foo = {};
-
 foo?.bar?.("baz")
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

It looks like `value` here is intended to replace `fixed.value` once the location has been inherited.
