### PR TITLE
fix(core): allow buffers for nonexistent files

### DIFF
--- a/internal/core/server/Server.ts
+++ b/internal/core/server/Server.ts
@@ -130,6 +130,10 @@ export type ServerRefreshFile =
 	| {
 			type: "BUFFER_UPDATE";
 			path: AbsoluteFilePath;
+		}
+	| {
+			type: "BUFFER_CLEARED";
+			path: AbsoluteFilePath;
 		};
 
 export default class Server {

--- a/internal/core/server/ServerRequest.ts
+++ b/internal/core/server/ServerRequest.ts
@@ -933,11 +933,12 @@ export default class ServerRequest {
 	): Promise<void> {
 		this.checkCancelled();
 
+		const mtimeNs = this.server.memoryFs.addBuffer(path, content);
+
 		await this.wrapRequestDiagnostic(
 			"updateBuffer",
 			path,
 			async (bridge, ref) => {
-				const mtimeNs = this.server.memoryFs.addBuffer(path, content);
 				await bridge.events.updateBuffer.call({
 					ref,
 					buffer: {
@@ -986,7 +987,7 @@ export default class ServerRequest {
 				await bridge.events.clearBuffer.call({ref});
 				this.server.memoryFs.clearBuffer(path);
 				this.server.refreshFileEvent.push({
-					type: "BUFFER_UPDATE",
+					type: "BUFFER_CLEARED",
 					path,
 				});
 			},

--- a/internal/core/server/fs/FileAllocator.ts
+++ b/internal/core/server/fs/FileAllocator.ts
@@ -165,7 +165,7 @@ export default class FileAllocator {
 			const {path} = event;
 
 			// Workers handle cache eviction internally when updating buffers
-			if (event.type === "BUFFER_UPDATE") {
+			if (event.type === "BUFFER_UPDATE" || event.type === "BUFFER_CLEARED") {
 				continue;
 			}
 

--- a/internal/core/server/fs/MemoryFileSystem.ts
+++ b/internal/core/server/fs/MemoryFileSystem.ts
@@ -640,7 +640,7 @@ export default class MemoryFileSystem {
 	}
 
 	public getFileStats(path: AbsoluteFilePath): undefined | SimpleStats {
-		return this.files.get(path);
+		return this.buffers.get(path) ?? this.files.get(path);
 	}
 
 	public getFileStatsAssert(path: AbsoluteFilePath): SimpleStats {
@@ -901,7 +901,11 @@ export default class MemoryFileSystem {
 
 	public exists(path: AbsoluteFilePath): undefined | boolean {
 		// if we have this in our cache then the file exists
-		if (this.files.has(path) || this.directories.has(path)) {
+		if (
+			this.buffers.has(path) ||
+			this.files.has(path) ||
+			this.directories.has(path)
+		) {
 			return true;
 		}
 

--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -107,7 +107,7 @@ export default class ProjectManager {
 		this.server.resources.add(
 			this.server.refreshFileEvent.subscribe((events) => {
 				for (const {path, type} of events) {
-					if (type === "DELETED") {
+					if (type === "DELETED" || type === "BUFFER_CLEARED") {
 						this.handleDeleted(path);
 					}
 				}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This allows the LSP server to handle `textDocument` sync notifications without crashing for files that aren't on disk (e.g. a file was deleted but is still open in VS Code).

This also closes #1165 by preventing symlinked files from crashing the server and allowing them to be formatted through LSP, but this doesn't add handling for symlinks in general.
