### PR TITLE
Add helpers for creating `FormatToken`s

### DIFF
--- a/crates/formatter/src/format_json.rs
+++ b/crates/formatter/src/format_json.rs
@@ -1,6 +1,7 @@
-use crate::format_token::{join_elements, soft_line_break_or_space, LineMode};
+use crate::format_token::{join_elements, soft_line_break_or_space};
 use crate::{
-	format_token::FormatToken, format_tokens, group, hard_line_break, indent, space_token, token,
+	format_token::FormatToken, format_tokens, group_elements, hard_line_break, soft_indent,
+	space_token, token,
 };
 use rslint_parser::ast::{
 	ArrayExpr, GroupingExpr, Literal, LiteralProp, ObjectExpr, ObjectProp, UnaryExpr,
@@ -52,7 +53,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 				.props()
 				.map(|prop| match prop {
 					ObjectProp::LiteralProp(prop) => {
-						format_tokens!(tokenize_node(prop.syntax().clone()))
+						format_tokens![tokenize_node(prop.syntax().clone())]
 					}
 					_ => panic!("Unsupported prop type {:?}", prop),
 				})
@@ -60,9 +61,9 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 
 			let properties = join_elements(separator, properties_list);
 
-			group(format_tokens![
+			group_elements(format_tokens![
 				token("{"),
-				indent(properties, LineMode::Soft),
+				soft_indent(properties),
 				token("}"),
 			])
 		}
@@ -78,9 +79,9 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 					.map(|element| tokenize_node(element.syntax().clone())),
 			);
 
-			group(format_tokens![
+			group_elements(format_tokens![
 				token("["),
-				indent(elements, LineMode::Soft),
+				soft_indent(elements),
 				token("]"),
 			])
 		}
@@ -103,13 +104,13 @@ pub fn tokenize_json(content: &str) -> FormatToken {
 	.unwrap();
 
 	let tokenized_content = tokenize_node(json_content.syntax().clone());
-	format_tokens!(tokenized_content, hard_line_break())
+	format_tokens![tokenized_content, hard_line_break()]
 }
 
 #[cfg(test)]
 mod test {
 	use crate::{
-		format_tokens, group, hard_line_break, soft_line_break, soft_line_break_or_space,
+		format_tokens, group_elements, hard_line_break, soft_line_break, soft_line_break_or_space,
 		space_token, token,
 	};
 
@@ -155,7 +156,7 @@ mod test {
 	fn tokenize_object() {
 		let input = r#"{ "foo": "bar", "num": 5 }"#;
 		let expected = format_tokens![
-			group(format_tokens![
+			group_elements(format_tokens![
 				token("{"),
 				FormatToken::Indent(Indent::new(format_tokens![
 					soft_line_break(),
@@ -185,7 +186,7 @@ mod test {
 	fn tokenize_array() {
 		let input = r#"[ "foo", "bar", 5 ]"#;
 		let expected = format_tokens![
-			group(format_tokens![
+			group_elements(format_tokens![
 				token("["),
 				FormatToken::Indent(Indent::new(format_tokens![
 					soft_line_break(),

--- a/crates/formatter/src/format_tokens_macro.rs
+++ b/crates/formatter/src/format_tokens_macro.rs
@@ -9,7 +9,7 @@
 ///
 /// ```rust
 /// use rome_formatter::{format_tokens, space_token, token};
-/// let element = format_tokens!(token("foo:"), space_token(), token("bar"));
+/// let element = format_tokens![token("foo:"), space_token(), token("bar")];
 /// ```
 ///
 /// The macro can be also nested, although the macro needs to be decorated with the token you need.
@@ -22,7 +22,7 @@
 ///
 /// ```rust
 /// use rome_formatter::{format_tokens, format_element, FormatOptions, space_token, token};
-/// let element = format_tokens!(
+/// let element = format_tokens![
 ///   token("foo:"),
 ///   space_token(),
 ///   token("{"),
@@ -32,19 +32,19 @@
 ///   token("lorem"),
 ///   space_token(),
 ///   token("}")
-/// );
+/// ];
 /// assert_eq!(r#"foo: { bar: lorem }"#, format_element(&element, FormatOptions::default()).code());
 /// ```
 /// Or you can also create single tokens:
 /// ```
 /// use rome_formatter::{format_tokens, format_element, FormatOptions, token};
-/// let element = format_tokens!(token("single"));
+/// let element = format_tokens![token("single")];
 /// assert_eq!(r#"single"#, format_element(&element, FormatOptions::default()).code());
 /// ```
 #[macro_export]
 macro_rules! format_tokens {
 
-	// called for things like format_tokens!("hey")
+	// called for things like format_tokens!["hey"]
 	($token:expr) => {
 		{
 			use $crate::FormatToken;

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! impl FormatValue for KeyValue {
 //!     fn format(&self) -> FormatToken {
-//!         format_tokens!(token(self.key.as_str()), space_token(), token("=>"), space_token(), token(self.value.as_str()))
+//!         format_tokens![token(self.key.as_str()), space_token(), token("=>"), space_token(), token(self.value.as_str())]
 //!     }
 //! }
 //!
@@ -51,9 +51,9 @@ use crate::format_json::tokenize_json;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
 pub use format_token::{
-	concat_elements, group, hard_line_break, if_group_breaks, if_group_fits_on_single_line, indent,
-	join_elements, soft_line_break, soft_line_break_or_space, space_token, token, FormatToken,
-	LineMode,
+	concat_elements, group_elements, hard_line_break, if_group_breaks,
+	if_group_fits_on_single_line, indent, join_elements, soft_indent, soft_line_break,
+	soft_line_break_or_space, space_token, token, FormatToken,
 };
 use printer::Printer;
 

--- a/crates/formatter/src/printer.rs
+++ b/crates/formatter/src/printer.rs
@@ -434,11 +434,11 @@ impl<'a> TokenCallQueue<'a> {
 
 #[cfg(test)]
 mod tests {
-	use crate::format_token::{join_elements, LineMode};
-	use crate::printer::{LineEnding, PrintResult, Printer, PrinterOptions};
+	use crate::format_token::join_elements;
+	use crate::printer::{LineEnding, Printer, PrinterOptions};
 	use crate::{
-		format_tokens, group, hard_line_break, if_group_breaks, indent, soft_line_break,
-		soft_line_break_or_space, token, FormatResult, FormatToken,
+		format_tokens, group_elements, hard_line_break, if_group_breaks, indent, soft_indent,
+		soft_line_break, soft_line_break_or_space, token, FormatResult, FormatToken,
 	};
 
 	/// Prints the given token with the default printer options
@@ -467,24 +467,15 @@ mod tests {
 	fn it_tracks_the_indent_for_each_token() {
 		let tokens = format_tokens![
 			token("a"),
-			indent(
-				format_tokens![
-					token("b"),
-					indent(
-						format_tokens![
-							token("c"),
-							indent(
-								format_tokens![token("d"), soft_line_break(), token("d"),],
-								LineMode::Soft
-							),
-							token("c"),
-						],
-						LineMode::Soft
-					),
-					token("b"),
-				],
-				LineMode::Soft
-			),
+			soft_indent(format_tokens![
+				token("b"),
+				soft_indent(format_tokens![
+					token("c"),
+					soft_indent(format_tokens![token("d"), soft_line_break(), token("d"),],),
+					token("c"),
+				],),
+				token("b"),
+			],),
 			token("a"),
 		];
 
@@ -527,10 +518,7 @@ two lines`,
 
 		let program = format_tokens![
 			token("function main() {"),
-			indent(
-				token("let x = `This is a multiline\nstring`;"),
-				LineMode::Soft
-			),
+			indent(token("let x = `This is a multiline\nstring`;"),),
 			token("}"),
 			hard_line_break(),
 		];
@@ -595,9 +583,9 @@ two lines`,
 
 		let elements = format_tokens![join_elements(separator, items), if_group_breaks(token(","))];
 
-		group(format_tokens![
+		group_elements(format_tokens![
 			token("["),
-			indent(elements, LineMode::Soft),
+			soft_indent(elements),
 			token("]"),
 		])
 	}


### PR DESCRIPTION
## Summary 

This PR introduces various helpers to create `FormatToken`s more conveniently and giving us the flexibility to lower repetitive patterns to the format IR understood by the printer.
Lowering allows us to model an IR that is optimal for the printer and without having to create a custom IR element for every use case.

This PR removes some implicit `Into<FormatToken>` conversions because I believe that the more explicit use of e.g. `token("test")` improves readability and discoverability.

This PR renames some tokens:

* Removes the `Token` postfix for all tokens
* `String` -> `Token` to align with the Rowan naming
* `IfBreak` -> `ConditionalGroupContent` because it only has meaning inside of groups

This PR intentionally refers to `FormatToken`s as `elements` because we plan to rename `FormatToken` to `FormatElement` as part of #1688.

Part of #1688 

## Test Plan

Added various doc-tests and all existing tests are still passing
