### PR TITLE
fix(compiler): build correct ancestryPaths in getChildPath

### DIFF
--- a/internal/compiler/lib/CompilerPath.ts
+++ b/internal/compiler/lib/CompilerPath.ts
@@ -170,7 +170,7 @@ export default class CompilerPath {
 			this.context,
 			{
 				parentScope: this.scope,
-				ancestryPaths: this.ancestryPaths.concat([this]),
+				ancestryPaths: [this, ...this.ancestryPaths],
 				nodeKey: key,
 			},
 		);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

The `ancestryPaths` array should be built with the [direct parent first](https://github.com/rome/tools/blob/86abd12e6ec6fc72c997407ee870c7abd9d8e810/internal/compiler/methods/reduce.ts#L251)
