### PR TITLE
feat: format macro

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 xtask = "run --package xtask --bin xtask --"
+lint = "clippy --workspace --all-targets --verbose -- --deny warnings"

--- a/crates/cli/tests/main.rs
+++ b/crates/cli/tests/main.rs
@@ -29,6 +29,7 @@ fn test_format_cli() {
 - file "fixtures/input.json"
 - with options Tab
 {"string": "foo", "boolean": false, "number": 15, "object": {"something": 15}}
+
 "#
 	);
 }

--- a/crates/formatter/src/format_token.rs
+++ b/crates/formatter/src/format_token.rs
@@ -62,6 +62,7 @@ impl IndentToken {
 	}
 }
 
+/// A token used to gather a list of tokens; optionally they can be printed with a separator, using [ListToken::join]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ListToken {
 	content: Vec<FormatToken>,
@@ -72,6 +73,7 @@ impl ListToken {
 		Self { content }
 	}
 
+	/// Emits a list of [ListToken] which contains a list of [FormatToken]
 	pub fn concat<T: IntoIterator<Item = FormatToken>>(tokens: T) -> Self {
 		let tokens: Vec<FormatToken> = tokens
 			.into_iter()
@@ -83,7 +85,7 @@ impl ListToken {
 		Self::new(tokens)
 	}
 
-	/// Takes a list of tokens and a separator as input and creates a list of tokens where they are separated by the separator.
+	/// Takes a list of tokens and a separator as input and creates a list of tokens where they are separated by that separator.
 	pub fn join<Separator: Into<FormatToken>, T: IntoIterator<Item = FormatToken>>(
 		separator: Separator,
 		tokens: T,

--- a/crates/formatter/src/format_token_macro.rs
+++ b/crates/formatter/src/format_token_macro.rs
@@ -1,0 +1,66 @@
+/// The macro `format_tokens` is a convenience macro to
+/// use when writing a list of tokens that should be at the same level
+/// without particular rule.
+///
+/// # Examples
+///
+/// Let's suppose you need to create tokens for the string `"foo": "bar"`,
+/// you would write:
+///
+/// ```rust
+/// use rome_formatter::{format_tokens, FormatToken};
+/// let token = format_tokens!("foo", ":", FormatToken::Space, "bar");
+/// ```
+///
+/// The macro can be also nested, although the macro needs to be decorated with the token you need.
+/// For example, let's try to format following string:
+///
+/// ```no_rust
+/// "foo": {
+///   "bar": "lorem"
+/// }
+/// ```
+/// You would write it like the following:
+///
+/// ```rust,no_test
+/// use rome_formatter::{format_tokens, IndentToken, LineToken, FormatToken};
+/// let token = format_tokens!(
+///   "foo",
+///   ":",
+///   IndentToken::new(
+///     format_tokens!(LineToken::hard(), "bar", ":", FormatToken::Space, "lorem")
+///   ),
+///   "}"
+/// );
+/// ```
+#[macro_export]
+macro_rules! format_tokens {
+
+	// called for things like format_tokens!("hey")
+	($token:ident) => {
+		{
+			use rome_formatter::FormatToken;
+			FormatToken::from($token)
+		}
+	};
+
+	($($token:literal),+ $(,)?) => {{
+		use rome_formatter::{FormatToken, ListToken};
+		FormatToken::from(ListToken::concat(vec![
+			$(
+					 FormatToken::from($token)
+			),+
+
+		]))
+	}};
+
+	( $( $token:expr ),+ $(,)?) => {{
+		use rome_formatter::{FormatToken, ListToken};
+		FormatToken::from(ListToken::concat(vec![
+			$(
+					 FormatToken::from($token)
+			),+
+
+		]))
+	}};
+}

--- a/crates/formatter/src/format_token_macro.rs
+++ b/crates/formatter/src/format_token_macro.rs
@@ -22,7 +22,7 @@
 /// ```
 /// You would write it like the following:
 ///
-/// ```rust, no_test
+/// ```rust
 /// use rome_formatter::{format_tokens, IndentToken, LineToken, FormatToken};
 /// let token = format_tokens!(
 ///   "foo",
@@ -32,35 +32,42 @@
 ///   ),
 ///   "}"
 /// );
+///
+/// let inner = FormatToken::concat(vec![
+///     FormatToken::from(LineToken::hard()),
+///     FormatToken::string("bar"),
+///     FormatToken::string(":"),
+///     FormatToken::Space,
+///     FormatToken::string("lorem")
+/// ]);
+/// let outer = FormatToken::concat(vec![
+///     FormatToken::string("foo"),
+///     FormatToken::string(":"),
+///     FormatToken::indent(inner),
+///     FormatToken::string("}")
+/// ]);
+///
+/// assert_eq!(token, outer);
+///
 /// ```
 #[macro_export]
 macro_rules! format_tokens {
 
 	// called for things like format_tokens!("hey")
-	($token:ident) => {
+	($token:expr) => {
 		{
-			use rome_formatter::FormatToken;
+			use $crate::FormatToken;
 			FormatToken::from($token)
 		}
 	};
 
-	($($token:literal),+ $(,)?) => {{
-		use rome_formatter::{FormatToken, ListToken};
-		FormatToken::from(ListToken::concat(vec![
-			$(
-					 FormatToken::from($token)
-			),+
-
-		]))
-	}};
-
 	( $( $token:expr ),+ $(,)?) => {{
-		use rome_formatter::{FormatToken, ListToken};
-		FormatToken::from(ListToken::concat(vec![
+		use $crate::{FormatToken, ListToken};
+		FormatToken::concat(vec![
 			$(
 					 FormatToken::from($token)
 			),+
 
-		]))
+		])
 	}};
 }

--- a/crates/formatter/src/format_token_macro.rs
+++ b/crates/formatter/src/format_token_macro.rs
@@ -64,4 +64,3 @@ macro_rules! format_tokens {
 		]))
 	}};
 }
