### PR TITLE
feature(formatter): Only print empty blocks on a single line

### DIFF
--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -56,7 +56,7 @@ pub use formatter::Formatter;
 
 use core::file_handlers::Language;
 pub use format_element::{
-	concat_elements, group_elements, hard_line_break, if_group_breaks,
+	concat_elements, empty_element, group_elements, hard_line_break, if_group_breaks,
 	if_group_fits_on_single_line, indent, join_elements, soft_indent, soft_line_break,
 	soft_line_break_or_space, space_token, token, FormatElement,
 };

--- a/crates/formatter/src/printer.rs
+++ b/crates/formatter/src/printer.rs
@@ -118,27 +118,26 @@ impl Printer {
 				self.state.pending_spaces += 1;
 				vec![]
 			}
+			FormatElement::Empty => vec![],
 			FormatElement::Token(token) => {
-				if !token.is_empty() {
-					// Print pending indention
-					if self.state.pending_indent > 0 {
-						self.print_str(
-							self.options
-								.indent_string
-								.repeat(self.state.pending_indent as usize)
-								.as_str(),
-						);
-						self.state.pending_indent = 0;
-					}
-
-					// Print pending spaces
-					if self.state.pending_spaces > 0 {
-						self.print_str(" ".repeat(self.state.pending_spaces as usize).as_str());
-						self.state.pending_spaces = 0;
-					}
-
-					self.print_str(token);
+				// Print pending indention
+				if self.state.pending_indent > 0 {
+					self.print_str(
+						self.options
+							.indent_string
+							.repeat(self.state.pending_indent as usize)
+							.as_str(),
+					);
+					self.state.pending_indent = 0;
 				}
+
+				// Print pending spaces
+				if self.state.pending_spaces > 0 {
+					self.print_str(" ".repeat(self.state.pending_spaces as usize).as_str());
+					self.state.pending_spaces = 0;
+				}
+
+				self.print_str(token);
 				vec![]
 			}
 
@@ -264,9 +263,10 @@ impl Printer {
 				..
 			}) => vec![],
 
-			FormatElement::Space | FormatElement::Indent { .. } | FormatElement::List { .. } => {
-				self.print_element(element, args)
-			}
+			FormatElement::Empty
+			| FormatElement::Space
+			| FormatElement::Indent { .. }
+			| FormatElement::List { .. } => self.print_element(element, args),
 		};
 
 		Ok(next_calls)

--- a/crates/formatter/src/ts/declarators/fn_decl.rs
+++ b/crates/formatter/src/ts/declarators/fn_decl.rs
@@ -17,9 +17,9 @@ impl ToFormatElement for FnDecl {
 		if let Some(token) = self.star_token() {
 			tokens.push(formatter.format_token(&token));
 		}
-		tokens.push(space_token());
 
 		if let Some(name) = self.name() {
+			tokens.push(space_token());
 			tokens.push(formatter.format_node(name));
 		}
 

--- a/crates/formatter/src/ts/mod.rs
+++ b/crates/formatter/src/ts/mod.rs
@@ -31,7 +31,12 @@ mod test {
 		let tree = parse_text(src, 0);
 		let child = Script::cast(tree.syntax()).unwrap();
 		let result = Formatter::default().format_root(child.syntax());
-		assert_eq!(result.code(), r#"function foo() {return "something";}"#);
+		assert_eq!(
+			result.code(),
+			r#"function foo() {
+	return "something";
+}"#
+		);
 	}
 
 	#[test]

--- a/crates/formatter/src/ts/statements/block.rs
+++ b/crates/formatter/src/ts/statements/block.rs
@@ -1,19 +1,18 @@
 use rslint_parser::ast::BlockStmt;
 
 use crate::{
-	format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
-	FormatElement, Formatter, ToFormatElement,
+	format_elements, hard_line_break, indent, join_elements, token, FormatElement, Formatter,
+	ToFormatElement,
 };
 
 impl ToFormatElement for BlockStmt {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatElement {
-		group_elements(format_elements![
+		let stmts = self.stmts().map(|stmt| formatter.format_node(stmt));
+
+		format_elements![
 			token("{"),
-			soft_indent(join_elements(
-				soft_line_break_or_space(),
-				self.stmts().map(|stmt| formatter.format_node(stmt))
-			)),
+			indent(join_elements(hard_line_break(), stmts)),
 			token("}")
-		])
+		]
 	}
 }

--- a/crates/formatter/src/ts/statements/statement.rs
+++ b/crates/formatter/src/ts/statements/statement.rs
@@ -5,7 +5,7 @@ use crate::{FormatElement, Formatter, ToFormatElement};
 impl ToFormatElement for Stmt {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatElement {
 		match self {
-			Stmt::BlockStmt(_) => todo!(),
+			Stmt::BlockStmt(block) => block.to_format_element(formatter),
 			Stmt::EmptyStmt(_) => todo!(),
 			Stmt::ExprStmt(expr_stmt) => expr_stmt.to_format_element(formatter),
 			Stmt::IfStmt(_) => todo!(),


### PR DESCRIPTION
## Summary

Changes the formatting of block statements to spawn multiple lines if the block isn't empty. Implementing this requires changes to `indent` to not insert a hard line break if the block isn't empty.

Added additional short-circuits to avoid creating additional elements if the *wrapped* content is empty.

## Test Plan

`cargo test`
