### PR TITLE
fix(project): remove old diagnostic, not needed anymore

### DIFF
--- a/internal/core/server/project/ProjectManager.ts
+++ b/internal/core/server/project/ProjectManager.ts
@@ -955,16 +955,5 @@ export default class ProjectManager {
 				},
 			});
 		}
-
-		if (PROJECT_CONFIG_FILENAMES.includes(path.getBasename())) {
-			diagnostics.addDiagnostic({
-				description: descriptions.PROJECT_MANAGER.MISPLACED_CONFIG(
-					path.getBasename(),
-				),
-				location: {
-					path,
-				},
-			});
-		}
 	}
 }

--- a/internal/diagnostics/descriptions/projectManager.ts
+++ b/internal/diagnostics/descriptions/projectManager.ts
@@ -99,5 +99,5 @@ export const projectManager = createDiagnosticsCategory({
 		category: DIAGNOSTIC_CATEGORIES["projectManager/typoConfigFilename"],
 		message: markup`Invalid Rome config filename <emphasis>${invalidFilename}</emphasis>`,
 		advice: buildSuggestionAdvice(invalidFilename, validFilenames),
-	})
+	}),
 });

--- a/internal/diagnostics/descriptions/projectManager.ts
+++ b/internal/diagnostics/descriptions/projectManager.ts
@@ -99,16 +99,5 @@ export const projectManager = createDiagnosticsCategory({
 		category: DIAGNOSTIC_CATEGORIES["projectManager/typoConfigFilename"],
 		message: markup`Invalid Rome config filename <emphasis>${invalidFilename}</emphasis>`,
 		advice: buildSuggestionAdvice(invalidFilename, validFilenames),
-	}),
-	MISPLACED_CONFIG: (misplacedName: string) => ({
-		category: DIAGNOSTIC_CATEGORIES["projectManager/misplacedConfig"],
-		message: markup`Misplaced project config <emphasis>${misplacedName}</emphasis>`,
-		advice: [
-			{
-				type: "log",
-				category: "info",
-				text: markup`This should be inside your project root folder`,
-			},
-		],
-	}),
+	})
 });

--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -18,7 +18,7 @@ npx rome init
 After running this command, Rome will:
 
 - Add itself to `package.json` as dependency if it wasn't present, and run your package manager to install
-- Generate `.config/rome.json` that serves as your project config.
+- Generate `rome.json` that serves as your project config.
 
 If you're putting Rome into an already established project and you'd like to automatically apply formatting and fixes, you can use:
 

--- a/website/src/_includes/docs/project-config.md
+++ b/website/src/_includes/docs/project-config.md
@@ -258,7 +258,7 @@ Ultimately, the configuration will look like this:
 
 You can specify your project config in a few different places.
 
-##### `.config/rome.json` (recommended)
+##### `rome.json` (recommended)
 
 This is the recommended location. It's the file we create when running `rome init`.
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Following [previous PR](https://github.com/rome/tools/pull/1655), this PR:
- updates the website by remove the mention of `.config` folder
- removes an old diagnostic from the `ProjectManager` that is not needed anymore

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
