### PR TITLE
fix(lsp): lint without unstable project-wide check watching

### DIFF
--- a/internal/core/server/commands/lsp.ts
+++ b/internal/core/server/commands/lsp.ts
@@ -26,7 +26,7 @@ export default createServerCommand({
 		reporter.redirectOutToErr(true);
 
 		const lsp = new LSPServer(req);
-		await lsp.init();
+		lsp.init();
 		server.onLSPServer(req, lsp);
 
 		const {transport} = lsp;

--- a/internal/core/server/commands/lsp.ts
+++ b/internal/core/server/commands/lsp.ts
@@ -26,6 +26,7 @@ export default createServerCommand({
 		reporter.redirectOutToErr(true);
 
 		const lsp = new LSPServer(req);
+		await lsp.init();
 		server.onLSPServer(req, lsp);
 
 		const {transport} = lsp;

--- a/internal/core/server/lsp/LSPServer.ts
+++ b/internal/core/server/lsp/LSPServer.ts
@@ -98,7 +98,7 @@ export default class LSPServer {
 	public watchProjectEvent: Event<AbsoluteFilePath, void>;
 	public textDocumentSyncEvent: EventQueue<TextDocumentSync>;
 
-	public async init() {
+	public init() {
 		this.server.resources.add(
 			this.textDocumentSyncEvent.subscribe(async (events) => {
 				await promiseAllFrom(
@@ -127,8 +127,8 @@ export default class LSPServer {
 				{applySafeFixes: false, save: false},
 			);
 		});
-		this.logDiagnostics(path, diagnostics);
 		if (value === undefined) {
+			this.logDiagnostics(path, diagnostics);
 			return;
 		}
 		this.diagnosticsProcessor.removePath(path);

--- a/internal/core/server/lsp/messages/general.ts
+++ b/internal/core/server/lsp/messages/general.ts
@@ -13,7 +13,8 @@ export const exit: LSPNotificationHandler = async () => {
 };
 
 export const initialized: LSPNotificationHandler = async () => {
-	// Project-wide check watching disabled for stability
+	// TODO: Re-enable project-wide check watching
+	// Disabled for stability
 	// await lsp.watchPendingProjects();
 };
 

--- a/internal/core/server/lsp/messages/general.ts
+++ b/internal/core/server/lsp/messages/general.ts
@@ -12,8 +12,9 @@ export const exit: LSPNotificationHandler = async () => {
 	await safeProcessExit(0);
 };
 
-export const initialized: LSPNotificationHandler = async (lsp) => {
-	await lsp.watchPendingProjects();
+export const initialized: LSPNotificationHandler = async () => {
+	// Project-wide check watching disabled for stability
+	// await lsp.watchPendingProjects();
 };
 
 export const initialize: LSPRequestHandler = async (lsp, params) => {

--- a/internal/core/server/lsp/messages/textDocument.ts
+++ b/internal/core/server/lsp/messages/textDocument.ts
@@ -106,6 +106,7 @@ export const didOpen: LSPNotificationHandler = async (lsp, params) => {
 	await lsp.request.requestWorkerUpdateBuffer(path, content);
 	lsp.fileBuffers.add(path);
 	lsp.logMessage(path, `Opened: ${path.join()}`);
+	lsp.textDocumentSyncEvent.push({path, type: "DID_OPEN"});
 };
 
 export const didChange: LSPNotificationHandler = async (lsp, params) => {
@@ -124,6 +125,7 @@ export const didChange: LSPNotificationHandler = async (lsp, params) => {
 		const content = contentChanges.getIndex(0).get("text").asString();
 		await lsp.request.requestWorkerUpdateBuffer(path, content);
 	}
+	lsp.textDocumentSyncEvent.push({path, type: "DID_CHANGE"});
 };
 
 export const didClose: LSPNotificationHandler = async (lsp, params) => {
@@ -135,4 +137,5 @@ export const didClose: LSPNotificationHandler = async (lsp, params) => {
 	lsp.fileVersions.delete(path);
 	await lsp.request.requestWorkerClearBuffer(path);
 	lsp.logMessage(path, `Closed: ${path.join()}`);
+	lsp.textDocumentSyncEvent.push({path, type: "DID_CLOSE"});
 };

--- a/internal/core/server/lsp/types.ts
+++ b/internal/core/server/lsp/types.ts
@@ -6,6 +6,7 @@
  */
 
 import {JSONArray, JSONObject, JSONPropertyValue} from "@internal/codec-config";
+import {AbsoluteFilePath} from "@internal/path";
 
 export type LSPRequestMessage = {
 	/**
@@ -381,3 +382,17 @@ export type LSPVersionedTextDocumentIdentifier = LSPTextDocumentIdentifier & {
 	 */
 	version: number | null;
 };
+
+export type TextDocumentSync =
+	| {
+			path: AbsoluteFilePath;
+			type: "DID_OPEN";
+		}
+	| {
+			path: AbsoluteFilePath;
+			type: "DID_CHANGE";
+		}
+	| {
+			path: AbsoluteFilePath;
+			type: "DID_CLOSE";
+		};


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR allows the LSP server to publish diagnostics for editor-synced `textDocument` paths without a dependence on `Checker#watch`, which has been a source of instability.

This temporarily restricts the LSP server to only operating on documents that are open in the editor. Later, project-wide checking through LSP can be restored when it can be made more stable.

This PR also prevents projects from being evicted/reloaded when a manifest is being modified unsaved in the editor. Saving a modified project manifest to disk can still cause the server to hang, which isn't addressed here.

Closes #1608 
