### PR TITLE
Revert "refactor: replace pico-args with clap on xtask"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -190,6 +190,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "regex",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -504,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
  "console",
  "lazy_static",
@@ -571,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "linked-hash-map"
@@ -691,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
@@ -734,6 +735,12 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pico-args"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
 
 [[package]]
 name = "plotters"
@@ -827,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1202,9 +1209,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1349,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -1544,12 +1551,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "ascii_table",
- "clap 3.0.0-beta.4",
  "colored",
  "convert_case",
  "indicatif",
  "num_cpus",
  "once_cell",
+ "pico-args",
  "proc-macro2",
  "quote",
  "regex",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,25 +5,25 @@ edition = "2018"
 publish = false
 
 [dependencies]
-quote = "1.0.10"
-proc-macro2 = { version = "1.0.29", features = ["span-locations"] }
-anyhow = "1.0.44"
-clap = "3.0.0-beta.4"
-syn = { version = "1.0.80", features = ["full", "parsing"] }
-unindent = "0.1.7"
+quote = "1.0.2"
+proc-macro2 = { version = "1.0.19", features = ["span-locations"] }
+anyhow = "1.0.26"
+pico-args = "0.3.4"
+syn = { version = "1.0.39", features = ["full", "parsing"] }
+unindent = "0.1.6"
 convert_case = "0.4.0"
-regex = "1.5.4"
-serde =  { version = "1.0.130", features = ["derive"] }
-serde_yaml = "0.8.21"
-once_cell = "1.8.0"
+regex = "1.3.9"
+serde =  { version = "1.0.116", features = ["derive"] }
+serde_yaml = "0.8.13"
+once_cell = "1.4.1"
 rslint_parser = { path = "../crates/rslint_parser", version = "0.3" }
 rslint_errors = { path = "../crates/rslint_errors", version = "0.2.0" }
 # rslint_config = { path = "../crates/rslint_config", version = "0.1", features = ["schema"] }
-ascii_table = "3.0.2"
+ascii_table = "3.0.1"
 colored = "2.0.0"
-indicatif = { version = "0.16.2", features = ["improved_unicode"] }
-walkdir = "2.3.2"
-serde_json = "1.0.68"
-schemars = "0.8.6"
-yastl = "0.1.2"
+indicatif = { version = "0.15.0", features = ["improved_unicode"] }
+walkdir = "2.3.1"
+serde_json = "1.0.59"
+schemars = "0.8"
+yastl = "0.1"
 num_cpus = "1.13"

--- a/xtask/src/coverage/files.rs
+++ b/xtask/src/coverage/files.rs
@@ -113,7 +113,7 @@ pub fn get_test_files(query: Option<&str>, pool: &Pool) -> Vec<TestFile> {
 		.collect::<Vec<_>>();
 
 	let pb = ProgressBar::new(files.len() as u64);
-	pb.set_message(format!("{} test files", "Loading".bold().cyan()));
+	pb.set_message(&format!("{} test files", "Loading".bold().cyan()));
 	pb.set_style(super::default_bar_style());
 
 	let (tx, rx) = std::sync::mpsc::channel();

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -16,7 +16,7 @@ pub fn run(query: Option<&str>, pool: Pool) {
 
 	let pb = indicatif::ProgressBar::new(num_ran as u64);
 	pb.set_position(1);
-	pb.set_message(format!("{} tests", "Running".bold().cyan()));
+	pb.set_message(&format!("{} tests", "Running".bold().cyan()));
 	pb.set_style(default_bar_style());
 
 	std::panic::set_hook(Box::new(|_| {}));


### PR DESCRIPTION
Reverts rome/tools#1705, opening this for discussion

Re: https://github.com/rome/tools/pull/1705#issuecomment-941963500

> I think the point of this crate was that it compiled much faster, which is something we want for xtask commands. It matters much less that it’s a complete CLI with tons of features

Also @yassere noted that the `cargo xtask coverage` command made `coverage_query` required which it was not previously