-

--- a/crates/formatter/src/format_token_macro.rs
+++ b/crates/formatter/src/format_token_macro.rs
@@ -9,7 +9,7 @@
 ///
 /// ```rust
 /// use rome_formatter::{format_tokens, FormatToken};
-/// let token = format_tokens!("foo", ":", FormatToken::Space, "bar");
+/// let token = format_tokens!("foo:", FormatToken::Space, "bar");
 /// ```
 ///
 /// The macro can be also nested, although the macro needs to be decorated with the token you need.
@@ -25,29 +25,17 @@
 /// ```rust
 /// use rome_formatter::{format_tokens, IndentToken, LineToken, FormatToken};
 /// let token = format_tokens!(
-///   "foo",
-///   ":",
+///   "foo:",
 ///   IndentToken::new(
-///     format_tokens!(LineToken::hard(), "bar", ":", FormatToken::Space, "lorem")
+///     format_tokens!(LineToken::hard(), "bar:", FormatToken::Space, "lorem")
 ///   ),
 ///   "}"
 /// );
 ///
-/// let inner = FormatToken::concat(vec![
-///     FormatToken::from(LineToken::hard()),
-///     FormatToken::string("bar"),
-///     FormatToken::string(":"),
-///     FormatToken::Space,
-///     FormatToken::string("lorem")
-/// ]);
-/// let outer = FormatToken::concat(vec![
-///     FormatToken::string("foo"),
-///     FormatToken::string(":"),
-///     FormatToken::indent(inner),
-///     FormatToken::string("}")
-/// ]);
-///
-/// assert_eq!(token, outer);
+/// 
+/// assert_eq!(r#"foo: {
+  bar: lorem
+}"#, format_token(&token).code());
 ///
 /// ```
 #[macro_export]

--- a/crates/formatter/src/format_token_macro.rs
+++ b/crates/formatter/src/format_token_macro.rs
@@ -22,7 +22,7 @@
 /// ```
 /// You would write it like the following:
 ///
-/// ```rust,no_test
+/// ```rust, no_test
 /// use rome_formatter::{format_tokens, IndentToken, LineToken, FormatToken};
 /// let token = format_tokens!(
 ///   "foo",
@@ -64,3 +64,4 @@ macro_rules! format_tokens {
 		]))
 	}};
 }
+

--- a/crates/formatter/src/format_tokens_macro.rs
+++ b/crates/formatter/src/format_tokens_macro.rs
@@ -16,27 +16,29 @@
 /// For example, let's try to format following string:
 ///
 /// ```no_rust
-/// "foo": {
-///   "bar": "lorem"
-/// }
+/// foo: { bar: lorem }
 /// ```
 /// You would write it like the following:
 ///
 /// ```rust
-/// use rome_formatter::{format_tokens, IndentToken, LineToken, FormatToken};
+/// use rome_formatter::{format_tokens, format_token, IndentToken, FormatToken, FormatOptions};
 /// let token = format_tokens!(
 ///   "foo:",
+///   FormatToken::Space,
+///   "{",
 ///   IndentToken::new(
-///     format_tokens!(LineToken::hard(), "bar:", FormatToken::Space, "lorem")
+///     format_tokens!(FormatToken::Space, "bar:", FormatToken::Space, "lorem")
 ///   ),
+///    FormatToken::Space,
 ///   "}"
 /// );
