### PR TITLE
feat(resolver, project, core): path aliases

### DIFF
--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -158,6 +158,8 @@ export default createLocalCommand({
 				);
 
 				if (paths.length > 0) {
+					reporter.info(markup`Rome detected path aliases configured in your <emphasis>tsconfig.json</emphasis> and will try to import them.`)
+
 					const pathKeys = paths.map((item) => `<emphasis>${item[0]}</emphasis>`).join(", ");
 					const addPaths = await reporter.radioConfirm(
 						markup`Would you like to import the following aliases ${pathKeys} in your Rome's configuration?`,
@@ -181,6 +183,9 @@ export default createLocalCommand({
 					}
 				}
 			}
+
+			reporter.warn(markup`Rome won't keep track of imported configuration from <emphasis>tsconfig.json</emphasis>.`);
+			reporter.warn(markup`You must re-run <emphasis>auto-config</emphasis> if you want to import settings from <emphasis>tsconfig.json</emphasis> again.`);
 		}
 
 		if (savedCheckFiles !== undefined && remainingCheckErrors !== undefined) {

--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -158,9 +158,13 @@ export default createLocalCommand({
 				);
 
 				if (paths.length > 0) {
-					reporter.info(markup`Rome detected path aliases configured in your <emphasis>tsconfig.json</emphasis> and will try to import them.`)
+					reporter.info(
+						markup`Rome detected path aliases configured in your <emphasis>tsconfig.json</emphasis> and will try to import them.`,
+					);
 
-					const pathKeys = paths.map((item) => `<emphasis>${item[0]}</emphasis>`).join(", ");
+					const pathKeys = paths.map((item) => `<emphasis>${item[0]}</emphasis>`).join(
+						", ",
+					);
 					const addPaths = await reporter.radioConfirm(
 						markup`Would you like to import the following aliases ${pathKeys} in your Rome's configuration?`,
 					);
@@ -171,7 +175,7 @@ export default createLocalCommand({
 								commandName: "config set",
 								args: [configPath, "[]"],
 							});
-	
+
 							await req.client.query(
 								{
 									commandName: "config push",
@@ -184,8 +188,12 @@ export default createLocalCommand({
 				}
 			}
 
-			reporter.warn(markup`Rome won't keep track of imported configuration from <emphasis>tsconfig.json</emphasis>.`);
-			reporter.warn(markup`You must re-run <emphasis>auto-config</emphasis> if you want to import settings from <emphasis>tsconfig.json</emphasis> again.`);
+			reporter.warn(
+				markup`Rome won't keep track of imported configuration from <emphasis>tsconfig.json</emphasis>.`,
+			);
+			reporter.warn(
+				markup`You must re-run <emphasis>auto-config</emphasis> if you want to import settings from <emphasis>tsconfig.json</emphasis> again.`,
+			);
 		}
 
 		if (savedCheckFiles !== undefined && remainingCheckErrors !== undefined) {

--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -4,7 +4,7 @@ import {markup} from "@internal/markup";
 import ClientRequest from "@internal/core/client/ClientRequest";
 import {consumeUnknown} from "@internal/consume";
 import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
-import { escapePath } from "@internal/core/server/utils/escapeObjectPaths";
+import {escapePath} from "@internal/core/server/utils/escapeObjectPaths";
 
 interface Flags {
 	allowDirty: boolean;
@@ -134,33 +134,45 @@ export default createLocalCommand({
 		}
 
 		if (data.has("aliases")) {
-			const aliases = data.get("aliases")
+			const aliases = data.get("aliases");
 			const base = aliases.get("base").asString();
-			const paths = aliases.get("paths").asMappedArray(item => item.asPlainArray() as [string, string[]]);
+			const paths = aliases.get("paths").asMappedArray((item) =>
+				(item.asPlainArray() as [string, string[]])
+			);
 
-			const changeBase = await reporter.radioConfirm(markup`Change base path to ${base}?`)
+			const changeBase = await reporter.radioConfirm(
+				markup`Change base path to ${base}?`,
+			);
 			if (changeBase) {
-				await req.client.query({
-					commandName: "config set",
-					args: ["aliases.base", base],
-				}, "server")
+				await req.client.query(
+					{
+						commandName: "config set",
+						args: ["aliases.base", base],
+					},
+					"server",
+				);
 			}
 
 			if (paths.length > 0) {
-				const pathKeys = paths.map(item => item[0]).join(', ')
-				const addPaths = await reporter.radioConfirm(markup`Add the following aliases to your config: ${pathKeys}?`)
+				const pathKeys = paths.map((item) => item[0]).join(", ");
+				const addPaths = await reporter.radioConfirm(
+					markup`Add the following aliases to your config: ${pathKeys}?`,
+				);
 				if (addPaths) {
 					for (const [alias, targets] of paths) {
-						const configPath = `aliases.paths.${escapePath(alias)}`
+						const configPath = `aliases.paths.${escapePath(alias)}`;
 						await req.client.query({
 							commandName: "config set",
-							args: [configPath, "[]"]
-						})
+							args: [configPath, "[]"],
+						});
 
-						await req.client.query({
-							commandName: "config push",
-							args: [configPath, ...targets] 
-						}, "server")
+						await req.client.query(
+							{
+								commandName: "config push",
+								args: [configPath, ...targets],
+							},
+							"server",
+						);
 					}
 				}
 			}

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -11,6 +11,7 @@ import {
 import {UnknownObject} from "@internal/typescript-helpers";
 import Checker from "../checker/Checker";
 import { consumeConfig } from "@internal/codec-config";
+import { aliasPatternToString } from "@internal/project/aliases";
 
 interface Flags extends UnknownObject {
 	checkVSC: boolean;
@@ -137,8 +138,17 @@ export default createServerCommand<Flags>({
 						const paths = compilerOptions.get("paths");
 						const resultPaths: [string, string[]][] = []
 						if (paths.exists()) {
-							for (const [alias, targets] of paths.asMap()) {
-								resultPaths.push([alias, targets.asMappedArray(target => target.asString())])
+							const currentPaths = currentProject.config.aliases.paths;
+							const currentPathsSet = new Set<string>();
+							for (const [alias, _] of currentPaths) {
+								currentPathsSet.add(aliasPatternToString(alias))
+							}
+
+							for (const [alias, targetsConsumer] of paths.asMap()) {
+								const targets = targetsConsumer.asMappedArray(target => target.asString());
+								if (!currentPathsSet.has(alias)) {
+									resultPaths.push([alias, targets])
+								}
 							}
 						}
 

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -10,8 +10,8 @@ import {
 } from "@internal/diagnostics";
 import {UnknownObject} from "@internal/typescript-helpers";
 import Checker from "../checker/Checker";
-import { consumeConfig } from "@internal/codec-config";
-import { aliasPatternToString } from "@internal/project/aliases";
+import {consumeConfig} from "@internal/codec-config";
+import {aliasPatternToString} from "@internal/project/aliases";
 
 interface Flags extends UnknownObject {
 	checkVSC: boolean;
@@ -24,9 +24,9 @@ export type AutoConfig = {
 	};
 	licenses?: Diagnostic[];
 	aliases?: {
-		base: string,
-		paths: [string, string[]][], 
-	}
+		base: string;
+		paths: [string, string[]][];
+	};
 };
 
 export default createServerCommand<Flags>({
@@ -123,31 +123,35 @@ export default createServerCommand<Flags>({
 						const {consumer: tsconfig} = consumeConfig({
 							path: tsconfigPath,
 							input: await tsconfigPath.readFileText(),
-						})
+						});
 
 						if (!tsconfig.has("compilerOptions")) {
-							return; 	
+							return;
 						}
 
 						const compilerOptions = tsconfig.get("compilerOptions");
 						const baseUrl = compilerOptions.get("baseUrl");
 						if (!baseUrl.exists()) {
-							return ;
+							return;
 						}
 
 						const paths = compilerOptions.get("paths");
-						const resultPaths: [string, string[]][] = []
+						const resultPaths: [string, string[]][] = [];
 						if (paths.exists()) {
-							const currentPaths = currentProject.config.aliases.paths;
+							const currentPaths = currentProject.config.aliases.paths.map((
+								item,
+							) => item[0]);
 							const currentPathsSet = new Set<string>();
-							for (const [alias, _] of currentPaths) {
-								currentPathsSet.add(aliasPatternToString(alias))
+							for (const alias of currentPaths) {
+								currentPathsSet.add(aliasPatternToString(alias));
 							}
 
 							for (const [alias, targetsConsumer] of paths.asMap()) {
-								const targets = targetsConsumer.asMappedArray(target => target.asString());
+								const targets = targetsConsumer.asMappedArray((target) =>
+									target.asString()
+								);
 								if (!currentPathsSet.has(alias)) {
-									resultPaths.push([alias, targets])
+									resultPaths.push([alias, targets]);
 								}
 							}
 						}
@@ -155,10 +159,10 @@ export default createServerCommand<Flags>({
 						result.aliases = {
 							base: baseUrl.asString(),
 							paths: resultPaths,
-						}
+						};
 					}
-				} 
-			}
+				},
+			},
 		]);
 
 		return result;

--- a/internal/core/server/commands/autoConfig.ts
+++ b/internal/core/server/commands/autoConfig.ts
@@ -4,16 +4,16 @@ import {commandCategories} from "@internal/core/common/commands";
 import {ServerRequest} from "@internal/core";
 import {getVCSClient} from "@internal/vcs";
 import {
+	DIAGNOSTIC_CATEGORIES,
 	Diagnostic,
 	createSingleDiagnosticsError,
 	descriptions,
-	DIAGNOSTIC_CATEGORIES,
 } from "@internal/diagnostics";
 import {UnknownObject} from "@internal/typescript-helpers";
 import Checker from "../checker/Checker";
 import {json5} from "@internal/codec-config";
 import {aliasPatternToString} from "@internal/project/aliases";
-import { consumeUnknown } from "@internal/consume";
+import {consumeUnknown} from "@internal/consume";
 
 interface Flags extends UnknownObject {
 	checkVSC: boolean;
@@ -122,15 +122,21 @@ export default createServerCommand<Flags>({
 				async callback() {
 					const tsconfigPath = currentProject.directory.append("tsconfig.json");
 					if (await tsconfigPath.exists()) {
-						const tsconfigData = json5.parse({ input: await tsconfigPath.readFileText() });
-						const tsconfig =  consumeUnknown(tsconfigData, DIAGNOSTIC_CATEGORIES.parse, "json")
+						const tsconfigData = json5.parse({
+							input: await tsconfigPath.readFileText(),
+						});
+						const tsconfig = consumeUnknown(
+							tsconfigData,
+							DIAGNOSTIC_CATEGORIES.parse,
+							"json",
+						);
 
 						if (!tsconfig.has("compilerOptions")) {
 							return;
 						}
 
 						const compilerOptions = tsconfig.get("compilerOptions");
-						result.aliases = {}
+						result.aliases = {};
 
 						const baseUrl = compilerOptions.get("baseUrl");
 						if (baseUrl.exists()) {

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -25,7 +25,7 @@ import {
 } from "@internal/core/common/userConfig";
 import {USER_CONFIG_DIRECTORY} from "@internal/core/common/constants";
 import prettyFormat from "@internal/pretty-format";
-import { splitEscapedObjectPath, unescapePath } from "../utils/escapeObjectPaths";
+import {splitEscapedObjectPath, unescapePath} from "../utils/escapeObjectPaths";
 
 type Flags = {
 	user: boolean;

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -25,6 +25,7 @@ import {
 } from "@internal/core/common/userConfig";
 import {USER_CONFIG_DIRECTORY} from "@internal/core/common/constants";
 import prettyFormat from "@internal/pretty-format";
+import { splitEscapedObjectPath, unescapePath } from "../utils/escapeObjectPaths";
 
 type Flags = {
 	user: boolean;
@@ -48,11 +49,11 @@ async function runCommand(
 	function modify(consumer: Consumer) {
 		// Set the specified value
 		let keyConsumer = consumer;
-		for (const key of keyParts.split(".")) {
+		for (const key of splitEscapedObjectPath(keyParts)) {
 			if (!keyConsumer.exists()) {
 				keyConsumer.setValue({});
 			}
-			keyConsumer = keyConsumer.get(key);
+			keyConsumer = keyConsumer.get(unescapePath(key));
 		}
 
 		if (action === "push") {

--- a/internal/core/server/fs/Resolver.ts
+++ b/internal/core/server/fs/Resolver.ts
@@ -12,7 +12,11 @@ import {
 } from "@internal/codec-js-manifest";
 import Server from "../Server";
 import {PLATFORM_ALIASES, Platform} from "../../common/types/platform";
-import {ProjectDefinition, createDefaultProjectConfig, ProjectConfig} from "@internal/project";
+import {
+	ProjectConfig,
+	ProjectDefinition,
+	createDefaultProjectConfig,
+} from "@internal/project";
 import {FileReference} from "@internal/core";
 import resolverSuggest from "./resolverSuggest";
 import {
@@ -22,7 +26,6 @@ import {
 	URLPath,
 	createRelativePath,
 	createRelativePathFromSegments,
-	FilePath,
 } from "@internal/path";
 import {DiagnosticAdvice, DiagnosticLocation} from "@internal/diagnostics";
 import {IMPLICIT_JS_EXTENSIONS} from "../../common/file-handlers/javascript";
@@ -30,7 +33,10 @@ import {MOCKS_DIRECTORY_NAME} from "@internal/core/common/constants";
 import {Consumer} from "@internal/consume";
 import {markup} from "@internal/markup";
 import https = require("https");
-import { matchAliasPattern, buildPathFromAliasPattern } from "@internal/project/aliases";
+import {
+	buildPathFromAliasPattern,
+	matchAliasPattern,
+} from "@internal/project/aliases";
 
 function request(
 	url: string,
@@ -430,7 +436,7 @@ export default class Resolver {
 			switch (protocol) {
 				case "http:":
 				case "https:": {
-					const projectConfig = this.getProjectConfig(query)
+					const projectConfig = this.getProjectConfig(query);
 					const remotePath = projectConfig.files.vendorPath.append(
 						source.join().replace(/[\/:]/g, "$").replace(/\$+/g, "$"),
 					);
@@ -507,7 +513,7 @@ export default class Resolver {
 		}
 
 		// Try aliased paths first if they exist
-		const projectConfig = this.getProjectConfig(query);		
+		const projectConfig = this.getProjectConfig(query);
 		for (const aliasedPath of this.getAliasedPaths(query, projectConfig.aliases)) {
 			const resolved = this.resolvePath({
 				...query,
@@ -529,7 +535,9 @@ export default class Resolver {
 		return resolved;
 	}
 
-	private getProjectConfig(query: ResolverLocalQuery | ResolverRemoteQuery): ProjectConfig {
+	private getProjectConfig(
+		query: ResolverLocalQuery | ResolverRemoteQuery,
+	): ProjectConfig {
 		let projectConfig = createDefaultProjectConfig();
 		if (query.origin.isAbsolute()) {
 			const project = this.server.projectManager.findLoadedProject(
@@ -539,12 +547,12 @@ export default class Resolver {
 				projectConfig = project.config;
 			}
 		}
-		return projectConfig
+		return projectConfig;
 	}
 
 	private *getAliasedPaths(
-		query: ResolverLocalQuery, 
-		aliasesConfig: ProjectConfig["aliases"]
+		query: ResolverLocalQuery,
+		aliasesConfig: ProjectConfig["aliases"],
 	): Iterable<AbsoluteFilePath> {
 		const queryPath = query.source.toString();
 		for (const [alias, targets] of aliasesConfig.paths) {
@@ -554,7 +562,7 @@ export default class Resolver {
 			}
 
 			for (const target of targets) {
-				const newPath = buildPathFromAliasPattern(matchedPath, target)
+				const newPath = buildPathFromAliasPattern(matchedPath, target);
 				yield aliasesConfig.base.resolve(newPath);
 			}
 		}

--- a/internal/core/server/utils/escapeObjectPaths.test.ts
+++ b/internal/core/server/utils/escapeObjectPaths.test.ts
@@ -1,19 +1,19 @@
-import {test} from 'rome'
-import { splitEscapedObjectPath } from './escapeObjectPaths'
+import {test} from "rome";
+import {splitEscapedObjectPath} from "./escapeObjectPaths";
 
 test(
-    "split object paths correctly",
-    (t) => { 
-        t.looksLike(splitEscapedObjectPath(""), [])
-        t.looksLike(splitEscapedObjectPath("abc"), ["abc"])
-        t.looksLike(splitEscapedObjectPath("a.b.c"), ["a", "b", "c"])
-        // repeated '.' or placed at edges should be ignored 
-        t.looksLike(splitEscapedObjectPath("a..b.c"), ["a", "b", "c"])
-        t.looksLike(splitEscapedObjectPath("a....b....c"), ["a", "b", "c"])
-        t.looksLike(splitEscapedObjectPath("a.b.c."), ["a", "b", "c"])
-        t.looksLike(splitEscapedObjectPath(".a.b.c"), ["a", "b", "c"])
-        // escaped '.' should be ignored
-        t.looksLike(splitEscapedObjectPath("a\\.b.c"), ["a\\.b", "c"])
-        t.looksLike(splitEscapedObjectPath("a.b.c\\."), ["a", "b", "c\\."])
-    }
-)
+	"split object paths correctly",
+	(t) => {
+		t.looksLike(splitEscapedObjectPath(""), []);
+		t.looksLike(splitEscapedObjectPath("abc"), ["abc"]);
+		t.looksLike(splitEscapedObjectPath("a.b.c"), ["a", "b", "c"]);
+		// repeated '.' or placed at edges should be ignored
+		t.looksLike(splitEscapedObjectPath("a..b.c"), ["a", "b", "c"]);
+		t.looksLike(splitEscapedObjectPath("a....b....c"), ["a", "b", "c"]);
+		t.looksLike(splitEscapedObjectPath("a.b.c."), ["a", "b", "c"]);
+		t.looksLike(splitEscapedObjectPath(".a.b.c"), ["a", "b", "c"]);
+		// escaped '.' should be ignored
+		t.looksLike(splitEscapedObjectPath("a\\.b.c"), ["a\\.b", "c"]);
+		t.looksLike(splitEscapedObjectPath("a.b.c\\."), ["a", "b", "c\\."]);
+	},
+);

--- a/internal/core/server/utils/escapeObjectPaths.test.ts
+++ b/internal/core/server/utils/escapeObjectPaths.test.ts
@@ -1,0 +1,19 @@
+import {test} from 'rome'
+import { splitEscapedObjectPath } from './escapeObjectPaths'
+
+test(
+    "split object paths correctly",
+    (t) => { 
+        t.looksLike(splitEscapedObjectPath(""), [])
+        t.looksLike(splitEscapedObjectPath("abc"), ["abc"])
+        t.looksLike(splitEscapedObjectPath("a.b.c"), ["a", "b", "c"])
+        // repeated '.' or placed at edges should be ignored 
+        t.looksLike(splitEscapedObjectPath("a..b.c"), ["a", "b", "c"])
+        t.looksLike(splitEscapedObjectPath("a....b....c"), ["a", "b", "c"])
+        t.looksLike(splitEscapedObjectPath("a.b.c."), ["a", "b", "c"])
+        t.looksLike(splitEscapedObjectPath(".a.b.c"), ["a", "b", "c"])
+        // escaped '.' should be ignored
+        t.looksLike(splitEscapedObjectPath("a\\.b.c"), ["a\\.b", "c"])
+        t.looksLike(splitEscapedObjectPath("a.b.c\\."), ["a", "b", "c\\."])
+    }
+)

--- a/internal/core/server/utils/escapeObjectPaths.ts
+++ b/internal/core/server/utils/escapeObjectPaths.ts
@@ -1,36 +1,36 @@
 // Split by "." but ignore "\."
 export function splitEscapedObjectPath(path: string): string[] {
-    const result: string[] = []
-    let lastIndex = 0;
-    for (let i = 0; i < path.length; i++) {
-        if (path[i] === "." && i === 0) {
-            lastIndex = 1;
-        } else if (path[i] === "." && i === path.length - 1 && path[i - 1] !== '\\') {
-            result.push(path.slice(lastIndex, i))
-            lastIndex = i + 1
-        } else if (path[i] === "." && path[i - 1] !== "\\") {
-            // ignore repeated dots
-            if (path[i - 1] === ".") {
-                lastIndex = i + 1;
-            } else {
-                result.push(path.slice(lastIndex, i))
-                lastIndex = i + 1
-            }
-        }
-    }
-    if (lastIndex < path.length) {
-        result.push(path.slice(lastIndex))
-    }
+	const result: string[] = [];
+	let lastIndex = 0;
+	for (let i = 0; i < path.length; i++) {
+		if (path[i] === "." && i === 0) {
+			lastIndex = 1;
+		} else if (path[i] === "." && i === path.length - 1 && path[i - 1] !== "\\") {
+			result.push(path.slice(lastIndex, i));
+			lastIndex = i + 1;
+		} else if (path[i] === "." && path[i - 1] !== "\\") {
+			// ignore repeated dots
+			if (path[i - 1] === ".") {
+				lastIndex = i + 1;
+			} else {
+				result.push(path.slice(lastIndex, i));
+				lastIndex = i + 1;
+			}
+		}
+	}
+	if (lastIndex < path.length) {
+		result.push(path.slice(lastIndex));
+	}
 
-    return result
+	return result;
 }
 
-// Replace "." with "\." 
+// Replace "." with "\."
 export function escapePath(path: string) {
-    return path.replace(/\./g, "\\.")
+	return path.replace(/\./g, "\\.");
 }
 
 // Replace "\." with "."
 export function unescapePath(path: string) {
-    return path.replace(/\\\./g, ".")
+	return path.replace(/\\\./g, ".");
 }

--- a/internal/core/server/utils/escapeObjectPaths.ts
+++ b/internal/core/server/utils/escapeObjectPaths.ts
@@ -1,0 +1,36 @@
+// Split by "." but ignore "\."
+export function splitEscapedObjectPath(path: string): string[] {
+    const result: string[] = []
+    let lastIndex = 0;
+    for (let i = 0; i < path.length; i++) {
+        if (path[i] === "." && i === 0) {
+            lastIndex = 1;
+        } else if (path[i] === "." && i === path.length - 1 && path[i - 1] !== '\\') {
+            result.push(path.slice(lastIndex, i))
+            lastIndex = i + 1
+        } else if (path[i] === "." && path[i - 1] !== "\\") {
+            // ignore repeated dots
+            if (path[i - 1] === ".") {
+                lastIndex = i + 1;
+            } else {
+                result.push(path.slice(lastIndex, i))
+                lastIndex = i + 1
+            }
+        }
+    }
+    if (lastIndex < path.length) {
+        result.push(path.slice(lastIndex))
+    }
+
+    return result
+}
+
+// Replace "." with "\." 
+export function escapePath(path: string) {
+    return path.replace(/\./g, "\\.")
+}
+
+// Replace "\." with "."
+export function unescapePath(path: string) {
+    return path.replace(/\\\./g, ".")
+}

--- a/internal/diagnostics/descriptions/projectConfig.ts
+++ b/internal/diagnostics/descriptions/projectConfig.ts
@@ -14,4 +14,19 @@ export const projectConfig = createDiagnosticsCategory({
 		],
 	}),
 	RECURSIVE_CONFIG: {message: markup`Recursive config`},
+
+	TOO_MANY_WILDCARDS: (pattern: string) => ({
+		message: markup`Pattern ${pattern} contains more than one wildacard.`,
+		advice: [
+			{
+				type: "log",
+				category: "info",
+				text: markup`Alias patterns should have the following format \\<prefix>[*]\\<sufix>.`
+			}
+		]
+	}),
+
+	EMPTY_PATTERN: {
+		message: markup`Alias pattern can't be empty.`
+	}
 });

--- a/internal/diagnostics/descriptions/projectConfig.ts
+++ b/internal/diagnostics/descriptions/projectConfig.ts
@@ -21,12 +21,12 @@ export const projectConfig = createDiagnosticsCategory({
 			{
 				type: "log",
 				category: "info",
-				text: markup`Alias patterns should have the following format \\<prefix>[*]\\<sufix>.`
-			}
-		]
+				text: markup`Alias patterns should have the following format \\<prefix>[*]\\<sufix>.`,
+			},
+		],
 	}),
 
 	EMPTY_PATTERN: {
-		message: markup`Alias pattern can't be empty.`
-	}
+		message: markup`Alias pattern can't be empty.`,
+	},
 });

--- a/internal/diagnostics/descriptions/projectConfig.ts
+++ b/internal/diagnostics/descriptions/projectConfig.ts
@@ -16,12 +16,12 @@ export const projectConfig = createDiagnosticsCategory({
 	RECURSIVE_CONFIG: {message: markup`Recursive config`},
 
 	TOO_MANY_WILDCARDS: (pattern: string) => ({
-		message: markup`Pattern ${pattern} contains more than one wildacard.`,
+		message: markup`Pattern <emphasis>${pattern}</emphasis> contains more than one wildacard.`,
 		advice: [
 			{
 				type: "log",
 				category: "info",
-				text: markup`Alias patterns should have the following format \\<prefix>[*]\\<sufix>.`,
+				text: markup`Alias patterns should have the following format <emphasis>\\<prefix>[*]\\<sufix></emphasis>.`,
 			},
 		],
 	}),

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -6,8 +6,8 @@ export interface PathAliasPattern {
     wildcard: boolean
 }
 
-export function consumePathAliasPattern(consumer: Consumer): PathAliasPattern {
-    const path = consumer.asString();
+export function consumePathAliasPattern(consumer: Consumer, alreadyConsumed?: string): PathAliasPattern {
+    const path = alreadyConsumed || consumer.asString();
 
     if (path.length === 0) {
         throw consumer.unexpected(descriptions.PROJECT_CONFIG.EMPTY_PATTERN)

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -1,54 +1,65 @@
-import { Consumer } from "@internal/consume";
-import { descriptions } from "@internal/diagnostics";
+import {Consumer} from "@internal/consume";
+import {descriptions} from "@internal/diagnostics";
 
 export interface PathAliasPattern {
-    parts: string[]
-    wildcard: boolean
+	parts: string[];
+	wildcard: boolean;
 }
 
-export function consumePathAliasPattern(consumer: Consumer, alreadyConsumed?: string): PathAliasPattern {
-    const path = alreadyConsumed || consumer.asString();
+export function consumePathAliasPattern(
+	consumer: Consumer,
+	alreadyConsumed?: string,
+): PathAliasPattern {
+	const path = alreadyConsumed || consumer.asString();
 
-    if (path.length === 0) {
-        throw consumer.unexpected(descriptions.PROJECT_CONFIG.EMPTY_PATTERN)
-    }
+	if (path.length === 0) {
+		throw consumer.unexpected(descriptions.PROJECT_CONFIG.EMPTY_PATTERN);
+	}
 
-    const wildcards = path.match(/\*/g) || []
-    if (wildcards.length > 1) {
-        throw consumer.unexpected(descriptions.PROJECT_CONFIG.TOO_MANY_WILDCARDS(path))
-    }
+	const wildcards = path.match(/\*/g) || [];
+	if (wildcards.length > 1) {
+		throw consumer.unexpected(
+			descriptions.PROJECT_CONFIG.TOO_MANY_WILDCARDS(path),
+		);
+	}
 
-    return {
-        parts: path.split('*'),
-        wildcard: wildcards.length === 1,
-    }
+	return {
+		parts: path.split("*"),
+		wildcard: wildcards.length === 1,
+	};
 }
 
-export function buildPathFromAliasPattern(path: string, pattern: PathAliasPattern): string {
-    const [prefix, sufix] = pattern.parts
-    if (pattern.wildcard) {
-        return prefix + path + sufix
-    }
-    return prefix
+export function buildPathFromAliasPattern(
+	path: string,
+	pattern: PathAliasPattern,
+): string {
+	const [prefix, sufix] = pattern.parts;
+	if (pattern.wildcard) {
+		return prefix + path + sufix;
+	}
+	return prefix;
 }
 
-export function matchAliasPattern(path: string, pattern: PathAliasPattern): string | undefined {
-    const [prefix, sufix] = pattern.parts
-    if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(sufix)) {
-        return path.slice(prefix.length, path.length - sufix.length)        
-    }
+export function matchAliasPattern(
+	path: string,
+	pattern: PathAliasPattern,
+): string | undefined {
+	const [prefix, sufix] = pattern.parts;
+	if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(sufix)) {
+		return path.slice(prefix.length, path.length - sufix.length);
+	}
 
-    if (path === prefix) {
-        return path;
-    }
+	if (path === prefix) {
+		return path;
+	}
 
-    return undefined;
+	return undefined;
 }
 
 export function aliasPatternToString(pattern: PathAliasPattern): string {
-    const [prefix, sufix] = pattern.parts
-    if (pattern.wildcard) {
-        return prefix + "*" + sufix
-    }
-    return prefix
+	const [prefix, sufix] = pattern.parts;
+	if (pattern.wildcard) {
+		return `${prefix}*${sufix}`;
+	}
+	return prefix;
 }

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -4,7 +4,7 @@ import {descriptions} from "@internal/diagnostics";
 export type PathAliasPattern = {
 	parts: string[];
 	wildcard: boolean;
-}
+};
 
 export function consumePathAliasPattern(
 	consumer: Consumer,
@@ -44,8 +44,8 @@ export function matchAliasPattern(
 	path: string,
 	pattern: PathAliasPattern,
 ): string | undefined {
-	const [prefix, sufix] = pattern.parts;
-	if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(sufix)) {
+	const [prefix, suffix] = pattern.parts;
+	if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(suffix)) {
 		return path.slice(prefix.length, path.length - suffix.length);
 	}
 
@@ -59,7 +59,7 @@ export function matchAliasPattern(
 export function aliasPatternToString(pattern: PathAliasPattern): string {
 	const [prefix, suffix] = pattern.parts;
 	if (pattern.wildcard) {
-		return `${prefix}*${sufix}`;
+		return `${prefix}*${suffix}`;
 	}
 	return prefix;
 }

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -33,9 +33,9 @@ export function buildPathFromAliasPattern(
 	path: string,
 	pattern: PathAliasPattern,
 ): string {
-	const [prefix, sufix] = pattern.parts;
+	const [prefix, suffix] = pattern.parts;
 	if (pattern.wildcard) {
-		return prefix + path + sufix;
+		return prefix + path + suffix;
 	}
 	return prefix;
 }
@@ -46,7 +46,7 @@ export function matchAliasPattern(
 ): string | undefined {
 	const [prefix, sufix] = pattern.parts;
 	if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(sufix)) {
-		return path.slice(prefix.length, path.length - sufix.length);
+		return path.slice(prefix.length, path.length - suffix.length);
 	}
 
 	if (path === prefix) {
@@ -57,7 +57,7 @@ export function matchAliasPattern(
 }
 
 export function aliasPatternToString(pattern: PathAliasPattern): string {
-	const [prefix, sufix] = pattern.parts;
+	const [prefix, suffix] = pattern.parts;
 	if (pattern.wildcard) {
 		return `${prefix}*${sufix}`;
 	}

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -44,3 +44,11 @@ export function matchAliasPattern(path: string, pattern: PathAliasPattern): stri
 
     return undefined;
 }
+
+export function aliasPatternToString(pattern: PathAliasPattern): string {
+    const [prefix, sufix] = pattern.parts
+    if (pattern.wildcard) {
+        return prefix + "*" + sufix
+    }
+    return prefix
+}

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -1,0 +1,46 @@
+import { Consumer } from "@internal/consume";
+import { descriptions } from "@internal/diagnostics";
+
+export interface PathAliasPattern {
+    parts: string[]
+    wildcard: boolean
+}
+
+export function consumePathAliasPattern(consumer: Consumer): PathAliasPattern {
+    const path = consumer.asString();
+
+    if (path.length === 0) {
+        throw consumer.unexpected(descriptions.PROJECT_CONFIG.EMPTY_PATTERN)
+    }
+
+    const wildcards = path.match(/\*/g) || []
+    if (wildcards.length > 1) {
+        throw consumer.unexpected(descriptions.PROJECT_CONFIG.TOO_MANY_WILDCARDS(path))
+    }
+
+    return {
+        parts: path.split('*'),
+        wildcard: wildcards.length === 1,
+    }
+}
+
+export function buildPathFromAliasPattern(path: string, pattern: PathAliasPattern): string {
+    const [prefix, sufix] = pattern.parts
+    if (pattern.wildcard) {
+        return prefix + path + sufix
+    }
+    return prefix
+}
+
+export function matchAliasPattern(path: string, pattern: PathAliasPattern): string | undefined {
+    const [prefix, sufix] = pattern.parts
+    if (pattern.wildcard && path.startsWith(prefix) && path.endsWith(sufix)) {
+        return path.slice(prefix.length, path.length - sufix.length)        
+    }
+
+    if (path === prefix) {
+        return path;
+    }
+
+    return undefined;
+}

--- a/internal/project/aliases.ts
+++ b/internal/project/aliases.ts
@@ -1,7 +1,7 @@
 import {Consumer} from "@internal/consume";
 import {descriptions} from "@internal/diagnostics";
 
-export interface PathAliasPattern {
+export type PathAliasPattern = {
 	parts: string[];
 	wildcard: boolean;
 }

--- a/internal/project/load.ts
+++ b/internal/project/load.ts
@@ -43,7 +43,7 @@ import {resolveBrowsers} from "@internal/codec-browsers";
 import {ParserOptions} from "@internal/parser-core";
 import {loadPrettier} from "@internal/project/integrations/loadPrettier";
 import {loadEslint} from "@internal/project/integrations/loadEslint";
-import { consumePathAliasPattern } from "./aliases";
+import {consumePathAliasPattern} from "./aliases";
 
 type NormalizedPartial = {
 	partial: PartialProjectConfig;
@@ -250,7 +250,7 @@ export async function normalizeProjectConfig(
 			typescriptChecker: {},
 			prettier: {},
 		},
-		aliases: {}
+		aliases: {},
 	};
 
 	if (inferredName !== undefined) {
@@ -568,16 +568,18 @@ export async function normalizeProjectConfig(
 	if (aliases.exists()) {
 		if (aliases.has("base")) {
 			const base = aliases.get("base").asFilePath();
-			config.aliases.base = projectDirectory.resolve(base)
+			config.aliases.base = projectDirectory.resolve(base);
 		}
 
 		if (aliases.has("paths")) {
 			const paths = aliases.get("paths").asMap();
 			config.aliases.paths = [];
 			for (const [alias, targets] of paths) {
-				const targetsAsPatterns = targets.asMappedArray(target => consumePathAliasPattern(target))
+				const targetsAsPatterns = targets.asMappedArray((target) =>
+					consumePathAliasPattern(target)
+				);
 				const aliasAsPattern = consumePathAliasPattern(targets, alias);
-				config.aliases.paths.push([aliasAsPattern, targetsAsPatterns])
+				config.aliases.paths.push([aliasAsPattern, targetsAsPatterns]);
 			}
 		}
 
@@ -734,8 +736,8 @@ async function extendProjectConfig(
 
 	const aliasesPaths = mergeArrays(
 		extendsObj.aliases.paths,
-		config.aliases.paths
-	)
+		config.aliases.paths,
+	);
 	if (aliasesPaths !== undefined) {
 		merged.aliases.paths = aliasesPaths;
 	}
@@ -847,6 +849,6 @@ function mergePartialConfig<
 		aliases: {
 			...a.aliases,
 			...b.aliases,
-		}
+		},
 	};
 }

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -19,6 +19,7 @@ import {SemverRange} from "@internal/codec-semver";
 import {LintRuleName} from "@internal/compiler";
 import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
 import {GetBrowserProps} from "@internal/browser-features";
+import { PathAliasPattern } from "./aliases";
 
 // Project wrapper that contains some other metadata
 export type ProjectDefinition = {
@@ -101,6 +102,10 @@ export type ProjectConfigObjects = {
 		exceptions: DependenciesExceptions;
 	};
 	targets: Map<string, GetBrowserProps[]>;
+	aliases: {
+		base: AbsoluteFilePath,
+		paths: [PathAliasPattern, PathAliasPattern[]][],
+	}
 };
 
 export type IntegrationPrettierConfig = {
@@ -232,6 +237,10 @@ export type RawUserProjectConfig = DeepPartial<{
 		typescriptChecker: Enableable;
 		prettier: Enableable & Partial<IntegrationPrettierConfig>;
 	};
+	aliases: {
+		base: string,
+		paths: {[key: string]: string},
+	}
 }>;
 
 export function createMockProjectConfigMeta(
@@ -316,5 +325,9 @@ export function createDefaultProjectConfig(): ProjectConfig {
 				enabled: false,
 			},
 		},
+		aliases: {
+			base: createAbsoluteFilePath("/"),
+			paths: [],
+		}
 	};
 }

--- a/internal/project/types.ts
+++ b/internal/project/types.ts
@@ -19,7 +19,7 @@ import {SemverRange} from "@internal/codec-semver";
 import {LintRuleName} from "@internal/compiler";
 import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
 import {GetBrowserProps} from "@internal/browser-features";
-import { PathAliasPattern } from "./aliases";
+import {PathAliasPattern} from "./aliases";
 
 // Project wrapper that contains some other metadata
 export type ProjectDefinition = {
@@ -103,9 +103,9 @@ export type ProjectConfigObjects = {
 	};
 	targets: Map<string, GetBrowserProps[]>;
 	aliases: {
-		base: AbsoluteFilePath,
-		paths: [PathAliasPattern, PathAliasPattern[]][],
-	}
+		base: AbsoluteFilePath;
+		paths: [PathAliasPattern, PathAliasPattern[]][];
+	};
 };
 
 export type IntegrationPrettierConfig = {
@@ -238,9 +238,11 @@ export type RawUserProjectConfig = DeepPartial<{
 		prettier: Enableable & Partial<IntegrationPrettierConfig>;
 	};
 	aliases: {
-		base: string,
-		paths: {[key: string]: string},
-	}
+		base: string;
+		paths: {
+			[key: string]: string;
+		};
+	};
 }>;
 
 export function createMockProjectConfigMeta(
@@ -328,6 +330,6 @@ export function createDefaultProjectConfig(): ProjectConfig {
 		aliases: {
 			base: createAbsoluteFilePath("/"),
 			paths: [],
-		}
+		},
 	};
 }


### PR DESCRIPTION
## Summary

I remade the PR #1569. Fixes #1555 
At the moment `auto-config` would simply read `tsconfig` and add the missing entries. It does not sync the path aliases entirely because there is no command to pop/reset arrays in the config. Also, there is no support for Node packages remapping. 

## Testing
Manual and some unit tests, no integration tests yet. 