### PR TITLE
feat(formatter): Support different line endings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
 

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -42,7 +42,6 @@ impl FromStr for IndentStyle {
 	}
 }
 
-// TODO: evaluate to remove it
 #[derive(Debug, Default)]
 pub struct FormatOptions {
 	/// The indent style


### PR DESCRIPTION



## Summary
Adds support for different line endings to the formatter's printer so that it emit's the users preferred line ending. 

Rome uses line feeds internally to push the complexity of having different line endings to the `Printer`, that then converts the line feeds to the user preferred ending.

## Test Plan

Added a unit test.