-///
-/// 
-/// assert_eq!(r#"foo: {
-  bar: lorem
-}"#, format_token(&token).code());
-///
+/// assert_eq!(r#"foo: { bar: lorem }"#, format_token(&token, FormatOptions::default()).code());
+/// ```
+/// Or you can also create single tokens:
+/// ```
+/// use rome_formatter::{format_tokens, format_token, FormatOptions};
+/// let unique_token = format_tokens!("single");
+/// assert_eq!(r#"single"#, format_token(&unique_token, FormatOptions::default()).code());
 /// ```
 #[macro_export]
 macro_rules! format_tokens {

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -1,16 +1,62 @@
+//! Rome's official formatter.
+//!
+//! The crate exposes some API and utilities to implement the formatting logic.
+//!
+//! The formatter relies on an [IR], which allows to format any kind of data structure.
+//!
+//! In order to implement the formatting logic, you need to implement the trait [FormatValue] for
+//! the data structure you want to format.
+//!
+//! Let's say, for example that you have a small data structure that represents a key/value data:
+//!
+//! ```rust,no_test
+//! struct KeyValue {
+//!     key: String,
+//!     value: String
+//! }
+//! ```
+//!
+//! Now, we do want to create this IR for the data structure:
+//! ```rust
+//! use rome_formatter::{format_tokens, format_token, FormatToken, FormatValue, FormatOptions};
+//!
+//! struct KeyValue {
+//!     key: String,
+//!     value: String
+//! }
+//!
+//! impl FormatValue for KeyValue {
+//!     fn format(&self) -> FormatToken {
+//!         format_tokens!(self.key.as_str(), FormatToken::Space, "=>", FormatToken::Space, self.value.as_str())
+//!     }
+//! }
+//!
+//! fn main() {
+//!	    let key_value = KeyValue { key: String::from("lorem"), value: String::from("ipsum") };
+//!     let token = key_value.format();
+//!     let options = FormatOptions::default();
+//!     let result = format_token(&token, options);
+//!     assert_eq!(result.code(), "lorem => ipsum");
+//! }
+//!
+//! ```
+//! [IR]: https://en.wikipedia.org/wiki/Intermediate_representation
+
 mod format_json;
 mod format_token;
+mod format_token_macro;
 mod intersperse;
 mod printer;
 
 use crate::format_json::json_to_tokens;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
-pub use format_token::{FormatToken, GroupToken, IfBreakToken, IndentToken, LineMode, ListToken};
+pub use format_token::{FormatToken, GroupToken, IfBreakToken, IndentToken, LineMode, ListToken, LineToken};
 pub use printer::PrintResult;
-use printer::Printer;
+pub use printer::Printer;
+pub use printer::PrinterOptions;
 
-/// This trait should implemented on each node/value that should have a formatted representation
+/// This trait should be implemented on each node/value that should have a formatted representation
 pub trait FormatValue {
 	fn format(&self) -> FormatToken;
 }

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -31,8 +31,8 @@
 //!     }
 //! }
 //!
-//! fn main() {
-//!	    let key_value = KeyValue { key: String::from("lorem"), value: String::from("ipsum") };
+//! fn my_function() {
+//!     let key_value = KeyValue { key: String::from("lorem"), value: String::from("ipsum") };
 //!     let token = key_value.format();
 //!     let options = FormatOptions::default();
 //!     let result = format_token(&token, options);

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -51,7 +51,9 @@ mod printer;
 use crate::format_json::json_to_tokens;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
-pub use format_token::{FormatToken, GroupToken, IfBreakToken, IndentToken, LineMode, ListToken, LineToken};
+pub use format_token::{
+	FormatToken, GroupToken, IfBreakToken, IndentToken, LineMode, LineToken, ListToken,
+};
 pub use printer::PrintResult;
 pub use printer::Printer;
 pub use printer::PrinterOptions;

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -44,7 +44,7 @@
 
 mod format_json;
 mod format_token;
-mod format_token_macro;
+mod format_tokens_macro;
 mod intersperse;
 mod printer;
 

--- a/crates/formatter/src/printer.rs
+++ b/crates/formatter/src/printer.rs
@@ -22,7 +22,6 @@ pub struct PrinterOptions {
 	pub indent_string: String,
 }
 
-
 impl From<FormatOptions> for PrinterOptions {
 	fn from(options: FormatOptions) -> Self {
 		let indent_string: String;

--- a/crates/formatter/src/printer.rs
+++ b/crates/formatter/src/printer.rs
@@ -11,6 +11,7 @@ pub struct PrinterOptions {
 	/// What's the max width of a line. Defaults to 80
 	pub print_width: u16,
 
+	/// The type of line ending to apply to the printed input
 	pub line_ending: LineEnding,
 
 	/// The never ending question whatever to use spaces or tabs, and if spaces, how many spaces
@@ -20,6 +21,7 @@ pub struct PrinterOptions {
 	/// * Spaces: String containing the number of spaces per indention level, e.g. "  " for using two spaces
 	pub indent_string: String,
 }
+
 
 impl From<FormatOptions> for PrinterOptions {
 	fn from(options: FormatOptions) -> Self {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR implements a `format_tokens` declarative macro. The name of the macro is still up in the air and needs to be consolidated because we have APIs that have similar names.

For example, we have the API called `format_token` (singular) which is the main function exposed by the `rome_formatter` crate. 

I think we can consolidate the name of the APIs later, once this crate becomes more stable.

I created documentation and doc test, which helped to unveil some bug around some struct that were not exposed by default.

I created an alias called `cargo lint` which basically runs `cargo clippy` with all the arguments we have in the CI. This should help the local development.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

```
cargo test
cargo doc
cargo lint
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
