### PR TITLE
Parse JSON to CST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,8 +867,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "rome-formatter"
 version = "0.0.0"
 dependencies = [
- "serde",
- "serde_json",
+ "rslint_parser",
 ]
 
 [[package]]
@@ -1070,7 +1069,6 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+rslint_parser = { path = "../rslint_parser" }
 
 [dev-dependencies]
 

--- a/crates/formatter/src/format_tokens_macro.rs
+++ b/crates/formatter/src/format_tokens_macro.rs
@@ -52,7 +52,7 @@ macro_rules! format_tokens {
 	};
 
 	( $( $token:expr ),+ $(,)?) => {{
-		use $crate::{FormatToken, ListToken};
+		use $crate::{FormatToken};
 		FormatToken::concat(vec![
 			$(
 					 FormatToken::from($token)

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -48,7 +48,7 @@ mod format_tokens_macro;
 mod intersperse;
 mod printer;
 
-use crate::format_json::json_to_tokens;
+use crate::format_json::tokenize_json;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
 pub use format_token::{
@@ -115,14 +115,14 @@ pub fn format(path: PathBuf, options: FormatOptions) {
 	file.read_to_string(&mut buffer)
 		.expect("cannot read the file to format");
 
-	let tokens = json_to_tokens(buffer.as_str());
+	let tokens = tokenize_json(buffer.as_str());
 	let print_result = format_token(&tokens, options);
 
 	println!("{}", print_result.code());
 }
 
 pub fn format_str(content: &str, options: FormatOptions) -> PrintResult {
-	let tokens = json_to_tokens(content);
+	let tokens = tokenize_json(content);
 	format_token(&tokens, options)
 }
 

--- a/crates/formatter/src/printer.rs
+++ b/crates/formatter/src/printer.rs
@@ -236,7 +236,7 @@ impl Printer {
 				let calls = self.print_token(token, args);
 
 				// If the line is too long, break the group
-				if self.state.line_width > self.options.print_width {
+				if self.state.line_width > self.options.print_width as usize {
 					return Err(LineBreakRequiredError);
 				}
 
@@ -299,7 +299,7 @@ impl Printer {
 				self.state.generated_column += 1;
 
 				let char_width = if char == '\t' {
-					self.options.tab_width as u16
+					self.options.tab_width as usize
 				} else {
 					1
 				};
@@ -319,9 +319,9 @@ struct PrinterState {
 	pending_indent: u16,
 	pending_spaces: u16,
 	generated_index: usize,
-	generated_line: u16,
-	generated_column: u16,
-	line_width: u16,
+	generated_line: usize,
+	generated_column: usize,
+	line_width: usize,
 	// mappings: Mapping[];
 	// We'll need to clone the line suffixes tokens into the state.
 	// I guess that's fine. They're only used for comments and should, therefore, be very limited
@@ -360,9 +360,9 @@ struct PrinterStateSnapshot {
 	pending_indents: u16,
 	pending_spaces: u16,
 	generated_index: usize,
-	generated_column: u16,
-	generated_line: u16,
-	line_width: u16,
+	generated_column: usize,
+	generated_line: usize,
+	line_width: usize,
 	buffer_position: usize,
 }
 

--- a/crates/formatter/tests/specs/json/int1.expected.json
+++ b/crates/formatter/tests/specs/json/int1.expected.json
@@ -9,7 +9,7 @@
 	null,
 	{
 		"integer": 1234567890,
-		"real": -9876.54321,
+		"real": -9876.543210,
 		"": 23456789012,
 		"zero": 0,
 		"one": 1,
@@ -17,7 +17,7 @@
 		"quote": "\"",
 		"backslash": "\\",
 		"controls": "\n\r\t",
-		"slash": "/ & /",
+		"slash": "/ & \/",
 		"alpha": "abcdefghijklmnopqrstuvwyz",
 		"ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
 		"digit": "0123456789",
@@ -34,7 +34,7 @@
 		" s p a c e d ": [1, 2, 3, 4, 5, 6, 7],
 		"compact": [1, 2, 3, 4, 5, 6, 7],
 		"jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
-		"/\\\"\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+		"\/\\\"\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
 	},
 	0.5,
 	98.6,


### PR DESCRIPTION
A hacky implementation that uses the rs-lint parser to parse a JSON string to a CST.

## Summary
Our current JSON parser uses serde for parsing, which works well enough but isn't lossless. For example, the parsing doesn't retain the exact number formats. We also want to get more experience working with CST's and do profiling which requires us to work with a CST. 

That's why this PR swaps the serde parser with the rslint JavaScript parser. Using a JS parser isn't ideal because it parses files that are valid JS but not JSON. I believe that's OK for now to have something to play around with CST and figure out multi-language support until we build our own JSON parser. 

## Test Plan

Tests are still passing. Parsed and formatted a large (+10 MB) JSON file 
