### PR TITLE
fix(core): update category check in auto-config command

### DIFF
--- a/internal/core/client/commands/autoConfig.ts
+++ b/internal/core/client/commands/autoConfig.ts
@@ -3,7 +3,11 @@ import {CommandName, commandCategories} from "@internal/core/common/commands";
 import {markup} from "@internal/markup";
 import ClientRequest from "@internal/core/client/ClientRequest";
 import {consumeUnknown} from "@internal/consume";
-import {DIAGNOSTIC_CATEGORIES} from "@internal/diagnostics";
+import {
+	DIAGNOSTIC_CATEGORIES,
+	equalCategoryNames,
+	isValidDiagnosticCategoryName,
+} from "@internal/diagnostics";
 
 interface Flags {
 	allowDirty: boolean;
@@ -78,7 +82,14 @@ export default createLocalCommand({
 								category.exists() &&
 								categoryValue.exists()
 							) {
-								if (category.asString() === "lint/js/noUndeclaredVariables") {
+								const categoryName = category.asMappedArray((c) => c.asString());
+								if (
+									isValidDiagnosticCategoryName(categoryName) &&
+									equalCategoryNames(
+										categoryName,
+										DIAGNOSTIC_CATEGORIES["lint/js/noUndeclaredVariables"],
+									)
+								) {
 									await req.client.query(
 										{
 											commandName: "config push",


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Diagnostic categories were changed from strings to arrays, so the `category.asString()` was throwing a fatal error if there were any diagnostics when running the auto-config command:
```
unknown:18:20 parse(json)  FATAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Expected a string at lint.diagnostics[0].description.category
```
