### PR TITLE
fix: trailing comma in JSON formatter

### DIFF
--- a/crates/cli/examples/input.json
+++ b/crates/cli/examples/input.json
@@ -1,6 +1,8 @@
 {
 	"string": "foo",
-	"boolean": false,
-	"number": 15,
-	"object": { "something": 15 }
+	"boolean": false,"number": 15,"object": { "something": 15 },
+	"e": "foo",
+	"a": false,
+	"d": { "something": 15 },
+	"c": 15
 }

--- a/crates/formatter/src/format_json.rs
+++ b/crates/formatter/src/format_json.rs
@@ -1,4 +1,4 @@
-use crate::format_token::{GroupToken, IfBreakToken, LineToken};
+use crate::format_token::{GroupToken, LineToken};
 use crate::{format_token::FormatToken, FormatValue};
 use serde_json::Value;
 
@@ -31,7 +31,6 @@ impl FormatValue for Value {
 				let properties = vec![
 					FormatToken::Line(LineToken::soft()),
 					FormatToken::join(separator, properties_list),
-					FormatToken::IfBreak(IfBreakToken::new(FormatToken::string(","))),
 				];
 
 				FormatToken::Group(GroupToken::new(vec![
@@ -58,7 +57,7 @@ mod test {
 	use crate::FormatToken;
 
 	use super::json_to_tokens;
-	use crate::format_token::{GroupToken, IfBreakToken, LineToken};
+	use crate::format_token::{GroupToken, LineToken};
 
 	#[test]
 	fn tokenize_number() {
@@ -110,7 +109,6 @@ mod test {
 				FormatToken::string("\"num\":"),
 				FormatToken::Space,
 				FormatToken::string("5"),
-				FormatToken::IfBreak(IfBreakToken::new(FormatToken::string(","))),
 			])),
 			FormatToken::Line(LineToken::soft()),
 			FormatToken::string("}"),


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a small bug in printing a JSON where a trailing comma was added at the end of the last property.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated current tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
