### PR TITLE
fix(cli): correctly apply disable/enable commands

### DIFF
--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -63,6 +63,10 @@ async function runCommand(
 				),
 				...(Array.isArray(value) ? value : []),
 			]);
+		} else if (action === "enable" || action === "disable") {
+			keyConsumer.setValue({
+				enabled: value,
+			});
 		} else {
 			keyConsumer.setValue(value);
 		}
@@ -77,11 +81,15 @@ async function runCommand(
 			reporter.log(configPath);
 			return;
 		}
+		const finalKeyParts =
+			action === "disable" || action === "enable"
+				? `${keyParts}.enabled`
+				: keyParts;
 
 		reporter.success(
 			markup`${action === "push" ? "Adding" : "Setting"} <emphasis>${prettyFormat(
 				value,
-			)}</emphasis> to <emphasis>${keyParts}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
+			)}</emphasis> to <emphasis>${finalKeyParts}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
 		);
 
 		if (value === "true" || value === "false") {
@@ -89,7 +97,7 @@ async function runCommand(
 			reporter.warn(
 				markup`Value is the string <emphasis>${value}</emphasis> but it looks like a boolean. You probably meant to use the command:`,
 			);
-			reporter.command(`config ${suggestedCommand} ${keyParts}`);
+			reporter.command(`config ${suggestedCommand} ${finalKeyParts}`);
 		}
 
 		// Load the config file again


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

`rome config enable` and `rome config disable` commands were not correctly apply the change.
They were just applying a simple boolean.

Now it correctly change the `enabled` keyword, which is a standard key to enable/disable various features inside Rome.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually run the command on a different project

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
