### PR TITLE
fix(lsp): improve LSP message handling

### DIFF
--- a/internal/core/server/lsp/messages/general.ts
+++ b/internal/core/server/lsp/messages/general.ts
@@ -1,0 +1,56 @@
+import {createAbsoluteFilePath} from "@internal/path";
+import {safeProcessExit} from "@internal/resources";
+import {getPathFromTextDocument} from "../utils";
+import {LSPNotificationHandler, LSPRequestHandler} from "./types";
+
+export const shutdown: LSPRequestHandler = async (lsp) => {
+	await lsp.shutdown();
+	return null;
+};
+
+export const exit: LSPNotificationHandler = async () => {
+	await safeProcessExit(0);
+};
+
+export const initialized: LSPNotificationHandler = async (lsp) => {
+	await lsp.watchPendingProjects();
+};
+
+export const initialize: LSPRequestHandler = async (lsp, params) => {
+	const rootUri = params.get("rootUri");
+	if (rootUri.exists()) {
+		const workspacePath = createAbsoluteFilePath(rootUri.asString());
+		await lsp.initProject(workspacePath);
+	}
+
+	const workspaceFolders = params.get("workspaceFolders");
+	if (workspaceFolders.exists()) {
+		for (const elem of workspaceFolders.asIterable()) {
+			await lsp.initProject(getPathFromTextDocument(elem));
+		}
+	}
+
+	return {
+		capabilities: {
+			textDocumentSync: {
+				openClose: true,
+				// This sends over incremental patches on change
+				change: 2,
+			},
+			documentFormattingProvider: true,
+			codeActionProvider: true,
+			executeCommandProvider: {
+				commands: ["rome.check.decisions", "rome.check.apply"],
+			},
+			workspace: {
+				workspaceFolders: {
+					supported: true,
+					changeNotifications: true,
+				},
+			},
+		},
+		serverInfo: {
+			name: "rome",
+		},
+	};
+};

--- a/internal/core/server/lsp/messages/index.ts
+++ b/internal/core/server/lsp/messages/index.ts
@@ -1,0 +1,23 @@
+import {LSPNotificationHandler, LSPRequestHandler} from "./types";
+import * as general from "./general";
+import * as textDocument from "./textDocument";
+import * as workspace from "./workspace";
+
+export const notificationHandlers = new Map<string, LSPNotificationHandler>();
+export const requestHandlers = new Map<string, LSPRequestHandler>();
+
+requestHandlers.set("initialize", general.initialize);
+requestHandlers.set("shutdown", general.shutdown);
+requestHandlers.set("textDocument/formatting", textDocument.formatting);
+requestHandlers.set("textDocument/codeAction", textDocument.codeAction);
+requestHandlers.set("workspace/executeCommand", workspace.executeCommand);
+
+notificationHandlers.set("exit", general.exit);
+notificationHandlers.set("initialized", general.initialized);
+notificationHandlers.set("textDocument/didOpen", textDocument.didOpen);
+notificationHandlers.set("textDocument/didChange", textDocument.didChange);
+notificationHandlers.set("textDocument/didClose", textDocument.didClose);
+notificationHandlers.set(
+	"workspace/didChangeWorkspaceFolders",
+	workspace.didChangeWorkspaceFolders,
+);

