### PR TITLE
avoid one alocation when calling concat_elements

### DIFF
--- a/crates/formatter/src/format_elements.rs
+++ b/crates/formatter/src/format_elements.rs
@@ -54,11 +54,10 @@ macro_rules! format_elements {
 
 	( $( $element:expr ),+ $(,)?) => {{
 		use $crate::{FormatElement, concat_elements};
-		concat_elements(vec![
+		concat_elements([
 			$(
 					 FormatElement::from($element)
 			),+
-
 		])
 	}};
 }


### PR DESCRIPTION
## Summary

Avoid allocating a std::Vec that will be consumed right after.
I think the only danger is that now we will be using stack allocation.

## Test Plan

```rust
cargo test
```
