### PR TITLE
refactor(codec-config): clean up `retrieveConfigHandler` implementation

### DIFF
--- a/internal/codec-config/retrieveConfigHandler.ts
+++ b/internal/codec-config/retrieveConfigHandler.ts
@@ -4,16 +4,12 @@ import {json, toml} from "@internal/codec-config";
 export default function retrieveConfigHandler(
 	extension: ConfigType,
 ): ConfigHandler {
-	let manifestHandler: ConfigHandler | undefined = undefined;
-	if (extension === "toml") {
-		manifestHandler = toml;
-	} else if (extension === "json") {
-		manifestHandler = json;
+	switch (extension) {
+		case "toml":
+			return toml;
+		case "json":
+			return json;
+		default:
+			return json;
 	}
-
-	if (!manifestHandler) {
-		manifestHandler = json;
-	}
-
-	return manifestHandler;
 }


### PR DESCRIPTION
## Summary

The logic in the `retrieveConfigHandler` seemed messy and kinda weird.

This is a tiny change to use a `switch` statement instead, which will make it a bit nicer to add other config formats in the future.