### PR TITLE
feat(core, project): config remove/pop commands

### DIFF
--- a/internal/core/client/commands.ts
+++ b/internal/core/client/commands.ts
@@ -12,6 +12,7 @@ import status from "./commands/status";
 import lsp from "./commands/lsp";
 import init from "./commands/init";
 import autoConfig from "./commands/autoConfig";
+import * as config from "./commands/config";
 
 //
 import {UnknownObject} from "@internal/typescript-helpers";
@@ -40,3 +41,5 @@ localCommands.set("status", status);
 localCommands.set("lsp", lsp);
 localCommands.set("init", init);
 localCommands.set("auto-config", autoConfig);
+localCommands.set("config remove", config.remove);
+localCommands.set("config pop", config.pop);

--- a/internal/core/client/commands/config.ts
+++ b/internal/core/client/commands/config.ts
@@ -5,7 +5,7 @@ import {Reporter} from "@internal/cli-reporter";
 
 export const remove = createLocalCommand({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove ${"<key>"}`,
+	description: markup`modify a project config - remove "\\<key>"`,
 	usage: "<key>",
 	examples: [],
 	defineFlags() {
@@ -31,9 +31,12 @@ export const remove = createLocalCommand({
 
 export const pop = createLocalCommand({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove "<values>" from "<key>"`,
+	description: markup`modify a project config - remove "\\<values>" from "\\<key>"`,
 	usage: "<key> <...values>",
-	examples: [],
+	examples: [{
+		command: "rome config pop aliases.paths path1 path2",
+		description: markup`Remove multiple values from aliases.paths configuration.`,
+	}],
 	defineFlags() {
 		return {};
 	},

--- a/internal/core/client/commands/config.ts
+++ b/internal/core/client/commands/config.ts
@@ -1,0 +1,63 @@
+import {createLocalCommand} from "../commands";
+import {commandCategories} from "@internal/core/common/commands";
+import {markup} from "@internal/markup";
+import {Reporter} from "@internal/cli-reporter";
+
+export const remove = createLocalCommand({
+	category: commandCategories.PROJECT_MANAGEMENT,
+	description: markup`modify a project config - remove ${"<key>"}`,
+	usage: "<key>",
+	examples: [],
+	defineFlags() {
+		return {};
+	},
+	async callback(req) {
+		const {client, query} = req;
+		const {reporter} = client;
+
+		if (await confirmDeletion(reporter)) {
+			await client.query(
+				{
+					commandName: "config remove",
+					args: query.args,
+				},
+				"server",
+			);
+		}
+
+		return true;
+	},
+});
+
+export const pop = createLocalCommand({
+	category: commandCategories.PROJECT_MANAGEMENT,
+	description: markup`modify a project config - remove ${"<values>"} from ${"<key>"}`,
+	usage: "<key> <...values>",
+	examples: [],
+	defineFlags() {
+		return {};
+	},
+	async callback(req) {
+		const {client, query} = req;
+		const {reporter} = client;
+
+		if (await confirmDeletion(reporter)) {
+			await client.query(
+				{
+					commandName: "config pop",
+					args: query.args,
+				},
+				"server",
+			);
+		}
+
+		return true;
+	},
+});
+
+function confirmDeletion(reporter: Reporter): Promise<boolean> {
+	reporter.warn("Your configuration will be affected by this command.");
+	return reporter.radioConfirm(
+		"Are you sure you want to remove the specified configs?",
+	);
+}

--- a/internal/core/client/commands/config.ts
+++ b/internal/core/client/commands/config.ts
@@ -31,7 +31,7 @@ export const remove = createLocalCommand({
 
 export const pop = createLocalCommand({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove ${"<values>"} from ${"<key>"}`,
+	description: markup`modify a project config - remove "<values>" from "<key>"`,
 	usage: "<key> <...values>",
 	examples: [],
 	defineFlags() {

--- a/internal/core/client/commands/config.ts
+++ b/internal/core/client/commands/config.ts
@@ -33,10 +33,12 @@ export const pop = createLocalCommand({
 	category: commandCategories.PROJECT_MANAGEMENT,
 	description: markup`modify a project config - remove "\\<values>" from "\\<key>"`,
 	usage: "<key> <...values>",
-	examples: [{
-		command: "rome config pop aliases.paths path1 path2",
-		description: markup`Remove multiple values from aliases.paths configuration.`,
-	}],
+	examples: [
+		{
+			command: "rome config pop aliases.paths path1 path2",
+			description: markup`Remove multiple values from aliases.paths configuration.`,
+		},
+	],
 	defineFlags() {
 		return {};
 	},

--- a/internal/core/common/commands.ts
+++ b/internal/core/common/commands.ts
@@ -28,6 +28,8 @@ export type CommandName =
 	| "config enable"
 	| "config push"
 	| "config set"
+	| "config pop"
+	| "config remove"
 	| "config set-directory"
 	| "config migrate"
 	| "develop"

--- a/internal/core/server/commands.ts
+++ b/internal/core/server/commands.ts
@@ -121,6 +121,8 @@ serverCommands.set("config disable", config.disable);
 serverCommands.set("config enable", config.enable);
 serverCommands.set("config push", config.push);
 serverCommands.set("config set", config.set);
+serverCommands.set("config pop", config.pop);
+serverCommands.set("config remove", config.remove);
 serverCommands.set("config set-directory", config.setDirectory);
 serverCommands.set("config migrate", config.migrate);
 serverCommands.set("format", format);

--- a/internal/core/server/commands/config.test.ts
+++ b/internal/core/server/commands/config.test.ts
@@ -86,3 +86,50 @@ test(
 		},
 	),
 );
+
+test(
+	"should remove an existing property",
+	createIntegrationTest(
+		{
+			files: {},
+			projectConfig: {
+				root: true,
+				name: "dummy",
+				format: {
+					indentSize: 2,
+				},
+			},
+			disableTest: true,
+		},
+		async (t, {client}) => {
+			await client.query({
+				commandName: "config remove",
+				args: ["format.indentSize"],
+			});
+		},
+	),
+);
+
+
+test(
+	"should pop a value from an existing array",
+	createIntegrationTest(
+		{
+			files: {},
+			projectConfig: {
+				root: true,
+				name: "dummy",
+				lint: {
+					globals: ["beforeEach"]
+				}
+			},
+			disableTest: true,
+		},
+		async (t, {client}) => {
+			await client.query({
+				commandName: "config pop",
+				args: ["lint.globals", "beforeEach"],
+			});
+		},
+	),
+);

--- a/internal/core/server/commands/config.test.ts
+++ b/internal/core/server/commands/config.test.ts
@@ -110,7 +110,6 @@ test(
 	),
 );
 
-
 test(
 	"should pop a value from an existing array",
 	createIntegrationTest(
@@ -120,8 +119,8 @@ test(
 				root: true,
 				name: "dummy",
 				lint: {
-					globals: ["beforeEach"]
-				}
+					globals: ["beforeEach"],
+				},
 			},
 			disableTest: true,
 		},

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -90,17 +90,19 @@ async function runCommand(
 			const lastKey = keyParts[keyParts.length - 1];
 			prevKeyConsumer.delete(lastKey);
 		} else if (action === "pop") {
-			const existingValues = Array.from(
-				keyConsumer.required([]).asIterable(),
-				(c) => c.asUnknown(),
-			);
-			const valuesToRemove = Array.isArray(value) ? value : [value];
+			if (keyConsumer.exists()) {
+				const existingValues = Array.from(
+					keyConsumer.asIterable(),
+					(c) => c.asUnknown(),
+				);
+				const valuesToRemove = Array.isArray(value) ? value : [value];
 
-			keyConsumer.setValue(
-				existingValues.filter((item) =>
-					!valuesToRemove.includes(item as string | boolean)
-				),
-			);
+				keyConsumer.setValue(
+					existingValues.filter((item) =>
+						!valuesToRemove.includes(item as string | boolean)
+					),
+				);
+			}
 		} else {
 			const currentValue = keyConsumer.asUnknown();
 			if (typeof currentValue === "number") {

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -413,7 +413,7 @@ export const remove = createServerCommand<Flags>({
 
 export const pop = createServerCommand<Flags>({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove ${"<values>"} from ${"<key>"}`,
+	description: markup`modify a project config - remove "<values>" from "<key>"`,
 	usage: "<key> <...values>",
 	examples: [],
 	hidden: true,

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -45,22 +45,36 @@ function defineFlags(c: Consumer): Flags {
 	};
 }
 
+type Action =
+	| "push"
+	| "set"
+	| "location"
+	| "enable"
+	| "disable"
+	| "remove"
+	| "pop"
+	| "setDirectory";
+
 async function runCommand(
 	req: ServerRequest,
 	flags: Flags,
 	value: boolean | string | (string[]),
-	action: string,
+	action: Action,
 ) {
 	const {reporter} = req;
-	const [keyParts] = req.query.args;
+	const [keyPath] = req.query.args;
 
 	function modify(consumer: Consumer) {
 		// Set the specified value
 		let keyConsumer = consumer;
-		for (const key of keyParts.split(".")) {
+		let prevKeyConsumer = consumer;
+		const keyParts = keyPath.split(".");
+
+		for (const key of keyParts) {
 			if (!keyConsumer.exists()) {
 				keyConsumer.setValue({});
 			}
+			prevKeyConsumer = keyConsumer;
 			keyConsumer = keyConsumer.get(key);
 		}
 
@@ -72,6 +86,21 @@ async function runCommand(
 				),
 				...(Array.isArray(value) ? value : []),
 			]);
+		} else if (action === "remove") {
+			const lastKey = keyParts[keyParts.length - 1];
+			prevKeyConsumer.delete(lastKey);
+		} else if (action === "pop") {
+			const existingValues = Array.from(
+				keyConsumer.required([]).asIterable(),
+				(c) => c.asUnknown(),
+			);
+			const valuesToRemove = Array.isArray(value) ? value : [value];
+
+			keyConsumer.setValue(
+				existingValues.filter((item) =>
+					!valuesToRemove.includes(item as string | boolean)
+				),
+			);
 		} else {
 			const currentValue = keyConsumer.asUnknown();
 			if (typeof currentValue === "number") {
@@ -91,19 +120,38 @@ async function runCommand(
 			reporter.log(configPath);
 			return;
 		}
+		const finalKeyPath =
+			action === "disable" || action === "enable"
+				? `${keyPath}.enabled`
+				: keyPath;
 
-		reporter.success(
-			markup`${action === "push" ? "Adding" : "Setting"} <emphasis>${prettyFormat(
-				value,
-			)}</emphasis> to <emphasis>${keyParts}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
-		);
+		switch (action) {
+			case "remove": {
+				reporter.success(
+					markup`Removing <emphasis>${keyPath}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
+				);
+				break;
+			}
+			case "pop": {
+				reporter.success(
+					markup`Removing <emphasis>${prettyFormat(value)}</emphasis> from <emphasis>${keyPath}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
+				);
+				break;
+			}
+			default:
+				reporter.success(
+					markup`${action === "push" ? "Adding" : "Setting"} <emphasis>${prettyFormat(
+						value,
+					)}</emphasis> to <emphasis>${keyPath}</emphasis> in the config <emphasis>${configPath}</emphasis>`,
+				);
+		}
 
 		if (value === "true" || value === "false") {
 			const suggestedCommand = value === "true" ? "enable" : "disable";
 			reporter.warn(
 				markup`Value is the string <emphasis>${value}</emphasis> but it looks like a boolean. You probably meant to use the command:`,
 			);
-			reporter.command(`config ${suggestedCommand} ${keyParts}`);
+			reporter.command(`config ${suggestedCommand} ${finalKeyPath}`);
 		}
 
 		// Load the config file again
@@ -345,5 +393,29 @@ export const migrate = createServerCommand({
 		});
 
 		await configPath.writeFile(stringified);
+	},
+});
+
+export const remove = createServerCommand<Flags>({
+	category: commandCategories.PROJECT_MANAGEMENT,
+	description: markup`modify a project config - remove ${"<key>"}`,
+	usage: "<key>",
+	examples: [],
+	defineFlags,
+	async callback(req, flags) {
+		req.expectArgumentLength(1);
+		await runCommand(req, flags, req.query.args[1], "remove");
+	},
+});
+
+export const pop = createServerCommand<Flags>({
+	category: commandCategories.PROJECT_MANAGEMENT,
+	description: markup`modify a project config - remove ${"<values>"} from ${"<key>"}`,
+	usage: "<key> <...values>",
+	examples: [],
+	defineFlags,
+	async callback(req, flags) {
+		req.expectArgumentLength(2, Infinity);
+		await runCommand(req, flags, req.query.args.slice(1), "pop");
 	},
 });

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -403,6 +403,7 @@ export const remove = createServerCommand<Flags>({
 	description: markup`modify a project config - remove ${"<key>"}`,
 	usage: "<key>",
 	examples: [],
+	hidden: true,
 	defineFlags,
 	async callback(req, flags) {
 		req.expectArgumentLength(1);
@@ -415,6 +416,7 @@ export const pop = createServerCommand<Flags>({
 	description: markup`modify a project config - remove ${"<values>"} from ${"<key>"}`,
 	usage: "<key> <...values>",
 	examples: [],
+	hidden: true,
 	defineFlags,
 	async callback(req, flags) {
 		req.expectArgumentLength(2, Infinity);

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -400,7 +400,7 @@ export const migrate = createServerCommand({
 
 export const remove = createServerCommand<Flags>({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove ${"<key>"}`,
+	description: markup`modify a project config - remove "<key>"`,
 	usage: "<key>",
 	examples: [],
 	hidden: true,

--- a/internal/core/server/commands/config.ts
+++ b/internal/core/server/commands/config.ts
@@ -400,7 +400,7 @@ export const migrate = createServerCommand({
 
 export const remove = createServerCommand<Flags>({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove "<key>"`,
+	description: markup`modify a project config - remove "\\<key>"`,
 	usage: "<key>",
 	examples: [],
 	hidden: true,
@@ -413,7 +413,7 @@ export const remove = createServerCommand<Flags>({
 
 export const pop = createServerCommand<Flags>({
 	category: commandCategories.PROJECT_MANAGEMENT,
-	description: markup`modify a project config - remove "<values>" from "<key>"`,
+	description: markup`modify a project config - remove "\\<values>" from "\\<key>"`,
 	usage: "<key> <...values>",
 	examples: [],
 	hidden: true,

--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -67,7 +67,7 @@ Push the string `value` to an array at `key`. You can pass multiple values to pu
 
 #### `rome config pop <key> <value>`
 
-Pop the string `value` from an array at `key`. If the `key` doesn't exist then it will be created. You pass multiple values to remove separated by space. 
+Pop the string `value` from an array at `key`. If the `key` doesn't exist then it will be created. You can pass multiple values to remove, separated by space. 
 
 #### `rome config location`
 

--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -63,11 +63,11 @@ Set the `key` to the string `value`. If `value` is an absolute path then it will
 
 #### `rome config push <key> <value>`
 
-Push the string `value` to an array at `key`. You can pass multiple values to push separated by space.
+Push the string `value` to an array at `key`. You can pass multiple values to push separated by space. For example, `rome config push lint.globals beforeEach afterEach`.
 
 #### `rome config pop <key> <value>`
 
-Pop the string `value` from an array at `key`. If the `key` doesn't exist then it will be created. You can pass multiple values to remove, separated by space. 
+Pop the string `value` from an array at `key`. If the `key` doesn't exist then it will be created. You can pass multiple values to remove, separated by space. For example, `rome config pop aliases.paths path1 path2`.
 
 #### `rome config location`
 

--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -53,13 +53,21 @@ Set the `key` to `false`.
 
 Set the `key` to a string `value`.
 
+### `rome config remove <key>`
+
+Remove `key` from configuration.
+
 #### `rome config set-directory <key> <value>`
 
 Set the `key` to the string `value`. If `value` is an absolute path then it will be made relative to the config path.
 
 #### `rome config push <key> <value>`
 
-Push the string `value` to an array at `key`. If `key` doesn't exist then it will be created.
+Push the string `value` to an array at `key`. If `key` doesn't exist then it will be created. You can pass multiple values to push separated by space.
+
+#### `rome config pop <key> <value>`
+
+Pop the string `value` from an array at `key`. If the `key` doesn't exist then it will be created. You pass multiple values to remove separated by space. 
 
 #### `rome config location`
 

--- a/website/src/_includes/docs/cli-commands.md
+++ b/website/src/_includes/docs/cli-commands.md
@@ -63,7 +63,7 @@ Set the `key` to the string `value`. If `value` is an absolute path then it will
 
 #### `rome config push <key> <value>`
 
-Push the string `value` to an array at `key`. If `key` doesn't exist then it will be created. You can pass multiple values to push separated by space.
+Push the string `value` to an array at `key`. You can pass multiple values to push separated by space.
 
 #### `rome config pop <key> <value>`
 


### PR DESCRIPTION
## Summary
Fixes #1617 

## Test plan
Tested on the following scenarios:
* `config remove <nonexistent key>` - ignores it
* `config remove <existing key>` - removes it from config
* `config pop <nonexistent key> <value>` - ignores it
* `config pop <existing key but not array> <value>` - fails with `Expected an array`
* `config pop <exiting key and is array> <...values>` - removes them