### PR TITLE
chore: remove version dropdown from bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -39,15 +39,6 @@ body:
       placeholder: It should not throw an error.
     validations:
       required: true
-  - type: dropdown
-    id: version
-    attributes:
-      label: Rome version
-      description: What version of Rome are you running?
-      options:
-        - 10.0.4-beta
-    validations:
-      required: true
   - type: textarea
     id: configuration
     attributes:


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Version info is included in `rome rage --summary` so this dropdown is unnecessary, and not having any dev or nightly versions listed might make people think we don’t want them opening issues for those versions.
