### PR TITLE
refactor: Rename `FormatToken` to `FormatElement`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,10 +921,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "rome-formatter"
 version = "0.0.0"
 dependencies = [
- "parser",
- "rowan",
  "rslint_parser",
- "syntax",
  "tests_macros",
 ]
 

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2018"
 
 [dependencies]
 rslint_parser = { path = "../rslint_parser" }
-parser = { path = "../parser" }
-syntax = { path = "../syntax" }
-rowan = "0.13.2"
+
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/formatter/src/format_elements.rs
+++ b/crates/formatter/src/format_elements.rs
@@ -8,8 +8,8 @@
 /// you would write:
 ///
 /// ```rust
-/// use rome_formatter::{format_tokens, space_token, token};
-/// let element = format_tokens![token("foo:"), space_token(), token("bar")];
+/// use rome_formatter::{format_elements, space_token, token};
+/// let element = format_elements![token("foo:"), space_token(), token("bar")];
 /// ```
 ///
 /// The macro can be also nested, although the macro needs to be decorated with the token you need.
@@ -21,8 +21,8 @@
 /// You would write it like the following:
 ///
 /// ```rust
-/// use rome_formatter::{format_tokens, format_element, FormatOptions, space_token, token};
-/// let element = format_tokens![
+/// use rome_formatter::{format_elements, format_element, FormatOptions, space_token, token};
+/// let element = format_elements![
 ///   token("foo:"),
 ///   space_token(),
 ///   token("{"),
@@ -35,28 +35,28 @@
 /// ];
 /// assert_eq!(r#"foo: { bar: lorem }"#, format_element(&element, FormatOptions::default()).code());
 /// ```
-/// Or you can also create single tokens:
+/// Or you can also create single element:
 /// ```
-/// use rome_formatter::{format_tokens, format_element, FormatOptions, token};
-/// let element = format_tokens![token("single")];
+/// use rome_formatter::{format_elements, format_element, FormatOptions, token};
+/// let element = format_elements![token("single")];
 /// assert_eq!(r#"single"#, format_element(&element, FormatOptions::default()).code());
 /// ```
 #[macro_export]