--- a/internal/core/server/lsp/messages/textDocument.ts
+++ b/internal/core/server/lsp/messages/textDocument.ts
@@ -1,0 +1,138 @@
+import {
+	catchDiagnostics,
+	formatCategoryDescription,
+	getActionAdviceFromDiagnostic,
+} from "@internal/diagnostics";
+import {readMarkup} from "@internal/markup";
+import {LSPCodeAction} from "../types";
+import {
+	convertDiagnosticLocationToLSPRange,
+	diffTextEdits,
+	doRangesOverlap,
+	getDecisionFromAdviceAction,
+	getLSPRange,
+	getPathFromTextDocument,
+	getWorkerBufferPatches,
+} from "../utils";
+import {LSPNotificationHandler, LSPRequestHandler} from "./types";
+
+export const formatting: LSPRequestHandler = async (lsp, params) => {
+	const path = getPathFromTextDocument(params.get("textDocument"));
+
+	const project = lsp.server.projectManager.findLoadedProject(path);
+	if (project === undefined) {
+		// Not in a Rome project
+		return null;
+	}
+
+	const {value, diagnostics} = await catchDiagnostics(async () => {
+		return lsp.request.requestWorkerFormat(path, {}, {});
+	});
+
+	lsp.logDiagnostics(path, diagnostics);
+
+	if (value === undefined) {
+		// Not a file we support formatting or has diagnostics
+		return null;
+	}
+
+	return diffTextEdits(value.original, value.formatted);
+};
+
+export const codeAction: LSPRequestHandler = async (lsp, params) => {
+	const path = getPathFromTextDocument(params.get("textDocument"));
+	const codeActionRange = getLSPRange(params.get("range"));
+
+	const codeActions: LSPCodeAction[] = [];
+	const seenDecisions = new Set<string>();
+
+	const diagnostics = lsp.diagnosticsProcessor.getDiagnosticsForPath(path);
+	if (diagnostics.length === 0) {
+		return codeActions;
+	}
+
+	for (const diag of diagnostics) {
+		const diagRange = convertDiagnosticLocationToLSPRange(diag.location);
+
+		if (!doRangesOverlap(diagRange, codeActionRange)) {
+			continue;
+		}
+		for (const item of getActionAdviceFromDiagnostic(diag)) {
+			if (item.secondary) {
+				continue;
+			}
+
+			const decision = getDecisionFromAdviceAction(item);
+			if (decision === undefined || seenDecisions.has(decision)) {
+				continue;
+			}
+			seenDecisions.add(decision);
+
+			codeActions.push({
+				title: `${readMarkup(item.description)}: ${formatCategoryDescription(
+					diag.description,
+				)}`,
+				command: {
+					title: "Rome: Check",
+					command: "rome.check.decisions",
+					arguments: [path.join(), decision],
+				},
+			});
+		}
+	}
+
+	codeActions.push({
+		title: "Rome: Fix All",
+		kind: "source.fixAll.rome",
+		command: {
+			title: "Rome: Fix All",
+			command: "rome.check.apply",
+			arguments: [path.join()],
+		},
+	});
+
+	return codeActions;
+};
+
+export const didOpen: LSPNotificationHandler = async (lsp, params) => {
+	const textDocument = params.get("textDocument");
+	const path = getPathFromTextDocument(textDocument);
+	const project = lsp.server.projectManager.findLoadedProject(path);
+	if (project === undefined) {
+		return;
+	}
+	lsp.fileVersions.set(path, textDocument.get("version").asNumber());
+	const content = textDocument.get("text").asString();
+	await lsp.request.requestWorkerUpdateBuffer(path, content);
+	lsp.fileBuffers.add(path);
+	lsp.logMessage(path, `Opened: ${path.join()}`);
+};
+
+export const didChange: LSPNotificationHandler = async (lsp, params) => {
+	const textDocument = params.get("textDocument");
+	const path = getPathFromTextDocument(textDocument);
+	if (!lsp.fileBuffers.has(path)) {
+		return;
+	}
+	lsp.fileVersions.set(path, textDocument.get("version").asNumber());
+	const contentChanges = params.get("contentChanges");
+
+	if (contentChanges.getIndex(0).has("range")) {
+		const patches = getWorkerBufferPatches(contentChanges);
+		await lsp.request.requestWorkerPatchBuffer(path, patches);
+	} else {
+		const content = contentChanges.getIndex(0).get("text").asString();
+		await lsp.request.requestWorkerUpdateBuffer(path, content);
+	}
+};
+
+export const didClose: LSPNotificationHandler = async (lsp, params) => {
+	const path = getPathFromTextDocument(params.get("textDocument"));
+	if (!lsp.fileBuffers.has(path)) {
+		return;
+	}
+	lsp.fileBuffers.delete(path);
+	lsp.fileVersions.delete(path);
+	await lsp.request.requestWorkerClearBuffer(path);
+	lsp.logMessage(path, `Closed: ${path.join()}`);
+};

--- a/internal/core/server/lsp/messages/types.ts
+++ b/internal/core/server/lsp/messages/types.ts
@@ -1,0 +1,15 @@
+import {JSONValue} from "@internal/codec-config";
+import {Consumer} from "@internal/consume";
+import {AsyncCallback, AsyncVoidCallback} from "@internal/typescript-helpers";
+import LSPServer from "../LSPServer";
+
+export type LSPNotificationHandler = AsyncVoidCallback<[
+	LSPServer,
+	Consumer,
+	string
+]>;
+
+export type LSPRequestHandler = AsyncCallback<
+	JSONValue,
+	[LSPServer, Consumer, string]
+>;

