### PR TITLE
chore: Use rome-crate naming for all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,14 +78,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cli"
-version = "0.0.0"
-dependencies = [
- "clap",
- "rome-formatter",
-]
-
-[[package]]
 name = "countme"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,22 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
 
 [[package]]
-name = "parser"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "indexmap",
- "proc-macro2",
- "quote",
- "rowan",
- "serde",
- "serde_json",
- "tree-sitter",
- "tree-sitter-typescript",
- "xshell",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,11 +217,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rome-cli"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "rome-formatter",
+]
+
+[[package]]
 name = "rome-formatter"
 version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rome-parser"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "rowan",
+ "serde",
+ "serde_json",
+ "tree-sitter",
+ "tree-sitter-typescript",
+ "xshell",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "rome-cli"
 version = "0.0.0"
 edition = "2018"
 

--- a/crates/cli/examples/run_cli.rs
+++ b/crates/cli/examples/run_cli.rs
@@ -1,4 +1,4 @@
-use cli::run_cli;
+use rome_cli::run_cli;
 
 ///
 /// To run this example, run:

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "parser"
+name = "rome-parser"
 version = "0.0.0"
 description = ""
 license = "MIT"
 edition = "2018"
-default-run = "parser"
+default-run = "rome-parser"
 
 [dependencies]
 anyhow = "1"

--- a/crates/parser/src/bin/sourcegen.rs
+++ b/crates/parser/src/bin/sourcegen.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use parser::sourcegen::Grammar;
+use rome_parser::sourcegen::Grammar;
 
 fn main() -> Result<()> {
 	let args: Vec<String> = std::env::args().collect();

--- a/crates/parser/src/main.rs
+++ b/crates/parser/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use parser::{languages, ParserLanguage};
+use rome_parser::{languages, Parser, ParserLanguage};
 
 fn main() -> Result<()> {
 	let args: Vec<String> = std::env::args().collect();
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
 }
 
 fn print_tree(src: &str, syntax: impl ParserLanguage) -> Result<()> {
-	let mut parser = parser::Parser::new(syntax)?;
+	let mut parser = Parser::new(syntax)?;
 	let tree = parser.parse_text(src)?;
 	println!("{:#?}", tree);
 	Ok(())


### PR DESCRIPTION
Rename the cli and parser crate to match the rome-{create-name} format and avoid
conflicts with other crates.

### Test plan

```
cargo build
```