### PR TITLE
json formatter spec tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,10 +921,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "rome-formatter"
 version = "0.0.0"
 dependencies = [
- "parser",
- "rowan",
  "rslint_parser",
- "syntax",
  "tests_macros",
 ]
 

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2018"
 
 [dependencies]
 rslint_parser = { path = "../rslint_parser" }
-parser = { path = "../parser" }
-syntax = { path = "../syntax" }
-rowan = "0.13.2"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/tests_macros/Readme.md
+++ b/crates/tests_macros/Readme.md
@@ -12,7 +12,7 @@ tests_macros = { path = "../tests_macros" }
 ## Usage
 
 First argument: glob that will passed to https://github.com/gilnaa/globwalk. Crate's cargo.toml will be the base directory. To pattern format see here: https://git-scm.com/docs/gitignore#_pattern_format  
-Second argument: method that will be called. 
+Second argument: method that will be called with full path to each file.
 
 One suggestion to organize tests is to put the macro inside a module.
 
@@ -20,6 +20,7 @@ One suggestion to organize tests is to put the macro inside a module.
 mod some_mod {
     tests_macros::gen_tests!{"tests/*.{js,json}", run_test}
 
+    // input_file and expected_file are full paths
     fn run_test(input_file: &str, expected_file: &str) {
         println!("{:?} {:?}", input_file, expected_file); 
     }


### PR DESCRIPTION
## Summary

Json formatter spec tests using gen_test macro.

## Test Plan

```
> cargo test -p rome-formatter -- formatter::json::
...
running 9 tests
test formatter::json::number ... ok
test formatter::json::boolean ... ok
test formatter::json::null ... ok
test formatter::json::multi_line ... ok
test formatter::json::single_line ... ok
test formatter::json::array ... ok
test formatter::json::key_value ... ok
test formatter::json::string ... ok
test formatter::json::int1 ... ok
...
```
