### PR TITLE
fix(integrations): use formatted content instead of content from file

### DIFF
--- a/internal/core/worker/integrations/prettier.ts
+++ b/internal/core/worker/integrations/prettier.ts
@@ -20,10 +20,11 @@ export interface MaybeRunPrettier {
 }
 
 export async function maybeRunPrettier(
-	{ref, project, worker}: {
+	{ref, project, worker, content}: {
 		worker: Worker;
 		ref: FileReference;
 		project: WorkerProject;
+		content: string
 	},
 ): Promise<undefined | MaybeRunPrettier> {
 	const options = project.config.integrations.prettier;
@@ -37,8 +38,6 @@ export async function maybeRunPrettier(
 	);
 
 	const timer = new DurationMeasurer();
-
-	const content = await worker.readFileText(ref);
 
 	// NOTE: check if we need diagnostics
 	const diagnostics: Diagnostic[] = [];

--- a/internal/core/worker/integrations/prettier.ts
+++ b/internal/core/worker/integrations/prettier.ts
@@ -1,5 +1,4 @@
 import IntegrationLoader from "@internal/core/common/IntegrationLoader";
-import Worker from "../Worker";
 import {FileReference, WorkerProject} from "@internal/core";
 import {Duration, DurationMeasurer} from "@internal/numbers";
 import {Diagnostic} from "@internal/diagnostics";
@@ -20,11 +19,10 @@ export interface MaybeRunPrettier {
 }
 
 export async function maybeRunPrettier(
-	{ref, project, worker, content}: {
-		worker: Worker;
+	{ref, project, content}: {
 		ref: FileReference;
 		project: WorkerProject;
-		content: string
+		content: string;
 	},
 ): Promise<undefined | MaybeRunPrettier> {
 	const options = project.config.integrations.prettier;

--- a/internal/core/worker/workerLint.ts
+++ b/internal/core/worker/workerLint.ts
@@ -262,7 +262,11 @@ export async function compilerLint(
 		diagnostics = [...diagnostics, ...eslintResult.diagnostics];
 	}
 
-	const prettierResult = await maybeRunPrettier({worker, ref, project, content: formatted});
+	const prettierResult = await maybeRunPrettier({
+		ref,
+		project,
+		content: formatted,
+	});
 
 	if (prettierResult) {
 		formatted = prettierResult.formatted;

--- a/internal/core/worker/workerLint.ts
+++ b/internal/core/worker/workerLint.ts
@@ -262,7 +262,7 @@ export async function compilerLint(
 		diagnostics = [...diagnostics, ...eslintResult.diagnostics];
 	}
 
-	const prettierResult = await maybeRunPrettier({worker, ref, project});
+	const prettierResult = await maybeRunPrettier({worker, ref, project, content: formatted});
 
 	if (prettierResult) {
 		formatted = prettierResult.formatted;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Before submitting a pull request, please make sure the following is done:

	1. Format and resolve any lint errors: `./rome check --apply`
	2. Verify that tests pass: `./rome test`
	3. Ensure there are no TypeScript errors: `./node_modules/.bin/tsc`

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a small bug inside the prettier integration, where we now pass the formatted content instead of reading the file from the file reference.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
