### PR TITLE
fix(core): prevent TypeError when handling unhandledRejection

### DIFF
--- a/internal/core/common/FatalErrorHandler.ts
+++ b/internal/core/common/FatalErrorHandler.ts
@@ -57,14 +57,17 @@ export default class FatalErrorHandler {
 	}
 
 	public setupGlobalHandlers(): Resource {
-		process.on("uncaughtException", this.handleBound);
-		process.on("unhandledRejection", this.handleBound);
+		// Only pass first argument to handler
+		const handleError = (err: Error) => this.handleBound(err);
+
+		process.on("uncaughtException", handleError);
+		process.on("unhandledRejection", handleError);
 
 		return createResourceFromCallback(
 			"FatalErrorHandlerEvents",
 			() => {
-				process.removeListener("uncaughtException", this.handleBound);
-				process.removeListener("unhandledRejection", this.handleBound);
+				process.removeListener("uncaughtException", handleError);
+				process.removeListener("unhandledRejection", handleError);
 			},
 		);
 	}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

The `unhandledRejection` listener is passed the rejected promise as the second argument, but the `FatalErrorHandler` handler has an optional `overrideSource?: StaticMarkup` as the second parameter.

This was causing a runtime TypeError when attempting to convert an unhandled rejection into a normalized diagnostic for printing:
```
TypeError: item is not iterable
  at item (project-rome/@internal/markup/escape.ts:206:21)
  at parseMarkup (project-rome/@internal/markup/parse.ts:444:10)
  at normalizeMarkup (project-rome/@internal/markup/normalize.ts:212:2)
  at diagnostics.normalizeMarkup (project-rome/@internal/diagnostics/DiagnosticsNormalizer.ts:307:10)
  at diagnostics.normalizeDiagnostic (project-rome/@internal/diagnostics/DiagnosticsNormalizer.ts:521:22)
  at normalizeDiagnostic (project-rome/@internal/diagnostics/DiagnosticsProcessor.ts:458:46)
  at Array.map
  at diagnostics.addDiagnostics (project-rome/@internal/diagnostics/DiagnosticsProcessor.ts:458:16)
  at addDiagnostics (project-rome/@internal/core/common/FatalErrorHandler.ts:118:14)
  at GlobalLock.wrap (project-rome/@internal/async/lockers.ts:170:16)
  at GlobalLock.series (project-rome/@internal/async/lockers.ts:163:15)
  at common.handle (project-rome/@internal/core/common/FatalErrorHandler.ts:74:26)
  at process.emit (node:events.js:315:19)
  at processPromiseRejections (node:internal/process/promises.js:245:32)
  at process.processTicksAndRejections (node:internal/process/task_queues.js:94:31)
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
