### PR TITLE
refactor(core): remove unnecessary auto-config double call

### DIFF
--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -45,20 +45,11 @@ export default createLocalCommand({
 			return false;
 		}
 
-		const res = await req.client.query(
-			{
-				commandName: "auto-config",
-			},
-			"server",
+		const data = consumeUnknown(
+			result.data,
+			DIAGNOSTIC_CATEGORIES.parse,
+			"json",
 		);
-
-		if (res.type !== "SUCCESS") {
-			reporter.log(
-				markup`Something went wrong during the execution of the command.`,
-			);
-			return true;
-		}
-		const data = consumeUnknown(res.data, DIAGNOSTIC_CATEGORIES.parse, "json");
 
 		if (!data.exists()) {
 			reporter.log(markup`No problems or updates found in you project.`);

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -75,42 +75,41 @@ export default createServerCommand<Flags>({
 					});
 				}
 			}
-		} else {
-			// Generate files
-			await reporter.steps([
-				{
-					message: markup`Generating lint config and apply formatting`,
-					async callback() {
-						const checker = new Checker(
-							req,
-							{
-								apply: true,
-							},
-						);
-						const {printer, savedCount} = await checker.runSingle();
-						result.lint = {
-							diagnostics: printer.processor.getDiagnostics(),
-							savedCount,
-						};
-					},
-				},
-				{
-					message: markup`Scanning dependencies their licenses.`,
-					async callback() {
-						for (const def of currentProject.manifests.values()) {
-							const diagnostics = def.manifest.diagnostics.license;
-
-							if (diagnostics && diagnostics.length > 0) {
-								if (!result.licenses) {
-									result.licenses = [];
-								}
-								result.licenses.push(...diagnostics);
-							}
-						}
-					},
-				},
-			]);
 		}
+		// Generate files
+		await reporter.steps([
+			{
+				message: markup`Generating lint config and apply formatting`,
+				async callback() {
+					const checker = new Checker(
+						req,
+						{
+							apply: true,
+						},
+					);
+					const {printer, savedCount} = await checker.runSingle();
+					result.lint = {
+						diagnostics: printer.processor.getDiagnostics(),
+						savedCount,
+					};
+				},
+			},
+			{
+				message: markup`Scanning dependencies their licenses.`,
+				async callback() {
+					for (const def of currentProject.manifests.values()) {
+						const diagnostics = def.manifest.diagnostics.license;
+
+						if (diagnostics && diagnostics.length > 0) {
+							if (!result.licenses) {
+								result.licenses = [];
+							}
+							result.licenses.push(...diagnostics);
+						}
+					}
+				},
+			},
+		]);
 
 		return result;
 	},


### PR DESCRIPTION
## Summary
There were two `auto-config` queries to the server. They are unnecessary and the same job could be done with only one. I discussed this with @ematipico on Discord.  