### PR TITLE
docs(website): remove trailing punctuation from headings

### DIFF
--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -2,14 +2,14 @@
 
 ### Installation and Usage
 
-#### [Yarn](https://yarnpkg.com/):
+#### [Yarn](https://yarnpkg.com/)
 
 ```bash
 yarn add rome
 yarn rome init
 ```
 
-#### [npm/npx](https://www.npmjs.com/):
+#### [npm/npx](https://www.npmjs.com/)
 
 ```bash
 npx rome init


### PR DESCRIPTION
## Summary

Remove trailing `:`s from the headings in the getting started file.
They look weird on the sidebar:

![sidebar](https://user-images.githubusercontent.com/7608555/125705879-6a1e33f5-1dae-44d3-aa4c-201a55d7577c.png)