--- a/internal/core/server/lsp/messages/workspace.ts
+++ b/internal/core/server/lsp/messages/workspace.ts
@@ -1,0 +1,88 @@
+import {PartialServerQueryRequest} from "@internal/core/common/bridges/ServerBridge";
+import {createAbsoluteFilePath} from "@internal/path";
+import {diffTextEdits, getPathFromTextDocument} from "../utils";
+import {LSPNotificationHandler, LSPRequestHandler} from "./types";
+
+export const didChangeWorkspaceFolders: LSPNotificationHandler = async (
+	lsp,
+	params,
+) => {
+	const event = params.get("event");
+	for (const elem of event.get("added").asIterable()) {
+		await lsp.initProject(getPathFromTextDocument(elem));
+	}
+	for (const elem of event.get("removed").asIterable()) {
+		lsp.unwatchProject(getPathFromTextDocument(elem));
+	}
+	await lsp.watchPendingProjects();
+};
+
+export const executeCommand: LSPRequestHandler = async (lsp, params) => {
+	const command = params.get("command").asString();
+	const filename = params.get("arguments").getIndex(0).asString();
+
+	const path = createAbsoluteFilePath(filename);
+	const startVersion = lsp.fileVersions.get(path);
+
+	let req: PartialServerQueryRequest | undefined;
+
+	if (command === "rome.check.apply") {
+		req = {
+			commandName: "check",
+			args: [filename],
+			commandFlags: {apply: true},
+			noFileWrites: true,
+		};
+	}
+
+	if (command === "rome.check.decisions") {
+		const decisions = params.get("arguments").getIndex(1).asString();
+		req = {
+			commandName: "check",
+			args: [filename],
+			commandFlags: {decisions, suppressionExplanation: "suppressed via editor"},
+			noFileWrites: true,
+		};
+	}
+
+	if (req === undefined) {
+		return null;
+	}
+
+	const response = await lsp.sendClientRequest(req);
+
+	if (response.type === "SUCCESS" || response.type === "DIAGNOSTICS") {
+		const original = await lsp.request.requestWorkerGetBuffer(path);
+		const saveFile = response.files[filename];
+		if (original === undefined || saveFile === undefined) {
+			return null;
+		}
+		const endVersion = lsp.fileVersions.get(path);
+		if (startVersion !== endVersion) {
+			lsp.logMessage(path, `Can't update ${filename} because it was modified,`);
+			return null;
+		}
+
+		const edits = diffTextEdits(original, saveFile.content);
+
+		await lsp.transport.request({
+			method: "workspace/applyEdit",
+			params: {
+				label: "Rome Action",
+				edit: {
+					documentChanges: [
+						{
+							textDocument: {
+								uri: `file://${filename}`,
+								version: endVersion,
+							},
+							edits,
+						},
+					],
+				},
+			},
+		});
+	}
+
+	return null;
+};

--- a/internal/core/server/lsp/protocol.ts
+++ b/internal/core/server/lsp/protocol.ts
@@ -84,7 +84,8 @@ export class LSPTransport {
 	public writeEvent: Event<string, void>;
 
 	public write(res: JSONObject) {
-		const json = JSON.stringify(res);
+		const message = {...res, jsonrpc: "2.0"};
+		const json = JSON.stringify(message);
 		const out = `Content-Length: ${getByteLength(json)}${HEADERS_END}${json}`;
 		this.writeEvent.send(out);
 	}
@@ -93,7 +94,7 @@ export class LSPTransport {
 		return new Promise((resolve, reject) => {
 			const id = ++this.requestIdCounter;
 			this.requestCallbacks.set(id, {resolve, reject});
-			this.write({...req, id, jsonrpc: "2.0"});
+			this.write({...req, id});
 		});
 	}
 
@@ -148,14 +149,12 @@ export class LSPTransport {
 					result = await this.requestEvent.call({method, params});
 				}
 				const res: LSPResponseMessage = {
-					jsonrpc: "2.0",
 					id,
 					result,
 				};
 				this.write(res);
 			} catch (err) {
 				const res: LSPResponseMessage = {
-					jsonrpc: "2.0",
 					id,
 					error: {
 						code: -32_603,

--- a/internal/core/server/lsp/types.ts
+++ b/internal/core/server/lsp/types.ts
@@ -9,11 +9,6 @@ import {JSONArray, JSONObject, JSONPropertyValue} from "@internal/codec-config";
 
 export type LSPRequestMessage = {
 	/**
-   * JSON-RPC version number. Must be "2.0".
-   */
-	jsonrpc: "2.0";
-
-	/**
    * The request id.
    */
 	id: number | string;
@@ -30,11 +25,6 @@ export type LSPRequestMessage = {
 };
 
 export type LSPResponseMessage = {
-	/**
-   * JSON-RPC version number. Must be "2.0".
-   */
-	jsonrpc: "2.0";
-
 	/**
    * The request id.
    */
@@ -71,11 +61,6 @@ export type LSPResponseError = {
 };
 
 export type LSPNotificationMessage = {
-	/**
-   * JSON-RPC version number. Must be "2.0".
-   */
-	jsonrpc: "2.0";
-
 	/**
    * The method to be invoked.
    */


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR addresses a handful of issues related to the LSP Server. There are still some bugs and stability issues affecting LSP that I’ll continue to work though.

- Add `exit` notification handler to avoid accumulating `rome-cli` processes.
- Prevent sending messages from server until receiving `initialized` notification
- Partially fix handling of `workspace/didChangeWorkspaceFolders` notification. TODO: Bugs related to changing workspace folders. Will track separately.
- Allow tearing down project sessions if workspace changes while initial check watch is being performed.
- Fix labels on code actions and inserted suppression comments.
- Disable `$/progress` notifications for now because they have a significant performance impact. TODO: Fix this.
- Extract LSP message handlers into separate folder. TODO: Clean this up more. Maybe extract workspace commands?

Closes #1578 #1558 