### PR TITLE
Change the visibility of green nodes to internal

### DIFF
--- a/crates/formatter/src/formatter.rs
+++ b/crates/formatter/src/formatter.rs
@@ -80,12 +80,12 @@ impl Formatter {
 	/// ```
 	///
 	/// use rome_formatter::{Formatter, token};
-	/// use rslint_parser::{SyntaxNode, T, SyntaxToken};
-	/// use rome_rowan::{NodeOrToken, SyntaxKind, TreeBuilder};
+	/// use rslint_parser::{SyntaxNode, T, SyntaxToken, JsLanguage, SyntaxKind};
+	/// use rome_rowan::{NodeOrToken, TreeBuilder};
 	///
-	/// let mut builder = TreeBuilder::new();
-	/// builder.start_node(SyntaxKind(1));
-	/// builder.token(SyntaxKind(T![=>].into()), "=>");
+	/// let mut builder = TreeBuilder::<'_, JsLanguage>::new();
+	/// builder.start_node(SyntaxKind::LITERAL);
+	/// builder.token(SyntaxKind::STRING, "'abc'");
 	/// builder.finish_node();
 	/// let node = builder.finish();
 	///
@@ -94,7 +94,7 @@ impl Formatter {
 	/// let formatter = Formatter::default();
 	/// let result = formatter.format_token(&syntax_token);
 	///
-	/// assert_eq!(Some(token("=>")), result)
+	/// assert_eq!(Some(token("\"abc\"")), result)
 	/// ```
 	pub fn format_token(&self, syntax_token: &SyntaxToken) -> Option<FormatElement> {
 		syntax_token.to_format_element(self)

--- a/crates/formatter/src/formatter.rs
+++ b/crates/formatter/src/formatter.rs
@@ -81,13 +81,13 @@ impl Formatter {
 	///
 	/// use rome_formatter::{Formatter, token};
 	/// use rslint_parser::{SyntaxNode, T, SyntaxToken};
-	/// use rome_rowan::{GreenNode, GreenToken, NodeOrToken, SyntaxKind};
+	/// use rome_rowan::{NodeOrToken, SyntaxKind, TreeBuilder};
 	///
-	/// let node = SyntaxNode::new_root(
-	///   GreenNode::new(SyntaxKind(1), vec![
-	///     NodeOrToken::Token(GreenToken::new(SyntaxKind(T![=>].into()), "=>"))
-	///   ])
-	/// );
+	/// let mut builder = TreeBuilder::new();
+	/// builder.start_node(SyntaxKind(1));
+	/// builder.token(SyntaxKind(T![=>].into()), "=>");
+	/// builder.finish_node();
+	/// let node = builder.finish();
 	///
 	/// let syntax_token = node.first_token().unwrap();
 	///

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -12,6 +12,21 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 	fn kind_to_raw(kind: Self::Kind) -> SyntaxKind;
 }
 
+#[derive(Debug, Hash, Copy, Eq, Ord, PartialEq, PartialOrd, Clone)]
+pub struct RawLanguage {}
+
+impl Language for RawLanguage {
+	type Kind = SyntaxKind;
+
+	fn kind_from_raw(raw: SyntaxKind) -> Self::Kind {
+		raw
+	}
+
+	fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
+		kind
+	}
+}
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SyntaxNode<L: Language> {
 	raw: cursor::SyntaxNode,

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -1,8 +1,8 @@
-use std::{borrow::Cow, fmt, iter, marker::PhantomData, ops::Range};
+use std::{fmt, iter, marker::PhantomData, ops::Range};
 
 use crate::{
-	cursor, green::GreenTokenData, Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken,
-	SyntaxKind, SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
+	cursor, Direction, GreenNode, NodeOrToken, SyntaxKind, SyntaxText, TextRange, TextSize,
+	TokenAtOffset, WalkEvent,
 };
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -95,14 +95,8 @@ impl<L: Language> From<SyntaxToken<L>> for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-	pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
+	pub(crate) fn new_root(green: GreenNode) -> SyntaxNode<L> {
 		SyntaxNode::from(cursor::SyntaxNode::new_root(green))
-	}
-	/// Returns a green tree, equal to the green tree this node
-	/// belongs two, except with this node substitute. The complexity
-	/// of operation is proportional to the depth of the tree
-	pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
-		self.raw.replace_with(replacement)
 	}
 
 	pub fn kind(&self) -> L::Kind {
@@ -119,10 +113,6 @@ impl<L: Language> SyntaxNode<L> {
 
 	pub fn text(&self) -> SyntaxText {
 		self.raw.text()
-	}
-
-	pub fn green(&self) -> Cow<'_, GreenNodeData> {
-		self.raw.green()
 	}
 
 	pub fn parent(&self) -> Option<SyntaxNode<L>> {
@@ -274,13 +264,6 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-	/// Returns a green tree, equal to the green tree this token
-	/// belongs two, except with this token substitute. The complexity
-	/// of operation is proportional to the depth of the tree
-	pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
-		self.raw.replace_with(new_token)
-	}
-
 	pub fn kind(&self) -> L::Kind {
 		L::kind_from_raw(self.raw.kind())
 	}
@@ -295,10 +278,6 @@ impl<L: Language> SyntaxToken<L> {
 
 	pub fn text(&self) -> &str {
 		self.raw.text()
-	}
-
-	pub fn green(&self) -> &GreenTokenData {
-		self.raw.green()
 	}
 
 	pub fn parent(&self) -> Option<SyntaxNode<L>> {

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -1,19 +1,15 @@
-mod builder;
 mod element;
 mod node;
 mod node_cache;
 mod token;
 
-use self::element::GreenElement;
-
-pub(crate) use self::{element::GreenElementRef, node::GreenChild};
-
-pub use self::{
-	builder::{Checkpoint, GreenNodeBuilder},
-	node::{Children, GreenNode, GreenNodeData},
-	node_cache::NodeCache,
+pub(crate) use self::{
+	element::{GreenElement, GreenElementRef},
+	node::{GreenChild, GreenNode, GreenNodeData},
 	token::{GreenToken, GreenTokenData},
 };
+
+pub use self::node_cache::NodeCache;
 
 /// SyntaxKind is a type tag for each token or node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/rome_rowan/src/green/element.rs
+++ b/crates/rome_rowan/src/green/element.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::GreenTokenData;
 
-pub(super) type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+pub(crate) type GreenElement = NodeOrToken<GreenNode, GreenToken>;
 pub(crate) type GreenElementRef<'a> = NodeOrToken<&'a GreenNodeData, &'a GreenTokenData>;
 
 impl From<GreenNode> for GreenElement {

--- a/crates/rome_rowan/src/green/node.rs
+++ b/crates/rome_rowan/src/green/node.rs
@@ -39,7 +39,7 @@ static_assert!(mem::size_of::<GreenChild>() == mem::size_of::<usize>() * 2);
 type Repr = HeaderSlice<GreenNodeHead, [GreenChild]>;
 type ReprThin = HeaderSlice<GreenNodeHead, [GreenChild; 0]>;
 #[repr(transparent)]
-pub struct GreenNodeData {
+pub(crate) struct GreenNodeData {
 	data: ReprThin,
 }
 
@@ -53,7 +53,7 @@ impl PartialEq for GreenNodeData {
 /// It has other nodes and tokens as children.
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct GreenNode {
+pub(crate) struct GreenNode {
 	ptr: ThinArc<GreenNodeHead, GreenChild>,
 }
 
@@ -290,7 +290,7 @@ impl GreenChild {
 }
 
 #[derive(Debug, Clone)]
-pub struct Children<'a> {
+pub(crate) struct Children<'a> {
 	pub(crate) raw: slice::Iter<'a, GreenChild>,
 }
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -22,7 +22,7 @@ struct GreenTokenHead {
 type Repr = HeaderSlice<GreenTokenHead, [u8]>;
 type ReprThin = HeaderSlice<GreenTokenHead, [u8; 0]>;
 #[repr(transparent)]
-pub struct GreenTokenData {
+pub(crate) struct GreenTokenData {
 	data: ReprThin,
 }
 
@@ -35,7 +35,7 @@ impl PartialEq for GreenTokenData {
 /// Leaf node in the immutable tree.
 #[derive(PartialEq, Eq, Hash, Clone)]
 #[repr(transparent)]
-pub struct GreenToken {
+pub(crate) struct GreenToken {
 	ptr: ThinArc<GreenTokenHead, u8>,
 }
 

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -24,6 +24,7 @@ mod cow_mut;
 mod serde_impls;
 #[allow(unsafe_code)]
 mod sll;
+mod tree_builder;
 
 pub use text_size::{TextLen, TextRange, TextSize};
 
@@ -31,10 +32,10 @@ pub use crate::{
 	api::{
 		Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
 	},
-	green::{
-		Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,
-		GreenTokenData, SyntaxKind,
-	},
+	green::SyntaxKind,
 	syntax_text::SyntaxText,
+	tree_builder::{Checkpoint, TreeBuilder},
 	utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
+
+pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -274,18 +274,42 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-	use crate::{green::SyntaxKind, GreenNodeBuilder};
+	use crate::{green::SyntaxKind, Language, SyntaxNode, TreeBuilder};
 
-	use super::*;
+	#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
+	struct PlayLanguage {}
 
-	fn build_tree(chunks: &[&str]) -> SyntaxNode {
-		let mut builder = GreenNodeBuilder::new();
-		builder.start_node(SyntaxKind(62));
+	#[allow(unused)]
+	#[derive(Debug, Hash, Copy, Clone, Eq, PartialEq, PartialOrd)]
+	#[repr(u16)]
+	enum PlayKind {
+		List,
+		Child,
+		__LAST,
+	}
+
+	impl Language for PlayLanguage {
+		type Kind = PlayKind;
+
+		#[allow(unsafe_code)]
+		fn kind_from_raw(raw: SyntaxKind) -> Self::Kind {
+			assert!(raw.0 <= (PlayKind::__LAST as u16));
+			unsafe { std::mem::transmute::<u16, PlayKind>(raw.0) }
+		}
+
+		fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
+			SyntaxKind(kind as u16)
+		}
+	}
+
+	fn build_tree(chunks: &[&str]) -> SyntaxNode<PlayLanguage> {
+		let mut builder = TreeBuilder::new();
+		builder.start_node(SyntaxKind(1));
 		for &chunk in chunks.iter() {
-			builder.token(SyntaxKind(92), chunk)
+			builder.token(SyntaxKind(2), chunk)
 		}
 		builder.finish_node();
-		SyntaxNode::new_root(builder.finish())
+		builder.finish()
 	}
 
 	#[test]

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -274,36 +274,11 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-	use crate::{green::SyntaxKind, Language, SyntaxNode, TreeBuilder};
+	use crate::api::RawLanguage;
+	use crate::{SyntaxKind, SyntaxNode, TreeBuilder};
 
-	#[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
-	struct PlayLanguage {}
-
-	#[allow(unused)]
-	#[derive(Debug, Hash, Copy, Clone, Eq, PartialEq, PartialOrd)]
-	#[repr(u16)]
-	enum PlayKind {
-		List,
-		Child,
-		__LAST,
-	}
-
-	impl Language for PlayLanguage {
-		type Kind = PlayKind;
-
-		#[allow(unsafe_code)]
-		fn kind_from_raw(raw: SyntaxKind) -> Self::Kind {
-			assert!(raw.0 <= (PlayKind::__LAST as u16));
-			unsafe { std::mem::transmute::<u16, PlayKind>(raw.0) }
-		}
-
-		fn kind_to_raw(kind: Self::Kind) -> SyntaxKind {
-			SyntaxKind(kind as u16)
-		}
-	}
-
-	fn build_tree(chunks: &[&str]) -> SyntaxNode<PlayLanguage> {
-		let mut builder = TreeBuilder::new();
+	fn build_tree(chunks: &[&str]) -> SyntaxNode<RawLanguage> {
+		let mut builder = TreeBuilder::<'_, RawLanguage>::new();
 		builder.start_node(SyntaxKind(1));
 		for &chunk in chunks.iter() {
 			builder.token(SyntaxKind(2), chunk)

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -3,7 +3,6 @@ use crate::{
 	green::{GreenElement, NodeCache},
 	Language, NodeOrToken, SyntaxNode,
 };
-use std::marker::PhantomData;
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]
@@ -15,7 +14,6 @@ pub struct TreeBuilder<'cache, L: Language> {
 	cache: CowMut<'cache, NodeCache>,
 	parents: Vec<(L::Kind, usize)>,
 	children: Vec<(u64, GreenElement)>,
-	ph: PhantomData<L>,
 }
 
 impl<L: Language> Default for TreeBuilder<'_, L> {
@@ -24,7 +22,6 @@ impl<L: Language> Default for TreeBuilder<'_, L> {
 			cache: CowMut::default(),
 			parents: Vec::default(),
 			children: Vec::default(),
-			ph: PhantomData,
 		}
 	}
 }
@@ -42,7 +39,6 @@ impl<L: Language> TreeBuilder<'_, L> {
 			cache: CowMut::Borrowed(cache),
 			parents: Vec::new(),
 			children: Vec::new(),
-			ph: PhantomData,
 		}
 	}
 

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -439,7 +439,7 @@ mod tests {
 
 	#[test]
 	fn var_decl_let_token() {
-		let parsed = parse_text("/* */let a = 5;", 0).syntax().clone();
+		let parsed = parse_text("/* */let a = 5;", 0).syntax();
 
 		assert!(parsed
 			.child_with_ast::<ast::VarDecl>()

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -439,7 +439,7 @@ mod tests {
 
 	#[test]
 	fn var_decl_let_token() {
-		let parsed = parse_text("/* */let a = 5;", 0).syntax();
+		let parsed = parse_text("/* */let a = 5;", 0).syntax().clone();
 
 		assert!(parsed
 			.child_with_ast::<ast::VarDecl>()

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -1,9 +1,7 @@
 use crate::{
-	ast,
-	syntax_node::GreenNode,
-	AstNode, ParserError,
+	ast, AstNode, ParserError,
 	SyntaxKind::{self, *},
-	SyntaxTreeBuilder, TextRange, TextSize, TreeSink,
+	SyntaxNode, SyntaxTreeBuilder, TextRange, TextSize, TreeSink,
 };
 use rslint_lexer::Token;
 use std::mem;
@@ -160,7 +158,7 @@ impl<'a> LosslessTreeSink<'a> {
 		panic!("Token start does not line up to a token or is out of bounds")
 	}
 
-	pub fn finish(mut self) -> (GreenNode, Vec<ParserError>) {
+	pub fn finish(mut self) -> (SyntaxNode, Vec<ParserError>) {
 		match mem::replace(&mut self.state, State::Normal) {
 			State::PendingFinish => {
 				self.eat_trivias();

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -1,6 +1,5 @@
 use crate::{
-	syntax_node::GreenNode, ParserError, SyntaxKind, SyntaxTreeBuilder, TextRange, TextSize,
-	TreeSink,
+	ParserError, SyntaxKind, SyntaxNode, SyntaxTreeBuilder, TextRange, TextSize, TreeSink,
 };
 use rslint_lexer::Token;
 use std::mem;
@@ -126,7 +125,7 @@ impl<'a> LossyTreeSink<'a> {
 		panic!("Token start does not line up to a token or is out of bounds")
 	}
 
-	pub fn finish(mut self) -> (GreenNode, Vec<ParserError>) {
+	pub fn finish(mut self) -> (SyntaxNode, Vec<ParserError>) {
 		match mem::replace(&mut self.state, State::Normal) {
 			State::PendingFinish => {
 				self.eat_trivias();

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -86,7 +86,7 @@ impl<T: AstNode> Parse<T> {
 
 	/// Try to convert this parse's untyped syntax node into an AST node.
 	pub fn try_tree(&self) -> Option<T> {
-		T::cast(self.syntax().clone())
+		T::cast(self.syntax())
 	}
 
 	/// Convert this parse into a result

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -62,12 +62,9 @@ use crate::*;
 /// let (events, errors) = parser.finish();
 /// process(&mut sink, events, errors);
 ///
-/// let (green, errors) = sink.finish();
+/// let (untyped_node, errors) = sink.finish();
 ///
 /// assert!(errors.is_empty());
-///
-/// // Make a new SyntaxNode from the green node
-/// let untyped_node = SyntaxNode::new_root(green);
 ///
 /// assert!(GroupingExpr::can_cast(untyped_node.kind()));
 ///
@@ -151,12 +148,12 @@ impl<'t> Parser<'t> {
 		self.nth_tok(0)
 	}
 
-	/// Look ahead at a token and get its kind, **The max lookahead is 4**.  
+	/// Look ahead at a token and get its kind, **The max lookahead is 4**.
 	pub fn nth(&self, n: usize) -> SyntaxKind {
 		self.tokens.lookahead_nth(n).kind
 	}
 
-	/// Look ahead at a token, **The max lookahead is 4**.  
+	/// Look ahead at a token, **The max lookahead is 4**.
 	pub fn nth_tok(&self, n: usize) -> Token {
 		self.overflow_check();
 		self.tokens.lookahead_nth(n)
@@ -368,8 +365,7 @@ impl<'t> Parser<'t> {
 		let mut sink =
 			LosslessTreeSink::with_offset(self.tokens.source(), self.tokens.raw_tokens, start);
 		process(&mut sink, events, vec![]);
-		T::cast(SyntaxNode::new_root(sink.finish().0))
-			.expect("Marker was parsed to the wrong ast node")
+		T::cast(sink.finish().0.clone()).expect("Marker was parsed to the wrong ast node")
 	}
 
 	/// Get the source code of a range

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -365,7 +365,7 @@ impl<'t> Parser<'t> {
 		let mut sink =
 			LosslessTreeSink::with_offset(self.tokens.source(), self.tokens.raw_tokens, start);
 		process(&mut sink, events, vec![]);
-		T::cast(sink.finish().0.clone()).expect("Marker was parsed to the wrong ast node")
+		T::cast(sink.finish().0).expect("Marker was parsed to the wrong ast node")
 	}
 
 	/// Get the source code of a range

--- a/crates/rslint_parser/src/syntax_node.rs
+++ b/crates/rslint_parser/src/syntax_node.rs
@@ -31,28 +31,4 @@ pub type SyntaxElementChildren = rome_rowan::SyntaxElementChildren<JsLanguage>;
 
 pub use rome_rowan::{Direction, NodeOrToken};
 
-/// Simple wrapper around a rome_rowan [`GreenNodeBuilder`]
-#[derive(Default, Debug)]
-pub struct SyntaxTreeBuilder {
-	inner: TreeBuilder<'static>,
-}
-
-impl SyntaxTreeBuilder {
-	pub fn finish(self) -> SyntaxNode {
-		self.inner.finish()
-	}
-
-	pub fn token(&mut self, kind: SyntaxKind, text: &str) {
-		let kind = JsLanguage::kind_to_raw(kind);
-		self.inner.token(kind, text)
-	}
-
-	pub fn start_node(&mut self, kind: SyntaxKind) {
-		let kind = JsLanguage::kind_to_raw(kind);
-		self.inner.start_node(kind)
-	}
-
-	pub fn finish_node(&mut self) {
-		self.inner.finish_node()
-	}
-}
+pub type SyntaxTreeBuilder = TreeBuilder<'static, JsLanguage>;

--- a/crates/rslint_parser/src/syntax_node.rs
+++ b/crates/rslint_parser/src/syntax_node.rs
@@ -6,9 +6,7 @@
 //! This is a simple wrapper around the `rowan` crate which does most of the heavy lifting and is language agnostic.
 
 use crate::SyntaxKind;
-use rome_rowan::{GreenNodeBuilder, Language};
-
-pub use rome_rowan::GreenNode;
+use rome_rowan::{Language, TreeBuilder};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct JsLanguage;
@@ -36,11 +34,11 @@ pub use rome_rowan::{Direction, NodeOrToken};
 /// Simple wrapper around a rome_rowan [`GreenNodeBuilder`]
 #[derive(Default, Debug)]
 pub struct SyntaxTreeBuilder {
-	inner: GreenNodeBuilder<'static>,
+	inner: TreeBuilder<'static>,
 }
 
 impl SyntaxTreeBuilder {
-	pub fn finish(self) -> GreenNode {
+	pub fn finish(self) -> SyntaxNode {
 		self.inner.finish()
 	}
 


### PR DESCRIPTION
## Summary

Changes the visibility of the `Green*` and `cursor::Syntax*` types to `pub(crate)` from previously `pub`. 

The motivation behind changing the visibility is that the `Green*` types are an internal optimisation of our CST to reduce memory usage by reusing identical nodes and tokens. The cursor types are also just internal representations that help navigate through a tree and is used by the public `Syntax*` types.

This PR has to remove the `replace_with` methods for now as they used to operate on `GreenNode`s. We should revisit the exact signature and behaviour when working on the mutation API. I may even suggest that the functionality should be super limited because mutating with `SyntaxNode`s directly voids all guarantees that the mutations will form a valid CST tree. Ideally, mutations should be limited to `AstNode`s (that e.g. use a `TreeWriter` to mutate the tree). 

RSLint exposes the `GreenNode` on `Script` with a note that that's useful for multithreading. I believe it should be sufficient for our use cases to just clone the root of the `SyntaxTree` and move it to the new thread rather than passing `GreenNode`s around.

Part of #1725 

## Test Plan

`cargo test`