-macro_rules! format_tokens {
+macro_rules! format_elements {
 
 	// called for things like format_tokens!["hey"]
-	($token:expr) => {
+	($element:expr) => {
 		{
-			use $crate::FormatToken;
-			FormatToken::from($token)
+			use $crate::FormatElement;
+			FormatElement::from($element)
 		}
 	};
 
-	( $( $token:expr ),+ $(,)?) => {{
-		use $crate::{FormatToken, concat_elements};
+	( $( $element:expr ),+ $(,)?) => {{
+		use $crate::{FormatElement, concat_elements};
 		concat_elements(vec![
 			$(
-					 FormatToken::from($token)
+					 FormatElement::from($element)
 			),+
 
 		])

--- a/crates/formatter/src/format_json.rs
+++ b/crates/formatter/src/format_json.rs
@@ -1,6 +1,6 @@
-use crate::format_token::{join_elements, soft_line_break_or_space};
+use crate::format_element::{join_elements, soft_line_break_or_space};
 use crate::{
-	format_token::FormatToken, format_tokens, group_elements, hard_line_break, soft_indent,
+	format_element::FormatElement, format_elements, group_elements, hard_line_break, soft_indent,
 	space_token, token,
 };
 use rslint_parser::ast::{
@@ -8,7 +8,7 @@ use rslint_parser::ast::{
 };
 use rslint_parser::{parse_text, AstNode, SyntaxKind, SyntaxNode, SyntaxToken};
 
-fn tokenize_token(syntax_token: SyntaxToken) -> FormatToken {
+fn tokenize_token(syntax_token: SyntaxToken) -> FormatElement {
 	match syntax_token.kind() {
 		SyntaxKind::NULL_KW => token("null"),
 		SyntaxKind::TRUE_KW => token("true"),
@@ -20,7 +20,7 @@ fn tokenize_token(syntax_token: SyntaxToken) -> FormatToken {
 	}
 }
 
-fn tokenize_node(node: SyntaxNode) -> FormatToken {
+fn tokenize_node(node: SyntaxNode) -> FormatElement {
 	match node.kind() {
 		SyntaxKind::LITERAL => {
 			let literal = Literal::cast(node).unwrap();
@@ -28,7 +28,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 		}
 		SyntaxKind::UNARY_EXPR => {
 			let expr = UnaryExpr::cast(node).unwrap();
-			format_tokens![
+			format_elements![
 				tokenize_token(expr.op_token().unwrap()),
 				tokenize_node(expr.expr().unwrap().syntax().clone())
 			]
@@ -36,7 +36,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 
 		SyntaxKind::LITERAL_PROP => {
 			let prop = LiteralProp::cast(node).unwrap();
-			format_tokens![
+			format_elements![
 				tokenize_node(prop.key().unwrap().syntax().clone()),
 				token(":"),
 				space_token(),
@@ -47,13 +47,13 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 		SyntaxKind::OBJECT_EXPR => {
 			let object = ObjectExpr::cast(node).unwrap();
 
-			let separator = format_tokens![token(","), soft_line_break_or_space()];
+			let separator = format_elements![token(","), soft_line_break_or_space()];
 
-			let properties_list: Vec<FormatToken> = object
+			let properties_list: Vec<FormatElement> = object
 				.props()
 				.map(|prop| match prop {
 					ObjectProp::LiteralProp(prop) => {
-						format_tokens![tokenize_node(prop.syntax().clone())]
+						format_elements![tokenize_node(prop.syntax().clone())]
 					}
 					_ => panic!("Unsupported prop type {:?}", prop),
 				})
@@ -61,7 +61,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 
 			let properties = join_elements(separator, properties_list);
 
-			group_elements(format_tokens![
+			group_elements(format_elements![
 				token("{"),
 				soft_indent(properties),
 				token("}"),
@@ -70,7 +70,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 		SyntaxKind::ARRAY_EXPR => {
 			let array = ArrayExpr::cast(node).unwrap();
 
-			let separator = format_tokens![token(","), soft_line_break_or_space(),];
+			let separator = format_elements![token(","), soft_line_break_or_space(),];
 
 			let elements = join_elements(
 				separator,
@@ -79,7 +79,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 					.map(|element| tokenize_node(element.syntax().clone())),
 			);
 
-			group_elements(format_tokens![
+			group_elements(format_elements![
 				token("["),
 				soft_indent(elements),
 				token("]"),
@@ -89,7 +89,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatToken {
 	}
 }
 
-pub fn tokenize_json(content: &str) -> FormatToken {
+pub fn tokenize_json(content: &str) -> FormatElement {
 	let script = parse_text(format!("({})", content).as_str(), 0);
 
 	// Unwrap the grouping to get to the JSON content. The grouping is only used as a trick to parse JSON
@@ -104,61 +104,64 @@ pub fn tokenize_json(content: &str) -> FormatToken {
 	.unwrap();
 
 	let tokenized_content = tokenize_node(json_content.syntax().clone());
-	format_tokens![tokenized_content, hard_line_break()]
+	format_elements![tokenized_content, hard_line_break()]
 }
 
 #[cfg(test)]
 mod test {
 	use crate::{
-		format_tokens, group_elements, hard_line_break, soft_line_break, soft_line_break_or_space,
-		space_token, token,
+		format_elements, group_elements, hard_line_break, soft_line_break,
+		soft_line_break_or_space, space_token, token,
 	};
 
 	use super::tokenize_json;
-	use crate::format_token::Indent;
+	use crate::format_element::Indent;
 
 	#[test]
 	fn tokenize_number() {
 		let result = tokenize_json("6.45");
 
-		assert_eq!(format_tokens![token("6.45"), hard_line_break()], result);
+		assert_eq!(format_elements![token("6.45"), hard_line_break()], result);
 	}
 
 	#[test]
 	fn tokenize_string() {
 		let result = tokenize_json(r#""foo""#);
 
-		assert_eq!(format_tokens![token(r#""foo""#), hard_line_break()], result);
+		assert_eq!(
+			format_elements![token(r#""foo""#), hard_line_break()],
+			result
+		);
 	}
 
 	#[test]
 	fn tokenize_boolean_false() {
 		let result = tokenize_json("false");
 
-		assert_eq!(format_tokens![token("false"), hard_line_break()], result);
+		assert_eq!(format_elements![token("false"), hard_line_break()], result);
 	}
 
 	#[test]
 	fn tokenize_boolean_true() {
 		let result = tokenize_json("true");
 
-		assert_eq!(format_tokens![token("true"), hard_line_break()], result);
+		assert_eq!(format_elements![token("true"), hard_line_break()], result);
 	}
 
 	#[test]
 	fn tokenize_boolean_null() {
 		let result = tokenize_json("null");
 
-		assert_eq!(format_tokens![token("null"), hard_line_break()], result);
+		assert_eq!(format_elements![token("null"), hard_line_break()], result);
 	}
 
 	#[test]
 	fn tokenize_object() {
 		let input = r#"{ "foo": "bar", "num": 5 }"#;
-		let expected = format_tokens![
-			group_elements(format_tokens![
+		let expected = format_elements![
+			group_elements(format_elements![
 				token("{"),
-				FormatToken::Indent(Indent::new(format_tokens![
+				FormatElement::Indent(Indent::new(format_elements![
 					soft_line_break(),
 					token("\"foo\""),
 					token(":"),
@@ -185,10 +188,10 @@ mod test {
 	#[test]
 	fn tokenize_array() {
 		let input = r#"[ "foo", "bar", 5 ]"#;
-		let expected = format_tokens![
-			group_elements(format_tokens![
+		let expected = format_elements![
+			group_elements(format_elements![
 				token("["),
-				FormatToken::Indent(Indent::new(format_tokens![
+				FormatElement::Indent(Indent::new(format_elements![
 					soft_line_break(),
 					token("\"foo\""),
 					token(","),

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! Now, we do want to create this IR for the data structure:
 //! ```rust
-//! use rome_formatter::{format_tokens, format_element, FormatToken, FormatValue, FormatOptions, space_token, token};
+//! use rome_formatter::{format_elements, format_element, FormatElement, FormatValue, FormatOptions, space_token, token};
 //!
 //! struct KeyValue {
 //!     key: String,
@@ -26,8 +26,8 @@
 //! }
 //!
 //! impl FormatValue for KeyValue {
-//!     fn format(&self) -> FormatToken {
-//!         format_tokens![token(self.key.as_str()), space_token(), token("=>"), space_token(), token(self.value.as_str())]
+//!     fn format(&self) -> FormatElement {
+//!         format_elements![token(self.key.as_str()), space_token(), token("=>"), space_token(), token(self.value.as_str())]
 //!     }
 //! }
 //!
@@ -41,9 +41,9 @@
 //! ```
 //! [IR]: https://en.wikipedia.org/wiki/Intermediate_representation
 
+mod format_element;
+mod format_elements;
 mod format_json;
-mod format_token;
-mod format_tokens_macro;
 mod intersperse;
 mod printer;
 mod ts;
@@ -51,16 +51,16 @@ mod ts;
 use crate::format_json::tokenize_json;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
-pub use format_token::{
+pub use format_element::{
 	concat_elements, group_elements, hard_line_break, if_group_breaks,
 	if_group_fits_on_single_line, indent, join_elements, soft_indent, soft_line_break,
-	soft_line_break_or_space, space_token, token, FormatToken,
+	soft_line_break_or_space, space_token, token, FormatElement,
 };
 use printer::Printer;
 
 /// This trait should be implemented on each node/value that should have a formatted representation
 pub trait FormatValue {
-	fn format(&self) -> FormatToken;
+	fn format(&self) -> FormatElement;
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -148,8 +148,8 @@ pub fn format(path: PathBuf, options: FormatOptions) -> FormatResult {
 	file.read_to_string(&mut buffer)
 		.expect("cannot read the file to format");
 
-	let tokens = tokenize_json(buffer.as_str());
-	let result = format_element(&tokens, options);
+	let elements = tokenize_json(buffer.as_str());
+	let result = format_element(&elements, options);
 
 	println!("{}", result.code());
 
@@ -157,11 +157,11 @@ pub fn format(path: PathBuf, options: FormatOptions) -> FormatResult {
 }
 
 pub fn format_str(content: &str, options: FormatOptions) -> FormatResult {
-	let tokens = tokenize_json(content);
-	format_element(&tokens, options)
+	let element = tokenize_json(content);
+	format_element(&element, options)
 }
 
-pub fn format_element(element: &FormatToken, options: FormatOptions) -> FormatResult {
+pub fn format_element(element: &FormatElement, options: FormatOptions) -> FormatResult {
 	let printer = Printer::new(options);
 	printer.print(element)
 }

--- a/crates/formatter/src/ts/array.rs
+++ b/crates/formatter/src/ts/array.rs
@@ -1,11 +1,11 @@
 use crate::{
-	format_tokens, group_elements, indent, join_elements, space_token, token, FormatToken,
+	format_elements, group_elements, indent, join_elements, space_token, token, FormatElement,
 	FormatValue,
 };
 use rslint_parser::ast::{ArrayExpr, ExprOrSpread};
 
 impl FormatValue for ArrayExpr {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let elements = self.elements();
 		let mut tokens = vec![];
 
@@ -19,8 +19,8 @@ impl FormatValue for ArrayExpr {
 				}
 			}
 		}
-		let separator = format_tokens!(token(","), space_token());
-		format_tokens!(
+		let separator = format_elements!(token(","), space_token());
+		format_elements!(
 			token("["),
 			indent(group_elements(join_elements(separator, tokens))),
 			token(","),

--- a/crates/formatter/src/ts/arrow_function.rs
+++ b/crates/formatter/src/ts/arrow_function.rs
@@ -1,16 +1,16 @@
 use rslint_parser::ast::{ArrowExpr, ArrowExprParams};
 
 use crate::{
-	concat_elements, format_tokens, space_token, token, ts::format_syntax_token, FormatToken,
+	concat_elements, format_elements, space_token, token, ts::format_syntax_token, FormatElement,
 	FormatValue,
 };
 
 impl FormatValue for ArrowExpr {
-	fn format(&self) -> FormatToken {
-		let mut tokens: Vec<FormatToken> = vec![];
+	fn format(&self) -> FormatElement {
+		let mut tokens: Vec<FormatElement> = vec![];
 
 		if let Some(async_token) = self.async_token() {
-			tokens.push(format_tokens!(
+			tokens.push(format_elements!(
 				format_syntax_token(async_token),
 				space_token()
 			));

--- a/crates/formatter/src/ts/declarators/decl.rs
+++ b/crates/formatter/src/ts/declarators/decl.rs
@@ -1,8 +1,8 @@
-use crate::{FormatToken, FormatValue};
+use crate::{FormatElement, FormatValue};
 use rslint_parser::ast::Decl;
 
 impl FormatValue for Decl {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		match self {
 			Decl::FnDecl(fn_decl) => fn_decl.format(),
 			Decl::ClassDecl(_) => todo!(),

--- a/crates/formatter/src/ts/declarators/declarator.rs
+++ b/crates/formatter/src/ts/declarators/declarator.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatToken, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
 };
 use rslint_parser::ast::{Declarator, Pattern};
 
 impl FormatValue for Declarator {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(pattern) = self.pattern() {

--- a/crates/formatter/src/ts/declarators/fn_decl.rs
+++ b/crates/formatter/src/ts/declarators/fn_decl.rs
@@ -1,8 +1,8 @@
-use crate::{concat_elements, space_token, ts::format_syntax_token, FormatToken, FormatValue};
+use crate::{concat_elements, space_token, ts::format_syntax_token, FormatElement, FormatValue};
 use rslint_parser::ast::FnDecl;
 
 impl FormatValue for FnDecl {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(token) = self.async_token() {

--- a/crates/formatter/src/ts/expressions/expression.rs
+++ b/crates/formatter/src/ts/expressions/expression.rs
@@ -1,8 +1,8 @@
-use crate::{FormatToken, FormatValue};
+use crate::{FormatElement, FormatValue};
 use rslint_parser::ast::Expr;
 
 impl FormatValue for Expr {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		match self {
 			Expr::ArrowExpr(arrow) => arrow.format(),
 			Expr::Literal(literal) => literal.format(),

--- a/crates/formatter/src/ts/expressions/sequence_expression.rs
+++ b/crates/formatter/src/ts/expressions/sequence_expression.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::SequenceExpr;
 
-use crate::{concat_elements, FormatToken, FormatValue};
+use crate::{concat_elements, FormatElement, FormatValue};
 
 impl FormatValue for SequenceExpr {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let tokens: Vec<_> = self.exprs().map(|expression| expression.format()).collect();
 		concat_elements(tokens)
 	}

--- a/crates/formatter/src/ts/literal.rs
+++ b/crates/formatter/src/ts/literal.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::Literal;
 
-use crate::{token, FormatToken, FormatValue};
+use crate::{token, FormatElement, FormatValue};
 
 impl FormatValue for Literal {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let new_string: String = self
 			.to_string()
 			.as_str()

--- a/crates/formatter/src/ts/mod.rs
+++ b/crates/formatter/src/ts/mod.rs
@@ -1,6 +1,6 @@
 use rslint_parser::SyntaxToken;
 
-use crate::{format_tokens, token, FormatToken};
+use crate::{format_elements, token, FormatElement};
 
 mod array;
 mod arrow_function;
@@ -16,8 +16,8 @@ mod spread;
 mod statements;
 mod var_decl;
 
-pub fn format_syntax_token(syntax_token: SyntaxToken) -> FormatToken {
-	format_tokens!(token(syntax_token.text().as_str()))
+pub fn format_syntax_token(syntax_token: SyntaxToken) -> FormatElement {
+	format_elements!(token(syntax_token.text().as_str()))
 }
 
 // NOTE: please leave this comment here, it will be removed once this logic will be ported to the proper place

--- a/crates/formatter/src/ts/name.rs
+++ b/crates/formatter/src/ts/name.rs
@@ -1,8 +1,8 @@
-use crate::{ts::format_syntax_token, FormatToken, FormatValue};
+use crate::{ts::format_syntax_token, FormatElement, FormatValue};
 use rslint_parser::ast::Name;
 
 impl FormatValue for Name {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		format_syntax_token(self.ident_token().unwrap())
 	}
 }

--- a/crates/formatter/src/ts/name_ref.rs
+++ b/crates/formatter/src/ts/name_ref.rs
@@ -3,7 +3,7 @@ use rslint_parser::ast::NameRef;
 use crate::{ts::format_syntax_token, FormatValue};
 
 impl FormatValue for NameRef {
-	fn format(&self) -> crate::FormatToken {
+	fn format(&self) -> crate::FormatElement {
 		if let Some(name_ref) = self.ident_token() {
 			return format_syntax_token(name_ref);
 		}

--- a/crates/formatter/src/ts/paramter_list.rs
+++ b/crates/formatter/src/ts/paramter_list.rs
@@ -1,11 +1,11 @@
 use crate::{
-	concat_elements, format_tokens, join_elements, space_token, token, ts::format_syntax_token,
-	FormatToken, FormatValue,
+	concat_elements, format_elements, join_elements, space_token, token, ts::format_syntax_token,
+	FormatElement, FormatValue,
 };
 use rslint_parser::ast::{ParameterList, Pattern};
 
 impl FormatValue for ParameterList {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(paren) = self.l_paren_token() {
 			tokens.push(format_syntax_token(paren))
@@ -23,8 +23,8 @@ impl FormatValue for ParameterList {
 			})
 			.collect();
 
-		tokens.push(format_tokens!(join_elements(
-			format_tokens!(token(","), space_token()),
+		tokens.push(format_elements!(join_elements(
+			format_elements!(token(","), space_token()),
 			param_tokens,
 		)));
 

--- a/crates/formatter/src/ts/script.rs
+++ b/crates/formatter/src/ts/script.rs
@@ -1,8 +1,10 @@
-use crate::{concat_elements, hard_line_break, ts::format_syntax_token, FormatToken, FormatValue};
+use crate::{
+	concat_elements, hard_line_break, ts::format_syntax_token, FormatElement, FormatValue,
+};
 use rslint_parser::ast::{Script, Stmt};
 
 impl FormatValue for Script {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(shebang) = self.shebang_token() {

--- a/crates/formatter/src/ts/single_pattern.rs
+++ b/crates/formatter/src/ts/single_pattern.rs
@@ -1,8 +1,8 @@
-use crate::{concat_elements, FormatToken, FormatValue};
+use crate::{concat_elements, FormatElement, FormatValue};
 use rslint_parser::ast::SinglePattern;
 
 impl FormatValue for SinglePattern {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(name) = self.name() {
 			tokens.push(name.format());

--- a/crates/formatter/src/ts/spread.rs
+++ b/crates/formatter/src/ts/spread.rs
@@ -1,11 +1,11 @@
-use crate::{format_tokens, ts::format_syntax_token, FormatToken, FormatValue};
+use crate::{format_elements, ts::format_syntax_token, FormatElement, FormatValue};
 use rslint_parser::ast::SpreadElement;
 
 impl FormatValue for SpreadElement {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let dotdotdot_token = self.dotdotdot_token().unwrap();
 		let child = self.element().unwrap();
 
-		format_tokens!(format_syntax_token(dotdotdot_token), child.format())
+		format_elements!(format_syntax_token(dotdotdot_token), child.format())
 	}
 }

--- a/crates/formatter/src/ts/statements/block.rs
+++ b/crates/formatter/src/ts/statements/block.rs
@@ -1,12 +1,12 @@
 use rslint_parser::ast::BlockStmt;
 
-use crate::{format_tokens, space_token, token, FormatToken, FormatValue};
+use crate::{format_elements, space_token, token, FormatElement, FormatValue};
 
 impl FormatValue for BlockStmt {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let body: Vec<_> = self.stmts().map(|stmt| stmt.format()).collect();
 
-		format_tokens![
+		format_elements![
 			token("{"),
 			space_token(),
 			concat_elements(body),

--- a/crates/formatter/src/ts/statements/expression_statement.rs
+++ b/crates/formatter/src/ts/statements/expression_statement.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::ExprStmt;
 
-use crate::{FormatToken, FormatValue};
+use crate::{FormatElement, FormatValue};
 
 impl FormatValue for ExprStmt {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		if let Some(expr) = self.expr() {
 			return expr.format();
 		}

--- a/crates/formatter/src/ts/statements/return_statement.rs
+++ b/crates/formatter/src/ts/statements/return_statement.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatToken, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
 };
 use rslint_parser::ast::ReturnStmt;
 
 impl FormatValue for ReturnStmt {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(return_token) = self.return_token() {
 			tokens.push(format_syntax_token(return_token));

--- a/crates/formatter/src/ts/statements/statement.rs
+++ b/crates/formatter/src/ts/statements/statement.rs
@@ -3,7 +3,7 @@ use rslint_parser::ast::Stmt;
 use crate::FormatValue;
 
 impl FormatValue for Stmt {
-	fn format(&self) -> crate::FormatToken {
+	fn format(&self) -> crate::FormatElement {
 		match self {
 			Stmt::BlockStmt(_) => todo!(),
 			Stmt::EmptyStmt(_) => todo!(),

--- a/crates/formatter/src/ts/var_decl.rs
+++ b/crates/formatter/src/ts/var_decl.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatToken, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
 };
 use rslint_parser::ast::VarDecl;
 
 impl FormatValue for VarDecl {
-	fn format(&self) -> FormatToken {
+	fn format(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(token) = self.const_token() {


### PR DESCRIPTION
## Summary

Renames `FormatToken` to `FormatElement` and `format_tokens` to `format_elements`. See #1688  for motivation.

All credit goes to clion for doing the hard renaming work :D 

## Test Plan

Ran all formatter tests.

