### PR TITLE
feat: macro to automatically generate expected/snapshot tests from files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "case"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +401,30 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -430,6 +466,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1138,9 +1192,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,6 +1245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_macros"
+version = "0.0.0"
+dependencies = [
+ "case",
+ "globwalk",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/crates/tests_macros/Cargo.toml
+++ b/crates/tests_macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "test_macros"
+version = "0.0.0"
+description = ""
+license = "MIT"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.29"
+syn = "1.0.78"
+globwalk = "0.8.1"
+case = "1.0.0"
+quote = "1.0.9"
+proc-macro-error = "1.0.4"

--- a/crates/tests_macros/Readme.md
+++ b/crates/tests_macros/Readme.md
@@ -1,0 +1,27 @@
+Automatically generate unit tests from files. 
+
+# Usage
+
+First argument: glob that will passed to https://github.com/gilnaa/globwalk. Crate's cargo.toml will be the base directory.  
+Second argument: method that will be called.
+
+```
+tests_macros::gen_tests!{"tests/*", run_test}
+
+fn run_test<S: AsRef<str> + std::fmt::Debug>(a: S, b: S) {
+    println!("{:?} {:?}", a, b);
+}
+```
+
+this will generate the following for each file:
+Test name is the "snake case" version of the file name.
+
+```
+#[test]
+pub fn sometest()
+{
+    let test_file = "<SOMEDIR>/tests/sometest.txt";
+    let test_expected_file = "<SOMEDIR>/tests/sometest.expected.txt";
+    run_test(test_file, test_expected_file);
+}
+```

--- a/crates/tests_macros/Readme.md
+++ b/crates/tests_macros/Readme.md
@@ -1,12 +1,14 @@
-Automatically generate unit tests from files. 
+# Tests macros
+
+A set of utilities that automatically generate unit tests from files.
 
 # Usage
 
-First argument: glob that will passed to https://github.com/gilnaa/globwalk. Crate's cargo.toml will be the base directory.  
+First argument: glob that will passed to https://github.com/gilnaa/globwalk. Crate's cargo.toml will be the base directory. To pattern format see here: https://git-scm.com/docs/gitignore#_pattern_format
 Second argument: method that will be called.
 
-```
-tests_macros::gen_tests!{"tests/*", run_test}
+```rust
+tests_macros::gen_tests!{"tests/*.{js,json}", run_test}
 
 fn run_test<S: AsRef<str> + std::fmt::Debug>(a: S, b: S) {
     println!("{:?} {:?}", a, b);
@@ -16,7 +18,7 @@ fn run_test<S: AsRef<str> + std::fmt::Debug>(a: S, b: S) {
 this will generate the following for each file:
 Test name is the "snake case" version of the file name.
 
-```
+```rust
 #[test]
 pub fn sometest()
 {

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -59,7 +59,7 @@ impl Arguments {
 		let test_expected_fullpath = test_expected_file.to_str()?;
 
 		Some((
-			test_name.to_string(),
+			test_name,
 			test_full_path,
 			test_expected_fullpath.to_string(),
 		))
@@ -111,6 +111,5 @@ pub fn gen_tests(input: TokenStream) -> TokenStream {
 	match args.gen() {
 		Ok(tokens) => tokens,
 		Err(e) => abort!(e, "{}", e),
-	};
-	args.gen().unwrap().into()
+	}
 }

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -8,7 +8,7 @@ use syn::parse::ParseStream;
 
 struct Arguments {
 	pattern: syn::ExprLit,
-	f: syn::Path,
+	called_function: syn::Path,
 }
 
 struct Variables {
@@ -116,7 +116,7 @@ impl Arguments {
 
 			let span = self.pattern.lit.span();
 			let test_name = syn::Ident::new(&test_name, span);
-			let f = &self.f;
+			let f = &self.called_function;
 			q.extend(quote! {
 				#[test]
 				pub fn #test_name () {
@@ -140,7 +140,7 @@ impl syn::parse::Parse for Arguments {
 		let call: syn::Path = input.parse()?;
 		Ok(Arguments {
 			pattern: path,
-			f: call,
+			called_function: call,
 		})
 	}
 }

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -62,20 +62,6 @@ impl Arguments {
 			.map_err(|_| "Cannot walk the requested glob")?;
 
 		Ok(AllFiles(walker))
-
-		// for entry in walker.flatten() {
-		// 	let file_name = entry.file_name().to_str().ok_or("File name not UTF8")?;
-
-		// 	if file_name.contains("expected") {
-		// 		continue;
-		// 	}
-		// 	let meta = entry.metadata().map_err(|_| "Cannot open file")?;
-		// 	if meta.is_file() {
-		// 		files.push(entry.path().to_path_buf());
-		// 	}
-		// }
-
-		// Ok(files)
 	}
 
 	fn get_variables<P: AsRef<Path>>(path: P) -> Option<Variables> {
@@ -126,8 +112,6 @@ impl Arguments {
 				}
 			});
 		}
-
-		// println!("{}", q);
 
 		Ok(q.into())
 	}

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -1,0 +1,116 @@
+use case::CaseExt;
+use proc_macro::TokenStream;
+use proc_macro_error::*;
+use quote::*;
+use std::path::{Path, PathBuf};
+use syn::parse::ParseStream;
+
+struct Arguments {
+	pattern: syn::ExprLit,
+	f: syn::Path,
+}
+
+impl Arguments {
+	fn get_all_files(&self) -> Result<Vec<PathBuf>, &str> {
+		let mut files = vec![];
+
+		let base = std::env::var("CARGO_MANIFEST_DIR")
+			.map_err(|_| "Cannot find CARGO_MANIFEST_DIR. What we using cargo?")?;
+		let glob = match &self.pattern.lit {
+			syn::Lit::Str(v) => v.value(),
+			_ => return Err("Only string literals supported"),
+		};
+		let walker = globwalk::GlobWalkerBuilder::new(base, &glob)
+			.build()
+			.map_err(|_| "Cannot walk the requested glob")?;
+
+		for entry in walker.flatten() {
+			let file_name = entry.file_name().to_str().ok_or("File name not UTF8")?;
+
+			if file_name.contains("expected") {
+				continue;
+			}
+			let meta = entry.metadata().map_err(|_| "Cannot open file")?;
+			if meta.is_file() {
+				files.push(entry.path().to_path_buf());
+			}
+		}
+
+		Ok(files)
+	}
+
+	fn get_variables<P: AsRef<Path>>(path: P) -> Option<(String, String, String)> {
+		let path = path.as_ref();
+		let file_stem = path.file_stem()?;
+		let file_stem = file_stem.to_str()?;
+		let test_name = file_stem.to_snake();
+
+		let test_full_path = path.display().to_string();
+
+		let extension = if let Some(ext) = path.extension() {
+			format!(".{}", ext.to_str().unwrap_or(""))
+		} else {
+			"".into()
+		};
+
+		let mut test_expected_file = path.to_path_buf();
+		test_expected_file.pop();
+		test_expected_file.push(format!("{}.expected{}", file_stem, extension));
+		let test_expected_fullpath = test_expected_file.to_str()?;
+
+		Some((
+			test_name.to_string(),
+			test_full_path,
+			test_expected_fullpath.to_string(),
+		))
+	}
+
+	pub fn gen(&self) -> Result<TokenStream, &str> {
+		let files = self.get_all_files()?;
+
+		let mut q = quote! {};
+		for file in files {
+			let (test_name, test_full_path, test_expected_fullpath) =
+				Arguments::get_variables(&file).ok_or("Cannot generate variables for this file")?;
+
+			let span = self.pattern.lit.span();
+			let test_name = syn::Ident::new(&test_name, span);
+			let f = &self.f;
+			q.extend(quote! {
+				#[test]
+				pub fn #test_name () {
+					let test_file = #test_full_path;
+					let test_expected_file = #test_expected_fullpath;
+					#f(test_file, test_expected_file);
+				}
+			});
+		}
+
+		// println!("{}", q);
+
+		Ok(q.into())
+	}
+}
+
+impl syn::parse::Parse for Arguments {
+	fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+		let path: syn::ExprLit = input.parse()?;
+		let _: syn::Token!(,) = input.parse()?;
+		let call: syn::Path = input.parse()?;
+		Ok(Arguments {
+			pattern: path,
+			f: call,
+		})
+	}
+}
+
+#[proc_macro]
+#[proc_macro_error]
+pub fn gen_tests(input: TokenStream) -> TokenStream {
+	let args = syn::parse_macro_input!(input as Arguments);
+	match args.gen() {
+		Ok(tokens) => tokens,
+		Err(e) => abort!(e, "{}", e),
+	};
+	args.gen().unwrap().into()
+}

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -15,7 +15,7 @@ impl Arguments {
 		let mut files = vec![];
 
 		let base = std::env::var("CARGO_MANIFEST_DIR")
-			.map_err(|_| "Cannot find CARGO_MANIFEST_DIR. What we using cargo?")?;
+			.map_err(|_| "Cannot find CARGO_MANIFEST_DIR. Are you using cargo?")?;
 		let glob = match &self.pattern.lit {
 			syn::Lit::Str(v) => v.value(),
 			_ => return Err("Only string literals supported"),


### PR DESCRIPTION
Automatically generate unit tests from files. 

# Usage

First argument: glob that will passed to https://github.com/gilnaa/globwalk. Crate's cargo.toml will be the base directory.  
Second argument: method that will be called.

```rust
tests_macros::gen_tests!{"tests/*", run_test}

fn run_test<S: AsRef<str> + std::fmt::Debug>(a: S, b: S) {
    println!("{:?} {:?}", a, b);
}
```

this will generate the following for each file:
Test name is the "snake case" version of the file name.

```rust
#[test]
pub fn sometest()
{
    let test_file = "<SOMEDIR>/tests/sometest.txt";
    let test_expected_file = "<SOMEDIR>/tests/sometest.expected.txt";
    run_test(test_file, test_expected_file);
}
```