### PR TITLE
refactor: Rename `FormatValue` to `ToFormatElement`

### DIFF
--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -18,22 +18,22 @@
 //!
 //! Now, we do want to create this IR for the data structure:
 //! ```rust
-//! use rome_formatter::{format_elements, format_element, FormatElement, FormatValue, FormatOptions, space_token, token};
+//! use rome_formatter::{format_elements, format_element, FormatElement, ToFormatElement, FormatOptions, space_token, token};
 //!
 //! struct KeyValue {
 //!     key: String,
 //!     value: String
 //! }
 //!
-//! impl FormatValue for KeyValue {
-//!     fn format(&self) -> FormatElement {
+//! impl ToFormatElement for KeyValue {
+//!     fn to_format_element(&self) -> FormatElement {
 //!         format_elements![token(self.key.as_str()), space_token(), token("=>"), space_token(), token(self.value.as_str())]
 //!     }
 //! }
 //!
 //! fn my_function() {
 //!     let key_value = KeyValue { key: String::from("lorem"), value: String::from("ipsum") };
-//!     let element = key_value.format();
+//!     let element = key_value.to_format_element();
 //!     let result = format_element(&element, FormatOptions::default());
 //!     assert_eq!(result.code(), "lorem => ipsum");
 //! }
@@ -59,8 +59,8 @@ pub use format_element::{
 use printer::Printer;
 
 /// This trait should be implemented on each node/value that should have a formatted representation
-pub trait FormatValue {
-	fn format(&self) -> FormatElement;
+pub trait ToFormatElement {
+	fn to_format_element(&self) -> FormatElement;
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/crates/formatter/src/ts/array.rs
+++ b/crates/formatter/src/ts/array.rs
@@ -1,21 +1,21 @@
 use crate::{
 	format_elements, group_elements, indent, join_elements, space_token, token, FormatElement,
-	FormatValue,
+	ToFormatElement,
 };
 use rslint_parser::ast::{ArrayExpr, ExprOrSpread};
 
-impl FormatValue for ArrayExpr {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for ArrayExpr {
+	fn to_format_element(&self) -> FormatElement {
 		let elements = self.elements();
 		let mut tokens = vec![];
 
 		for element in elements {
 			match element {
 				ExprOrSpread::Expr(expr) => {
-					tokens.push(expr.format());
+					tokens.push(expr.to_format_element());
 				}
 				ExprOrSpread::Spread(spread) => {
-					tokens.push(spread.format());
+					tokens.push(spread.to_format_element());
 				}
 			}
 		}

--- a/crates/formatter/src/ts/arrow_function.rs
+++ b/crates/formatter/src/ts/arrow_function.rs
@@ -2,11 +2,11 @@ use rslint_parser::ast::{ArrowExpr, ArrowExprParams};
 
 use crate::{
 	concat_elements, format_elements, space_token, token, ts::format_syntax_token, FormatElement,
-	FormatValue,
+	ToFormatElement,
 };
 
-impl FormatValue for ArrowExpr {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for ArrowExpr {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens: Vec<FormatElement> = vec![];
 
 		if let Some(async_token) = self.async_token() {
@@ -20,10 +20,10 @@ impl FormatValue for ArrowExpr {
 			match arrow_expression_params {
 				ArrowExprParams::Name(name) => {
 					tokens.push(token("("));
-					tokens.push(name.format());
+					tokens.push(name.to_format_element());
 					tokens.push(token(")"));
 				}
-				ArrowExprParams::ParameterList(params) => tokens.push(params.format()),
+				ArrowExprParams::ParameterList(params) => tokens.push(params.to_format_element()),
 			}
 		}
 
@@ -40,9 +40,11 @@ impl FormatValue for ArrowExpr {
 		if let Some(body) = body {
 			match body {
 				rslint_parser::ast::ExprOrBlock::Expr(expression) => {
-					tokens.push(expression.format());
+					tokens.push(expression.to_format_element());
 				}
-				rslint_parser::ast::ExprOrBlock::Block(block) => tokens.push(block.format()),
+				rslint_parser::ast::ExprOrBlock::Block(block) => {
+					tokens.push(block.to_format_element())
+				}
 			}
 		}
 

--- a/crates/formatter/src/ts/declarators/decl.rs
+++ b/crates/formatter/src/ts/declarators/decl.rs
@@ -1,12 +1,12 @@
-use crate::{FormatElement, FormatValue};
+use crate::{FormatElement, ToFormatElement};
 use rslint_parser::ast::Decl;
 
-impl FormatValue for Decl {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Decl {
+	fn to_format_element(&self) -> FormatElement {
 		match self {
-			Decl::FnDecl(fn_decl) => fn_decl.format(),
+			Decl::FnDecl(fn_decl) => fn_decl.to_format_element(),
 			Decl::ClassDecl(_) => todo!(),
-			Decl::VarDecl(var_decl) => var_decl.format(),
+			Decl::VarDecl(var_decl) => var_decl.to_format_element(),
 			Decl::TsEnum(_) => todo!(),
 			Decl::TsTypeAliasDecl(_) => todo!(),
 			Decl::TsNamespaceDecl(_) => todo!(),

--- a/crates/formatter/src/ts/declarators/declarator.rs
+++ b/crates/formatter/src/ts/declarators/declarator.rs
@@ -1,15 +1,15 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, ToFormatElement,
 };
 use rslint_parser::ast::{Declarator, Pattern};
 
-impl FormatValue for Declarator {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Declarator {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(pattern) = self.pattern() {
 			let token = match pattern {
-				Pattern::SinglePattern(single_pattern) => single_pattern.format(),
+				Pattern::SinglePattern(single_pattern) => single_pattern.to_format_element(),
 				Pattern::RestPattern(_) => todo!(),
 				Pattern::AssignPattern(_) => todo!(),
 				Pattern::ObjectPattern(_) => todo!(),
@@ -26,7 +26,7 @@ impl FormatValue for Declarator {
 		}
 
 		if let Some(expression) = self.value() {
-			tokens.push(expression.format());
+			tokens.push(expression.to_format_element());
 		}
 		tokens.push(token(";"));
 

--- a/crates/formatter/src/ts/declarators/fn_decl.rs
+++ b/crates/formatter/src/ts/declarators/fn_decl.rs
@@ -1,8 +1,10 @@
-use crate::{concat_elements, space_token, ts::format_syntax_token, FormatElement, FormatValue};
+use crate::{
+	concat_elements, space_token, ts::format_syntax_token, FormatElement, ToFormatElement,
+};
 use rslint_parser::ast::FnDecl;
 
-impl FormatValue for FnDecl {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for FnDecl {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(token) = self.async_token() {
@@ -20,17 +22,17 @@ impl FormatValue for FnDecl {
 		tokens.push(space_token());
 
 		if let Some(name) = self.name() {
-			tokens.push(name.format());
+			tokens.push(name.to_format_element());
 		}
 
 		if let Some(params) = self.parameters() {
-			tokens.push(params.format());
+			tokens.push(params.to_format_element());
 		}
 
 		tokens.push(space_token());
 
 		if let Some(body) = self.body() {
-			tokens.push(body.format());
+			tokens.push(body.to_format_element());
 		}
 
 		concat_elements(tokens)

--- a/crates/formatter/src/ts/expressions/expression.rs
+++ b/crates/formatter/src/ts/expressions/expression.rs
@@ -1,15 +1,15 @@
-use crate::{FormatElement, FormatValue};
+use crate::{FormatElement, ToFormatElement};
 use rslint_parser::ast::Expr;
 
-impl FormatValue for Expr {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Expr {
+	fn to_format_element(&self) -> FormatElement {
 		match self {
-			Expr::ArrowExpr(arrow) => arrow.format(),
-			Expr::Literal(literal) => literal.format(),
+			Expr::ArrowExpr(arrow) => arrow.to_format_element(),
+			Expr::Literal(literal) => literal.to_format_element(),
 			Expr::Template(_) => todo!(),
-			Expr::NameRef(name_ref) => name_ref.format(),
+			Expr::NameRef(name_ref) => name_ref.to_format_element(),
 			Expr::ThisExpr(_) => todo!(),
-			Expr::ArrayExpr(array_expression) => array_expression.format(),
+			Expr::ArrayExpr(array_expression) => array_expression.to_format_element(),
 			Expr::ObjectExpr(_) => todo!(),
 			Expr::GroupingExpr(_) => todo!(),
 			Expr::BracketExpr(_) => todo!(),

--- a/crates/formatter/src/ts/expressions/sequence_expression.rs
+++ b/crates/formatter/src/ts/expressions/sequence_expression.rs
@@ -1,10 +1,13 @@
 use rslint_parser::ast::SequenceExpr;
 
-use crate::{concat_elements, FormatElement, FormatValue};
+use crate::{concat_elements, FormatElement, ToFormatElement};
 
-impl FormatValue for SequenceExpr {
-	fn format(&self) -> FormatElement {
-		let tokens: Vec<_> = self.exprs().map(|expression| expression.format()).collect();
+impl ToFormatElement for SequenceExpr {
+	fn to_format_element(&self) -> FormatElement {
+		let tokens: Vec<_> = self
+			.exprs()
+			.map(|expression| expression.to_format_element())
+			.collect();
 		concat_elements(tokens)
 	}
 }

--- a/crates/formatter/src/ts/literal.rs
+++ b/crates/formatter/src/ts/literal.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::Literal;
 
-use crate::{token, FormatElement, FormatValue};
+use crate::{token, FormatElement, ToFormatElement};
 
-impl FormatValue for Literal {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Literal {
+	fn to_format_element(&self) -> FormatElement {
 		let new_string: String = self
 			.to_string()
 			.as_str()

--- a/crates/formatter/src/ts/mod.rs
+++ b/crates/formatter/src/ts/mod.rs
@@ -38,14 +38,14 @@ pub fn format_syntax_token(syntax_token: SyntaxToken) -> FormatElement {
 mod test {
 	use rslint_parser::{ast::Script, parse_text, AstNode};
 
-	use crate::{format_element, FormatOptions, FormatValue};
+	use crate::{format_element, FormatOptions, ToFormatElement};
 
 	#[test]
 	fn arrow_function() {
 		let src = "let v = (value  , second_value) =>    true";
 		let tree = parse_text(src, 0);
 		let child = Script::cast(tree.syntax()).unwrap();
-		let result = format_element(&child.format(), FormatOptions::default());
+		let result = format_element(&child.to_format_element(), FormatOptions::default());
 		assert_eq!(result.code(), "let v = (value, second_value) => true;");
 	}
 
@@ -54,7 +54,7 @@ mod test {
 		let src = r#"function foo() { return 'something' }"#;
 		let tree = parse_text(src, 0);
 		let child = Script::cast(tree.syntax()).unwrap();
-		let result = format_element(&child.format(), FormatOptions::default());
+		let result = format_element(&child.to_format_element(), FormatOptions::default());
 		assert_eq!(result.code(), r#"function foo() { return "something"; }"#);
 	}
 

--- a/crates/formatter/src/ts/name.rs
+++ b/crates/formatter/src/ts/name.rs
@@ -1,8 +1,8 @@
-use crate::{ts::format_syntax_token, FormatElement, FormatValue};
+use crate::{ts::format_syntax_token, FormatElement, ToFormatElement};
 use rslint_parser::ast::Name;
 
-impl FormatValue for Name {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Name {
+	fn to_format_element(&self) -> FormatElement {
 		format_syntax_token(self.ident_token().unwrap())
 	}
 }

--- a/crates/formatter/src/ts/name_ref.rs
+++ b/crates/formatter/src/ts/name_ref.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::NameRef;
 
-use crate::{ts::format_syntax_token, FormatValue};
+use crate::{ts::format_syntax_token, ToFormatElement};
 
-impl FormatValue for NameRef {
-	fn format(&self) -> crate::FormatElement {
+impl ToFormatElement for NameRef {
+	fn to_format_element(&self) -> crate::FormatElement {
 		if let Some(name_ref) = self.ident_token() {
 			return format_syntax_token(name_ref);
 		}

--- a/crates/formatter/src/ts/paramter_list.rs
+++ b/crates/formatter/src/ts/paramter_list.rs
@@ -1,11 +1,11 @@
 use crate::{
 	concat_elements, format_elements, join_elements, space_token, token, ts::format_syntax_token,
-	FormatElement, FormatValue,
+	FormatElement, ToFormatElement,
 };
 use rslint_parser::ast::{ParameterList, Pattern};
 
-impl FormatValue for ParameterList {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for ParameterList {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(paren) = self.l_paren_token() {
 			tokens.push(format_syntax_token(paren))
@@ -14,7 +14,7 @@ impl FormatValue for ParameterList {
 		let param_tokens: Vec<_> = self
 			.parameters()
 			.map(|param| match param {
-				Pattern::SinglePattern(single_pattern) => single_pattern.format(),
+				Pattern::SinglePattern(single_pattern) => single_pattern.to_format_element(),
 				Pattern::RestPattern(_) => todo!(),
 				Pattern::AssignPattern(_) => todo!(),
 				Pattern::ObjectPattern(_) => todo!(),

--- a/crates/formatter/src/ts/script.rs
+++ b/crates/formatter/src/ts/script.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, hard_line_break, ts::format_syntax_token, FormatElement, FormatValue,
+	concat_elements, hard_line_break, ts::format_syntax_token, FormatElement, ToFormatElement,
 };
 use rslint_parser::ast::{Script, Stmt};
 
-impl FormatValue for Script {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for Script {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(shebang) = self.shebang_token() {
@@ -14,9 +14,9 @@ impl FormatValue for Script {
 
 		for item in self.items() {
 			let token = match item {
-				Stmt::BlockStmt(block) => block.format(),
+				Stmt::BlockStmt(block) => block.to_format_element(),
 				Stmt::EmptyStmt(_) => todo!(),
-				Stmt::ExprStmt(expression_statement) => expression_statement.format(),
+				Stmt::ExprStmt(expression_statement) => expression_statement.to_format_element(),
 				Stmt::IfStmt(_) => todo!(),
 				Stmt::DoWhileStmt(_) => todo!(),
 				Stmt::WhileStmt(_) => todo!(),
@@ -24,14 +24,14 @@ impl FormatValue for Script {
 				Stmt::ForInStmt(_) => todo!(),
 				Stmt::ContinueStmt(_) => todo!(),
 				Stmt::BreakStmt(_) => todo!(),
-				Stmt::ReturnStmt(statement) => statement.format(),
+				Stmt::ReturnStmt(statement) => statement.to_format_element(),
 				Stmt::WithStmt(_) => todo!(),
 				Stmt::LabelledStmt(_) => todo!(),
 				Stmt::SwitchStmt(_) => todo!(),
 				Stmt::ThrowStmt(_) => todo!(),
 				Stmt::TryStmt(_) => todo!(),
 				Stmt::DebuggerStmt(_) => todo!(),
-				Stmt::Decl(decl) => decl.format(),
+				Stmt::Decl(decl) => decl.to_format_element(),
 			};
 
 			tokens.push(token);

--- a/crates/formatter/src/ts/single_pattern.rs
+++ b/crates/formatter/src/ts/single_pattern.rs
@@ -1,11 +1,11 @@
-use crate::{concat_elements, FormatElement, FormatValue};
+use crate::{concat_elements, FormatElement, ToFormatElement};
 use rslint_parser::ast::SinglePattern;
 
-impl FormatValue for SinglePattern {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for SinglePattern {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(name) = self.name() {
-			tokens.push(name.format());
+			tokens.push(name.to_format_element());
 		}
 
 		concat_elements(tokens)

--- a/crates/formatter/src/ts/spread.rs
+++ b/crates/formatter/src/ts/spread.rs
@@ -1,11 +1,14 @@
-use crate::{format_elements, ts::format_syntax_token, FormatElement, FormatValue};
+use crate::{format_elements, ts::format_syntax_token, FormatElement, ToFormatElement};
 use rslint_parser::ast::SpreadElement;
 
-impl FormatValue for SpreadElement {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for SpreadElement {
+	fn to_format_element(&self) -> FormatElement {
 		let dotdotdot_token = self.dotdotdot_token().unwrap();
 		let child = self.element().unwrap();
 
-		format_elements!(format_syntax_token(dotdotdot_token), child.format())
+		format_elements!(
+			format_syntax_token(dotdotdot_token),
+			child.to_format_element()
+		)
 	}
 }

--- a/crates/formatter/src/ts/statements/block.rs
+++ b/crates/formatter/src/ts/statements/block.rs
@@ -1,10 +1,10 @@
 use rslint_parser::ast::BlockStmt;
 
-use crate::{format_elements, space_token, token, FormatElement, FormatValue};
+use crate::{format_elements, space_token, token, FormatElement, ToFormatElement};
 
-impl FormatValue for BlockStmt {
-	fn format(&self) -> FormatElement {
-		let body: Vec<_> = self.stmts().map(|stmt| stmt.format()).collect();
+impl ToFormatElement for BlockStmt {
+	fn to_format_element(&self) -> FormatElement {
+		let body: Vec<_> = self.stmts().map(|stmt| stmt.to_format_element()).collect();
 
 		format_elements![
 			token("{"),

--- a/crates/formatter/src/ts/statements/expression_statement.rs
+++ b/crates/formatter/src/ts/statements/expression_statement.rs
@@ -1,11 +1,11 @@
 use rslint_parser::ast::ExprStmt;
 
-use crate::{FormatElement, FormatValue};
+use crate::{FormatElement, ToFormatElement};
 
-impl FormatValue for ExprStmt {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for ExprStmt {
+	fn to_format_element(&self) -> FormatElement {
 		if let Some(expr) = self.expr() {
-			return expr.format();
+			return expr.to_format_element();
 		}
 		// TODO: understand what to do here
 		panic!("Strange error?")

--- a/crates/formatter/src/ts/statements/return_statement.rs
+++ b/crates/formatter/src/ts/statements/return_statement.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, ToFormatElement,
 };
 use rslint_parser::ast::ReturnStmt;
 
-impl FormatValue for ReturnStmt {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for ReturnStmt {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 		if let Some(return_token) = self.return_token() {
 			tokens.push(format_syntax_token(return_token));
@@ -13,7 +13,7 @@ impl FormatValue for ReturnStmt {
 		}
 		tokens.push(space_token());
 		if let Some(value) = self.value() {
-			tokens.push(value.format());
+			tokens.push(value.to_format_element());
 		}
 		tokens.push(token(";"));
 

--- a/crates/formatter/src/ts/statements/statement.rs
+++ b/crates/formatter/src/ts/statements/statement.rs
@@ -1,9 +1,9 @@
 use rslint_parser::ast::Stmt;
 
-use crate::FormatValue;
+use crate::ToFormatElement;
 
-impl FormatValue for Stmt {
-	fn format(&self) -> crate::FormatElement {
+impl ToFormatElement for Stmt {
+	fn to_format_element(&self) -> crate::FormatElement {
 		match self {
 			Stmt::BlockStmt(_) => todo!(),
 			Stmt::EmptyStmt(_) => todo!(),
@@ -15,7 +15,7 @@ impl FormatValue for Stmt {
 			Stmt::ForInStmt(_) => todo!(),
 			Stmt::ContinueStmt(_) => todo!(),
 			Stmt::BreakStmt(_) => todo!(),
-			Stmt::ReturnStmt(stmt) => stmt.format(),
+			Stmt::ReturnStmt(stmt) => stmt.to_format_element(),
 			Stmt::WithStmt(_) => todo!(),
 			Stmt::LabelledStmt(_) => todo!(),
 			Stmt::SwitchStmt(_) => todo!(),

--- a/crates/formatter/src/ts/var_decl.rs
+++ b/crates/formatter/src/ts/var_decl.rs
@@ -1,10 +1,10 @@
 use crate::{
-	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, FormatValue,
+	concat_elements, space_token, token, ts::format_syntax_token, FormatElement, ToFormatElement,
 };
 use rslint_parser::ast::VarDecl;
 
-impl FormatValue for VarDecl {
-	fn format(&self) -> FormatElement {
+impl ToFormatElement for VarDecl {
+	fn to_format_element(&self) -> FormatElement {
 		let mut tokens = vec![];
 
 		if let Some(token) = self.const_token() {
@@ -20,7 +20,7 @@ impl FormatValue for VarDecl {
 		tokens.push(space_token());
 
 		for declarator in self.declared() {
-			tokens.push(declarator.format());
+			tokens.push(declarator.to_format_element());
 		}
 
 		concat_elements(tokens)


### PR DESCRIPTION
## Summary
Renames `FormatValue` to `ToFormatValue` as proposed in #1688

## Test Plan

Ran the formatter tests
