### PR TITLE
Attaching trivia to GreenToken

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -731,6 +731,76 @@ impl FormatElement {
 	pub fn is_empty(&self) -> bool {
 		self == &FormatElement::Empty
 	}
+
+	pub fn trim_start(&self) -> FormatElement {
+		dbg!(self);
+		match self {
+			FormatElement::Empty => FormatElement::Empty,
+			FormatElement::Space => FormatElement::Empty,
+			FormatElement::Line(_) => FormatElement::Empty,
+			FormatElement::Indent(_) => FormatElement::Empty,
+			FormatElement::Group(_) => todo!(),
+			FormatElement::ConditionalGroupContent(_) => todo!(),
+			FormatElement::List(list) => {
+				let mut content: Vec<_> = list
+					.iter()
+					.skip_while(|e| match e {
+						FormatElement::Empty => true,
+						FormatElement::Space => true,
+						FormatElement::Line(_) => true,
+						FormatElement::Indent(_) => true,
+						FormatElement::Token(t) => {
+							let s = t.trim_start();
+							s.is_empty()
+						}
+						_ => false,
+					})
+					.map(Clone::clone)
+					.collect();
+				if let Some(FormatElement::Token(s)) = content.get_mut(0) {
+					s.0 = s.trim_start().to_string()
+				}
+				FormatElement::List(List::new(content))
+			}
+			FormatElement::Token(s) => token(s.trim_start()),
+		}
+	}
+
+	pub fn trim_end(&self) -> FormatElement {
+		dbg!(self);
+		match self {
+			FormatElement::Empty => FormatElement::Empty,
+			FormatElement::Space => FormatElement::Empty,
+			FormatElement::Line(_) => FormatElement::Empty,
+			FormatElement::Indent(_) => FormatElement::Empty,
+			FormatElement::Group(_) => todo!(),
+			FormatElement::ConditionalGroupContent(_) => todo!(),
+			FormatElement::List(list) => {
+				let mut content: Vec<_> = list
+					.iter()
+					.rev()
+					.skip_while(|e| match e {
+						FormatElement::Empty => true,
+						FormatElement::Space => true,
+						FormatElement::Line(_) => true,
+						FormatElement::Indent(_) => true,
+						FormatElement::Token(t) => {
+							let s = t.trim_end();
+							s.is_empty()
+						}
+						_ => false,
+					})
+					.map(Clone::clone)
+					.collect();
+				content.reverse();
+				if let Some(FormatElement::Token(s)) = content.last_mut() {
+					s.0 = s.trim_end().to_string()
+				}
+				FormatElement::List(List::new(content))
+			}
+			FormatElement::Token(s) => token(s.trim_end()),
+		}
+	}
 }
 
 impl From<Group> for FormatElement {

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -138,7 +138,7 @@ impl Formatter {
 				// need to be tracked for every node.
 				self.format_raw(&child_node)
 			}
-			SyntaxElement::Token(syntax_token) => token(syntax_token.text()),
+			SyntaxElement::Token(syntax_token) => token(&syntax_token.text_with_trivia()),
 		}))
 	}
 }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -138,7 +138,7 @@ impl Formatter {
 				// need to be tracked for every node.
 				self.format_raw(&child_node)
 			}
-			SyntaxElement::Token(syntax_token) => token(&syntax_token.text_with_trivia()),
+			SyntaxElement::Token(syntax_token) => token(syntax_token.text_with_trivia()),
 		}))
 	}
 }

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -1,4 +1,4 @@
-use crate::{concat_elements, hard_line_break, join_elements, FormatElement, Formatter};
+use crate::{hard_line_break, join_elements, FormatElement, Formatter};
 use rslint_parser::ast::{AstNodeList, JsAnyStatement};
 use rslint_parser::AstNode;
 

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -31,7 +31,7 @@ pub fn format_statements(
 		stmts.iter().map(|stmt| {
 			formatter
 				.format_node(stmt.clone())
-				.unwrap_or_else(|| formatter.format_raw(stmt.syntax()).trim_start().trim_end())
+				.unwrap_or_else(|_| formatter.format_raw(stmt.syntax()).trim_start().trim_end())
 		}),
 	)
 }

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -29,26 +29,9 @@ pub fn format_statements(
 	join_elements(
 		hard_line_break(),
 		stmts.iter().map(|stmt| {
-			formatter.format_node(stmt.clone()).unwrap_or_else(|_| {
-				let verbatim = formatter.format_raw(stmt.syntax());
-
-				match verbatim {
-					FormatElement::List(list) => {
-						if let Some(FormatElement::Token(token)) = list.last() {
-							if token.as_str() == "\n" {
-								let mut elements = (*list).clone();
-								elements.pop(); // Pop the last new line
-								concat_elements(elements)
-							} else {
-								FormatElement::List(list)
-							}
-						} else {
-							FormatElement::List(list)
-						}
-					}
-					_ => verbatim,
-				}
-			})
+			formatter
+				.format_node(stmt.clone())
+				.unwrap_or_else(|| formatter.format_raw(stmt.syntax()).trim_start().trim_end())
 		}),
 	)
 }

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -58,7 +58,10 @@ impl<L: Language> fmt::Debug for SyntaxNode<L> {
 						}
 						match element {
 							NodeOrToken::Node(node) => writeln!(f, "{:?}", node)?,
-							NodeOrToken::Token(token) => writeln!(f, "{:?}", token)?,
+							NodeOrToken::Token(token) => {
+								let g = token.green();
+								writeln!(f, "{:?} {:?} {:?}", g.leading(), token, g.trailing())?;
+							},
 						}
 						level += 1;
 					}

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -76,7 +76,7 @@ impl<L: Language> fmt::Debug for SyntaxNode<L> {
 			assert_eq!(level, 0);
 			Ok(())
 		} else {
-			write!(f, "{:?}@{:?}", self.kind(), self.text_range())
+			write!(f, "{:?}@{:?}", self.kind(), self.text_with_trivia_range())
 		}
 	}
 }
@@ -143,8 +143,23 @@ impl<L: Language> SyntaxNode<L> {
 		self.raw.text_range()
 	}
 
+<<<<<<< HEAD
+=======
+	pub fn text_with_trivia_range(&self) -> TextRange {
+		self.raw.text_with_trivia_range()
+	}
+
+	pub fn index(&self) -> usize {
+		self.raw.index()
+	}
+
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
 	pub fn text(&self) -> SyntaxText {
 		self.raw.text()
+	}
+
+	pub fn text_with_trivia(&self) -> SyntaxText {
+		self.raw.text_with_trivia()
 	}
 
 	pub fn parent(&self) -> Option<SyntaxNode<L>> {
@@ -312,6 +327,10 @@ impl<L: Language> SyntaxToken<L> {
 		self.raw.text_range()
 	}
 
+	pub fn text_with_trivia_range(&self) -> TextRange {
+		self.raw.text_with_trivia_range()
+	}
+
 	pub fn index(&self) -> usize {
 		self.raw.index()
 	}
@@ -375,7 +394,7 @@ impl<L: Language> SyntaxToken<L> {
 impl<L: Language> SyntaxElement<L> {
 	pub fn text_range(&self) -> TextRange {
 		match self {
-			NodeOrToken::Node(it) => it.text_range(),
+			NodeOrToken::Node(it) => it.text_with_trivia_range(),
 			NodeOrToken::Token(it) => it.text_range(),
 		}
 	}

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -320,7 +320,7 @@ impl<L: Language> SyntaxToken<L> {
 		self.raw.text()
 	}
 
-	pub fn text_with_trivia(&self) -> String {
+	pub fn text_with_trivia(&self) -> &str {
 		self.raw.text_with_trivia()
 	}
 

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -320,6 +320,10 @@ impl<L: Language> SyntaxToken<L> {
 		self.raw.text()
 	}
 
+	pub fn text_with_trivia(&self) -> String {
+		self.raw.text_with_trivia()
+	}
+
 	pub fn parent(&self) -> Option<SyntaxNode<L>> {
 		self.raw.parent().map(SyntaxNode::from)
 	}
@@ -359,11 +363,11 @@ impl<L: Language> SyntaxToken<L> {
 
 	//TODO we don't wanna Green stuff leaking here
 	// should we return &str?
-	pub fn leading(&self) -> &[GreenTokenTrivia] {
+	pub fn leading(&self) -> &GreenTokenTrivia {
 		self.raw.leading()
 	}
 
-	pub fn trailing(&self) -> &[GreenTokenTrivia] {
+	pub fn trailing(&self) -> &GreenTokenTrivia {
 		self.raw.trailing()
 	}
 }

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -143,8 +143,6 @@ impl<L: Language> SyntaxNode<L> {
 		self.raw.text_range()
 	}
 
-<<<<<<< HEAD
-=======
 	pub fn text_with_trivia_range(&self) -> TextRange {
 		self.raw.text_with_trivia_range()
 	}
@@ -153,7 +151,6 @@ impl<L: Language> SyntaxNode<L> {
 		self.raw.index()
 	}
 
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
 	pub fn text(&self) -> SyntaxText {
 		self.raw.text()
 	}

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -1,8 +1,8 @@
 use std::{fmt, iter, marker::PhantomData, ops::Range};
 
 use crate::{
-	cursor, Direction, GreenNode, NodeOrToken, SyntaxKind, SyntaxText, TextRange, TextSize,
-	TokenAtOffset, WalkEvent,
+	cursor, green::GreenTokenTrivia, Direction, GreenNode, NodeOrToken, SyntaxKind, SyntaxText,
+	TextRange, TextSize, TokenAtOffset, WalkEvent,
 };
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -59,9 +59,14 @@ impl<L: Language> fmt::Debug for SyntaxNode<L> {
 						match element {
 							NodeOrToken::Node(node) => writeln!(f, "{:?}", node)?,
 							NodeOrToken::Token(token) => {
-								let g = token.green();
-								writeln!(f, "{:?} {:?} {:?}", g.leading(), token, g.trailing())?;
-							},
+								writeln!(
+									f,
+									"{:?} {:?} {:?}",
+									token.leading(),
+									token,
+									token.trailing()
+								)?;
+							}
 						}
 						level += 1;
 					}
@@ -350,6 +355,16 @@ impl<L: Language> SyntaxToken<L> {
 
 	pub fn detach(&self) {
 		self.raw.detach()
+	}
+
+	//TODO we don't wanna Green stuff leaking here
+	// should we return &str?
+	pub fn leading(&self) -> &[GreenTokenTrivia] {
+		self.raw.leading()
+	}
+
+	pub fn trailing(&self) -> &[GreenTokenTrivia] {
+		self.raw.trailing()
 	}
 }
 

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -993,6 +993,22 @@ impl SyntaxToken {
 		assert!(self.data().mutable, "immutable tree: {}", self);
 		self.data().detach()
 	}
+
+	pub fn leading(&self) -> &[crate::GreenTokenTrivia] {
+		let g = self.data().green();
+		match g {
+			NodeOrToken::Node(_) => unreachable!("SyntaxToken should not point to a GreenNode"),
+			NodeOrToken::Token(t) => t.leading(),
+		}
+	}
+
+	pub fn trailing(&self) -> &[crate::GreenTokenTrivia] {
+		let g = self.data().green();
+		match g {
+			NodeOrToken::Node(_) => unreachable!("SyntaxToken should not point to a GreenNode"),
+			NodeOrToken::Token(t) => t.trailing(),
+		}
+	}
 }
 
 impl SyntaxElement {

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -939,6 +939,21 @@ impl SyntaxToken {
 	}
 
 	#[inline]
+	pub fn text_with_trivia(&self) -> String {
+		match self.data().green().as_token() {
+			Some(it) => it.text_with_trivia(),
+			None => {
+				debug_assert!(
+					false,
+					"corrupted tree: a node thinks it is a token: {:?}",
+					self.data().green().as_node().unwrap().to_string()
+				);
+				String::new()
+			}
+		}
+	}
+
+	#[inline]
 	pub fn parent(&self) -> Option<SyntaxNode> {
 		self.data().parent_node()
 	}
@@ -994,7 +1009,7 @@ impl SyntaxToken {
 		self.data().detach()
 	}
 
-	pub fn leading(&self) -> &[crate::GreenTokenTrivia] {
+	pub fn leading(&self) -> &crate::GreenTokenTrivia {
 		let g = self.data().green();
 		match g {
 			NodeOrToken::Node(_) => unreachable!("SyntaxToken should not point to a GreenNode"),
@@ -1002,7 +1017,7 @@ impl SyntaxToken {
 		}
 	}
 
-	pub fn trailing(&self) -> &[crate::GreenTokenTrivia] {
+	pub fn trailing(&self) -> &crate::GreenTokenTrivia {
 		let g = self.data().green();
 		match g {
 			NodeOrToken::Node(_) => unreachable!("SyntaxToken should not point to a GreenNode"),

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -384,8 +384,16 @@ impl NodeData {
 		res
 	}
 
+	//TODO we have to skip the leading trivia here
 	#[inline]
 	fn text_range(&self) -> TextRange {
+		let offset = self.offset();
+		let len = self.green().text_len();
+		TextRange::at(offset, len)
+	}
+
+	#[inline]
+	fn text_with_trivia_range(&self) -> TextRange {
 		let offset = self.offset();
 		let len = self.green().text_len();
 		TextRange::at(offset, len)
@@ -919,6 +927,11 @@ impl SyntaxToken {
 	}
 
 	#[inline]
+	pub fn text_with_trivia_range(&self) -> TextRange {
+		self.data().text_with_trivia_range()
+	}
+
+	#[inline]
 	pub fn index(&self) -> usize {
 		self.data().slot() as usize
 	}
@@ -939,7 +952,7 @@ impl SyntaxToken {
 	}
 
 	#[inline]
-	pub fn text_with_trivia(&self) -> String {
+	pub fn text_with_trivia(&self) -> &str {
 		match self.data().green().as_token() {
 			Some(it) => it.text_with_trivia(),
 			None => {
@@ -948,7 +961,7 @@ impl SyntaxToken {
 					"corrupted tree: a node thinks it is a token: {:?}",
 					self.data().green().as_node().unwrap().to_string()
 				);
-				String::new()
+				""
 			}
 		}
 	}

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -38,6 +38,4 @@ mod tests {
 		eprintln!("GreenToken         {}", size_of::<GreenToken>());
 		eprintln!("GreenElement       {}", size_of::<GreenElement>());
 	}
-
-	
 }

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -9,6 +9,8 @@ pub(crate) use self::{
 	token::{GreenToken, GreenTokenData},
 };
 
+pub use token::GreenTokenTrivia;
+
 pub use self::node_cache::NodeCache;
 
 /// SyntaxKind is a type tag for each token or node.

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -10,7 +10,6 @@ pub(crate) use self::{
 };
 
 pub use token::GreenTokenTrivia;
-pub use token::ThinTrivia;
 pub use token::Trivia;
 
 pub use self::node_cache::NodeCache;
@@ -39,4 +38,6 @@ mod tests {
 		eprintln!("GreenToken         {}", size_of::<GreenToken>());
 		eprintln!("GreenElement       {}", size_of::<GreenElement>());
 	}
+
+	
 }

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -10,6 +10,8 @@ pub(crate) use self::{
 };
 
 pub use token::GreenTokenTrivia;
+pub use token::ThinTrivia;
+pub use token::Trivia;
 
 pub use self::node_cache::NodeCache;
 

--- a/crates/rome_rowan/src/green/element.rs
+++ b/crates/rome_rowan/src/green/element.rs
@@ -60,10 +60,9 @@ impl GreenElement {
 		self.as_deref().kind()
 	}
 
-	/// Returns the length of the text covered by this element.
 	#[inline]
-	pub fn text_len(&self) -> TextSize {
-		self.as_deref().text_len()
+	pub fn text_with_trivia_len(&self) -> TextSize {
+		self.as_deref().text_with_trivia_len()
 	}
 }
 
@@ -79,10 +78,17 @@ impl GreenElementRef<'_> {
 
 	/// Returns the length of the text covered by this element.
 	#[inline]
-	pub fn text_len(self) -> TextSize {
+	pub fn text_with_trivia_len(&self) -> TextSize {
 		match self {
-			NodeOrToken::Node(it) => it.text_len(),
+			NodeOrToken::Node(it) => it.text_with_trivia_len(),
 			NodeOrToken::Token(it) => it.text_with_trivia_len(),
+		}
+	}
+
+	pub fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
+		match self {
+			NodeOrToken::Node(it) => it.leading_trailing_total_len(),
+			NodeOrToken::Token(it) => it.leading_trailing_total_len(),
 		}
 	}
 }

--- a/crates/rome_rowan/src/green/element.rs
+++ b/crates/rome_rowan/src/green/element.rs
@@ -82,7 +82,7 @@ impl GreenElementRef<'_> {
 	pub fn text_len(self) -> TextSize {
 		match self {
 			NodeOrToken::Node(it) => it.text_len(),
-			NodeOrToken::Token(it) => it.text_len(),
+			NodeOrToken::Token(it) => it.text_with_trivia_len(),
 		}
 	}
 }

--- a/crates/rome_rowan/src/green/node.rs
+++ b/crates/rome_rowan/src/green/node.rs
@@ -161,15 +161,15 @@ impl GreenNodeData {
 
 	pub fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
 		let leading_len = match self.slice().first() {
-			Some(GreenChild::Node { node, .. }) => node.leading_trailing_total_len().0,
-			Some(GreenChild::Token { token, .. }) => token.leading_trailing_total_len().0,
-			None => 0.into(),
+			Some(Slot::Node { node, .. }) => node.leading_trailing_total_len().0,
+			Some(Slot::Token { token, .. }) => token.leading_trailing_total_len().0,
+			_ => 0.into(),
 		};
 
 		let trailing_len = match self.slice().last() {
-			Some(GreenChild::Node { node, .. }) => node.leading_trailing_total_len().1,
-			Some(GreenChild::Token { token, .. }) => token.leading_trailing_total_len().1,
-			None => 0.into(),
+			Some(Slot::Node { node, .. }) => node.leading_trailing_total_len().1,
+			Some(Slot::Token { token, .. }) => token.leading_trailing_total_len().1,
+			_ => 0.into(),
 		};
 
 		(
@@ -279,22 +279,12 @@ impl GreenNode {
 		I: IntoIterator<Item = Option<GreenElement>>,
 		I::IntoIter: ExactSizeIterator,
 	{
-<<<<<<< HEAD
-		let mut text_len: TextSize = 0.into();
-		let slots = slots.into_iter().map(|el| {
-			let rel_offset = text_len;
-			text_len += el.text_len();
-=======
-		// println!("GreenNode: {:?}", kind);
 		let mut text_with_trivia_len: TextSize = 0.into();
-		let children = children.into_iter().map(|el| {
+		let slots = slots.into_iter().map(|el| {
 			let rel_offset = text_with_trivia_len;
-			text_with_trivia_len += el.text_with_trivia_len();
-			// println!("\t\t{:?} text_len:{:?}", el, el.text_len());
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
 			match el {
 				Some(el) => {
-					text_len += el.text_len();
+					text_with_trivia_len += el.text_with_trivia_len();
 					match el {
 						NodeOrToken::Node(node) => Slot::Node { rel_offset, node },
 						NodeOrToken::Token(token) => Slot::Token { rel_offset, token },
@@ -358,17 +348,12 @@ impl Slot {
 	}
 	#[inline]
 	fn rel_range(&self) -> TextRange {
-<<<<<<< HEAD
-		let text_len = match self.as_ref() {
-			None => TextSize::from(0),
-			Some(element) => element.text_len(),
+		let len = match self {
+			Slot::Node { node, .. } => node.text_with_trivia_len(),
+			Slot::Token { token, .. } => token.text_with_trivia_len(),
+			_ => 0.into(),
 		};
-
-		TextRange::at(self.rel_offset(), text_len)
-=======
-		let len = self.as_ref().text_with_trivia_len();
 		TextRange::at(self.rel_offset(), len)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
 	}
 }
 

--- a/crates/rome_rowan/src/green/node.rs
+++ b/crates/rome_rowan/src/green/node.rs
@@ -22,6 +22,7 @@ use crate::{
 pub(super) struct GreenNodeHead {
 	kind: SyntaxKind,
 	text_len: TextSize,
+
 	_c: Count<GreenNode>,
 }
 
@@ -261,6 +262,7 @@ impl GreenNode {
 		let mut text_len: TextSize = 0.into();
 		let slots = slots.into_iter().map(|el| {
 			let rel_offset = text_len;
+			text_len += el.text_len();
 			match el {
 				Some(el) => {
 					text_len += el.text_len();

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -147,11 +147,19 @@ impl NodeCache {
 		(hash, node)
 	}
 
-	pub(crate) fn token(&mut self, kind: SyntaxKind, text: &str) -> (u64, GreenToken) {
+	pub(crate) fn token(
+		&mut self,
+		kind: SyntaxKind,
+		text: &str,
+		leading: Vec<super::token::GreenTokenTrivia>,
+		trailing: Vec<super::token::GreenTokenTrivia>,
+	) -> (u64, GreenToken) {
 		let hash = {
 			let mut h = FxHasher::default();
 			kind.hash(&mut h);
 			text.hash(&mut h);
+			leading.hash(&mut h);
+			trailing.hash(&mut h);
 			h.finish()
 		};
 
@@ -162,7 +170,7 @@ impl NodeCache {
 		let token = match entry {
 			RawEntryMut::Occupied(entry) => entry.key().0.clone(),
 			RawEntryMut::Vacant(entry) => {
-				let token = GreenToken::new(kind, text);
+				let token = GreenToken::new(kind, text, leading, trailing);
 				entry.insert_with_hasher(hash, NoHash(token.clone()), (), |t| token_hash(&t.0));
 				token
 			}

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -148,15 +148,20 @@ impl NodeCache {
 	}
 
 	pub(crate) fn token(&mut self, kind: SyntaxKind, text: &str) -> (u64, GreenToken) {
-		self.token_with_trivia(kind, text, vec![], vec![])
+		self.token_with_trivia(
+			kind,
+			text,
+			super::token::GreenTokenTrivia::None,
+			super::token::GreenTokenTrivia::None,
+		)
 	}
 
 	pub(crate) fn token_with_trivia(
 		&mut self,
 		kind: SyntaxKind,
 		text: &str,
-		leading: Vec<super::token::GreenTokenTrivia>,
-		trailing: Vec<super::token::GreenTokenTrivia>,
+		leading: super::token::GreenTokenTrivia,
+		trailing: super::token::GreenTokenTrivia,
 	) -> (u64, GreenToken) {
 		let hash = {
 			let mut h = FxHasher::default();
@@ -174,7 +179,7 @@ impl NodeCache {
 		let token = match entry {
 			RawEntryMut::Occupied(entry) => entry.key().0.clone(),
 			RawEntryMut::Vacant(entry) => {
-				let token = GreenToken::new(kind, text, leading, trailing);
+				let token = GreenToken::with_trivia(kind, text, leading, trailing);
 				entry.insert_with_hasher(hash, NoHash(token.clone()), (), |t| token_hash(&t.0));
 				token
 			}

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -147,7 +147,11 @@ impl NodeCache {
 		(hash, node)
 	}
 
-	pub(crate) fn token(
+	pub(crate) fn token(&mut self, kind: SyntaxKind, text: &str) -> (u64, GreenToken) {
+		self.token_with_trivia(kind, text, vec![], vec![])
+	}
+
+	pub(crate) fn token_with_trivia(
 		&mut self,
 		kind: SyntaxKind,
 		text: &str,

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -152,6 +152,7 @@ impl GreenTokenData {
 
 	/// Returns the length of the text covered by this token.
 	#[inline]
+	#[allow(dead_code)]
 	pub fn text_len(&self) -> TextSize {
 		TextSize::of(self.text())
 	}
@@ -181,6 +182,13 @@ impl GreenTokenData {
 
 	pub(crate) fn cache_hash(&self) -> u64 {
 		Self::cache_hash_of(self.kind(), self.text_with_trivia())
+	}
+
+	pub fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
+		let leading_len = self.data.header.leading_trivia.text_len();
+		let trailing_len = self.data.header.trailing_trivia.text_len();
+		let total_len = self.data.slice().len() as u32;
+		(leading_len, trailing_len, total_len.into())
 	}
 }
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -127,6 +127,16 @@ impl GreenTokenData {
 	pub fn text_len(&self) -> TextSize {
 		TextSize::of(self.text())
 	}
+
+	#[inline]
+	pub fn leading(&self) -> &[GreenTokenTrivia] {
+		self.data.header.leading_trivia.as_slice()
+	}
+
+	#[inline]
+	pub fn trailing(&self) -> &[GreenTokenTrivia] {
+		self.data.header.trailing_trivia.as_slice()
+	}
 }
 
 impl GreenToken {

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -29,6 +29,7 @@ impl Trivia {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(clippy::box_vec)]
 pub enum GreenTokenTrivia {
 	None,
 	Whitespace(usize),

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -1,12 +1,11 @@
 use std::{
 	borrow::Borrow,
-	fmt::{self, Pointer},
+	fmt,
 	mem::{self, ManuallyDrop},
 	ops, ptr,
 };
 
 use countme::Count;
-use text_size::TextLen;
 
 use crate::{
 	arc::{Arc, HeaderSlice, ThinArc},
@@ -68,7 +67,7 @@ pub enum GreenTokenTrivia {
 }
 
 impl GreenTokenTrivia {
-	fn text_len(&self) -> TextSize {
+	pub fn text_len(&self) -> TextSize {
 		match self {
 			GreenTokenTrivia::None => 0.into(),
 			GreenTokenTrivia::One(x) => x.text_len(),
@@ -242,6 +241,7 @@ impl GreenTokenData {
 impl GreenToken {
 	/// Creates new Token.
 	#[inline]
+	#[allow(dead_code)]
 	pub fn new(kind: SyntaxKind, text: &str) -> GreenToken {
 		Self::with_trivia(kind, text, GreenTokenTrivia::None, GreenTokenTrivia::None)
 	}

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -41,5 +41,7 @@ pub use crate::{
 
 //TODO
 pub use crate::green::GreenTokenTrivia;
+pub use crate::green::ThinTrivia;
+pub use crate::green::Trivia;
 
 pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -41,7 +41,6 @@ pub use crate::{
 
 //TODO
 pub use crate::green::GreenTokenTrivia;
-pub use crate::green::ThinTrivia;
 pub use crate::green::Trivia;
 
 pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -39,4 +39,7 @@ pub use crate::{
 	utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
 
+//TODO
+pub use crate::green::GreenTokenTrivia;
+
 pub(crate) use crate::green::{GreenNode, GreenNodeData, GreenToken, GreenTokenData};

--- a/crates/rome_rowan/src/serde_impls.rs
+++ b/crates/rome_rowan/src/serde_impls.rs
@@ -30,7 +30,7 @@ impl<L: Language> Serialize for SyntaxNode<L> {
 	{
 		let mut state = serializer.serialize_map(Some(3))?;
 		state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
-		state.serialize_entry("text_range", &self.text_range())?;
+		state.serialize_entry("text_with_trivia_range", &self.text_with_trivia_range())?;
 		state.serialize_entry("children", &Children(self))?;
 		state.end()
 	}
@@ -43,7 +43,7 @@ impl<L: Language> Serialize for SyntaxToken<L> {
 	{
 		let mut state = serializer.serialize_map(Some(3))?;
 		state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
-		state.serialize_entry("text_range", &self.text_range())?;
+		state.serialize_entry("text_with_trivia_range", &self.text_with_trivia_range())?;
 		state.serialize_entry("text", &self.text())?;
 		state.end()
 	}

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -89,7 +89,8 @@ impl SyntaxText {
 	{
 		self.tokens_with_ranges()
 			.try_fold(init, move |acc, (token, range)| {
-				f(acc, &token.text_with_trivia())
+				let token_str = token.text_with_trivia();
+				f(acc, &token_str[range])
 			})
 	}
 

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -89,7 +89,7 @@ impl SyntaxText {
 	{
 		self.tokens_with_ranges()
 			.try_fold(init, move |acc, (token, range)| {
-				f(acc, &token.text()[range])
+				f(acc, &token.text_with_trivia())
 			})
 	}
 

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -13,7 +13,11 @@ pub struct SyntaxText {
 
 impl SyntaxText {
 	pub(crate) fn new(node: SyntaxNode) -> SyntaxText {
-		let range = node.text_range();
+		let range = node.text_with_trivia_range();
+		SyntaxText { node, range }
+	}
+
+	pub(crate) fn with_range(node: SyntaxNode, range: TextRange) -> SyntaxText {
 		SyntaxText { node, range }
 	}
 
@@ -118,7 +122,7 @@ impl SyntaxText {
 			.descendants_with_tokens()
 			.filter_map(|element| element.into_token())
 			.filter_map(move |token| {
-				let token_range = token.text_range();
+				let token_range = token.text_with_trivia_range();
 				let range = text_range.intersect(token_range)?;
 				Some((token, range - token_range.start()))
 			})

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
 	cow_mut::CowMut,
-	green::{GreenElement, NodeCache},
-	GreenNode, Language, NodeOrToken, SyntaxNode,
+	green::{GreenElement, GreenTokenTrivia, NodeCache},
+	GreenNode, Language, Language, NodeOrToken, NodeOrToken, SyntaxNode, SyntaxNode,
 };
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
@@ -55,6 +55,22 @@ impl<L: Language> TreeBuilder<'_, L> {
 	#[inline]
 	pub fn missing(&mut self) {
 		self.children.push(NodeCache::empty());
+	}
+
+	// Adds new token to the current branch.
+	// TODO we don't wanna Green stuff leaking here.
+	#[inline]
+	pub fn token_with_trivia(
+		&mut self,
+		kind: L::Kind,
+		text: &str,
+		leading: Vec<GreenTokenTrivia>,
+		trailing: Vec<GreenTokenTrivia>,
+	) {
+		let (hash, token) =
+			self.cache
+				.token_with_trivia(L::kind_to_raw(kind), text, leading, trailing);
+		self.children.push((hash, token.into()));
 	}
 
 	/// Start new node and make it current.

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
 	cow_mut::CowMut,
 	green::{GreenElement, GreenTokenTrivia, NodeCache},
-	GreenNode, Language, Language, NodeOrToken, NodeOrToken, SyntaxNode, SyntaxNode,
+	GreenNode, Language, NodeOrToken, SyntaxNode,
 };
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
@@ -67,18 +67,15 @@ impl<L: Language> TreeBuilder<'_, L> {
 		leading: GreenTokenTrivia,
 		trailing: GreenTokenTrivia,
 	) {
-		// println!("TreeBuilder::token_with_trivia {:?}", kind);
 		let (hash, token) =
 			self.cache
 				.token_with_trivia(L::kind_to_raw(kind), text, leading, trailing);
-		// println!("\ttoken: {:?}", token);
-		self.children.push((hash, token.into()));
+		self.children.push((hash, Some(token.into())));
 	}
 
 	/// Start new node and make it current.
 	#[inline]
 	pub fn start_node(&mut self, kind: L::Kind) {
-		// println!("TreeBuilder::start_node {:?}", kind);
 		let len = self.children.len();
 		self.parents.push((kind, len));
 	}

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -64,18 +64,21 @@ impl<L: Language> TreeBuilder<'_, L> {
 		&mut self,
 		kind: L::Kind,
 		text: &str,
-		leading: Vec<GreenTokenTrivia>,
-		trailing: Vec<GreenTokenTrivia>,
+		leading: GreenTokenTrivia,
+		trailing: GreenTokenTrivia,
 	) {
+		println!("TreeBuilder::token_with_trivia {:?}", kind);
 		let (hash, token) =
 			self.cache
 				.token_with_trivia(L::kind_to_raw(kind), text, leading, trailing);
+		println!("\ttoken: {:?}", token);
 		self.children.push((hash, token.into()));
 	}
 
 	/// Start new node and make it current.
 	#[inline]
 	pub fn start_node(&mut self, kind: L::Kind) {
+		println!("TreeBuilder::start_node {:?}", kind);
 		let len = self.children.len();
 		self.parents.push((kind, len));
 	}
@@ -84,7 +87,7 @@ impl<L: Language> TreeBuilder<'_, L> {
 	/// branch as current.
 	#[inline]
 	pub fn finish_node(&mut self) {
-		// println!("GreenNodeBuilder::finish_node");
+		println!("TreeBuilder::finish_node");
 		let (kind, first_child) = self.parents.pop().unwrap();
 		let (hash, node) = self
 			.cache

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -42,7 +42,7 @@ impl<L: Language> TreeBuilder<'_, L> {
 		}
 	}
 
-	/// Adds new token to the current branch.
+	// Adds new token to the current branch.
 	#[inline]
 	pub fn token(&mut self, kind: L::Kind, text: &str) {
 		let (hash, token) = self.cache.token(L::kind_to_raw(kind), text);
@@ -68,6 +68,7 @@ impl<L: Language> TreeBuilder<'_, L> {
 	/// branch as current.
 	#[inline]
 	pub fn finish_node(&mut self) {
+		// println!("GreenNodeBuilder::finish_node");
 		let (kind, first_child) = self.parents.pop().unwrap();
 		let (hash, node) = self
 			.cache
@@ -103,6 +104,7 @@ impl<L: Language> TreeBuilder<'_, L> {
 	/// ```
 	#[inline]
 	pub fn checkpoint(&self) -> Checkpoint {
+		// println!("GreenNodeBuilder::checkpoint");
 		Checkpoint(self.children.len())
 	}
 

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -67,18 +67,18 @@ impl<L: Language> TreeBuilder<'_, L> {
 		leading: GreenTokenTrivia,
 		trailing: GreenTokenTrivia,
 	) {
-		println!("TreeBuilder::token_with_trivia {:?}", kind);
+		// println!("TreeBuilder::token_with_trivia {:?}", kind);
 		let (hash, token) =
 			self.cache
 				.token_with_trivia(L::kind_to_raw(kind), text, leading, trailing);
-		println!("\ttoken: {:?}", token);
+		// println!("\ttoken: {:?}", token);
 		self.children.push((hash, token.into()));
 	}
 
 	/// Start new node and make it current.
 	#[inline]
 	pub fn start_node(&mut self, kind: L::Kind) {
-		println!("TreeBuilder::start_node {:?}", kind);
+		// println!("TreeBuilder::start_node {:?}", kind);
 		let len = self.children.len();
 		self.parents.push((kind, len));
 	}
@@ -87,7 +87,7 @@ impl<L: Language> TreeBuilder<'_, L> {
 	/// branch as current.
 	#[inline]
 	pub fn finish_node(&mut self) {
-		println!("TreeBuilder::finish_node");
+		// println!("TreeBuilder::finish_node");
 		let (kind, first_child) = self.parents.pop().unwrap();
 		let (hash, node) = self
 			.cache

--- a/crates/rslint_errors/src/file.rs
+++ b/crates/rslint_errors/src/file.rs
@@ -88,21 +88,21 @@ where
 
 impl<T: Language> Span for SyntaxNode<T> {
 	fn as_range(&self) -> Range<usize> {
-		self.text_range().into()
+		self.text_with_trivia_range().into()
 	}
 }
 
 impl<T: Language> Span for SyntaxToken<T> {
 	fn as_range(&self) -> Range<usize> {
-		self.text_range().into()
+		self.text_with_trivia_range().into()
 	}
 }
 
 impl<T: Language> Span for SyntaxElement<T> {
 	fn as_range(&self) -> Range<usize> {
 		match self {
-			SyntaxElement::Node(n) => n.text_range(),
-			SyntaxElement::Token(t) => t.text_range(),
+			SyntaxElement::Node(n) => n.text_with_trivia_range(),
+			SyntaxElement::Token(t) => t.text_with_trivia_range(),
 		}
 		.into()
 	}

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -90,6 +90,7 @@ pub struct Lexer<'src> {
 	state: LexerState,
 	pub file_id: usize,
 	returned_eof: bool,
+	break_on_newline: bool,
 }
 
 impl<'src> Lexer<'src> {
@@ -104,6 +105,7 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
+			break_on_newline: true,
 		}
 	}
 
@@ -115,6 +117,7 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
+			break_on_newline: true,
 		}
 	}
 
@@ -136,6 +139,7 @@ impl<'src> Lexer<'src> {
 		}
 	}
 
+<<<<<<< HEAD
 	fn consume_whitespace_until_newline(&mut self) {
 		while let Some(current) = self.current().copied() {
 			let chr = self.get_unicode_char();
@@ -149,6 +153,49 @@ impl<'src> Lexer<'src> {
 				|| (UNICODE_WHITESPACE_STARTS.contains(&current) && UNICODE_SPACES.contains(&chr))
 			{
 				self.cur += chr.len_utf8();
+=======
+	// Consume all whitespace starting from the current byte
+	fn consume_whitespace(&mut self, break_on_newline: bool) {
+		unwind_loop! {
+			if let Some(byte) = self.next().copied() {
+				// This is the most likely scenario, unicode spaces are very uncommon
+				if DISPATCHER[byte as usize] != Dispatch::WHS {
+					// try to short circuit the branch by checking the first byte of the potential unicode space
+					if byte > 0xC1 && UNICODE_WHITESPACE_STARTS.contains(&byte) {
+						let chr = self.get_unicode_char();
+						let is_newline = is_linebreak(chr);
+						if is_newline {
+							self.state.had_linebreak = true;
+						}
+						if !UNICODE_SPACES.contains(&chr) {
+							return;
+						}
+						self.cur += chr.len_utf8() - 1;
+
+						if is_newline && self.should_break_whitespace_now(byte) {
+							self.next();
+							return
+						}
+					} else {
+						return;
+					}
+				}
+
+				if is_linebreak(byte as char) {
+					self.state.had_linebreak = true;
+<<<<<<< HEAD
+
+					if self.should_break_whitespace_now(byte) {
+						self.next();
+						return;
+=======
+					if break_on_newline {
+						self.next();
+						return
+>>>>>>> 66ba73769 (rslint_lexer breaking newline and space in two tokens)
+					}
+				}
+>>>>>>> ad8f1cf7a (rslint_lexer breaking newline and space in two tokens)
 			} else {
 				break;
 			}

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -90,7 +90,7 @@ pub struct Lexer<'src> {
 	state: LexerState,
 	pub file_id: usize,
 	returned_eof: bool,
-	break_on_newline: bool,
+	break_trivia_on_newline: bool,
 }
 
 impl<'src> Lexer<'src> {
@@ -105,7 +105,7 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
-			break_on_newline: true,
+			break_trivia_on_newline: true,
 		}
 	}
 
@@ -117,7 +117,7 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
-			break_on_newline: true,
+			break_trivia_on_newline: true,
 		}
 	}
 
@@ -183,16 +183,10 @@ impl<'src> Lexer<'src> {
 
 				if is_linebreak(byte as char) {
 					self.state.had_linebreak = true;
-<<<<<<< HEAD
 
 					if self.should_break_whitespace_now(byte) {
 						self.next();
 						return;
-=======
-					if break_on_newline {
-						self.next();
-						return
->>>>>>> 66ba73769 (rslint_lexer breaking newline and space in two tokens)
 					}
 				}
 >>>>>>> ad8f1cf7a (rslint_lexer breaking newline and space in two tokens)

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -136,7 +136,6 @@ impl<'src> Lexer<'src> {
 		}
 	}
 
-<<<<<<< HEAD
 	fn consume_whitespace_until_newline(&mut self) {
 		while let Some(current) = self.current().copied() {
 			let chr = self.get_unicode_char();
@@ -150,44 +149,6 @@ impl<'src> Lexer<'src> {
 				|| (UNICODE_WHITESPACE_STARTS.contains(&current) && UNICODE_SPACES.contains(&chr))
 			{
 				self.cur += chr.len_utf8();
-=======
-	// Consume all whitespace starting from the current byte
-	fn consume_whitespace(&mut self) {
-		unwind_loop! {
-			if let Some(byte) = self.next().copied() {
-				println!("consume_whitespace {}", byte);
-				// This is the most likely scenario, unicode spaces are very uncommon
-				if DISPATCHER[byte as usize] != Dispatch::WHS {
-					// try to short circuit the branch by checking the first byte of the potential unicode space
-					if byte > 0xC1 && UNICODE_WHITESPACE_STARTS.contains(&byte) {
-						let chr = self.get_unicode_char();
-						let is_newline = is_linebreak(chr);
-						if is_newline {
-							self.state.had_linebreak = true;
-						}
-						if !UNICODE_SPACES.contains(&chr) {
-							return;
-						}
-						self.cur += chr.len_utf8() - 1;
-
-						if is_newline && self.should_break_whitespace_now(byte) {
-							self.next();
-							return
-						}
-					} else {
-						return;
-					}
-				}
-
-				if is_linebreak(byte as char) {
-					self.state.had_linebreak = true;
-
-					if self.should_break_whitespace_now(byte) {
-						self.next();
-						return;
-					}
-				}
->>>>>>> ad8f1cf7a (rslint_lexer breaking newline and space in two tokens)
 			} else {
 				break;
 			}

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -90,7 +90,6 @@ pub struct Lexer<'src> {
 	state: LexerState,
 	pub file_id: usize,
 	returned_eof: bool,
-	break_trivia_on_newline: bool,
 }
 
 impl<'src> Lexer<'src> {
@@ -105,7 +104,6 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
-			break_trivia_on_newline: true,
 		}
 	}
 
@@ -117,7 +115,6 @@ impl<'src> Lexer<'src> {
 			file_id,
 			state: LexerState::new(),
 			returned_eof: false,
-			break_trivia_on_newline: true,
 		}
 	}
 
@@ -155,9 +152,10 @@ impl<'src> Lexer<'src> {
 				self.cur += chr.len_utf8();
 =======
 	// Consume all whitespace starting from the current byte
-	fn consume_whitespace(&mut self, break_on_newline: bool) {
+	fn consume_whitespace(&mut self) {
 		unwind_loop! {
 			if let Some(byte) = self.next().copied() {
+				println!("consume_whitespace {}", byte);
 				// This is the most likely scenario, unicode spaces are very uncommon
 				if DISPATCHER[byte as usize] != Dispatch::WHS {
 					// try to short circuit the branch by checking the first byte of the potential unicode space

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -1050,7 +1050,7 @@ fn object_expr_getter() {
 }
 
 #[test]
-fn newline_space_must_be_two_tokens() {
+fn space_newline_must_be_two_tokens() {
 	assert_lex! {
 		"\n ",
 		WHITESPACE:2

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -13,7 +13,6 @@ macro_rules! assert_lex {
     ($src:expr, $($kind:ident:$len:expr $(,)?)*) => {{
         let mut lexer = Lexer::from_str($src, 0);
         let mut tokens = lexer.collect::<Vec<_>>();
-		println!("{:?}", tokens);
         let mut idx = 0;
         let mut tok_idx = 0;
 

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -13,6 +13,7 @@ macro_rules! assert_lex {
     ($src:expr, $($kind:ident:$len:expr $(,)?)*) => {{
         let mut lexer = Lexer::from_str($src, 0);
         let mut tokens = lexer.collect::<Vec<_>>();
+		println!("{:?}", tokens);
         let mut idx = 0;
         let mut tok_idx = 0;
 

--- a/crates/rslint_parser/src/ast/expr_ext.rs
+++ b/crates/rslint_parser/src/ast/expr_ext.rs
@@ -408,12 +408,12 @@ impl Literal {
 			.char_at(self.syntax().text().len() - TextSize::from(1))
 			.unwrap();
 		let end = if end_char == '"' || end_char == '\'' {
-			self.syntax().text_range().end() - TextSize::from(1)
+			self.syntax().text_with_trivia_range().end() - TextSize::from(1)
 		} else {
-			self.syntax().text_range().end()
+			self.syntax().text_with_trivia_range().end()
 		};
 
-		let offset = self.syntax().text_range().start();
+		let offset = self.syntax().text_with_trivia_range().start();
 
 		Some(
 			self.syntax()
@@ -475,7 +475,7 @@ impl Template {
 			.find(|tok| tok.kind() == BACKTICK)?;
 		Some(TextRange::new(
 			start.text_range().start(),
-			self.syntax().text_range().end(),
+			self.syntax().text_with_trivia_range().end(),
 		))
 	}
 }

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -34,7 +34,7 @@ impl VarDecl {
 	// TODO: switch this to a contextual keyword once the typescript pr lands
 	pub fn let_token(&self) -> Option<SyntaxToken> {
 		self.syntax()
-			.first_lossy_token()
+			.first_token()
 			.filter(|t| t.kind() == T![ident] && t.text() == "let")
 	}
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -1,9 +1,9 @@
 use crate::{
-	ast, AstNode, ParserError,
+	ParserError,
 	SyntaxKind::{self, *},
 	SyntaxNode, SyntaxTreeBuilder, TextRange, TextSize, TreeSink,
 };
-use rome_rowan::{GreenTokenTrivia, Trivia};
+use rome_rowan::GreenTokenTrivia;
 use rslint_lexer::Token;
 use std::mem;
 
@@ -55,7 +55,7 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 	}
 
 	fn token(&mut self, kind: SyntaxKind) {
-		println!("LosslessTreeSink::token: {:?} {:?}", kind, self.text_pos);
+		// println!("LosslessTreeSink::token: {:?} {:?}", kind, self.text_pos);
 		match mem::replace(&mut self.state, State::Normal) {
 			State::PendingStart => unreachable!(),
 			State::PendingFinish => self.inner.finish_node(),
@@ -155,10 +155,10 @@ impl<'a> LosslessTreeSink<'a> {
 	}
 
 	fn do_token(&mut self, kind: SyntaxKind, len: TextSize) {
-		println!(
-			"LosslessTreeSink::do_token: {:?} len {:?} pos {:?}",
-			kind, len, self.text_pos
-		);
+		// println!(
+		// 	"LosslessTreeSink::do_token: {:?} len {:?} pos {:?}",
+		// 	kind, len, self.text_pos
+		// );
 		let range = TextRange::at(self.text_pos, len);
 		let text = &self.text[range];
 		self.text_pos += len;
@@ -171,7 +171,7 @@ impl<'a> LosslessTreeSink<'a> {
 	}
 
 	fn get_trivia(&mut self, break_on_newline: bool) -> rome_rowan::GreenTokenTrivia {
-		use rome_rowan::{GreenTokenTrivia, Trivia};
+		use rome_rowan::Trivia;
 
 		let mut trivia = GreenTokenTrivia::None;
 
@@ -180,11 +180,10 @@ impl<'a> LosslessTreeSink<'a> {
 				break;
 			}
 
-			//TODO ask if is new line
 			let pos: u32 = self.text_pos.into();
 			let pos = pos as usize;
 			let text = &self.text[pos..(pos + token.len)];
-			if break_on_newline && text.contains("\n") {
+			if break_on_newline && text.chars().any(rslint_lexer::is_linebreak) {
 				break;
 			}
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -207,8 +207,8 @@ impl<'a> LosslessTreeSink<'a> {
 			};
 
 			use GreenTokenTrivia::*;
-			use Trivia::Whitespace as TWhitespace;
 			use Trivia::Comment as TComments;
+			use Trivia::Whitespace as TWhitespace;
 			trivia = match (trivia, current_trivia) {
 				(None, TWhitespace(len)) => Whitespace(len),
 				(None, TComments(len)) => Comment(len),

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -18,6 +18,7 @@ pub struct LosslessTreeSink<'a> {
 	state: State,
 	errors: Vec<ParserError>,
 	inner: SyntaxTreeBuilder,
+	next_token_leading_trivia: Vec<Token>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -34,7 +35,6 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 			State::PendingFinish => self.inner.finish_node(),
 			State::Normal => (),
 		}
-		self.eat_trivias();
 		let len = TextSize::from(
 			self.tokens[self.token_pos..self.token_pos + amount as usize]
 				.iter()
@@ -46,7 +46,7 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 		let text = &self.text[range];
 		self.text_pos += len;
 		self.token_pos += amount as usize;
-		self.inner.token(kind, text);
+		self.inner.token(kind, text, vec![], vec![]);
 	}
 
 	fn token(&mut self, kind: SyntaxKind) {
@@ -55,11 +55,9 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 			State::PendingFinish => self.inner.finish_node(),
 			State::Normal => (),
 		}
-		self.eat_trivias();
-		if self.tokens.get(self.token_pos).is_none() {
-			println!("{:#?}", self.tokens);
-		}
 		let len = TextSize::from(self.tokens[self.token_pos].len as u32);
+
+		// println!("Leading trivia: {:?}", leading);
 		self.do_token(kind, len);
 	}
 
@@ -75,47 +73,17 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 
 	// TODO: Attach comment whitespace to nodes
 	fn start_node(&mut self, kind: SyntaxKind) {
+		// println!("LosslessTreeSink::start_node: {:?} {:?}", kind, self.state);
 		match mem::replace(&mut self.state, State::Normal) {
 			State::PendingStart => {
 				self.inner.start_node(kind);
-				// No need to attach trivias to previous node: there is no
-				// previous node.
 				return;
 			}
 			State::PendingFinish => self.inner.finish_node(),
 			State::Normal => (),
 		}
 
-		// If this is a statement then attach a leading comment to it
-		let n_trivias = self.tokens[self.token_pos..]
-			.iter()
-			.take_while(|it| it.kind.is_trivia())
-			.count();
-		let leading_trivias = &self.tokens[self.token_pos..self.token_pos + n_trivias];
-		let mut trivia_end = self.text_pos
-			+ leading_trivias
-				.iter()
-				.map(|it| TextSize::from(it.len as u32))
-				.sum::<TextSize>()
-			+ TextSize::from(1);
-
-		let n_attached_trivias = {
-			let leading_trivias = leading_trivias.iter().rev().map(|it| {
-				let next_end = trivia_end - TextSize::from(it.len as u32);
-				let (start, end) = (next_end.into(), trivia_end.into());
-				trivia_end = next_end;
-				(
-					it.kind,
-					self.text
-						.get(start..end)
-						.unwrap_or_else(|| self.text.get(start - 1..end).unwrap()),
-				)
-			});
-			n_attached_trivias(kind, leading_trivias.rev())
-		};
-		self.eat_n_trivias(n_trivias - n_attached_trivias);
 		self.inner.start_node(kind);
-		self.eat_n_trivias(n_attached_trivias);
 	}
 
 	fn finish_node(&mut self) {
@@ -141,6 +109,7 @@ impl<'a> LosslessTreeSink<'a> {
 			state: State::PendingStart,
 			inner: SyntaxTreeBuilder::default(),
 			errors: vec![],
+			next_token_leading_trivia: vec![],
 		}
 	}
 
@@ -161,6 +130,7 @@ impl<'a> LosslessTreeSink<'a> {
 					state: State::PendingStart,
 					inner: SyntaxTreeBuilder::default(),
 					errors: vec![],
+					next_token_leading_trivia: vec![],
 				};
 			}
 			len += tok.len;
@@ -170,78 +140,63 @@ impl<'a> LosslessTreeSink<'a> {
 
 	pub fn finish(mut self) -> (SyntaxNode, Vec<ParserError>) {
 		match mem::replace(&mut self.state, State::Normal) {
-			State::PendingFinish => {
-				self.eat_trivias();
-				self.inner.finish_node()
-			}
+			State::PendingFinish => self.inner.finish_node(),
 			State::PendingStart | State::Normal => unreachable!(),
 		}
 
 		(self.inner.finish(), self.errors)
 	}
 
-	fn eat_trivias(&mut self) {
-		while let Some(&token) = self.tokens.get(self.token_pos) {
-			if !token.kind.is_trivia() {
-				break;
-			}
-			self.do_token(token.kind, TextSize::from(token.len as u32));
-		}
-	}
-
-	fn eat_n_trivias(&mut self, n: usize) {
-		for _ in 0..n {
-			let token = self.tokens[self.token_pos];
-			assert!(token.kind.is_trivia());
-			self.do_token(token.kind, TextSize::from(token.len as u32));
-		}
-	}
-
 	fn do_token(&mut self, kind: SyntaxKind, len: TextSize) {
+		// println!("LosslessTreeSink::do_token {:?} {:?}", kind, len);
 		let range = TextRange::at(self.text_pos, len);
 		let text = &self.text[range];
 		self.text_pos += len;
 		self.token_pos += 1;
-		self.inner.token(kind, text);
+
+		let trailing = self.get_trivia(true);
+		let leading = self.get_trivia(false);
+		let leading = std::mem::replace(&mut self.next_token_leading_trivia, leading);
+		let leading = leading
+			.iter()
+			.map(|x| rome_rowan::GreenTokenTrivia::Whitespace)
+			.collect();
+		let trailing: Vec<_> = trailing
+			.iter()
+			.map(|x| rome_rowan::GreenTokenTrivia::Whitespace)
+			.collect();
+
+		self.inner.token(kind, text, leading, trailing);
 	}
-}
 
-/// We need to attach any comment to statements
-fn n_attached_trivias<'a>(
-	kind: SyntaxKind,
-	trivias: impl Iterator<Item = (SyntaxKind, &'a str)>,
-) -> usize {
-	if ast::JsAnyStatement::can_cast(kind) {
-		let mut trivias = trivias.enumerate().peekable();
+	fn get_trivia(&mut self, break_on_newline: bool) -> Vec<Token> {
+		let mut trivia = Vec::new();
 
-		match trivias.next() {
-			Some((idx, (kind, text))) => match kind {
-				WHITESPACE => {
-					if linebreak_count(text) > 1 {
-						return 0;
-					} else if trivias
-						.peek()
-						.map_or(false, |(_, (kind, _))| *kind == COMMENT)
-					{
-						return trivias.next().unwrap().0 + 1;
-					}
-				}
-				COMMENT => {
-					return idx + 1;
-				}
-				_ => {}
-			},
-			_ => return 0,
+		let mut should_break = false;
+		while let Some(&token) = self.tokens.get(self.token_pos) {
+			if should_break {
+				break;
+			}
+
+			if !token.kind.is_trivia() {
+				break;
+			}
+
+			//TODO ask if is new line
+			let pos: u32 = self.text_pos.into();
+			let pos = pos as usize;
+			let text = &self.text[pos..(pos + token.len)];
+			if break_on_newline && text.ends_with("\n") {
+				should_break = true
+			}
+
+			self.token_pos += 1;
+			let len = TextSize::from(token.len as u32);
+			self.text_pos += len;
+
+			trivia.push(token);
 		}
-		0
-	} else {
-		0
-	}
-}
 
-fn linebreak_count(text: &str) -> usize {
-	text.matches('\n').count()
-		+ text.matches('\r').count()
-		+ text.matches('\u{2028}').count()
-		+ text.matches('\u{2029}').count()
+		trivia
+	}
 }

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -46,7 +46,7 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 		let text = &self.text[range];
 		self.text_pos += len;
 		self.token_pos += amount as usize;
-		self.inner.token(kind, text, vec![], vec![]);
+		self.inner.token(kind, text);
 	}
 
 	fn token(&mut self, kind: SyntaxKind) {
@@ -166,7 +166,7 @@ impl<'a> LosslessTreeSink<'a> {
 			.map(|x| rome_rowan::GreenTokenTrivia::Whitespace)
 			.collect();
 
-		self.inner.token(kind, text, leading, trailing);
+		self.inner.token_with_trivia(kind, text, leading, trailing);
 	}
 
 	fn get_trivia(&mut self, break_on_newline: bool) -> Vec<Token> {

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -42,7 +42,7 @@ impl<'a> TreeSink for LossyTreeSink<'a> {
 		let text = &self.text[range];
 		self.text_pos += len;
 		self.token_pos += amount as usize;
-		self.inner.token(kind, text, vec![], vec![]);
+		self.inner.token(kind, text);
 	}
 
 	fn token(&mut self, kind: SyntaxKind) {
@@ -170,7 +170,7 @@ impl<'a> LossyTreeSink<'a> {
 		self.text_pos += len;
 		self.token_pos += 1;
 		if !skip {
-			self.inner.token(kind, text, vec![], vec![]);
+			self.inner.token(kind, text);
 		}
 	}
 }

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -42,7 +42,7 @@ impl<'a> TreeSink for LossyTreeSink<'a> {
 		let text = &self.text[range];
 		self.text_pos += len;
 		self.token_pos += amount as usize;
-		self.inner.token(kind, text);
+		self.inner.token(kind, text, vec![], vec![]);
 	}
 
 	fn token(&mut self, kind: SyntaxKind) {
@@ -170,7 +170,7 @@ impl<'a> LossyTreeSink<'a> {
 		self.text_pos += len;
 		self.token_pos += 1;
 		if !skip {
-			self.inner.token(kind, text);
+			self.inner.token(kind, text, vec![], vec![]);
 		}
 	}
 }

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -164,7 +164,7 @@ pub fn parse_text(text: &str, file_id: usize) -> Parse<JsScript> {
 }
 
 #[test]
-pub fn test_parse_text() {
+pub fn test_trivia_attached_to_tokens() {
 	let text = "let a = 1; // nice variable \n /*hey*/ let b = 2; // another nice variable";
 	let (mut tokens, mut errors) = tokenize(text, 0);
 

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -191,15 +191,14 @@ pub fn test_trivia_attached_to_tokens() {
 	let mut tree_sink = LosslessTreeSink::new(text, &tokens);
 	crate::process(&mut tree_sink, events, errors);
 
-	let (green, parse_errors) = tree_sink.finish();
+	let (syntax, parse_errors) = tree_sink.finish();
 
-	let syntax = SyntaxNode::new_root(green);
 	for item in syntax.descendants_with_tokens() {
 		// println!("{}{:?}", "\t".repeat(token.ancestors().count() - 1), item);
 		let qty = item.ancestors().count() - 1;
 		match item {
-			NodeOrToken::Node(n) => println!("{}{:?}", "\t".repeat(qty), n.green()),
-			NodeOrToken::Token(t) => println!("{}{:?}", "\t".repeat(qty), t.green()),
+			NodeOrToken::Node(n) => println!("{}{:?}", "\t".repeat(qty), n),
+			NodeOrToken::Token(t) => println!("{}{:?}", "\t".repeat(qty), t),
 		}
 	}
 

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -220,11 +220,11 @@ pub fn test_trivia_attached_to_tokens() {
 	use rome_rowan::GreenTokenTrivia::*;
 	use rome_rowan::Trivia::*;
 	assert!(matches!(
-		tokens.iter().nth(0).unwrap().leading(), // first let
+		tokens.get(0).unwrap().leading(), // first let
 		One(x) if x.trivia() == &Comment(4)
 	));
 
-	let second_let = tokens.iter().nth(5).unwrap();
+	let second_let = tokens.get(5).unwrap();
 	assert!(matches!(second_let.leading(),
 		Many(v) if v[0].trivia() == &Whitespace(2) && v[1].trivia() == &Comment(7) && v[2].trivia() == &Whitespace(1)
 	));

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -194,8 +194,7 @@ pub fn token_range_must_be_correct() {
 	let eq = s
 		.tokens()
 		.iter()
-		.filter(|x| x.text() == "=")
-		.nth(0)
+		.find(|x| x.text() == "=")
 		.map(Clone::clone)
 		.unwrap();
 	let range = eq.text_with_trivia_range();
@@ -216,8 +215,7 @@ pub fn node_range_must_be_correct() {
 	let var_decl = m
 		.syntax()
 		.descendants()
-		.filter(|x| x.kind() == SyntaxKind::VAR_DECL)
-		.nth(0)
+		.find(|x| x.kind() == SyntaxKind::VAR_DECL)
 		.unwrap();
 
 	let range = var_decl.text_with_trivia_range();
@@ -240,7 +238,7 @@ pub fn test_trivia_attached_to_tokens() {
 
 	use rome_rowan::GreenTokenTrivia::*;
 	use rome_rowan::Trivia;
-	let first_let = lets.iter().filter(predicate).nth(0).unwrap();
+	let first_let = lets.iter().find(predicate).unwrap();
 	assert!(matches!(first_let.leading(), Comment(4)));
 	assert!(matches!(first_let.trailing(), Whitespace(1)));
 

--- a/crates/rslint_parser/src/parse.rs
+++ b/crates/rslint_parser/src/parse.rs
@@ -181,20 +181,21 @@ pub fn token_range_must_be_correct() {
 	dbg!(t);
 }
 
+//TODO Tidy up this test
 #[test]
 pub fn test_trivia_attached_to_tokens() {
 	let text = "/**/let a = 1; // nice variable \n /*hey*/ let \t b = 2; // another nice variable";
-	let (mut tokens, mut errors) = tokenize(text, 0);
+	let (tokens, errors) = tokenize(text, 0);
 
 	// let tokens: Vec<_> = tokens
 	// 	.drain(..)
 	// 	.filter(|x| (x.kind != SyntaxKind::WHITESPACE) && (x.kind != SyntaxKind::COMMENT))
 	// 	.collect();
-	let mut i = 0;
-	for token in &tokens {
-		println!("{:?} {:?}", &text[i..(i + token.len)], token);
-		i += token.len;
-	}
+	// let mut i = 0;
+	// for token in &tokens {
+	// 	// println!("{:?} {:?}", &text[i..(i + token.len)], token);
+	// 	i += token.len;
+	// }
 
 	let tok_source = TokenSource::new(text, &tokens);
 
@@ -202,19 +203,19 @@ pub fn test_trivia_attached_to_tokens() {
 	let mut parser = crate::Parser::new(tok_source, 0, syntax);
 	crate::syntax::program::parse(&mut parser);
 
-	let (events, p_errs) = parser.finish();
+	let (events, _p_errs) = parser.finish();
 
 	// println!("{:?}", events);
 
 	let mut tree_sink = LosslessTreeSink::new(text, &tokens);
 	crate::process(&mut tree_sink, events, errors);
 
-	let (syntax, parse_errors) = tree_sink.finish();
+	let (syntax, _parse_errors) = tree_sink.finish();
 
-	dbg!(&syntax);
+	// dbg!(&syntax);
 
 	let tokens = syntax.tokens();
-	dbg!(&tokens);
+	// dbg!(&tokens);
 
 	use rome_rowan::GreenTokenTrivia::*;
 	use rome_rowan::Trivia::*;

--- a/crates/rslint_parser/src/util.rs
+++ b/crates/rslint_parser/src/util.rs
@@ -17,21 +17,21 @@ pub trait SyntaxNodeExt {
 			.collect()
 	}
 
-	/// Get all the tokens of this node, recursively, not including whitespace and comments.
-	fn lossy_tokens(&self) -> Vec<SyntaxToken> {
-		self.to_node()
-			.descendants_with_tokens()
-			.filter_map(|x| x.into_token().filter(|token| !token.kind().is_trivia()))
-			.collect()
-	}
+	// /// Get all the tokens of this node, recursively, not including whitespace and comments.
+	// fn lossy_tokens(&self) -> Vec<SyntaxToken> {
+	// 	self.to_node()
+	// 		.descendants_with_tokens()
+	// 		.filter_map(|x| x.into_token().filter(|token| !token.kind().is_trivia()))
+	// 		.collect()
+	// }
 
-	/// Get the first non-whitespace child token.
-	fn first_lossy_token(&self) -> Option<SyntaxToken> {
-		self.to_node()
-			.children_with_tokens()
-			.filter_map(|it| it.into_token().filter(|x| !x.kind().is_trivia()))
-			.next()
-	}
+	// /// Get the first non-whitespace child token.
+	// fn first_lossy_token(&self) -> Option<SyntaxToken> {
+	// 	self.to_node()
+	// 		.children_with_tokens()
+	// 		.filter_map(|it| it.into_token().filter(|x| !x.kind().is_trivia()))
+	// 		.next()
+	// }
 
 	/// Check if the node is a certain AST node and that it can be casted to it.
 	fn is<T: AstNode>(&self) -> bool {
@@ -75,8 +75,8 @@ pub trait SyntaxNodeExt {
 	/// assert_ne!(left.text(), right.text());
 	/// ```
 	fn lexical_eq(&self, right: &SyntaxNode) -> bool {
-		let left = self.lossy_tokens();
-		let right = right.lossy_tokens();
+		let left = self.tokens();
+		let right = right.tokens();
 
 		if left.len() == right.len() {
 			left.iter()
@@ -101,7 +101,7 @@ pub trait SyntaxNodeExt {
 	/// ```
 	/// use rslint_parser::{SyntaxNodeExt, parse_expr, TextRange};
 	///
-	/// let node = parse_expr(" foo. bar  ", 0).syntax();
+	/// let node = dbg!(parse_expr(" foo. bar  ", 0).syntax());
 	///
 	/// assert_eq!(node.trimmed_range(), TextRange::new(1.into(), 9.into()));
 	///
@@ -109,7 +109,7 @@ pub trait SyntaxNodeExt {
 	/// ```
 	fn trimmed_range(&self) -> TextRange {
 		let node = self.to_node();
-		let tokens = node.lossy_tokens();
+		let tokens = dbg!(node.tokens());
 		let start = tokens
 			.first()
 			.map(|t| t.text_range().start())
@@ -208,7 +208,7 @@ pub trait SyntaxNodeExt {
 	/// Separate all the lossy tokens of this node, then compare each token's text with the corresponding
 	/// text in `tokens`.
 	fn structural_lossy_token_eq(&self, tokens: &[impl AsRef<str>]) -> bool {
-		let node_tokens = self.to_node().lossy_tokens();
+		let node_tokens = self.to_node().tokens();
 		if node_tokens.len() == tokens.len() {
 			node_tokens
 				.iter()
@@ -374,7 +374,7 @@ pub enum CommentKind {
 pub fn concat_tokens(tokens: &[SyntaxToken]) -> String {
 	tokens
 		.iter()
-		.map(|token| token.text().to_string())
+		.map(|token| token.text_with_trivia())
 		.collect()
 }
 

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 JS_MODULE@0..26
   LIST@0..25
     VAR_DECL@0..13
@@ -24,27 +23,6 @@ JS_MODULE@0..26
         WHITESPACE@22..23 " "
         JS_BLOCK_STATEMENT@23..25
           L_CURLY@23..24 "{"
-=======
-MODULE@0..25
-  LIST@0..25
-    VAR_DECL@0..14
-       IDENT@0..4 "let" " "
-      LIST@4..14
-        DECLARATOR@4..14
-          SINGLE_PATTERN@4..6
-            NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
-          NAME_REF@8..14
-             IDENT@8..14 "async" " "
-    EXPR_STMT@14..25
-      ARROW_EXPR@14..25
-        NAME@14..20
-           IDENT@14..20 "await" " "
-         FAT_ARROW@20..23 "=>" " "
-        BLOCK_STMT@23..25
-           L_CURLY@23..24 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@24..24
            R_CURLY@24..25 "}" 
 --

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,5 +1,6 @@
 JS_MODULE@0..26
   LIST@0..25
+<<<<<<< HEAD
     VAR_DECL@0..13
       IDENT@0..3 "let"
       WHITESPACE@3..4 " "
@@ -23,8 +24,27 @@ JS_MODULE@0..26
         WHITESPACE@22..23 " "
         JS_BLOCK_STATEMENT@23..25
           L_CURLY@23..24 "{"
+=======
+    VAR_DECL@0..14
+      None IDENT@0..4 "let" Whitespace(1)
+      LIST@4..14
+        DECLARATOR@4..14
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
+          NAME_REF@8..14
+            None IDENT@8..14 "async" Whitespace(1)
+    EXPR_STMT@14..25
+      ARROW_EXPR@14..25
+        NAME@14..20
+          None IDENT@14..20 "await" Whitespace(1)
+        None FAT_ARROW@20..23 "=>" Whitespace(1)
+        BLOCK_STMT@23..25
+          None L_CURLY@23..24 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@24..24
-           R_CURLY@24..25 "}" 
+          None R_CURLY@24..25 "}" None
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ async_arrow_expr_await_parameter.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,28 +1,22 @@
-JS_MODULE@0..26
+JS_MODULE@0..25
   LIST@0..25
-    VAR_DECL@0..13
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
-      LIST@4..13
-        DECLARATOR@4..13
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
-          NAME_REF@8..13
-            IDENT@8..13 "async"
-    WHITESPACE@13..14 " "
+    VAR_DECL@0..14
+      None IDENT@0..3 "let" Whitespace(1)
+      LIST@4..14
+        DECLARATOR@4..14
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
+          NAME_REF@8..14
+            None IDENT@8..13 "async" Whitespace(1)
     JS_EXPRESSION_STATEMENT@14..25
       ARROW_EXPR@14..25
-        NAME@14..19
-          IDENT@14..19 "await"
-        WHITESPACE@19..20 " "
-        FAT_ARROW@20..22 "=>"
-        WHITESPACE@22..23 " "
+        NAME@14..20
+          None IDENT@14..19 "await" Whitespace(1)
+        None FAT_ARROW@20..22 "=>" Whitespace(1)
         JS_BLOCK_STATEMENT@23..25
-          L_CURLY@23..24 "{"
+          None L_CURLY@23..24 "{" None
           LIST@24..24
           None R_CURLY@24..25 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,6 +1,5 @@
 JS_MODULE@0..26
   LIST@0..25
-<<<<<<< HEAD
     VAR_DECL@0..13
       IDENT@0..3 "let"
       WHITESPACE@3..4 " "
@@ -24,25 +23,6 @@ JS_MODULE@0..26
         WHITESPACE@22..23 " "
         JS_BLOCK_STATEMENT@23..25
           L_CURLY@23..24 "{"
-=======
-    VAR_DECL@0..14
-      None IDENT@0..4 "let" Whitespace(1)
-      LIST@4..14
-        DECLARATOR@4..14
-          SINGLE_PATTERN@4..6
-            NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
-          NAME_REF@8..14
-            None IDENT@8..14 "async" Whitespace(1)
-    EXPR_STMT@14..25
-      ARROW_EXPR@14..25
-        NAME@14..20
-          None IDENT@14..20 "await" Whitespace(1)
-        None FAT_ARROW@20..23 "=>" Whitespace(1)
-        BLOCK_STMT@23..25
-          None L_CURLY@23..24 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@24..24
           None R_CURLY@24..25 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..26
   LIST@0..25
     VAR_DECL@0..13
@@ -23,9 +24,29 @@ JS_MODULE@0..26
         WHITESPACE@22..23 " "
         JS_BLOCK_STATEMENT@23..25
           L_CURLY@23..24 "{"
+=======
+MODULE@0..25
+  LIST@0..25
+    VAR_DECL@0..14
+       IDENT@0..4 "let" " "
+      LIST@4..14
+        DECLARATOR@4..14
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
+          NAME_REF@8..14
+             IDENT@8..14 "async" " "
+    EXPR_STMT@14..25
+      ARROW_EXPR@14..25
+        NAME@14..20
+           IDENT@14..20 "await" " "
+         FAT_ARROW@20..23 "=>" " "
+        BLOCK_STMT@23..25
+           L_CURLY@23..24 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@24..24
-          R_CURLY@24..25 "}"
-  WHITESPACE@25..26 "\n"
+           R_CURLY@24..25 "}" 
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ async_arrow_expr_await_parameter.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..35
-=======
-MODULE@0..34
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..34
   LIST@0..34
     JS_EXPRESSION_STATEMENT@0..11
       CALL_EXPR@0..10
@@ -12,85 +8,28 @@ MODULE@0..34
           None L_PAREN@3..4 "(" None
           LIST@4..9
             BIN_EXPR@4..9
-<<<<<<< HEAD
-              NAME_REF@4..7
-                IDENT@4..7 "foo"
-              WHITESPACE@7..8 " "
-              PLUS@8..9 "+"
-          R_PAREN@9..10 ")"
-      SEMICOLON@10..11 ";"
-    WHITESPACE@11..12 "\n"
-    JS_EXPRESSION_STATEMENT@12..22
-      BIN_EXPR@12..21
-        NAME_REF@12..15
-          IDENT@12..15 "foo"
-        WHITESPACE@15..16 " "
-        PLUS@16..17 "+"
-        WHITESPACE@17..18 " "
-=======
               NAME_REF@4..8
                 None IDENT@4..7 "foo" Whitespace(1)
               None PLUS@8..9 "+" None
           None R_PAREN@9..10 ")" None
       None SEMICOLON@10..11 ";" None
-    EXPR_STMT@11..22
+    JS_EXPRESSION_STATEMENT@11..22
       BIN_EXPR@11..21
         NAME_REF@11..16
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" IDENT@11..16 "foo" " "
-         PLUS@16..18 "+" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) IDENT@11..16 "foo" Whitespace(1)
-        None PLUS@16..18 "+" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) IDENT@12..15 "foo" Whitespace(1)
         None PLUS@16..17 "+" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@18..21
           None STAR@18..19 "*" Whitespace(1)
           LITERAL@20..21
-<<<<<<< HEAD
-<<<<<<< HEAD
-            NUMBER@20..21 "2"
-      SEMICOLON@21..22 ";"
-    WHITESPACE@22..23 "\n"
-    JS_EXPRESSION_STATEMENT@23..34
-      BIN_EXPR@23..33
-        UNARY_EXPR@23..27
-          BANG@23..24 "!"
-          NAME_REF@24..27
-            IDENT@24..27 "foo"
-        WHITESPACE@27..28 " "
-        STAR@28..29 "*"
-        WHITESPACE@29..30 " "
-=======
-             NUMBER@20..21 "2" 
-       SEMICOLON@21..22 ";" 
-=======
             None NUMBER@20..21 "2" None
       None SEMICOLON@21..22 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@22..34
+    JS_EXPRESSION_STATEMENT@22..34
       BIN_EXPR@22..33
         UNARY_EXPR@22..28
           Whitespace(1) BANG@23..24 "!" None
           NAME_REF@24..28
-<<<<<<< HEAD
-<<<<<<< HEAD
-             IDENT@24..28 "foo" " "
-         STAR@28..30 "*" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            None IDENT@24..28 "foo" Whitespace(1)
-        None STAR@28..30 "*" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
             None IDENT@24..27 "foo" Whitespace(1)
         None STAR@28..29 "*" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@30..33
           None IDENT@30..33 "bar" None
       None SEMICOLON@33..34 ";" None

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -7,9 +7,9 @@ MODULE@0..34
     JS_EXPRESSION_STATEMENT@0..11
       CALL_EXPR@0..10
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
+          None IDENT@0..3 "foo" None
         ARG_LIST@3..10
-           L_PAREN@3..4 "(" 
+          None L_PAREN@3..4 "(" None
           LIST@4..9
             BIN_EXPR@4..9
 <<<<<<< HEAD
@@ -29,19 +29,25 @@ MODULE@0..34
         WHITESPACE@17..18 " "
 =======
               NAME_REF@4..8
-                 IDENT@4..8 "foo" " "
-               PLUS@8..9 "+" 
-           R_PAREN@9..10 ")" 
-       SEMICOLON@10..11 ";" 
+                None IDENT@4..8 "foo" Whitespace(1)
+              None PLUS@8..9 "+" None
+          None R_PAREN@9..10 ")" None
+      None SEMICOLON@10..11 ";" None
     EXPR_STMT@11..22
       BIN_EXPR@11..21
         NAME_REF@11..16
+<<<<<<< HEAD
           "\n" IDENT@11..16 "foo" " "
          PLUS@16..18 "+" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) IDENT@11..16 "foo" Whitespace(1)
+        None PLUS@16..18 "+" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@18..21
-           STAR@18..20 "*" " "
+          None STAR@18..20 "*" Whitespace(1)
           LITERAL@20..21
+<<<<<<< HEAD
 <<<<<<< HEAD
             NUMBER@20..21 "2"
       SEMICOLON@21..22 ";"
@@ -58,17 +64,26 @@ MODULE@0..34
 =======
              NUMBER@20..21 "2" 
        SEMICOLON@21..22 ";" 
+=======
+            None NUMBER@20..21 "2" None
+      None SEMICOLON@21..22 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@22..34
       BIN_EXPR@22..33
         UNARY_EXPR@22..28
-          "\n" BANG@22..24 "!" 
+          Whitespace(1) BANG@22..24 "!" None
           NAME_REF@24..28
+<<<<<<< HEAD
              IDENT@24..28 "foo" " "
          STAR@28..30 "*" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None IDENT@24..28 "foo" Whitespace(1)
+        None STAR@28..30 "*" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@30..33
-           IDENT@30..33 "bar" 
-       SEMICOLON@33..34 ";" 
+          None IDENT@30..33 "bar" None
+      None SEMICOLON@33..34 ";" None
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ binary_expressions_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -1,13 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..35
+=======
+MODULE@0..34
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..34
     JS_EXPRESSION_STATEMENT@0..11
       CALL_EXPR@0..10
         NAME_REF@0..3
-          IDENT@0..3 "foo"
+           IDENT@0..3 "foo" 
         ARG_LIST@3..10
-          L_PAREN@3..4 "("
+           L_PAREN@3..4 "(" 
           LIST@4..9
             BIN_EXPR@4..9
+<<<<<<< HEAD
               NAME_REF@4..7
                 IDENT@4..7 "foo"
               WHITESPACE@7..8 " "
@@ -22,10 +27,22 @@ JS_MODULE@0..35
         WHITESPACE@15..16 " "
         PLUS@16..17 "+"
         WHITESPACE@17..18 " "
+=======
+              NAME_REF@4..8
+                 IDENT@4..8 "foo" " "
+               PLUS@8..9 "+" 
+           R_PAREN@9..10 ")" 
+       SEMICOLON@10..11 ";" 
+    EXPR_STMT@11..22
+      BIN_EXPR@11..21
+        NAME_REF@11..16
+          "\n" IDENT@11..16 "foo" " "
+         PLUS@16..18 "+" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@18..21
-          STAR@18..19 "*"
-          WHITESPACE@19..20 " "
+           STAR@18..20 "*" " "
           LITERAL@20..21
+<<<<<<< HEAD
             NUMBER@20..21 "2"
       SEMICOLON@21..22 ";"
     WHITESPACE@22..23 "\n"
@@ -38,10 +55,20 @@ JS_MODULE@0..35
         WHITESPACE@27..28 " "
         STAR@28..29 "*"
         WHITESPACE@29..30 " "
+=======
+             NUMBER@20..21 "2" 
+       SEMICOLON@21..22 ";" 
+    EXPR_STMT@22..34
+      BIN_EXPR@22..33
+        UNARY_EXPR@22..28
+          "\n" BANG@22..24 "!" 
+          NAME_REF@24..28
+             IDENT@24..28 "foo" " "
+         STAR@28..30 "*" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME_REF@30..33
-          IDENT@30..33 "bar"
-      SEMICOLON@33..34 ";"
-  WHITESPACE@34..35 "\n"
+           IDENT@30..33 "bar" 
+       SEMICOLON@33..34 ";" 
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ binary_expressions_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -29,13 +29,14 @@ MODULE@0..34
         WHITESPACE@17..18 " "
 =======
               NAME_REF@4..8
-                None IDENT@4..8 "foo" Whitespace(1)
+                None IDENT@4..7 "foo" Whitespace(1)
               None PLUS@8..9 "+" None
           None R_PAREN@9..10 ")" None
       None SEMICOLON@10..11 ";" None
     EXPR_STMT@11..22
       BIN_EXPR@11..21
         NAME_REF@11..16
+<<<<<<< HEAD
 <<<<<<< HEAD
           "\n" IDENT@11..16 "foo" " "
          PLUS@16..18 "+" " "
@@ -44,8 +45,12 @@ MODULE@0..34
           Whitespace(1) IDENT@11..16 "foo" Whitespace(1)
         None PLUS@16..18 "+" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) IDENT@12..15 "foo" Whitespace(1)
+        None PLUS@16..17 "+" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@18..21
-          None STAR@18..20 "*" Whitespace(1)
+          None STAR@18..19 "*" Whitespace(1)
           LITERAL@20..21
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -71,8 +76,9 @@ MODULE@0..34
     EXPR_STMT@22..34
       BIN_EXPR@22..33
         UNARY_EXPR@22..28
-          Whitespace(1) BANG@22..24 "!" None
+          Whitespace(1) BANG@23..24 "!" None
           NAME_REF@24..28
+<<<<<<< HEAD
 <<<<<<< HEAD
              IDENT@24..28 "foo" " "
          STAR@28..30 "*" " "
@@ -81,6 +87,10 @@ MODULE@0..34
             None IDENT@24..28 "foo" Whitespace(1)
         None STAR@28..30 "*" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            None IDENT@24..27 "foo" Whitespace(1)
+        None STAR@28..29 "*" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@30..33
           None IDENT@30..33 "bar" None
       None SEMICOLON@33..34 ";" None

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -6,10 +6,11 @@ MODULE@0..82
   LIST@0..82
     JS_EXPRESSION_STATEMENT@0..30
       ARROW_EXPR@0..30
-         ASYNC_KW@0..6 "async" " "
+        None ASYNC_KW@0..6 "async" Whitespace(1)
         PARAMETER_LIST@6..9
-           L_PAREN@6..7 "(" 
+          None L_PAREN@6..7 "(" None
           LIST@7..7
+<<<<<<< HEAD
 <<<<<<< HEAD
           R_PAREN@7..8 ")"
         WHITESPACE@8..9 " "
@@ -25,30 +26,39 @@ MODULE@0..82
 =======
            R_PAREN@7..9 ")" " "
          FAT_ARROW@9..12 "=>" " "
+=======
+          None R_PAREN@7..9 ")" Whitespace(1)
+        None FAT_ARROW@9..12 "=>" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BLOCK_STMT@12..30
-           L_CURLY@12..14 "{" " "
+          None L_CURLY@12..14 "{" Whitespace(1)
           LIST@14..29
             VAR_DECL@14..29
+<<<<<<< HEAD
                IDENT@14..18 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None IDENT@14..18 "let" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@18..27
                 DECLARATOR@18..27
                   SINGLE_PATTERN@18..24
                     NAME@18..24
-                       IDENT@18..24 "await" " "
-                   EQ@24..26 "=" " "
+                      None IDENT@18..24 "await" Whitespace(1)
+                  None EQ@24..26 "=" Whitespace(1)
                   LITERAL@26..27
-                     NUMBER@26..27 "5" 
-               SEMICOLON@27..29 ";" " "
-           R_CURLY@29..30 "}" 
+                    None NUMBER@26..27 "5" None
+              None SEMICOLON@27..29 ";" Whitespace(1)
+          None R_CURLY@29..30 "}" None
     FN_DECL@30..68
-      "\n" FUNCTION_KW@30..40 "function" " "
-       STAR@40..41 "*" 
+      Whitespace(1) FUNCTION_KW@30..40 "function" Whitespace(1)
+      None STAR@40..41 "*" None
       NAME@41..44
-         IDENT@41..44 "foo" 
+        None IDENT@41..44 "foo" None
       PARAMETER_LIST@44..47
-         L_PAREN@44..45 "(" 
+        None L_PAREN@44..45 "(" None
         LIST@45..45
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@45..46 ")"
       WHITESPACE@46..47 " "
@@ -61,33 +71,40 @@ MODULE@0..82
             WHITESPACE@55..56 " "
 =======
          R_PAREN@45..47 ")" " "
+=======
+        None R_PAREN@45..47 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@47..68
-         L_CURLY@47..48 "{" 
+        None L_CURLY@47..48 "{" None
         LIST@48..66
           VAR_DECL@48..66
+<<<<<<< HEAD
             "\n   " IDENT@48..56 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            Whitespace(4) IDENT@48..56 "let" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
             LIST@56..65
               DECLARATOR@56..65
                 SINGLE_PATTERN@56..62
                   NAME@56..62
-                     IDENT@56..62 "yield" " "
-                 EQ@62..64 "=" " "
+                    None IDENT@56..62 "yield" Whitespace(1)
+                None EQ@62..64 "=" Whitespace(1)
                 LITERAL@64..65
-                   NUMBER@64..65 "5" 
-             SEMICOLON@65..66 ";" 
-        "\n" R_CURLY@66..68 "}" 
+                  None NUMBER@64..65 "5" None
+            None SEMICOLON@65..66 ";" None
+        Whitespace(1) R_CURLY@66..68 "}" None
     VAR_DECL@68..82
-      "\n" IDENT@68..73 "let" " "
+      Whitespace(1) IDENT@68..73 "let" Whitespace(1)
       LIST@73..81
         DECLARATOR@73..81
           SINGLE_PATTERN@73..78
             NAME@73..78
-               IDENT@73..78 "eval" " "
-           EQ@78..80 "=" " "
+              None IDENT@73..78 "eval" Whitespace(1)
+          None EQ@78..80 "=" Whitespace(1)
           LITERAL@80..81
-             NUMBER@80..81 "5" 
-       SEMICOLON@81..82 ";" 
+            None NUMBER@80..81 "5" None
+      None SEMICOLON@81..82 ";" None
 --
 error[SyntaxError]: Illegal use of `await` as an identifier in an async context
   ┌─ binding_identifier_invalid.js:1:19

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..83
-=======
-MODULE@0..82
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..82
   LIST@0..82
     JS_EXPRESSION_STATEMENT@0..30
       ARROW_EXPR@0..30
@@ -10,45 +6,13 @@ MODULE@0..82
         PARAMETER_LIST@6..9
           None L_PAREN@6..7 "(" None
           LIST@7..7
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-          R_PAREN@7..8 ")"
-        WHITESPACE@8..9 " "
-        FAT_ARROW@9..11 "=>"
-        WHITESPACE@11..12 " "
-        JS_BLOCK_STATEMENT@12..30
-          L_CURLY@12..13 "{"
-          WHITESPACE@13..14 " "
-          LIST@14..28
-            VAR_DECL@14..28
-              IDENT@14..17 "let"
-              WHITESPACE@17..18 " "
-=======
-           R_PAREN@7..9 ")" " "
-         FAT_ARROW@9..12 "=>" " "
-=======
-          None R_PAREN@7..9 ")" Whitespace(1)
-        None FAT_ARROW@9..12 "=>" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           None R_PAREN@7..8 ")" Whitespace(1)
         None FAT_ARROW@9..11 "=>" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-        BLOCK_STMT@12..30
+        JS_BLOCK_STATEMENT@12..30
           None L_CURLY@12..13 "{" Whitespace(1)
           LIST@14..29
             VAR_DECL@14..29
-<<<<<<< HEAD
-<<<<<<< HEAD
-               IDENT@14..18 "let" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None IDENT@14..18 "let" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               None IDENT@14..17 "let" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               LIST@18..27
                 DECLARATOR@18..27
                   SINGLE_PATTERN@18..24
@@ -67,40 +31,12 @@ MODULE@0..82
       PARAMETER_LIST@44..47
         None L_PAREN@44..45 "(" None
         LIST@45..45
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@45..46 ")"
-      WHITESPACE@46..47 " "
-      JS_BLOCK_STATEMENT@47..68
-        L_CURLY@47..48 "{"
-        WHITESPACE@48..52 "\n   "
-        LIST@52..66
-          VAR_DECL@52..66
-            IDENT@52..55 "let"
-            WHITESPACE@55..56 " "
-=======
-         R_PAREN@45..47 ")" " "
-=======
-        None R_PAREN@45..47 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@45..46 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@47..68
+      JS_BLOCK_STATEMENT@47..68
         None L_CURLY@47..48 "{" None
         LIST@48..66
           VAR_DECL@48..66
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "\n   " IDENT@48..56 "let" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            Whitespace(4) IDENT@48..56 "let" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
             Whitespace(4) IDENT@52..55 "let" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             LIST@56..65
               DECLARATOR@56..65
                 SINGLE_PATTERN@56..62

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -1,12 +1,16 @@
+<<<<<<< HEAD
 JS_MODULE@0..83
+=======
+MODULE@0..82
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..82
     JS_EXPRESSION_STATEMENT@0..30
       ARROW_EXPR@0..30
-        ASYNC_KW@0..5 "async"
-        WHITESPACE@5..6 " "
-        PARAMETER_LIST@6..8
-          L_PAREN@6..7 "("
+         ASYNC_KW@0..6 "async" " "
+        PARAMETER_LIST@6..9
+           L_PAREN@6..7 "(" 
           LIST@7..7
+<<<<<<< HEAD
           R_PAREN@7..8 ")"
         WHITESPACE@8..9 " "
         FAT_ARROW@9..11 "=>"
@@ -18,29 +22,34 @@ JS_MODULE@0..83
             VAR_DECL@14..28
               IDENT@14..17 "let"
               WHITESPACE@17..18 " "
+=======
+           R_PAREN@7..9 ")" " "
+         FAT_ARROW@9..12 "=>" " "
+        BLOCK_STMT@12..30
+           L_CURLY@12..14 "{" " "
+          LIST@14..29
+            VAR_DECL@14..29
+               IDENT@14..18 "let" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@18..27
                 DECLARATOR@18..27
-                  SINGLE_PATTERN@18..23
-                    NAME@18..23
-                      IDENT@18..23 "await"
-                  WHITESPACE@23..24 " "
-                  EQ@24..25 "="
-                  WHITESPACE@25..26 " "
+                  SINGLE_PATTERN@18..24
+                    NAME@18..24
+                       IDENT@18..24 "await" " "
+                   EQ@24..26 "=" " "
                   LITERAL@26..27
-                    NUMBER@26..27 "5"
-              SEMICOLON@27..28 ";"
-          WHITESPACE@28..29 " "
-          R_CURLY@29..30 "}"
-    WHITESPACE@30..31 "\n"
-    FN_DECL@31..68
-      FUNCTION_KW@31..39 "function"
-      WHITESPACE@39..40 " "
-      STAR@40..41 "*"
+                     NUMBER@26..27 "5" 
+               SEMICOLON@27..29 ";" " "
+           R_CURLY@29..30 "}" 
+    FN_DECL@30..68
+      "\n" FUNCTION_KW@30..40 "function" " "
+       STAR@40..41 "*" 
       NAME@41..44
-        IDENT@41..44 "foo"
-      PARAMETER_LIST@44..46
-        L_PAREN@44..45 "("
+         IDENT@41..44 "foo" 
+      PARAMETER_LIST@44..47
+         L_PAREN@44..45 "(" 
         LIST@45..45
+<<<<<<< HEAD
         R_PAREN@45..46 ")"
       WHITESPACE@46..47 " "
       JS_BLOCK_STATEMENT@47..68
@@ -50,35 +59,35 @@ JS_MODULE@0..83
           VAR_DECL@52..66
             IDENT@52..55 "let"
             WHITESPACE@55..56 " "
+=======
+         R_PAREN@45..47 ")" " "
+      BLOCK_STMT@47..68
+         L_CURLY@47..48 "{" 
+        LIST@48..66
+          VAR_DECL@48..66
+            "\n   " IDENT@48..56 "let" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
             LIST@56..65
               DECLARATOR@56..65
-                SINGLE_PATTERN@56..61
-                  NAME@56..61
-                    IDENT@56..61 "yield"
-                WHITESPACE@61..62 " "
-                EQ@62..63 "="
-                WHITESPACE@63..64 " "
+                SINGLE_PATTERN@56..62
+                  NAME@56..62
+                     IDENT@56..62 "yield" " "
+                 EQ@62..64 "=" " "
                 LITERAL@64..65
-                  NUMBER@64..65 "5"
-            SEMICOLON@65..66 ";"
-        WHITESPACE@66..67 "\n"
-        R_CURLY@67..68 "}"
-    WHITESPACE@68..69 "\n"
-    VAR_DECL@69..82
-      IDENT@69..72 "let"
-      WHITESPACE@72..73 " "
+                   NUMBER@64..65 "5" 
+             SEMICOLON@65..66 ";" 
+        "\n" R_CURLY@66..68 "}" 
+    VAR_DECL@68..82
+      "\n" IDENT@68..73 "let" " "
       LIST@73..81
         DECLARATOR@73..81
-          SINGLE_PATTERN@73..77
-            NAME@73..77
-              IDENT@73..77 "eval"
-          WHITESPACE@77..78 " "
-          EQ@78..79 "="
-          WHITESPACE@79..80 " "
+          SINGLE_PATTERN@73..78
+            NAME@73..78
+               IDENT@73..78 "eval" " "
+           EQ@78..80 "=" " "
           LITERAL@80..81
-            NUMBER@80..81 "5"
-      SEMICOLON@81..82 ";"
-  WHITESPACE@82..83 "\n"
+             NUMBER@80..81 "5" 
+       SEMICOLON@81..82 ";" 
 --
 error[SyntaxError]: Illegal use of `await` as an identifier in an async context
   ┌─ binding_identifier_invalid.js:1:19

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -6,10 +6,11 @@ MODULE@0..82
   LIST@0..82
     JS_EXPRESSION_STATEMENT@0..30
       ARROW_EXPR@0..30
-        None ASYNC_KW@0..6 "async" Whitespace(1)
+        None ASYNC_KW@0..5 "async" Whitespace(1)
         PARAMETER_LIST@6..9
           None L_PAREN@6..7 "(" None
           LIST@7..7
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
           R_PAREN@7..8 ")"
@@ -30,34 +31,43 @@ MODULE@0..82
           None R_PAREN@7..9 ")" Whitespace(1)
         None FAT_ARROW@9..12 "=>" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          None R_PAREN@7..8 ")" Whitespace(1)
+        None FAT_ARROW@9..11 "=>" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BLOCK_STMT@12..30
-          None L_CURLY@12..14 "{" Whitespace(1)
+          None L_CURLY@12..13 "{" Whitespace(1)
           LIST@14..29
             VAR_DECL@14..29
+<<<<<<< HEAD
 <<<<<<< HEAD
                IDENT@14..18 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None IDENT@14..18 "let" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              None IDENT@14..17 "let" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               LIST@18..27
                 DECLARATOR@18..27
                   SINGLE_PATTERN@18..24
                     NAME@18..24
-                      None IDENT@18..24 "await" Whitespace(1)
-                  None EQ@24..26 "=" Whitespace(1)
+                      None IDENT@18..23 "await" Whitespace(1)
+                  None EQ@24..25 "=" Whitespace(1)
                   LITERAL@26..27
                     None NUMBER@26..27 "5" None
-              None SEMICOLON@27..29 ";" Whitespace(1)
+              None SEMICOLON@27..28 ";" Whitespace(1)
           None R_CURLY@29..30 "}" None
     FN_DECL@30..68
-      Whitespace(1) FUNCTION_KW@30..40 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@31..39 "function" Whitespace(1)
       None STAR@40..41 "*" None
       NAME@41..44
         None IDENT@41..44 "foo" None
       PARAMETER_LIST@44..47
         None L_PAREN@44..45 "(" None
         LIST@45..45
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@45..46 ")"
@@ -74,34 +84,41 @@ MODULE@0..82
 =======
         None R_PAREN@45..47 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@45..46 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@47..68
         None L_CURLY@47..48 "{" None
         LIST@48..66
           VAR_DECL@48..66
+<<<<<<< HEAD
 <<<<<<< HEAD
             "\n   " IDENT@48..56 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             Whitespace(4) IDENT@48..56 "let" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            Whitespace(4) IDENT@52..55 "let" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             LIST@56..65
               DECLARATOR@56..65
                 SINGLE_PATTERN@56..62
                   NAME@56..62
-                    None IDENT@56..62 "yield" Whitespace(1)
-                None EQ@62..64 "=" Whitespace(1)
+                    None IDENT@56..61 "yield" Whitespace(1)
+                None EQ@62..63 "=" Whitespace(1)
                 LITERAL@64..65
                   None NUMBER@64..65 "5" None
             None SEMICOLON@65..66 ";" None
-        Whitespace(1) R_CURLY@66..68 "}" None
+        Whitespace(1) R_CURLY@67..68 "}" None
     VAR_DECL@68..82
-      Whitespace(1) IDENT@68..73 "let" Whitespace(1)
+      Whitespace(1) IDENT@69..72 "let" Whitespace(1)
       LIST@73..81
         DECLARATOR@73..81
           SINGLE_PATTERN@73..78
             NAME@73..78
-              None IDENT@73..78 "eval" Whitespace(1)
-          None EQ@78..80 "=" Whitespace(1)
+              None IDENT@73..77 "eval" Whitespace(1)
+          None EQ@78..79 "=" Whitespace(1)
           LITERAL@80..81
             None NUMBER@80..81 "5" None
       None SEMICOLON@81..82 ";" None

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -5,17 +5,17 @@ MODULE@0..11
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     CLASS_DECL@0..10
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..7
-         IDENT@6..7 "S" 
+        None IDENT@6..7 "S" None
       CLASS_BODY@7..10
-         L_CURLY@7..8 "{" 
+        None L_CURLY@7..8 "{" None
         LIST@8..9
           ERROR@8..9
-             L_CURLY@8..9 "{" 
-         R_CURLY@9..10 "}" 
+            None L_CURLY@8..9 "{" None
+        None R_CURLY@9..10 "}" None
     ERROR@10..11
-       R_CURLY@10..11 "}" 
+      None R_CURLY@10..11 "}" None
 --
 error[SyntaxError]: Expected an identifier or keyword
   ┌─ block_stmt_in_class.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -5,7 +5,7 @@ MODULE@0..11
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     CLASS_DECL@0..10
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..7
         None IDENT@6..7 "S" None
       CLASS_BODY@7..10

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..12
-=======
-MODULE@0..11
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..11
   LIST@0..11
     CLASS_DECL@0..10
       None CLASS_KW@0..5 "class" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -1,19 +1,21 @@
+<<<<<<< HEAD
 JS_MODULE@0..12
+=======
+MODULE@0..11
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     CLASS_DECL@0..10
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
+       CLASS_KW@0..6 "class" " "
       NAME@6..7
-        IDENT@6..7 "S"
+         IDENT@6..7 "S" 
       CLASS_BODY@7..10
-        L_CURLY@7..8 "{"
+         L_CURLY@7..8 "{" 
         LIST@8..9
           ERROR@8..9
-            L_CURLY@8..9 "{"
-        R_CURLY@9..10 "}"
+             L_CURLY@8..9 "{" 
+         R_CURLY@9..10 "}" 
     ERROR@10..11
-      R_CURLY@10..11 "}"
-  WHITESPACE@11..12 "\n"
+       R_CURLY@10..11 "}" 
 --
 error[SyntaxError]: Expected an identifier or keyword
   ┌─ block_stmt_in_class.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..19
   LIST@0..19
     JS_EXPRESSION_STATEMENT@0..5
@@ -22,6 +23,29 @@ JS_MODULE@0..19
         L_BRACK@17..18 "["
         WHITESPACE@18..19 "\n"
         ERROR@19..19
+=======
+MODULE@0..18
+  LIST@0..18
+    EXPR_STMT@0..5
+      BRACKET_EXPR@0..5
+        NAME_REF@0..3
+           IDENT@0..3 "foo" 
+         L_BRACK@3..4 "[" 
+         R_BRACK@4..5 "]" 
+    EXPR_STMT@5..13
+      BRACKET_EXPR@5..13
+        NAME_REF@5..9
+          "\n" IDENT@5..9 "foo" 
+         QUESTIONDOT@9..11 "?." 
+         L_BRACK@11..12 "[" 
+         R_BRACK@12..13 "]" 
+    EXPR_STMT@13..18
+      BRACKET_EXPR@13..18
+        NAME_REF@13..17
+          "\n" IDENT@13..17 "foo" 
+         L_BRACK@17..18 "[" 
+        ERROR@18..18
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ bracket_expr_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -29,21 +29,21 @@ MODULE@0..18
     EXPR_STMT@0..5
       BRACKET_EXPR@0..5
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
-         L_BRACK@3..4 "[" 
-         R_BRACK@4..5 "]" 
+          None IDENT@0..3 "foo" None
+        None L_BRACK@3..4 "[" None
+        None R_BRACK@4..5 "]" None
     EXPR_STMT@5..13
       BRACKET_EXPR@5..13
         NAME_REF@5..9
-          "\n" IDENT@5..9 "foo" 
-         QUESTIONDOT@9..11 "?." 
-         L_BRACK@11..12 "[" 
-         R_BRACK@12..13 "]" 
+          Whitespace(1) IDENT@5..9 "foo" None
+        None QUESTIONDOT@9..11 "?." None
+        None L_BRACK@11..12 "[" None
+        None R_BRACK@12..13 "]" None
     EXPR_STMT@13..18
       BRACKET_EXPR@13..18
         NAME_REF@13..17
-          "\n" IDENT@13..17 "foo" 
-         L_BRACK@17..18 "[" 
+          Whitespace(1) IDENT@13..17 "foo" None
+        None L_BRACK@17..18 "[" None
         ERROR@18..18
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 --

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -1,51 +1,24 @@
-<<<<<<< HEAD
-JS_MODULE@0..19
-  LIST@0..19
-    JS_EXPRESSION_STATEMENT@0..5
-      BRACKET_EXPR@0..5
-        NAME_REF@0..3
-          IDENT@0..3 "foo"
-        L_BRACK@3..4 "["
-        R_BRACK@4..5 "]"
-    WHITESPACE@5..6 "\n"
-    JS_EXPRESSION_STATEMENT@6..13
-      BRACKET_EXPR@6..13
-        NAME_REF@6..9
-          IDENT@6..9 "foo"
-        QUESTIONDOT@9..11 "?."
-        L_BRACK@11..12 "["
-        R_BRACK@12..13 "]"
-    WHITESPACE@13..14 "\n"
-    JS_EXPRESSION_STATEMENT@14..19
-      BRACKET_EXPR@14..19
-        NAME_REF@14..17
-          IDENT@14..17 "foo"
-        L_BRACK@17..18 "["
-        WHITESPACE@18..19 "\n"
-        ERROR@19..19
-=======
-MODULE@0..18
+JS_MODULE@0..18
   LIST@0..18
-    EXPR_STMT@0..5
+    JS_EXPRESSION_STATEMENT@0..5
       BRACKET_EXPR@0..5
         NAME_REF@0..3
           None IDENT@0..3 "foo" None
         None L_BRACK@3..4 "[" None
         None R_BRACK@4..5 "]" None
-    EXPR_STMT@5..13
+    JS_EXPRESSION_STATEMENT@5..13
       BRACKET_EXPR@5..13
         NAME_REF@5..9
           Whitespace(1) IDENT@6..9 "foo" None
         None QUESTIONDOT@9..11 "?." None
         None L_BRACK@11..12 "[" None
         None R_BRACK@12..13 "]" None
-    EXPR_STMT@13..18
+    JS_EXPRESSION_STATEMENT@13..18
       BRACKET_EXPR@13..18
         NAME_REF@13..17
           Whitespace(1) IDENT@14..17 "foo" None
         None L_BRACK@17..18 "[" None
         ERROR@18..18
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ bracket_expr_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -35,14 +35,14 @@ MODULE@0..18
     EXPR_STMT@5..13
       BRACKET_EXPR@5..13
         NAME_REF@5..9
-          Whitespace(1) IDENT@5..9 "foo" None
+          Whitespace(1) IDENT@6..9 "foo" None
         None QUESTIONDOT@9..11 "?." None
         None L_BRACK@11..12 "[" None
         None R_BRACK@12..13 "]" None
     EXPR_STMT@13..18
       BRACKET_EXPR@13..18
         NAME_REF@13..17
-          Whitespace(1) IDENT@13..17 "foo" None
+          Whitespace(1) IDENT@14..17 "foo" None
         None L_BRACK@17..18 "[" None
         ERROR@18..18
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..74
-=======
-MODULE@0..73
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..73
   LIST@0..73
     CLASS_DECL@0..8
       None CLASS_KW@0..5 "class" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -5,23 +5,23 @@ MODULE@0..73
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..73
     CLASS_DECL@0..8
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       CLASS_BODY@6..8
         None L_CURLY@6..7 "{" None
         LIST@7..7
         None R_CURLY@7..8 "}" None
     CLASS_DECL@8..29
-      Whitespace(1) CLASS_KW@8..15 "class" Whitespace(1)
-      None EXTENDS_KW@15..23 "extends" Whitespace(1)
+      Whitespace(1) CLASS_KW@9..14 "class" Whitespace(1)
+      None EXTENDS_KW@15..22 "extends" Whitespace(1)
       NAME_REF@23..27
-        None IDENT@23..27 "bar" Whitespace(1)
+        None IDENT@23..26 "bar" Whitespace(1)
       CLASS_BODY@27..29
         None L_CURLY@27..28 "{" None
         LIST@28..28
         None R_CURLY@28..29 "}" None
     CLASS_DECL@29..72
-      Whitespace(1) CLASS_KW@29..36 "class" Whitespace(1)
-      None EXTENDS_KW@36..44 "extends" Whitespace(1)
+      Whitespace(1) CLASS_KW@30..35 "class" Whitespace(1)
+      None EXTENDS_KW@36..43 "extends" Whitespace(1)
       OBJECT_EXPR@44..46
         None L_CURLY@44..45 "{" None
         LIST@45..45
@@ -29,19 +29,19 @@ MODULE@0..73
       CLASS_BODY@46..72
         LIST@46..70
           NAME@46..52
-            Whitespace(1) IDENT@46..52 "class" None
+            Whitespace(1) IDENT@47..52 "class" None
           ERROR@52..59
-            Whitespace(1) CLASS_KW@52..59 "class" Whitespace(1)
+            Whitespace(1) CLASS_KW@53..58 "class" Whitespace(1)
           NAME@59..63
-            None IDENT@59..63 "foo" Whitespace(1)
+            None IDENT@59..62 "foo" Whitespace(1)
           ERROR@63..65
-            None L_CURLY@63..65 "{" Whitespace(1)
+            None L_CURLY@63..64 "{" Whitespace(1)
           CLASS_PROP@65..69
             NAME@65..69
-              None IDENT@65..69 "set" Whitespace(1)
+              None IDENT@65..68 "set" Whitespace(1)
           ERROR@69..70
             None L_CURLY@69..70 "{" None
-        None R_CURLY@70..72 "}" Whitespace(1)
+        None R_CURLY@70..71 "}" Whitespace(1)
     ERROR@72..73
       None R_CURLY@72..73 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -1,61 +1,49 @@
+<<<<<<< HEAD
 JS_MODULE@0..74
+=======
+MODULE@0..73
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..73
     CLASS_DECL@0..8
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
+       CLASS_KW@0..6 "class" " "
       CLASS_BODY@6..8
-        L_CURLY@6..7 "{"
+         L_CURLY@6..7 "{" 
         LIST@7..7
-        R_CURLY@7..8 "}"
-    WHITESPACE@8..9 "\n"
-    CLASS_DECL@9..29
-      CLASS_KW@9..14 "class"
-      WHITESPACE@14..15 " "
-      EXTENDS_KW@15..22 "extends"
-      WHITESPACE@22..23 " "
-      NAME_REF@23..26
-        IDENT@23..26 "bar"
-      WHITESPACE@26..27 " "
+         R_CURLY@7..8 "}" 
+    CLASS_DECL@8..29
+      "\n" CLASS_KW@8..15 "class" " "
+       EXTENDS_KW@15..23 "extends" " "
+      NAME_REF@23..27
+         IDENT@23..27 "bar" " "
       CLASS_BODY@27..29
-        L_CURLY@27..28 "{"
+         L_CURLY@27..28 "{" 
         LIST@28..28
-        R_CURLY@28..29 "}"
-    WHITESPACE@29..30 "\n"
-    CLASS_DECL@30..71
-      CLASS_KW@30..35 "class"
-      WHITESPACE@35..36 " "
-      EXTENDS_KW@36..43 "extends"
-      WHITESPACE@43..44 " "
+         R_CURLY@28..29 "}" 
+    CLASS_DECL@29..72
+      "\n" CLASS_KW@29..36 "class" " "
+       EXTENDS_KW@36..44 "extends" " "
       OBJECT_EXPR@44..46
-        L_CURLY@44..45 "{"
+         L_CURLY@44..45 "{" 
         LIST@45..45
-        R_CURLY@45..46 "}"
-      WHITESPACE@46..47 "\n"
-      CLASS_BODY@47..71
-        LIST@47..70
-          NAME@47..52
-            IDENT@47..52 "class"
-          WHITESPACE@52..53 "\n"
-          ERROR@53..58
-            CLASS_KW@53..58 "class"
-          WHITESPACE@58..59 " "
-          NAME@59..62
-            IDENT@59..62 "foo"
-          WHITESPACE@62..63 " "
-          ERROR@63..64
-            L_CURLY@63..64 "{"
-          WHITESPACE@64..65 " "
-          CLASS_PROP@65..68
-            NAME@65..68
-              IDENT@65..68 "set"
-          WHITESPACE@68..69 " "
+         R_CURLY@45..46 "}" 
+      CLASS_BODY@46..72
+        LIST@46..70
+          NAME@46..52
+            "\n" IDENT@46..52 "class" 
+          ERROR@52..59
+            "\n" CLASS_KW@52..59 "class" " "
+          NAME@59..63
+             IDENT@59..63 "foo" " "
+          ERROR@63..65
+             L_CURLY@63..65 "{" " "
+          CLASS_PROP@65..69
+            NAME@65..69
+               IDENT@65..69 "set" " "
           ERROR@69..70
-            L_CURLY@69..70 "{"
-        R_CURLY@70..71 "}"
-    WHITESPACE@71..72 " "
+             L_CURLY@69..70 "{" 
+         R_CURLY@70..72 "}" " "
     ERROR@72..73
-      R_CURLY@72..73 "}"
-  WHITESPACE@73..74 "\n"
+       R_CURLY@72..73 "}" 
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ class_decl_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -5,45 +5,45 @@ MODULE@0..73
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..73
     CLASS_DECL@0..8
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       CLASS_BODY@6..8
-         L_CURLY@6..7 "{" 
+        None L_CURLY@6..7 "{" None
         LIST@7..7
-         R_CURLY@7..8 "}" 
+        None R_CURLY@7..8 "}" None
     CLASS_DECL@8..29
-      "\n" CLASS_KW@8..15 "class" " "
-       EXTENDS_KW@15..23 "extends" " "
+      Whitespace(1) CLASS_KW@8..15 "class" Whitespace(1)
+      None EXTENDS_KW@15..23 "extends" Whitespace(1)
       NAME_REF@23..27
-         IDENT@23..27 "bar" " "
+        None IDENT@23..27 "bar" Whitespace(1)
       CLASS_BODY@27..29
-         L_CURLY@27..28 "{" 
+        None L_CURLY@27..28 "{" None
         LIST@28..28
-         R_CURLY@28..29 "}" 
+        None R_CURLY@28..29 "}" None
     CLASS_DECL@29..72
-      "\n" CLASS_KW@29..36 "class" " "
-       EXTENDS_KW@36..44 "extends" " "
+      Whitespace(1) CLASS_KW@29..36 "class" Whitespace(1)
+      None EXTENDS_KW@36..44 "extends" Whitespace(1)
       OBJECT_EXPR@44..46
-         L_CURLY@44..45 "{" 
+        None L_CURLY@44..45 "{" None
         LIST@45..45
-         R_CURLY@45..46 "}" 
+        None R_CURLY@45..46 "}" None
       CLASS_BODY@46..72
         LIST@46..70
           NAME@46..52
-            "\n" IDENT@46..52 "class" 
+            Whitespace(1) IDENT@46..52 "class" None
           ERROR@52..59
-            "\n" CLASS_KW@52..59 "class" " "
+            Whitespace(1) CLASS_KW@52..59 "class" Whitespace(1)
           NAME@59..63
-             IDENT@59..63 "foo" " "
+            None IDENT@59..63 "foo" Whitespace(1)
           ERROR@63..65
-             L_CURLY@63..65 "{" " "
+            None L_CURLY@63..65 "{" Whitespace(1)
           CLASS_PROP@65..69
             NAME@65..69
-               IDENT@65..69 "set" " "
+              None IDENT@65..69 "set" Whitespace(1)
           ERROR@69..70
-             L_CURLY@69..70 "{" 
-         R_CURLY@70..72 "}" " "
+            None L_CURLY@69..70 "{" None
+        None R_CURLY@70..72 "}" Whitespace(1)
     ERROR@72..73
-       R_CURLY@72..73 "}" 
+      None R_CURLY@72..73 "}" None
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ class_decl_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -7,11 +7,12 @@ MODULE@0..39
     JS_EXPRESSION_STATEMENT@0..13
       COND_EXPR@0..13
         NAME_REF@0..4
-           IDENT@0..4 "foo" " "
-         QUESTION@4..6 "?" " "
+          None IDENT@0..4 "foo" Whitespace(1)
+        None QUESTION@4..6 "?" Whitespace(1)
         NAME_REF@6..10
-           IDENT@6..10 "bar" " "
+          None IDENT@6..10 "bar" Whitespace(1)
         NAME_REF@10..13
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@10..13 "baz"
     WHITESPACE@13..14 "\n"
@@ -27,23 +28,30 @@ MODULE@0..39
         WHITESPACE@23..24 " "
 =======
            IDENT@10..13 "baz" 
+=======
+          None IDENT@10..13 "baz" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@13..39
       COND_EXPR@13..39
         NAME_REF@13..18
-          "\n" IDENT@13..18 "foo" " "
-         QUESTION@18..20 "?" " "
+          Whitespace(1) IDENT@13..18 "foo" Whitespace(1)
+        None QUESTION@18..20 "?" Whitespace(1)
         NAME_REF@20..24
+<<<<<<< HEAD
            IDENT@20..24 "bar" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@20..24 "bar" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         COND_EXPR@24..39
           NAME_REF@24..28
-             IDENT@24..28 "baz" " "
-           QUESTION@28..30 "?" " "
+            None IDENT@24..28 "baz" Whitespace(1)
+          None QUESTION@28..30 "?" Whitespace(1)
           NAME_REF@30..34
-             IDENT@30..34 "foo" " "
-           COLON@34..36 ":" " "
+            None IDENT@30..34 "foo" Whitespace(1)
+          None COLON@34..36 ":" Whitespace(1)
           NAME_REF@36..39
-             IDENT@36..39 "bar" 
+            None IDENT@36..39 "bar" None
 --
 error[SyntaxError]: expected `:` but instead found `baz`
   ┌─ conditional_expr_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -1,16 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..40
+=======
+MODULE@0..39
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     JS_EXPRESSION_STATEMENT@0..13
       COND_EXPR@0..13
-        NAME_REF@0..3
-          IDENT@0..3 "foo"
-        WHITESPACE@3..4 " "
-        QUESTION@4..5 "?"
-        WHITESPACE@5..6 " "
-        NAME_REF@6..9
-          IDENT@6..9 "bar"
-        WHITESPACE@9..10 " "
+        NAME_REF@0..4
+           IDENT@0..4 "foo" " "
+         QUESTION@4..6 "?" " "
+        NAME_REF@6..10
+           IDENT@6..10 "bar" " "
         NAME_REF@10..13
+<<<<<<< HEAD
           IDENT@10..13 "baz"
     WHITESPACE@13..14 "\n"
     JS_EXPRESSION_STATEMENT@14..39
@@ -23,20 +25,25 @@ JS_MODULE@0..40
         NAME_REF@20..23
           IDENT@20..23 "bar"
         WHITESPACE@23..24 " "
+=======
+           IDENT@10..13 "baz" 
+    EXPR_STMT@13..39
+      COND_EXPR@13..39
+        NAME_REF@13..18
+          "\n" IDENT@13..18 "foo" " "
+         QUESTION@18..20 "?" " "
+        NAME_REF@20..24
+           IDENT@20..24 "bar" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         COND_EXPR@24..39
-          NAME_REF@24..27
-            IDENT@24..27 "baz"
-          WHITESPACE@27..28 " "
-          QUESTION@28..29 "?"
-          WHITESPACE@29..30 " "
-          NAME_REF@30..33
-            IDENT@30..33 "foo"
-          WHITESPACE@33..34 " "
-          COLON@34..35 ":"
-          WHITESPACE@35..36 " "
+          NAME_REF@24..28
+             IDENT@24..28 "baz" " "
+           QUESTION@28..30 "?" " "
+          NAME_REF@30..34
+             IDENT@30..34 "foo" " "
+           COLON@34..36 ":" " "
           NAME_REF@36..39
-            IDENT@36..39 "bar"
-  WHITESPACE@39..40 "\n"
+             IDENT@36..39 "bar" 
 --
 error[SyntaxError]: expected `:` but instead found `baz`
   ┌─ conditional_expr_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -7,10 +7,10 @@ MODULE@0..39
     JS_EXPRESSION_STATEMENT@0..13
       COND_EXPR@0..13
         NAME_REF@0..4
-          None IDENT@0..4 "foo" Whitespace(1)
-        None QUESTION@4..6 "?" Whitespace(1)
+          None IDENT@0..3 "foo" Whitespace(1)
+        None QUESTION@4..5 "?" Whitespace(1)
         NAME_REF@6..10
-          None IDENT@6..10 "bar" Whitespace(1)
+          None IDENT@6..9 "bar" Whitespace(1)
         NAME_REF@10..13
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -34,22 +34,26 @@ MODULE@0..39
     EXPR_STMT@13..39
       COND_EXPR@13..39
         NAME_REF@13..18
-          Whitespace(1) IDENT@13..18 "foo" Whitespace(1)
-        None QUESTION@18..20 "?" Whitespace(1)
+          Whitespace(1) IDENT@14..17 "foo" Whitespace(1)
+        None QUESTION@18..19 "?" Whitespace(1)
         NAME_REF@20..24
+<<<<<<< HEAD
 <<<<<<< HEAD
            IDENT@20..24 "bar" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           None IDENT@20..24 "bar" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          None IDENT@20..23 "bar" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         COND_EXPR@24..39
           NAME_REF@24..28
-            None IDENT@24..28 "baz" Whitespace(1)
-          None QUESTION@28..30 "?" Whitespace(1)
+            None IDENT@24..27 "baz" Whitespace(1)
+          None QUESTION@28..29 "?" Whitespace(1)
           NAME_REF@30..34
-            None IDENT@30..34 "foo" Whitespace(1)
-          None COLON@34..36 ":" Whitespace(1)
+            None IDENT@30..33 "foo" Whitespace(1)
+          None COLON@34..35 ":" Whitespace(1)
           NAME_REF@36..39
             None IDENT@36..39 "bar" None
 --

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..40
-=======
-MODULE@0..39
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..39
   LIST@0..39
     JS_EXPRESSION_STATEMENT@0..13
       COND_EXPR@0..13
@@ -12,41 +8,14 @@ MODULE@0..39
         NAME_REF@6..10
           None IDENT@6..9 "bar" Whitespace(1)
         NAME_REF@10..13
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@10..13 "baz"
-    WHITESPACE@13..14 "\n"
-    JS_EXPRESSION_STATEMENT@14..39
-      COND_EXPR@14..39
-        NAME_REF@14..17
-          IDENT@14..17 "foo"
-        WHITESPACE@17..18 " "
-        QUESTION@18..19 "?"
-        WHITESPACE@19..20 " "
-        NAME_REF@20..23
-          IDENT@20..23 "bar"
-        WHITESPACE@23..24 " "
-=======
-           IDENT@10..13 "baz" 
-=======
           None IDENT@10..13 "baz" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@13..39
+    JS_EXPRESSION_STATEMENT@13..39
       COND_EXPR@13..39
         NAME_REF@13..18
           Whitespace(1) IDENT@14..17 "foo" Whitespace(1)
         None QUESTION@18..19 "?" Whitespace(1)
         NAME_REF@20..24
-<<<<<<< HEAD
-<<<<<<< HEAD
-           IDENT@20..24 "bar" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          None IDENT@20..24 "bar" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           None IDENT@20..23 "bar" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         COND_EXPR@24..39
           NAME_REF@24..28
             None IDENT@24..27 "baz" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..42
   LIST@0..42
     DO_WHILE_STMT@0..42
@@ -6,39 +7,40 @@ JS_MODULE@0..42
       WHILE_STMT@3..42
         WHILE_KW@3..8 "while"
         WHITESPACE@8..9 " "
+=======
+MODULE@0..41
+  LIST@0..41
+    DO_WHILE_STMT@0..41
+       DO_KW@0..3 "do" " "
+      WHILE_STMT@3..41
+         WHILE_KW@3..9 "while" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         CONDITION@9..15
-          L_PAREN@9..10 "("
+           L_PAREN@9..10 "(" 
           LITERAL@10..14
-            TRUE_KW@10..14 "true"
-          R_PAREN@14..15 ")"
-        WHITESPACE@15..16 "\n"
-        DO_WHILE_STMT@16..42
-          DO_KW@16..18 "do"
-          WHITESPACE@18..19 " "
-          WHILE_STMT@19..42
-            WHILE_KW@19..24 "while"
-            WHITESPACE@24..25 " "
+             TRUE_KW@10..14 "true" 
+           R_PAREN@14..15 ")" 
+        DO_WHILE_STMT@15..41
+          "\n" DO_KW@15..19 "do" " "
+          WHILE_STMT@19..41
+             WHILE_KW@19..25 "while" " "
             CONDITION@25..27
-              L_PAREN@25..26 "("
-              R_PAREN@26..27 ")"
-            WHITESPACE@27..28 "\n"
-            DO_WHILE_STMT@28..42
-              DO_KW@28..30 "do"
-              WHITESPACE@30..31 " "
-              WHILE_STMT@31..42
-                WHILE_KW@31..36 "while"
-                WHITESPACE@36..37 " "
+               L_PAREN@25..26 "(" 
+               R_PAREN@26..27 ")" 
+            DO_WHILE_STMT@27..41
+              "\n" DO_KW@27..31 "do" " "
+              WHILE_STMT@31..41
+                 WHILE_KW@31..37 "while" " "
                 CONDITION@37..41
                   LITERAL@37..41
-                    TRUE_KW@37..41 "true"
-                WHITESPACE@41..42 "\n"
-                ERROR@42..42
-              CONDITION@42..42
-                ERROR@42..42
-          CONDITION@42..42
-            ERROR@42..42
-      CONDITION@42..42
-        ERROR@42..42
+                     TRUE_KW@37..41 "true" 
+                ERROR@41..41
+              CONDITION@41..41
+                ERROR@41..41
+          CONDITION@41..41
+            ERROR@41..41
+      CONDITION@41..41
+        ERROR@41..41
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ do_while_stmt_err.js:2:11

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -11,30 +11,34 @@ JS_MODULE@0..42
 MODULE@0..41
   LIST@0..41
     DO_WHILE_STMT@0..41
-      None DO_KW@0..3 "do" Whitespace(1)
+      None DO_KW@0..2 "do" Whitespace(1)
       WHILE_STMT@3..41
+<<<<<<< HEAD
 <<<<<<< HEAD
          WHILE_KW@3..9 "while" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None WHILE_KW@3..9 "while" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None WHILE_KW@3..8 "while" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         CONDITION@9..15
           None L_PAREN@9..10 "(" None
           LITERAL@10..14
             None TRUE_KW@10..14 "true" None
           None R_PAREN@14..15 ")" None
         DO_WHILE_STMT@15..41
-          Whitespace(1) DO_KW@15..19 "do" Whitespace(1)
+          Whitespace(1) DO_KW@16..18 "do" Whitespace(1)
           WHILE_STMT@19..41
-            None WHILE_KW@19..25 "while" Whitespace(1)
+            None WHILE_KW@19..24 "while" Whitespace(1)
             CONDITION@25..27
               None L_PAREN@25..26 "(" None
               None R_PAREN@26..27 ")" None
             DO_WHILE_STMT@27..41
-              Whitespace(1) DO_KW@27..31 "do" Whitespace(1)
+              Whitespace(1) DO_KW@28..30 "do" Whitespace(1)
               WHILE_STMT@31..41
-                None WHILE_KW@31..37 "while" Whitespace(1)
+                None WHILE_KW@31..36 "while" Whitespace(1)
                 CONDITION@37..41
                   LITERAL@37..41
                     None TRUE_KW@37..41 "true" None

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -1,28 +1,9 @@
-<<<<<<< HEAD
-JS_MODULE@0..42
-  LIST@0..42
-    DO_WHILE_STMT@0..42
-      DO_KW@0..2 "do"
-      WHITESPACE@2..3 " "
-      WHILE_STMT@3..42
-        WHILE_KW@3..8 "while"
-        WHITESPACE@8..9 " "
-=======
-MODULE@0..41
+JS_MODULE@0..41
   LIST@0..41
     DO_WHILE_STMT@0..41
       None DO_KW@0..2 "do" Whitespace(1)
       WHILE_STMT@3..41
-<<<<<<< HEAD
-<<<<<<< HEAD
-         WHILE_KW@3..9 "while" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None WHILE_KW@3..9 "while" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None WHILE_KW@3..8 "while" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         CONDITION@9..15
           None L_PAREN@9..10 "(" None
           LITERAL@10..14

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -11,29 +11,33 @@ JS_MODULE@0..42
 MODULE@0..41
   LIST@0..41
     DO_WHILE_STMT@0..41
-       DO_KW@0..3 "do" " "
+      None DO_KW@0..3 "do" Whitespace(1)
       WHILE_STMT@3..41
+<<<<<<< HEAD
          WHILE_KW@3..9 "while" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None WHILE_KW@3..9 "while" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         CONDITION@9..15
-           L_PAREN@9..10 "(" 
+          None L_PAREN@9..10 "(" None
           LITERAL@10..14
-             TRUE_KW@10..14 "true" 
-           R_PAREN@14..15 ")" 
+            None TRUE_KW@10..14 "true" None
+          None R_PAREN@14..15 ")" None
         DO_WHILE_STMT@15..41
-          "\n" DO_KW@15..19 "do" " "
+          Whitespace(1) DO_KW@15..19 "do" Whitespace(1)
           WHILE_STMT@19..41
-             WHILE_KW@19..25 "while" " "
+            None WHILE_KW@19..25 "while" Whitespace(1)
             CONDITION@25..27
-               L_PAREN@25..26 "(" 
-               R_PAREN@26..27 ")" 
+              None L_PAREN@25..26 "(" None
+              None R_PAREN@26..27 ")" None
             DO_WHILE_STMT@27..41
-              "\n" DO_KW@27..31 "do" " "
+              Whitespace(1) DO_KW@27..31 "do" Whitespace(1)
               WHILE_STMT@31..41
-                 WHILE_KW@31..37 "while" " "
+                None WHILE_KW@31..37 "while" Whitespace(1)
                 CONDITION@37..41
                   LITERAL@37..41
-                     TRUE_KW@37..41 "true" 
+                    None TRUE_KW@37..41 "true" None
                 ERROR@41..41
               CONDITION@41..41
                 ERROR@41..41

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -1,30 +1,10 @@
-<<<<<<< HEAD
-JS_MODULE@0..34
+JS_MODULE@0..33
   LIST@0..33
     JS_BLOCK_STATEMENT@0..33
-      L_CURLY@0..1 "{"
-      WHITESPACE@1..3 "\n "
-      LIST@3..31
-        ERROR@3..31
-          EXPORT_KW@3..9 "export"
-          WHITESPACE@9..10 " "
-=======
-MODULE@0..33
-  LIST@0..33
-    BLOCK_STMT@0..33
       None L_CURLY@0..1 "{" None
       LIST@1..31
         ERROR@1..31
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n " EXPORT_KW@1..10 "export" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(2) EXPORT_KW@1..10 "export" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(2) EXPORT_KW@3..9 "export" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           EXPORT_NAMED@10..31
             None L_CURLY@10..11 "{" Whitespace(1)
             LIST@12..17

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..34
   LIST@0..33
     JS_BLOCK_STATEMENT@0..33
@@ -7,24 +8,27 @@ JS_MODULE@0..34
         ERROR@3..31
           EXPORT_KW@3..9 "export"
           WHITESPACE@9..10 " "
+=======
+MODULE@0..33
+  LIST@0..33
+    BLOCK_STMT@0..33
+       L_CURLY@0..1 "{" 
+      LIST@1..31
+        ERROR@1..31
+          "\n " EXPORT_KW@1..10 "export" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           EXPORT_NAMED@10..31
-            L_CURLY@10..11 "{"
-            WHITESPACE@11..12 " "
-            LIST@12..16
-              SPECIFIER@12..16
-                NAME@12..16
-                  IDENT@12..16 "pain"
-            WHITESPACE@16..17 " "
-            R_CURLY@17..18 "}"
-            WHITESPACE@18..19 " "
-            FROM_KW@19..23 "from"
-            WHITESPACE@23..24 " "
+             L_CURLY@10..12 "{" " "
+            LIST@12..17
+              SPECIFIER@12..17
+                NAME@12..17
+                   IDENT@12..17 "pain" " "
+             R_CURLY@17..19 "}" " "
+             FROM_KW@19..24 "from" " "
             LITERAL@24..30
-              STRING@24..30 "\"life\""
-            SEMICOLON@30..31 ";"
-      WHITESPACE@31..32 "\n"
-      R_CURLY@32..33 "}"
-  WHITESPACE@33..34 "\n"
+               STRING@24..30 "\"life\"" 
+             SEMICOLON@30..31 ";" 
+      "\n" R_CURLY@31..33 "}" 
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ export_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -12,23 +12,27 @@ JS_MODULE@0..34
 MODULE@0..33
   LIST@0..33
     BLOCK_STMT@0..33
-       L_CURLY@0..1 "{" 
+      None L_CURLY@0..1 "{" None
       LIST@1..31
         ERROR@1..31
+<<<<<<< HEAD
           "\n " EXPORT_KW@1..10 "export" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(2) EXPORT_KW@1..10 "export" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           EXPORT_NAMED@10..31
-             L_CURLY@10..12 "{" " "
+            None L_CURLY@10..12 "{" Whitespace(1)
             LIST@12..17
               SPECIFIER@12..17
                 NAME@12..17
-                   IDENT@12..17 "pain" " "
-             R_CURLY@17..19 "}" " "
-             FROM_KW@19..24 "from" " "
+                  None IDENT@12..17 "pain" Whitespace(1)
+            None R_CURLY@17..19 "}" Whitespace(1)
+            None FROM_KW@19..24 "from" Whitespace(1)
             LITERAL@24..30
-               STRING@24..30 "\"life\"" 
-             SEMICOLON@30..31 ";" 
-      "\n" R_CURLY@31..33 "}" 
+              None STRING@24..30 "\"life\"" None
+            None SEMICOLON@30..31 ";" None
+      Whitespace(1) R_CURLY@31..33 "}" None
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ export_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -16,23 +16,27 @@ MODULE@0..33
       LIST@1..31
         ERROR@1..31
 <<<<<<< HEAD
+<<<<<<< HEAD
           "\n " EXPORT_KW@1..10 "export" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(2) EXPORT_KW@1..10 "export" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(2) EXPORT_KW@3..9 "export" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           EXPORT_NAMED@10..31
-            None L_CURLY@10..12 "{" Whitespace(1)
+            None L_CURLY@10..11 "{" Whitespace(1)
             LIST@12..17
               SPECIFIER@12..17
                 NAME@12..17
-                  None IDENT@12..17 "pain" Whitespace(1)
-            None R_CURLY@17..19 "}" Whitespace(1)
-            None FROM_KW@19..24 "from" Whitespace(1)
+                  None IDENT@12..16 "pain" Whitespace(1)
+            None R_CURLY@17..18 "}" Whitespace(1)
+            None FROM_KW@19..23 "from" Whitespace(1)
             LITERAL@24..30
               None STRING@24..30 "\"life\"" None
             None SEMICOLON@30..31 ";" None
-      Whitespace(1) R_CURLY@31..33 "}" None
+      Whitespace(1) R_CURLY@32..33 "}" None
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ export_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -49,10 +49,10 @@ MODULE@0..39
                NUMBER@29..31 "10" 
          SEMICOLON@31..33 ";" " "
         FOR_STMT_UPDATE@33..37
-          UNARY_EXPR@33..37
-            NAME_REF@33..34
-               IDENT@33..34 "i" 
-             PLUS2@34..37 "++" " "
+          PRE_UPDATE_EXPRESSION@33..37
+             PLUS2@33..35 "++" 
+            NAME_REF@35..37
+               IDENT@35..37 "i" " "
         BLOCK_STMT@37..39
            L_CURLY@37..38 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -5,33 +5,33 @@ MODULE@0..39
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     FOR_STMT@0..39
-      None FOR_KW@0..4 "for" Whitespace(1)
+      None FOR_KW@0..3 "for" Whitespace(1)
       None SEMICOLON@4..5 ";" None
-      None SEMICOLON@5..7 ";" Whitespace(1)
+      None SEMICOLON@5..6 ";" Whitespace(1)
       FOR_STMT_UPDATE@7..9
         OBJECT_EXPR@7..9
           None L_CURLY@7..8 "{" None
           LIST@8..8
           None R_CURLY@8..9 "}" None
       FOR_STMT@9..39
-        Whitespace(1) FOR_KW@9..14 "for" Whitespace(1)
+        Whitespace(1) FOR_KW@10..13 "for" Whitespace(1)
         FOR_STMT_INIT@14..23
           VAR_DECL@14..23
-            None IDENT@14..18 "let" Whitespace(1)
+            None IDENT@14..17 "let" Whitespace(1)
             LIST@18..23
               DECLARATOR@18..23
                 SINGLE_PATTERN@18..20
                   NAME@18..20
-                    None IDENT@18..20 "i" Whitespace(1)
-                None EQ@20..22 "=" Whitespace(1)
+                    None IDENT@18..19 "i" Whitespace(1)
+                None EQ@20..21 "=" Whitespace(1)
                 LITERAL@22..23
                   None NUMBER@22..23 "5" None
-        None SEMICOLON@23..25 ";" Whitespace(1)
+        None SEMICOLON@23..24 ";" Whitespace(1)
         FOR_STMT_TEST@25..31
           BIN_EXPR@25..31
             NAME_REF@25..27
-              None IDENT@25..27 "i" Whitespace(1)
-            None L_ANGLE@27..29 "<" Whitespace(1)
+              None IDENT@25..26 "i" Whitespace(1)
+            None L_ANGLE@27..28 "<" Whitespace(1)
             LITERAL@29..31
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -51,13 +51,17 @@ MODULE@0..39
          SEMICOLON@31..33 ";" " "
 =======
               None NUMBER@29..31 "10" None
+<<<<<<< HEAD
         None SEMICOLON@31..33 ";" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None SEMICOLON@31..32 ";" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         FOR_STMT_UPDATE@33..37
           PRE_UPDATE_EXPRESSION@33..37
             None PLUS2@33..35 "++" None
             NAME_REF@35..37
-              None IDENT@35..37 "i" Whitespace(1)
+              None IDENT@35..36 "i" Whitespace(1)
         BLOCK_STMT@37..39
 <<<<<<< HEAD
            L_CURLY@37..38 "{" 

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -1,44 +1,39 @@
+<<<<<<< HEAD
 JS_MODULE@0..40
+=======
+MODULE@0..39
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     FOR_STMT@0..39
-      FOR_KW@0..3 "for"
-      WHITESPACE@3..4 " "
-      SEMICOLON@4..5 ";"
-      SEMICOLON@5..6 ";"
-      WHITESPACE@6..7 " "
+       FOR_KW@0..4 "for" " "
+       SEMICOLON@4..5 ";" 
+       SEMICOLON@5..7 ";" " "
       FOR_STMT_UPDATE@7..9
         OBJECT_EXPR@7..9
-          L_CURLY@7..8 "{"
+           L_CURLY@7..8 "{" 
           LIST@8..8
-          R_CURLY@8..9 "}"
-      WHITESPACE@9..10 "\n"
-      FOR_STMT@10..39
-        FOR_KW@10..13 "for"
-        WHITESPACE@13..14 " "
+           R_CURLY@8..9 "}" 
+      FOR_STMT@9..39
+        "\n" FOR_KW@9..14 "for" " "
         FOR_STMT_INIT@14..23
           VAR_DECL@14..23
-            IDENT@14..17 "let"
-            WHITESPACE@17..18 " "
+             IDENT@14..18 "let" " "
             LIST@18..23
               DECLARATOR@18..23
-                SINGLE_PATTERN@18..19
-                  NAME@18..19
-                    IDENT@18..19 "i"
-                WHITESPACE@19..20 " "
-                EQ@20..21 "="
-                WHITESPACE@21..22 " "
+                SINGLE_PATTERN@18..20
+                  NAME@18..20
+                     IDENT@18..20 "i" " "
+                 EQ@20..22 "=" " "
                 LITERAL@22..23
-                  NUMBER@22..23 "5"
-        SEMICOLON@23..24 ";"
-        WHITESPACE@24..25 " "
+                   NUMBER@22..23 "5" 
+         SEMICOLON@23..25 ";" " "
         FOR_STMT_TEST@25..31
           BIN_EXPR@25..31
-            NAME_REF@25..26
-              IDENT@25..26 "i"
-            WHITESPACE@26..27 " "
-            L_ANGLE@27..28 "<"
-            WHITESPACE@28..29 " "
+            NAME_REF@25..27
+               IDENT@25..27 "i" " "
+             L_ANGLE@27..29 "<" " "
             LITERAL@29..31
+<<<<<<< HEAD
               NUMBER@29..31 "10"
         SEMICOLON@31..32 ";"
         WHITESPACE@32..33 " "
@@ -50,9 +45,19 @@ JS_MODULE@0..40
         WHITESPACE@36..37 " "
         JS_BLOCK_STATEMENT@37..39
           L_CURLY@37..38 "{"
+=======
+               NUMBER@29..31 "10" 
+         SEMICOLON@31..33 ";" " "
+        FOR_STMT_UPDATE@33..37
+          UNARY_EXPR@33..37
+            NAME_REF@33..34
+               IDENT@33..34 "i" 
+             PLUS2@34..37 "++" " "
+        BLOCK_STMT@37..39
+           L_CURLY@37..38 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@38..38
-          R_CURLY@38..39 "}"
-  WHITESPACE@39..40 "\n"
+           R_CURLY@38..39 "}" 
 --
 error[SyntaxError]: expected `'('` but instead found `;`
   ┌─ for_stmt_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..40
-=======
-MODULE@0..39
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..39
   LIST@0..39
     FOR_STMT@0..39
       None FOR_KW@0..3 "for" Whitespace(1)
@@ -33,42 +29,15 @@ MODULE@0..39
               None IDENT@25..26 "i" Whitespace(1)
             None L_ANGLE@27..28 "<" Whitespace(1)
             LITERAL@29..31
-<<<<<<< HEAD
-<<<<<<< HEAD
-              NUMBER@29..31 "10"
-        SEMICOLON@31..32 ";"
-        WHITESPACE@32..33 " "
-        FOR_STMT_UPDATE@33..36
-          PRE_UPDATE_EXPRESSION@33..36
-            PLUS2@33..35 "++"
-            NAME_REF@35..36
-              IDENT@35..36 "i"
-        WHITESPACE@36..37 " "
-        JS_BLOCK_STATEMENT@37..39
-          L_CURLY@37..38 "{"
-=======
-               NUMBER@29..31 "10" 
-         SEMICOLON@31..33 ";" " "
-=======
               None NUMBER@29..31 "10" None
-<<<<<<< HEAD
-        None SEMICOLON@31..33 ";" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None SEMICOLON@31..32 ";" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         FOR_STMT_UPDATE@33..37
           PRE_UPDATE_EXPRESSION@33..37
             None PLUS2@33..35 "++" None
             NAME_REF@35..37
               None IDENT@35..36 "i" Whitespace(1)
-        BLOCK_STMT@37..39
-<<<<<<< HEAD
-           L_CURLY@37..38 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+        JS_BLOCK_STATEMENT@37..39
           None L_CURLY@37..38 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@38..38
           None R_CURLY@38..39 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -5,34 +5,35 @@ MODULE@0..39
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     FOR_STMT@0..39
-       FOR_KW@0..4 "for" " "
-       SEMICOLON@4..5 ";" 
-       SEMICOLON@5..7 ";" " "
+      None FOR_KW@0..4 "for" Whitespace(1)
+      None SEMICOLON@4..5 ";" None
+      None SEMICOLON@5..7 ";" Whitespace(1)
       FOR_STMT_UPDATE@7..9
         OBJECT_EXPR@7..9
-           L_CURLY@7..8 "{" 
+          None L_CURLY@7..8 "{" None
           LIST@8..8
-           R_CURLY@8..9 "}" 
+          None R_CURLY@8..9 "}" None
       FOR_STMT@9..39
-        "\n" FOR_KW@9..14 "for" " "
+        Whitespace(1) FOR_KW@9..14 "for" Whitespace(1)
         FOR_STMT_INIT@14..23
           VAR_DECL@14..23
-             IDENT@14..18 "let" " "
+            None IDENT@14..18 "let" Whitespace(1)
             LIST@18..23
               DECLARATOR@18..23
                 SINGLE_PATTERN@18..20
                   NAME@18..20
-                     IDENT@18..20 "i" " "
-                 EQ@20..22 "=" " "
+                    None IDENT@18..20 "i" Whitespace(1)
+                None EQ@20..22 "=" Whitespace(1)
                 LITERAL@22..23
-                   NUMBER@22..23 "5" 
-         SEMICOLON@23..25 ";" " "
+                  None NUMBER@22..23 "5" None
+        None SEMICOLON@23..25 ";" Whitespace(1)
         FOR_STMT_TEST@25..31
           BIN_EXPR@25..31
             NAME_REF@25..27
-               IDENT@25..27 "i" " "
-             L_ANGLE@27..29 "<" " "
+              None IDENT@25..27 "i" Whitespace(1)
+            None L_ANGLE@27..29 "<" Whitespace(1)
             LITERAL@29..31
+<<<<<<< HEAD
 <<<<<<< HEAD
               NUMBER@29..31 "10"
         SEMICOLON@31..32 ";"
@@ -48,16 +49,24 @@ MODULE@0..39
 =======
                NUMBER@29..31 "10" 
          SEMICOLON@31..33 ";" " "
+=======
+              None NUMBER@29..31 "10" None
+        None SEMICOLON@31..33 ";" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         FOR_STMT_UPDATE@33..37
           PRE_UPDATE_EXPRESSION@33..37
-             PLUS2@33..35 "++" 
+            None PLUS2@33..35 "++" None
             NAME_REF@35..37
-               IDENT@35..37 "i" " "
+              None IDENT@35..37 "i" Whitespace(1)
         BLOCK_STMT@37..39
+<<<<<<< HEAD
            L_CURLY@37..38 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None L_CURLY@37..38 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@38..38
-           R_CURLY@38..39 "}" 
+          None R_CURLY@38..39 "}" None
 --
 error[SyntaxError]: expected `'('` but instead found `;`
   ┌─ for_stmt_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..22
-=======
-MODULE@0..21
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..21
   LIST@0..21
     FN_DECL@0..21
       None FUNCTION_KW@0..8 "function" Whitespace(1)
@@ -12,25 +8,10 @@ MODULE@0..21
         None L_PAREN@12..13 "(" None
         LIST@13..17
           ERROR@13..17
-<<<<<<< HEAD
-<<<<<<< HEAD
-            TRUE_KW@13..17 "true"
-        R_PAREN@17..18 ")"
-      WHITESPACE@18..19 " "
-      JS_BLOCK_STATEMENT@19..21
-        L_CURLY@19..20 "{"
-=======
-             TRUE_KW@13..17 "true" 
-         R_PAREN@17..19 ")" " "
-      BLOCK_STMT@19..21
-         L_CURLY@19..20 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None TRUE_KW@13..17 "true" None
         None R_PAREN@17..18 ")" Whitespace(1)
-      BLOCK_STMT@19..21
+      JS_BLOCK_STATEMENT@19..21
         None L_CURLY@19..20 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@20..20
         None R_CURLY@20..21 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -5,7 +5,7 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     FN_DECL@0..21
-      None FUNCTION_KW@0..9 "function" Whitespace(1)
+      None FUNCTION_KW@0..8 "function" Whitespace(1)
       NAME@9..12
         None IDENT@9..12 "foo" None
       PARAMETER_LIST@12..19
@@ -27,7 +27,7 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             None TRUE_KW@13..17 "true" None
-        None R_PAREN@17..19 ")" Whitespace(1)
+        None R_PAREN@17..18 ")" Whitespace(1)
       BLOCK_STMT@19..21
         None L_CURLY@19..20 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -5,13 +5,14 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     FN_DECL@0..21
-       FUNCTION_KW@0..9 "function" " "
+      None FUNCTION_KW@0..9 "function" Whitespace(1)
       NAME@9..12
-         IDENT@9..12 "foo" 
+        None IDENT@9..12 "foo" None
       PARAMETER_LIST@12..19
-         L_PAREN@12..13 "(" 
+        None L_PAREN@12..13 "(" None
         LIST@13..17
           ERROR@13..17
+<<<<<<< HEAD
 <<<<<<< HEAD
             TRUE_KW@13..17 "true"
         R_PAREN@17..18 ")"
@@ -24,8 +25,14 @@ MODULE@0..21
       BLOCK_STMT@19..21
          L_CURLY@19..20 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None TRUE_KW@13..17 "true" None
+        None R_PAREN@17..19 ")" Whitespace(1)
+      BLOCK_STMT@19..21
+        None L_CURLY@19..20 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@20..20
-         R_CURLY@20..21 "}" 
+        None R_CURLY@20..21 "}" None
 --
 error[SyntaxError]: Expected an identifier or pattern, but found none
   ┌─ formal_params_no_binding_element.js:1:14

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -1,22 +1,31 @@
+<<<<<<< HEAD
 JS_MODULE@0..22
+=======
+MODULE@0..21
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     FN_DECL@0..21
-      FUNCTION_KW@0..8 "function"
-      WHITESPACE@8..9 " "
+       FUNCTION_KW@0..9 "function" " "
       NAME@9..12
-        IDENT@9..12 "foo"
-      PARAMETER_LIST@12..18
-        L_PAREN@12..13 "("
+         IDENT@9..12 "foo" 
+      PARAMETER_LIST@12..19
+         L_PAREN@12..13 "(" 
         LIST@13..17
           ERROR@13..17
+<<<<<<< HEAD
             TRUE_KW@13..17 "true"
         R_PAREN@17..18 ")"
       WHITESPACE@18..19 " "
       JS_BLOCK_STATEMENT@19..21
         L_CURLY@19..20 "{"
+=======
+             TRUE_KW@13..17 "true" 
+         R_PAREN@17..19 ")" " "
+      BLOCK_STMT@19..21
+         L_CURLY@19..20 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@20..20
-        R_CURLY@20..21 "}"
-  WHITESPACE@21..22 "\n"
+         R_CURLY@20..21 "}" 
 --
 error[SyntaxError]: Expected an identifier or pattern, but found none
   ┌─ formal_params_no_binding_element.js:1:14

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -1,34 +1,13 @@
-<<<<<<< HEAD
-JS_MODULE@0..114
-=======
-MODULE@0..113
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..113
   LIST@0..113
     FN_DECL@0..13
       None FUNCTION_KW@0..8 "function" None
       PARAMETER_LIST@8..11
         None L_PAREN@8..9 "(" None
         LIST@9..9
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@9..10 ")"
-      WHITESPACE@10..11 " "
-      JS_BLOCK_STATEMENT@11..13
-        L_CURLY@11..12 "{"
-=======
-         R_PAREN@9..11 ")" " "
-      BLOCK_STMT@11..13
-         L_CURLY@11..12 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@9..11 ")" Whitespace(1)
-=======
         None R_PAREN@9..10 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@11..13
+      JS_BLOCK_STATEMENT@11..13
         None L_CURLY@11..12 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@12..12
         None R_CURLY@12..13 "}" None
     FN_DECL@13..41
@@ -44,25 +23,10 @@ MODULE@0..113
           ERROR@35..36
             None STAR@35..36 "*" None
           ERROR@36..37
-<<<<<<< HEAD
-<<<<<<< HEAD
-            L_PAREN@36..37 "("
-        R_PAREN@37..38 ")"
-      WHITESPACE@38..39 " "
-      JS_BLOCK_STATEMENT@39..41
-        L_CURLY@39..40 "{"
-=======
-             L_PAREN@36..37 "(" 
-         R_PAREN@37..39 ")" " "
-      BLOCK_STMT@39..41
-         L_CURLY@39..40 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None L_PAREN@36..37 "(" None
         None R_PAREN@37..38 ")" Whitespace(1)
-      BLOCK_STMT@39..41
+      JS_BLOCK_STATEMENT@39..41
         None L_CURLY@39..40 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@40..40
         None R_CURLY@40..41 "}" None
     FN_DECL@41..61
@@ -71,26 +35,9 @@ MODULE@0..113
       PARAMETER_LIST@56..59
         None L_PAREN@56..57 "(" None
         LIST@57..57
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@57..58 ")"
-      WHITESPACE@58..59 " "
-      JS_BLOCK_STATEMENT@59..61
-        L_CURLY@59..60 "{"
-=======
-         R_PAREN@57..59 ")" " "
-      BLOCK_STMT@59..61
-         L_CURLY@59..60 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@57..59 ")" Whitespace(1)
-=======
         None R_PAREN@57..58 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@59..61
+      JS_BLOCK_STATEMENT@59..61
         None L_CURLY@59..60 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@60..60
         None R_CURLY@60..61 "}" None
     FN_DECL@61..83
@@ -100,26 +47,9 @@ MODULE@0..113
       PARAMETER_LIST@78..81
         None L_PAREN@78..79 "(" None
         LIST@79..79
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@79..80 ")"
-      WHITESPACE@80..81 " "
-      JS_BLOCK_STATEMENT@81..83
-        L_CURLY@81..82 "{"
-=======
-         R_PAREN@79..81 ")" " "
-      BLOCK_STMT@81..83
-         L_CURLY@81..82 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@79..81 ")" Whitespace(1)
-=======
         None R_PAREN@79..80 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@81..83
+      JS_BLOCK_STATEMENT@81..83
         None L_CURLY@81..82 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@82..82
         None R_CURLY@82..83 "}" None
     FN_DECL@83..102
@@ -130,38 +60,15 @@ MODULE@0..113
       PARAMETER_LIST@97..100
         None L_PAREN@97..98 "(" None
         LIST@98..98
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@98..99 ")"
-      WHITESPACE@99..100 " "
-      JS_BLOCK_STATEMENT@100..102
-        L_CURLY@100..101 "{"
-        LIST@101..101
-        R_CURLY@101..102 "}"
-    WHITESPACE@102..103 "\n"
-    JS_EXPRESSION_STATEMENT@103..108
-      NAME_REF@103..108
-        IDENT@103..108 "yield"
-    WHITESPACE@108..109 " "
-    JS_EXPRESSION_STATEMENT@109..113
-=======
-         R_PAREN@98..100 ")" " "
-=======
-        None R_PAREN@98..100 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@98..99 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@100..102
+      JS_BLOCK_STATEMENT@100..102
         None L_CURLY@100..101 "{" None
         LIST@101..101
         None R_CURLY@101..102 "}" None
-    EXPR_STMT@102..109
+    JS_EXPRESSION_STATEMENT@102..109
       NAME_REF@102..109
         Whitespace(1) IDENT@103..108 "yield" Whitespace(1)
-    EXPR_STMT@109..113
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+    JS_EXPRESSION_STATEMENT@109..113
       NAME_REF@109..112
         None IDENT@109..112 "foo" None
       None SEMICOLON@112..113 ";" None

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -5,10 +5,11 @@ MODULE@0..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..113
     FN_DECL@0..13
-       FUNCTION_KW@0..8 "function" 
+      None FUNCTION_KW@0..8 "function" None
       PARAMETER_LIST@8..11
-         L_PAREN@8..9 "(" 
+        None L_PAREN@8..9 "(" None
         LIST@9..9
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@9..10 ")"
       WHITESPACE@10..11 " "
@@ -19,21 +20,27 @@ MODULE@0..113
       BLOCK_STMT@11..13
          L_CURLY@11..12 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@9..11 ")" Whitespace(1)
+      BLOCK_STMT@11..13
+        None L_CURLY@11..12 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@12..12
-         R_CURLY@12..13 "}" 
+        None R_CURLY@12..13 "}" None
     FN_DECL@13..41
-      "\n" FUNCTION_KW@13..23 "function" " "
+      Whitespace(1) FUNCTION_KW@13..23 "function" Whitespace(1)
       PARAMETER_LIST@23..39
         LIST@23..37
           ERROR@23..24
-             L_CURLY@23..24 "{" 
+            None L_CURLY@23..24 "{" None
           ERROR@24..25
-             R_CURLY@24..25 "}" 
+            None R_CURLY@24..25 "}" None
           ERROR@25..35
-            "\n" FUNCTION_KW@25..35 "function" " "
+            Whitespace(1) FUNCTION_KW@25..35 "function" Whitespace(1)
           ERROR@35..36
-             STAR@35..36 "*" 
+            None STAR@35..36 "*" None
           ERROR@36..37
+<<<<<<< HEAD
 <<<<<<< HEAD
             L_PAREN@36..37 "("
         R_PAREN@37..38 ")"
@@ -46,14 +53,21 @@ MODULE@0..113
       BLOCK_STMT@39..41
          L_CURLY@39..40 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None L_PAREN@36..37 "(" None
+        None R_PAREN@37..39 ")" Whitespace(1)
+      BLOCK_STMT@39..41
+        None L_CURLY@39..40 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@40..40
-         R_CURLY@40..41 "}" 
+        None R_CURLY@40..41 "}" None
     FN_DECL@41..61
-      "\n" IDENT@41..48 "async" " "
-       FUNCTION_KW@48..56 "function" 
+      Whitespace(1) IDENT@41..48 "async" Whitespace(1)
+      None FUNCTION_KW@48..56 "function" None
       PARAMETER_LIST@56..59
-         L_PAREN@56..57 "(" 
+        None L_PAREN@56..57 "(" None
         LIST@57..57
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@57..58 ")"
       WHITESPACE@58..59 " "
@@ -64,15 +78,21 @@ MODULE@0..113
       BLOCK_STMT@59..61
          L_CURLY@59..60 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@57..59 ")" Whitespace(1)
+      BLOCK_STMT@59..61
+        None L_CURLY@59..60 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@60..60
-         R_CURLY@60..61 "}" 
+        None R_CURLY@60..61 "}" None
     FN_DECL@61..83
-      "\n" IDENT@61..68 "async" " "
-       FUNCTION_KW@68..77 "function" " "
-       STAR@77..78 "*" 
+      Whitespace(1) IDENT@61..68 "async" Whitespace(1)
+      None FUNCTION_KW@68..77 "function" Whitespace(1)
+      None STAR@77..78 "*" None
       PARAMETER_LIST@78..81
-         L_PAREN@78..79 "(" 
+        None L_PAREN@78..79 "(" None
         LIST@79..79
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@79..80 ")"
       WHITESPACE@80..81 " "
@@ -83,16 +103,22 @@ MODULE@0..113
       BLOCK_STMT@81..83
          L_CURLY@81..82 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@79..81 ")" Whitespace(1)
+      BLOCK_STMT@81..83
+        None L_CURLY@81..82 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@82..82
-         R_CURLY@82..83 "}" 
+        None R_CURLY@82..83 "}" None
     FN_DECL@83..102
-      "\n" FUNCTION_KW@83..93 "function" " "
-       STAR@93..94 "*" 
+      Whitespace(1) FUNCTION_KW@83..93 "function" Whitespace(1)
+      None STAR@93..94 "*" None
       NAME@94..97
-         IDENT@94..97 "foo" 
+        None IDENT@94..97 "foo" None
       PARAMETER_LIST@97..100
-         L_PAREN@97..98 "(" 
+        None L_PAREN@97..98 "(" None
         LIST@98..98
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@98..99 ")"
       WHITESPACE@99..100 " "
@@ -108,18 +134,21 @@ MODULE@0..113
     JS_EXPRESSION_STATEMENT@109..113
 =======
          R_PAREN@98..100 ")" " "
+=======
+        None R_PAREN@98..100 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@100..102
-         L_CURLY@100..101 "{" 
+        None L_CURLY@100..101 "{" None
         LIST@101..101
-         R_CURLY@101..102 "}" 
+        None R_CURLY@101..102 "}" None
     EXPR_STMT@102..109
       NAME_REF@102..109
-        "\n" IDENT@102..109 "yield" " "
+        Whitespace(1) IDENT@102..109 "yield" Whitespace(1)
     EXPR_STMT@109..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NAME_REF@109..112
-         IDENT@109..112 "foo" 
-       SEMICOLON@112..113 ";" 
+        None IDENT@109..112 "foo" None
+      None SEMICOLON@112..113 ";" None
 --
 error[SyntaxError]: expected `'('` but instead found `{`
   ┌─ function_decl_err.js:2:10

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -1,80 +1,99 @@
+<<<<<<< HEAD
 JS_MODULE@0..114
+=======
+MODULE@0..113
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..113
     FN_DECL@0..13
-      FUNCTION_KW@0..8 "function"
-      PARAMETER_LIST@8..10
-        L_PAREN@8..9 "("
+       FUNCTION_KW@0..8 "function" 
+      PARAMETER_LIST@8..11
+         L_PAREN@8..9 "(" 
         LIST@9..9
+<<<<<<< HEAD
         R_PAREN@9..10 ")"
       WHITESPACE@10..11 " "
       JS_BLOCK_STATEMENT@11..13
         L_CURLY@11..12 "{"
+=======
+         R_PAREN@9..11 ")" " "
+      BLOCK_STMT@11..13
+         L_CURLY@11..12 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@12..12
-        R_CURLY@12..13 "}"
-    WHITESPACE@13..14 "\n"
-    FN_DECL@14..41
-      FUNCTION_KW@14..22 "function"
-      WHITESPACE@22..23 " "
-      PARAMETER_LIST@23..38
+         R_CURLY@12..13 "}" 
+    FN_DECL@13..41
+      "\n" FUNCTION_KW@13..23 "function" " "
+      PARAMETER_LIST@23..39
         LIST@23..37
           ERROR@23..24
-            L_CURLY@23..24 "{"
+             L_CURLY@23..24 "{" 
           ERROR@24..25
-            R_CURLY@24..25 "}"
-          WHITESPACE@25..26 "\n"
-          ERROR@26..34
-            FUNCTION_KW@26..34 "function"
-          WHITESPACE@34..35 " "
+             R_CURLY@24..25 "}" 
+          ERROR@25..35
+            "\n" FUNCTION_KW@25..35 "function" " "
           ERROR@35..36
-            STAR@35..36 "*"
+             STAR@35..36 "*" 
           ERROR@36..37
+<<<<<<< HEAD
             L_PAREN@36..37 "("
         R_PAREN@37..38 ")"
       WHITESPACE@38..39 " "
       JS_BLOCK_STATEMENT@39..41
         L_CURLY@39..40 "{"
+=======
+             L_PAREN@36..37 "(" 
+         R_PAREN@37..39 ")" " "
+      BLOCK_STMT@39..41
+         L_CURLY@39..40 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@40..40
-        R_CURLY@40..41 "}"
-    WHITESPACE@41..42 "\n"
-    FN_DECL@42..61
-      IDENT@42..47 "async"
-      WHITESPACE@47..48 " "
-      FUNCTION_KW@48..56 "function"
-      PARAMETER_LIST@56..58
-        L_PAREN@56..57 "("
+         R_CURLY@40..41 "}" 
+    FN_DECL@41..61
+      "\n" IDENT@41..48 "async" " "
+       FUNCTION_KW@48..56 "function" 
+      PARAMETER_LIST@56..59
+         L_PAREN@56..57 "(" 
         LIST@57..57
+<<<<<<< HEAD
         R_PAREN@57..58 ")"
       WHITESPACE@58..59 " "
       JS_BLOCK_STATEMENT@59..61
         L_CURLY@59..60 "{"
+=======
+         R_PAREN@57..59 ")" " "
+      BLOCK_STMT@59..61
+         L_CURLY@59..60 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@60..60
-        R_CURLY@60..61 "}"
-    WHITESPACE@61..62 "\n"
-    FN_DECL@62..83
-      IDENT@62..67 "async"
-      WHITESPACE@67..68 " "
-      FUNCTION_KW@68..76 "function"
-      WHITESPACE@76..77 " "
-      STAR@77..78 "*"
-      PARAMETER_LIST@78..80
-        L_PAREN@78..79 "("
+         R_CURLY@60..61 "}" 
+    FN_DECL@61..83
+      "\n" IDENT@61..68 "async" " "
+       FUNCTION_KW@68..77 "function" " "
+       STAR@77..78 "*" 
+      PARAMETER_LIST@78..81
+         L_PAREN@78..79 "(" 
         LIST@79..79
+<<<<<<< HEAD
         R_PAREN@79..80 ")"
       WHITESPACE@80..81 " "
       JS_BLOCK_STATEMENT@81..83
         L_CURLY@81..82 "{"
+=======
+         R_PAREN@79..81 ")" " "
+      BLOCK_STMT@81..83
+         L_CURLY@81..82 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@82..82
-        R_CURLY@82..83 "}"
-    WHITESPACE@83..84 "\n"
-    FN_DECL@84..102
-      FUNCTION_KW@84..92 "function"
-      WHITESPACE@92..93 " "
-      STAR@93..94 "*"
+         R_CURLY@82..83 "}" 
+    FN_DECL@83..102
+      "\n" FUNCTION_KW@83..93 "function" " "
+       STAR@93..94 "*" 
       NAME@94..97
-        IDENT@94..97 "foo"
-      PARAMETER_LIST@97..99
-        L_PAREN@97..98 "("
+         IDENT@94..97 "foo" 
+      PARAMETER_LIST@97..100
+         L_PAREN@97..98 "(" 
         LIST@98..98
+<<<<<<< HEAD
         R_PAREN@98..99 ")"
       WHITESPACE@99..100 " "
       JS_BLOCK_STATEMENT@100..102
@@ -87,10 +106,20 @@ JS_MODULE@0..114
         IDENT@103..108 "yield"
     WHITESPACE@108..109 " "
     JS_EXPRESSION_STATEMENT@109..113
+=======
+         R_PAREN@98..100 ")" " "
+      BLOCK_STMT@100..102
+         L_CURLY@100..101 "{" 
+        LIST@101..101
+         R_CURLY@101..102 "}" 
+    EXPR_STMT@102..109
+      NAME_REF@102..109
+        "\n" IDENT@102..109 "yield" " "
+    EXPR_STMT@109..113
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NAME_REF@109..112
-        IDENT@109..112 "foo"
-      SEMICOLON@112..113 ";"
-  WHITESPACE@113..114 "\n"
+         IDENT@109..112 "foo" 
+       SEMICOLON@112..113 ";" 
 --
 error[SyntaxError]: expected `'('` but instead found `{`
   ┌─ function_decl_err.js:2:10

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -11,6 +11,7 @@ MODULE@0..113
         LIST@9..9
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
         R_PAREN@9..10 ")"
       WHITESPACE@10..11 " "
       JS_BLOCK_STATEMENT@11..13
@@ -22,13 +23,16 @@ MODULE@0..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@9..11 ")" Whitespace(1)
+=======
+        None R_PAREN@9..10 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@11..13
         None L_CURLY@11..12 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@12..12
         None R_CURLY@12..13 "}" None
     FN_DECL@13..41
-      Whitespace(1) FUNCTION_KW@13..23 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@14..22 "function" Whitespace(1)
       PARAMETER_LIST@23..39
         LIST@23..37
           ERROR@23..24
@@ -36,7 +40,7 @@ MODULE@0..113
           ERROR@24..25
             None R_CURLY@24..25 "}" None
           ERROR@25..35
-            Whitespace(1) FUNCTION_KW@25..35 "function" Whitespace(1)
+            Whitespace(1) FUNCTION_KW@26..34 "function" Whitespace(1)
           ERROR@35..36
             None STAR@35..36 "*" None
           ERROR@36..37
@@ -55,18 +59,19 @@ MODULE@0..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             None L_PAREN@36..37 "(" None
-        None R_PAREN@37..39 ")" Whitespace(1)
+        None R_PAREN@37..38 ")" Whitespace(1)
       BLOCK_STMT@39..41
         None L_CURLY@39..40 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@40..40
         None R_CURLY@40..41 "}" None
     FN_DECL@41..61
-      Whitespace(1) IDENT@41..48 "async" Whitespace(1)
+      Whitespace(1) IDENT@42..47 "async" Whitespace(1)
       None FUNCTION_KW@48..56 "function" None
       PARAMETER_LIST@56..59
         None L_PAREN@56..57 "(" None
         LIST@57..57
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@57..58 ")"
@@ -80,18 +85,22 @@ MODULE@0..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@57..59 ")" Whitespace(1)
+=======
+        None R_PAREN@57..58 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@59..61
         None L_CURLY@59..60 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@60..60
         None R_CURLY@60..61 "}" None
     FN_DECL@61..83
-      Whitespace(1) IDENT@61..68 "async" Whitespace(1)
-      None FUNCTION_KW@68..77 "function" Whitespace(1)
+      Whitespace(1) IDENT@62..67 "async" Whitespace(1)
+      None FUNCTION_KW@68..76 "function" Whitespace(1)
       None STAR@77..78 "*" None
       PARAMETER_LIST@78..81
         None L_PAREN@78..79 "(" None
         LIST@79..79
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@79..80 ")"
@@ -105,19 +114,23 @@ MODULE@0..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@79..81 ")" Whitespace(1)
+=======
+        None R_PAREN@79..80 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@81..83
         None L_CURLY@81..82 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@82..82
         None R_CURLY@82..83 "}" None
     FN_DECL@83..102
-      Whitespace(1) FUNCTION_KW@83..93 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@84..92 "function" Whitespace(1)
       None STAR@93..94 "*" None
       NAME@94..97
         None IDENT@94..97 "foo" None
       PARAMETER_LIST@97..100
         None L_PAREN@97..98 "(" None
         LIST@98..98
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@98..99 ")"
@@ -137,13 +150,16 @@ MODULE@0..113
 =======
         None R_PAREN@98..100 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@98..99 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@100..102
         None L_CURLY@100..101 "{" None
         LIST@101..101
         None R_CURLY@101..102 "}" None
     EXPR_STMT@102..109
       NAME_REF@102..109
-        Whitespace(1) IDENT@102..109 "yield" Whitespace(1)
+        Whitespace(1) IDENT@103..108 "yield" Whitespace(1)
     EXPR_STMT@109..113
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NAME_REF@109..112

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -1,113 +1,47 @@
-<<<<<<< HEAD
-JS_MODULE@0..61
+JS_MODULE@0..60
   LIST@0..60
     JS_IF_STATEMENT@0..17
-      IF_KW@0..2 "if"
-      WHITESPACE@2..3 " "
-      L_PAREN@3..4 "("
-      LITERAL@4..8
-        TRUE_KW@4..8 "true"
-      R_PAREN@8..9 ")"
-      WHITESPACE@9..10 " "
-      JS_ELSE_CLAUSE@10..17
-        ELSE_KW@10..14 "else"
-        WHITESPACE@14..15 " "
-        JS_BLOCK_STATEMENT@15..17
-          L_CURLY@15..16 "{"
-          LIST@16..16
-          R_CURLY@16..17 "}"
-    WHITESPACE@17..18 "\n"
-    JS_IF_STATEMENT@18..43
-      IF_KW@18..20 "if"
-      WHITESPACE@20..21 " "
-      L_PAREN@21..22 "("
-      LITERAL@22..26
-        TRUE_KW@22..26 "true"
-      R_PAREN@26..27 ")"
-      WHITESPACE@27..28 " "
-      JS_ELSE_CLAUSE@28..43
-        ELSE_KW@28..32 "else"
-        WHITESPACE@32..33 "\n"
-        JS_IF_STATEMENT@33..43
-          IF_KW@33..35 "if"
-          WHITESPACE@35..36 " "
-          JS_ELSE_CLAUSE@36..43
-            ELSE_KW@36..40 "else"
-            WHITESPACE@40..41 " "
-            JS_BLOCK_STATEMENT@41..43
-              L_CURLY@41..42 "{"
-              LIST@42..42
-              R_CURLY@42..43 "}"
-    WHITESPACE@43..44 "\n"
-    JS_IF_STATEMENT@44..60
-      IF_KW@44..46 "if"
-      WHITESPACE@46..47 " "
-      L_PAREN@47..48 "("
-      R_PAREN@48..49 ")"
-      WHITESPACE@49..50 " "
-      JS_BLOCK_STATEMENT@50..52
-        L_CURLY@50..51 "{"
-        LIST@51..51
-        R_CURLY@51..52 "}"
-      WHITESPACE@52..53 " "
-      JS_ELSE_CLAUSE@53..60
-        ELSE_KW@53..57 "else"
-        WHITESPACE@57..58 " "
-        JS_BLOCK_STATEMENT@58..60
-          L_CURLY@58..59 "{"
-          LIST@59..59
-          R_CURLY@59..60 "}"
-  WHITESPACE@60..61 "\n"
-=======
-MODULE@0..60
-  LIST@0..60
-    IF_STMT@0..17
       None IF_KW@0..2 "if" Whitespace(1)
-      CONDITION@3..10
-        None L_PAREN@3..4 "(" None
-        LITERAL@4..8
-          None TRUE_KW@4..8 "true" None
-        None R_PAREN@8..9 ")" Whitespace(1)
-      None ELSE_KW@10..14 "else" Whitespace(1)
-      BLOCK_STMT@15..17
-        None L_CURLY@15..16 "{" None
-        LIST@16..16
-        None R_CURLY@16..17 "}" None
-    IF_STMT@17..43
+      None L_PAREN@3..4 "(" None
+      LITERAL@4..8
+        None TRUE_KW@4..8 "true" None
+      None R_PAREN@8..9 ")" Whitespace(1)
+      JS_ELSE_CLAUSE@10..17
+        None ELSE_KW@10..14 "else" Whitespace(1)
+        JS_BLOCK_STATEMENT@15..17
+          None L_CURLY@15..16 "{" None
+          LIST@16..16
+          None R_CURLY@16..17 "}" None
+    JS_IF_STATEMENT@17..43
       Whitespace(1) IF_KW@18..20 "if" Whitespace(1)
-      CONDITION@21..28
-        None L_PAREN@21..22 "(" None
-        LITERAL@22..26
-          None TRUE_KW@22..26 "true" None
-        None R_PAREN@26..27 ")" Whitespace(1)
-      None ELSE_KW@28..32 "else" None
-      IF_STMT@32..43
-        Whitespace(1) IF_KW@33..35 "if" Whitespace(1)
-        CONDITION@36..36
-        None ELSE_KW@36..40 "else" Whitespace(1)
-        BLOCK_STMT@41..43
-          None L_CURLY@41..42 "{" None
-          LIST@42..42
-          None R_CURLY@42..43 "}" None
-    IF_STMT@43..60
+      None L_PAREN@21..22 "(" None
+      LITERAL@22..26
+        None TRUE_KW@22..26 "true" None
+      None R_PAREN@26..27 ")" Whitespace(1)
+      JS_ELSE_CLAUSE@28..43
+        None ELSE_KW@28..32 "else" None
+        JS_IF_STATEMENT@32..43
+          Whitespace(1) IF_KW@33..35 "if" Whitespace(1)
+          JS_ELSE_CLAUSE@36..43
+            None ELSE_KW@36..40 "else" Whitespace(1)
+            JS_BLOCK_STATEMENT@41..43
+              None L_CURLY@41..42 "{" None
+              LIST@42..42
+              None R_CURLY@42..43 "}" None
+    JS_IF_STATEMENT@43..60
       Whitespace(1) IF_KW@44..46 "if" Whitespace(1)
-      CONDITION@47..50
-        None L_PAREN@47..48 "(" None
-        None R_PAREN@48..49 ")" Whitespace(1)
-      BLOCK_STMT@50..53
+      None L_PAREN@47..48 "(" None
+      None R_PAREN@48..49 ")" Whitespace(1)
+      JS_BLOCK_STATEMENT@50..53
         None L_CURLY@50..51 "{" None
         LIST@51..51
         None R_CURLY@51..52 "}" Whitespace(1)
-      None ELSE_KW@53..57 "else" Whitespace(1)
-      BLOCK_STMT@58..60
-        None L_CURLY@58..59 "{" None
-        LIST@59..59
-<<<<<<< HEAD
-         R_CURLY@59..60 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_CURLY@59..60 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+      JS_ELSE_CLAUSE@53..60
+        None ELSE_KW@53..57 "else" Whitespace(1)
+        JS_BLOCK_STATEMENT@58..60
+          None L_CURLY@58..59 "{" None
+          LIST@59..59
+          None R_CURLY@59..60 "}" None
 --
 error[SyntaxError]: Expected a statement or declaration, but found none
   ┌─ if_stmt_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..61
   LIST@0..60
     JS_IF_STATEMENT@0..17
@@ -57,6 +58,52 @@ JS_MODULE@0..61
           LIST@59..59
           R_CURLY@59..60 "}"
   WHITESPACE@60..61 "\n"
+=======
+MODULE@0..60
+  LIST@0..60
+    IF_STMT@0..17
+       IF_KW@0..3 "if" " "
+      CONDITION@3..10
+         L_PAREN@3..4 "(" 
+        LITERAL@4..8
+           TRUE_KW@4..8 "true" 
+         R_PAREN@8..10 ")" " "
+       ELSE_KW@10..15 "else" " "
+      BLOCK_STMT@15..17
+         L_CURLY@15..16 "{" 
+        LIST@16..16
+         R_CURLY@16..17 "}" 
+    IF_STMT@17..43
+      "\n" IF_KW@17..21 "if" " "
+      CONDITION@21..28
+         L_PAREN@21..22 "(" 
+        LITERAL@22..26
+           TRUE_KW@22..26 "true" 
+         R_PAREN@26..28 ")" " "
+       ELSE_KW@28..32 "else" 
+      IF_STMT@32..43
+        "\n" IF_KW@32..36 "if" " "
+        CONDITION@36..36
+         ELSE_KW@36..41 "else" " "
+        BLOCK_STMT@41..43
+           L_CURLY@41..42 "{" 
+          LIST@42..42
+           R_CURLY@42..43 "}" 
+    IF_STMT@43..60
+      "\n" IF_KW@43..47 "if" " "
+      CONDITION@47..50
+         L_PAREN@47..48 "(" 
+         R_PAREN@48..50 ")" " "
+      BLOCK_STMT@50..53
+         L_CURLY@50..51 "{" 
+        LIST@51..51
+         R_CURLY@51..53 "}" " "
+       ELSE_KW@53..58 "else" " "
+      BLOCK_STMT@58..60
+         L_CURLY@58..59 "{" 
+        LIST@59..59
+         R_CURLY@59..60 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 --
 error[SyntaxError]: Expected a statement or declaration, but found none
   ┌─ if_stmt_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -62,43 +62,43 @@ JS_MODULE@0..61
 MODULE@0..60
   LIST@0..60
     IF_STMT@0..17
-      None IF_KW@0..3 "if" Whitespace(1)
+      None IF_KW@0..2 "if" Whitespace(1)
       CONDITION@3..10
         None L_PAREN@3..4 "(" None
         LITERAL@4..8
           None TRUE_KW@4..8 "true" None
-        None R_PAREN@8..10 ")" Whitespace(1)
-      None ELSE_KW@10..15 "else" Whitespace(1)
+        None R_PAREN@8..9 ")" Whitespace(1)
+      None ELSE_KW@10..14 "else" Whitespace(1)
       BLOCK_STMT@15..17
         None L_CURLY@15..16 "{" None
         LIST@16..16
         None R_CURLY@16..17 "}" None
     IF_STMT@17..43
-      Whitespace(1) IF_KW@17..21 "if" Whitespace(1)
+      Whitespace(1) IF_KW@18..20 "if" Whitespace(1)
       CONDITION@21..28
         None L_PAREN@21..22 "(" None
         LITERAL@22..26
           None TRUE_KW@22..26 "true" None
-        None R_PAREN@26..28 ")" Whitespace(1)
+        None R_PAREN@26..27 ")" Whitespace(1)
       None ELSE_KW@28..32 "else" None
       IF_STMT@32..43
-        Whitespace(1) IF_KW@32..36 "if" Whitespace(1)
+        Whitespace(1) IF_KW@33..35 "if" Whitespace(1)
         CONDITION@36..36
-        None ELSE_KW@36..41 "else" Whitespace(1)
+        None ELSE_KW@36..40 "else" Whitespace(1)
         BLOCK_STMT@41..43
           None L_CURLY@41..42 "{" None
           LIST@42..42
           None R_CURLY@42..43 "}" None
     IF_STMT@43..60
-      Whitespace(1) IF_KW@43..47 "if" Whitespace(1)
+      Whitespace(1) IF_KW@44..46 "if" Whitespace(1)
       CONDITION@47..50
         None L_PAREN@47..48 "(" None
-        None R_PAREN@48..50 ")" Whitespace(1)
+        None R_PAREN@48..49 ")" Whitespace(1)
       BLOCK_STMT@50..53
         None L_CURLY@50..51 "{" None
         LIST@51..51
-        None R_CURLY@51..53 "}" Whitespace(1)
-      None ELSE_KW@53..58 "else" Whitespace(1)
+        None R_CURLY@51..52 "}" Whitespace(1)
+      None ELSE_KW@53..57 "else" Whitespace(1)
       BLOCK_STMT@58..60
         None L_CURLY@58..59 "{" None
         LIST@59..59

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -62,48 +62,52 @@ JS_MODULE@0..61
 MODULE@0..60
   LIST@0..60
     IF_STMT@0..17
-       IF_KW@0..3 "if" " "
+      None IF_KW@0..3 "if" Whitespace(1)
       CONDITION@3..10
-         L_PAREN@3..4 "(" 
+        None L_PAREN@3..4 "(" None
         LITERAL@4..8
-           TRUE_KW@4..8 "true" 
-         R_PAREN@8..10 ")" " "
-       ELSE_KW@10..15 "else" " "
+          None TRUE_KW@4..8 "true" None
+        None R_PAREN@8..10 ")" Whitespace(1)
+      None ELSE_KW@10..15 "else" Whitespace(1)
       BLOCK_STMT@15..17
-         L_CURLY@15..16 "{" 
+        None L_CURLY@15..16 "{" None
         LIST@16..16
-         R_CURLY@16..17 "}" 
+        None R_CURLY@16..17 "}" None
     IF_STMT@17..43
-      "\n" IF_KW@17..21 "if" " "
+      Whitespace(1) IF_KW@17..21 "if" Whitespace(1)
       CONDITION@21..28
-         L_PAREN@21..22 "(" 
+        None L_PAREN@21..22 "(" None
         LITERAL@22..26
-           TRUE_KW@22..26 "true" 
-         R_PAREN@26..28 ")" " "
-       ELSE_KW@28..32 "else" 
+          None TRUE_KW@22..26 "true" None
+        None R_PAREN@26..28 ")" Whitespace(1)
+      None ELSE_KW@28..32 "else" None
       IF_STMT@32..43
-        "\n" IF_KW@32..36 "if" " "
+        Whitespace(1) IF_KW@32..36 "if" Whitespace(1)
         CONDITION@36..36
-         ELSE_KW@36..41 "else" " "
+        None ELSE_KW@36..41 "else" Whitespace(1)
         BLOCK_STMT@41..43
-           L_CURLY@41..42 "{" 
+          None L_CURLY@41..42 "{" None
           LIST@42..42
-           R_CURLY@42..43 "}" 
+          None R_CURLY@42..43 "}" None
     IF_STMT@43..60
-      "\n" IF_KW@43..47 "if" " "
+      Whitespace(1) IF_KW@43..47 "if" Whitespace(1)
       CONDITION@47..50
-         L_PAREN@47..48 "(" 
-         R_PAREN@48..50 ")" " "
+        None L_PAREN@47..48 "(" None
+        None R_PAREN@48..50 ")" Whitespace(1)
       BLOCK_STMT@50..53
-         L_CURLY@50..51 "{" 
+        None L_CURLY@50..51 "{" None
         LIST@51..51
-         R_CURLY@51..53 "}" " "
-       ELSE_KW@53..58 "else" " "
+        None R_CURLY@51..53 "}" Whitespace(1)
+      None ELSE_KW@53..58 "else" Whitespace(1)
       BLOCK_STMT@58..60
-         L_CURLY@58..59 "{" 
+        None L_CURLY@58..59 "{" None
         LIST@59..59
+<<<<<<< HEAD
          R_CURLY@59..60 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_CURLY@59..60 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
 --
 error[SyntaxError]: Expected a statement or declaration, but found none
   ┌─ if_stmt_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -5,13 +5,13 @@ MODULE@0..24
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..24
     VAR_DECL@0..17
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           IMPORT_CALL@8..16
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -42,8 +42,12 @@ MODULE@0..24
     EXPR_STMT@17..24
       CALL_EXPR@17..23
         NAME_REF@17..21
+<<<<<<< HEAD
           Whitespace(1) IDENT@17..21 "foo" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) IDENT@18..21 "foo" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ARG_LIST@21..23
           None L_PAREN@21..22 "(" None
           LIST@22..22

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -5,14 +5,15 @@ MODULE@0..24
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..24
     VAR_DECL@0..17
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           IMPORT_CALL@8..16
+<<<<<<< HEAD
 <<<<<<< HEAD
             IMPORT_KW@8..14 "import"
             L_PAREN@14..15 "("
@@ -33,11 +34,21 @@ MODULE@0..24
         NAME_REF@17..21
           "\n" IDENT@17..21 "foo" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None IMPORT_KW@8..14 "import" None
+            None L_PAREN@14..15 "(" None
+            None R_PAREN@15..16 ")" None
+      None SEMICOLON@16..17 ";" None
+    EXPR_STMT@17..24
+      CALL_EXPR@17..23
+        NAME_REF@17..21
+          Whitespace(1) IDENT@17..21 "foo" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ARG_LIST@21..23
-           L_PAREN@21..22 "(" 
+          None L_PAREN@21..22 "(" None
           LIST@22..22
-           R_PAREN@22..23 ")" 
-       SEMICOLON@23..24 ";" 
+          None R_PAREN@22..23 ")" None
+      None SEMICOLON@23..24 ";" None
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ import_call_no_arg.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..25
-=======
-MODULE@0..24
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..24
   LIST@0..24
     VAR_DECL@0..17
       None IDENT@0..3 "let" Whitespace(1)
@@ -13,41 +9,14 @@ MODULE@0..24
               None IDENT@4..5 "a" Whitespace(1)
           None EQ@6..7 "=" Whitespace(1)
           IMPORT_CALL@8..16
-<<<<<<< HEAD
-<<<<<<< HEAD
-            IMPORT_KW@8..14 "import"
-            L_PAREN@14..15 "("
-            R_PAREN@15..16 ")"
-      SEMICOLON@16..17 ";"
-    WHITESPACE@17..18 "\n"
-    JS_EXPRESSION_STATEMENT@18..24
-      CALL_EXPR@18..23
-        NAME_REF@18..21
-          IDENT@18..21 "foo"
-=======
-             IMPORT_KW@8..14 "import" 
-             L_PAREN@14..15 "(" 
-             R_PAREN@15..16 ")" 
-       SEMICOLON@16..17 ";" 
-    EXPR_STMT@17..24
-      CALL_EXPR@17..23
-        NAME_REF@17..21
-          "\n" IDENT@17..21 "foo" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None IMPORT_KW@8..14 "import" None
             None L_PAREN@14..15 "(" None
             None R_PAREN@15..16 ")" None
       None SEMICOLON@16..17 ";" None
-    EXPR_STMT@17..24
+    JS_EXPRESSION_STATEMENT@17..24
       CALL_EXPR@17..23
         NAME_REF@17..21
-<<<<<<< HEAD
-          Whitespace(1) IDENT@17..21 "foo" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) IDENT@18..21 "foo" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ARG_LIST@21..23
           None L_PAREN@21..22 "(" None
           LIST@22..22

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -1,17 +1,19 @@
+<<<<<<< HEAD
 JS_MODULE@0..25
+=======
+MODULE@0..24
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..24
     VAR_DECL@0..17
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..16
         DECLARATOR@4..16
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           IMPORT_CALL@8..16
+<<<<<<< HEAD
             IMPORT_KW@8..14 "import"
             L_PAREN@14..15 "("
             R_PAREN@15..16 ")"
@@ -21,12 +23,21 @@ JS_MODULE@0..25
       CALL_EXPR@18..23
         NAME_REF@18..21
           IDENT@18..21 "foo"
+=======
+             IMPORT_KW@8..14 "import" 
+             L_PAREN@14..15 "(" 
+             R_PAREN@15..16 ")" 
+       SEMICOLON@16..17 ";" 
+    EXPR_STMT@17..24
+      CALL_EXPR@17..23
+        NAME_REF@17..21
+          "\n" IDENT@17..21 "foo" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         ARG_LIST@21..23
-          L_PAREN@21..22 "("
+           L_PAREN@21..22 "(" 
           LIST@22..22
-          R_PAREN@22..23 ")"
-      SEMICOLON@23..24 ";"
-  WHITESPACE@24..25 "\n"
+           R_PAREN@22..23 ")" 
+       SEMICOLON@23..24 ";" 
 --
 error[SyntaxError]: Expected an expression, but found none
   ┌─ import_call_no_arg.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -18,19 +18,24 @@ JS_MODULE@0..28
 MODULE@0..27
   LIST@0..27
     BLOCK_STMT@0..27
-       L_CURLY@0..1 "{" 
+      None L_CURLY@0..1 "{" None
       LIST@1..25
         ERROR@1..25
-          "\n " IMPORT_KW@1..10 "import" " "
+          Whitespace(2) IMPORT_KW@1..10 "import" Whitespace(1)
           LIST@10..14
             NAME@10..14
+<<<<<<< HEAD
                IDENT@10..14 "foo" " "
            FROM_KW@14..19 "from" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None IDENT@10..14 "foo" Whitespace(1)
+          None FROM_KW@14..19 "from" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LITERAL@19..24
-             STRING@19..24 "\"bar\"" 
-           SEMICOLON@24..25 ";" 
-      "\n" R_CURLY@25..27 "}" 
+            None STRING@19..24 "\"bar\"" None
+          None SEMICOLON@24..25 ";" None
+      Whitespace(1) R_CURLY@25..27 "}" None
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ import_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -1,42 +1,14 @@
-<<<<<<< HEAD
-JS_MODULE@0..28
+JS_MODULE@0..27
   LIST@0..27
     JS_BLOCK_STATEMENT@0..27
-      L_CURLY@0..1 "{"
-      WHITESPACE@1..3 "\n "
-      LIST@3..25
-        ERROR@3..25
-          IMPORT_KW@3..9 "import"
-          WHITESPACE@9..10 " "
-          LIST@10..13
-            NAME@10..13
-              IDENT@10..13 "foo"
-          WHITESPACE@13..14 " "
-          FROM_KW@14..18 "from"
-          WHITESPACE@18..19 " "
-=======
-MODULE@0..27
-  LIST@0..27
-    BLOCK_STMT@0..27
       None L_CURLY@0..1 "{" None
       LIST@1..25
         ERROR@1..25
           Whitespace(2) IMPORT_KW@3..9 "import" Whitespace(1)
           LIST@10..14
             NAME@10..14
-<<<<<<< HEAD
-<<<<<<< HEAD
-               IDENT@10..14 "foo" " "
-           FROM_KW@14..19 "from" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None IDENT@10..14 "foo" Whitespace(1)
-          None FROM_KW@14..19 "from" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               None IDENT@10..13 "foo" Whitespace(1)
           None FROM_KW@14..18 "from" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LITERAL@19..24
             None STRING@19..24 "\"bar\"" None
           None SEMICOLON@24..25 ";" None

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -21,9 +21,10 @@ MODULE@0..27
       None L_CURLY@0..1 "{" None
       LIST@1..25
         ERROR@1..25
-          Whitespace(2) IMPORT_KW@1..10 "import" Whitespace(1)
+          Whitespace(2) IMPORT_KW@3..9 "import" Whitespace(1)
           LIST@10..14
             NAME@10..14
+<<<<<<< HEAD
 <<<<<<< HEAD
                IDENT@10..14 "foo" " "
            FROM_KW@14..19 "from" " "
@@ -32,10 +33,14 @@ MODULE@0..27
               None IDENT@10..14 "foo" Whitespace(1)
           None FROM_KW@14..19 "from" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              None IDENT@10..13 "foo" Whitespace(1)
+          None FROM_KW@14..18 "from" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LITERAL@19..24
             None STRING@19..24 "\"bar\"" None
           None SEMICOLON@24..25 ";" None
-      Whitespace(1) R_CURLY@25..27 "}" None
+      Whitespace(1) R_CURLY@26..27 "}" None
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ import_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..28
   LIST@0..27
     JS_BLOCK_STATEMENT@0..27
@@ -13,12 +14,23 @@ JS_MODULE@0..28
           WHITESPACE@13..14 " "
           FROM_KW@14..18 "from"
           WHITESPACE@18..19 " "
+=======
+MODULE@0..27
+  LIST@0..27
+    BLOCK_STMT@0..27
+       L_CURLY@0..1 "{" 
+      LIST@1..25
+        ERROR@1..25
+          "\n " IMPORT_KW@1..10 "import" " "
+          LIST@10..14
+            NAME@10..14
+               IDENT@10..14 "foo" " "
+           FROM_KW@14..19 "from" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LITERAL@19..24
-            STRING@19..24 "\"bar\""
-          SEMICOLON@24..25 ";"
-      WHITESPACE@25..26 "\n"
-      R_CURLY@26..27 "}"
-  WHITESPACE@27..28 "\n"
+             STRING@19..24 "\"bar\"" 
+           SEMICOLON@24..25 ";" 
+      "\n" R_CURLY@25..27 "}" 
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ import_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -1,36 +1,15 @@
-<<<<<<< HEAD
-JS_MODULE@0..24
-=======
-MODULE@0..23
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..23
   LIST@0..23
     JS_EXPRESSION_STATEMENT@0..10
       ERROR@0..10
         None IMPORT_KW@0..6 "import" None
         None DOT@6..7 "." None
         ERROR@7..10
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@7..10 "foo"
-    WHITESPACE@10..11 "\n"
-    JS_EXPRESSION_STATEMENT@11..23
-      ERROR@11..23
-        IMPORT_KW@11..17 "import"
-        DOT@17..18 "."
-=======
-           IDENT@7..10 "foo" 
-    EXPR_STMT@10..23
-      ERROR@10..23
-        "\n" IMPORT_KW@10..17 "import" 
-         DOT@17..18 "." 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None IDENT@7..10 "foo" None
-    EXPR_STMT@10..23
+    JS_EXPRESSION_STATEMENT@10..23
       ERROR@10..23
         Whitespace(1) IMPORT_KW@11..17 "import" None
         None DOT@17..18 "." None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ERROR@18..23
           None IDENT@18..23 "metaa" None
 --

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -28,7 +28,7 @@ MODULE@0..23
           None IDENT@7..10 "foo" None
     EXPR_STMT@10..23
       ERROR@10..23
-        Whitespace(1) IMPORT_KW@10..17 "import" None
+        Whitespace(1) IMPORT_KW@11..17 "import" None
         None DOT@17..18 "." None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ERROR@18..23

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -1,19 +1,30 @@
+<<<<<<< HEAD
 JS_MODULE@0..24
+=======
+MODULE@0..23
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..23
     JS_EXPRESSION_STATEMENT@0..10
       ERROR@0..10
-        IMPORT_KW@0..6 "import"
-        DOT@6..7 "."
+         IMPORT_KW@0..6 "import" 
+         DOT@6..7 "." 
         ERROR@7..10
+<<<<<<< HEAD
           IDENT@7..10 "foo"
     WHITESPACE@10..11 "\n"
     JS_EXPRESSION_STATEMENT@11..23
       ERROR@11..23
         IMPORT_KW@11..17 "import"
         DOT@17..18 "."
+=======
+           IDENT@7..10 "foo" 
+    EXPR_STMT@10..23
+      ERROR@10..23
+        "\n" IMPORT_KW@10..17 "import" 
+         DOT@17..18 "." 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         ERROR@18..23
-          IDENT@18..23 "metaa"
-  WHITESPACE@23..24 "\n"
+           IDENT@18..23 "metaa" 
 --
 error[SyntaxError]: Expected `meta` following an import keyword, but found `foo`
   ┌─ import_no_meta.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -6,9 +6,10 @@ MODULE@0..23
   LIST@0..23
     JS_EXPRESSION_STATEMENT@0..10
       ERROR@0..10
-         IMPORT_KW@0..6 "import" 
-         DOT@6..7 "." 
+        None IMPORT_KW@0..6 "import" None
+        None DOT@6..7 "." None
         ERROR@7..10
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@7..10 "foo"
     WHITESPACE@10..11 "\n"
@@ -23,8 +24,15 @@ MODULE@0..23
         "\n" IMPORT_KW@10..17 "import" 
          DOT@17..18 "." 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@7..10 "foo" None
+    EXPR_STMT@10..23
+      ERROR@10..23
+        Whitespace(1) IMPORT_KW@10..17 "import" None
+        None DOT@17..18 "." None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ERROR@18..23
-           IDENT@18..23 "metaa" 
+          None IDENT@18..23 "metaa" None
 --
 error[SyntaxError]: Expected `meta` following an import keyword, but found `foo`
   ┌─ import_no_meta.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -1,16 +1,23 @@
+<<<<<<< HEAD
 JS_MODULE@0..21
   LIST@0..21
     JS_EXPRESSION_STATEMENT@0..8
+=======
+MODULE@0..20
+  LIST@0..20
+    EXPR_STMT@0..8
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       CALL_EXPR@0..7
         NAME_REF@0..3
-          IDENT@0..3 "foo"
+           IDENT@0..3 "foo" 
         ARG_LIST@3..7
-          L_PAREN@3..4 "("
+           L_PAREN@3..4 "(" 
           LIST@4..7
             NAME_REF@4..5
-              IDENT@4..5 "a"
-            COMMA@5..6 ","
+               IDENT@4..5 "a" 
+             COMMA@5..6 "," 
             NAME_REF@6..7
+<<<<<<< HEAD
               IDENT@6..7 "b"
       SEMICOLON@7..8 ";"
     WHITESPACE@8..9 "\n"
@@ -21,17 +28,26 @@ JS_MODULE@0..21
         ARG_LIST@12..16
           L_PAREN@12..13 "("
           LIST@13..16
+=======
+               IDENT@6..7 "b" 
+       SEMICOLON@7..8 ";" 
+    EXPR_STMT@8..17
+      CALL_EXPR@8..17
+        NAME_REF@8..12
+          "\n" IDENT@8..12 "foo" 
+        ARG_LIST@12..17
+           L_PAREN@12..13 "(" 
+          LIST@13..17
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
             NAME_REF@13..14
-              IDENT@13..14 "a"
-            COMMA@14..15 ","
-            NAME_REF@15..16
-              IDENT@15..16 "b"
-    WHITESPACE@16..17 " "
-    VAR_DECL@17..21
-      VAR_KW@17..20 "var"
-      WHITESPACE@20..21 "\n"
-      LIST@21..21
-        ERROR@21..21
+               IDENT@13..14 "a" 
+             COMMA@14..15 "," 
+            NAME_REF@15..17
+               IDENT@15..17 "b" " "
+    VAR_DECL@17..20
+       VAR_KW@17..20 "var" 
+      LIST@20..20
+        ERROR@20..20
 --
 error[SyntaxError]: expected `')'` but instead found `;`
   ┌─ invalid_arg_list.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -9,14 +9,15 @@ MODULE@0..20
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       CALL_EXPR@0..7
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
+          None IDENT@0..3 "foo" None
         ARG_LIST@3..7
-           L_PAREN@3..4 "(" 
+          None L_PAREN@3..4 "(" None
           LIST@4..7
             NAME_REF@4..5
-               IDENT@4..5 "a" 
-             COMMA@5..6 "," 
+              None IDENT@4..5 "a" None
+            None COMMA@5..6 "," None
             NAME_REF@6..7
+<<<<<<< HEAD
 <<<<<<< HEAD
               IDENT@6..7 "b"
       SEMICOLON@7..8 ";"
@@ -31,21 +32,25 @@ MODULE@0..20
 =======
                IDENT@6..7 "b" 
        SEMICOLON@7..8 ";" 
+=======
+              None IDENT@6..7 "b" None
+      None SEMICOLON@7..8 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@8..17
       CALL_EXPR@8..17
         NAME_REF@8..12
-          "\n" IDENT@8..12 "foo" 
+          Whitespace(1) IDENT@8..12 "foo" None
         ARG_LIST@12..17
-           L_PAREN@12..13 "(" 
+          None L_PAREN@12..13 "(" None
           LIST@13..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
             NAME_REF@13..14
-               IDENT@13..14 "a" 
-             COMMA@14..15 "," 
+              None IDENT@13..14 "a" None
+            None COMMA@14..15 "," None
             NAME_REF@15..17
-               IDENT@15..17 "b" " "
+              None IDENT@15..17 "b" Whitespace(1)
     VAR_DECL@17..20
-       VAR_KW@17..20 "var" 
+      None VAR_KW@17..20 "var" None
       LIST@20..20
         ERROR@20..20
 --

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -39,7 +39,7 @@ MODULE@0..20
     EXPR_STMT@8..17
       CALL_EXPR@8..17
         NAME_REF@8..12
-          Whitespace(1) IDENT@8..12 "foo" None
+          Whitespace(1) IDENT@9..12 "foo" None
         ARG_LIST@12..17
           None L_PAREN@12..13 "(" None
           LIST@13..17
@@ -48,7 +48,7 @@ MODULE@0..20
               None IDENT@13..14 "a" None
             None COMMA@14..15 "," None
             NAME_REF@15..17
-              None IDENT@15..17 "b" Whitespace(1)
+              None IDENT@15..16 "b" Whitespace(1)
     VAR_DECL@17..20
       None VAR_KW@17..20 "var" None
       LIST@20..20

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-JS_MODULE@0..21
-  LIST@0..21
-    JS_EXPRESSION_STATEMENT@0..8
-=======
-MODULE@0..20
+JS_MODULE@0..20
   LIST@0..20
-    EXPR_STMT@0..8
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+    JS_EXPRESSION_STATEMENT@0..8
       CALL_EXPR@0..7
         NAME_REF@0..3
           None IDENT@0..3 "foo" None
@@ -17,33 +11,15 @@ MODULE@0..20
               None IDENT@4..5 "a" None
             None COMMA@5..6 "," None
             NAME_REF@6..7
-<<<<<<< HEAD
-<<<<<<< HEAD
-              IDENT@6..7 "b"
-      SEMICOLON@7..8 ";"
-    WHITESPACE@8..9 "\n"
-    JS_EXPRESSION_STATEMENT@9..16
-      CALL_EXPR@9..16
-        NAME_REF@9..12
-          IDENT@9..12 "foo"
-        ARG_LIST@12..16
-          L_PAREN@12..13 "("
-          LIST@13..16
-=======
-               IDENT@6..7 "b" 
-       SEMICOLON@7..8 ";" 
-=======
               None IDENT@6..7 "b" None
       None SEMICOLON@7..8 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@8..17
+    JS_EXPRESSION_STATEMENT@8..17
       CALL_EXPR@8..17
         NAME_REF@8..12
           Whitespace(1) IDENT@9..12 "foo" None
         ARG_LIST@12..17
           None L_PAREN@12..13 "(" None
           LIST@13..17
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
             NAME_REF@13..14
               None IDENT@13..14 "a" None
             None COMMA@14..15 "," None

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..48
-=======
-MODULE@0..47
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..47
   LIST@0..47
     CLASS_DECL@0..46
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -24,45 +20,13 @@ MODULE@0..47
               PARAMETER_LIST@20..23
                 None L_PAREN@20..21 "(" None
                 LIST@21..21
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                R_PAREN@21..22 ")"
-              WHITESPACE@22..23 " "
-              FAT_ARROW@23..25 "=>"
-              WHITESPACE@25..26 " "
-              JS_BLOCK_STATEMENT@26..43
-                L_CURLY@26..27 "{"
-                WHITESPACE@27..32 "\n    "
-                LIST@32..39
-                  VAR_DECL@32..39
-                    IDENT@32..35 "let"
-                    WHITESPACE@35..36 " "
-=======
-                 R_PAREN@21..23 ")" " "
-               FAT_ARROW@23..26 "=>" " "
-=======
-                None R_PAREN@21..23 ")" Whitespace(1)
-              None FAT_ARROW@23..26 "=>" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                 None R_PAREN@21..22 ")" Whitespace(1)
               None FAT_ARROW@23..25 "=>" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-              BLOCK_STMT@26..43
+              JS_BLOCK_STATEMENT@26..43
                 None L_CURLY@26..27 "{" None
                 LIST@27..39
                   VAR_DECL@27..39
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "\n    " IDENT@27..36 "let" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                    Whitespace(5) IDENT@27..36 "let" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                     Whitespace(5) IDENT@32..35 "let" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                     LIST@36..39
                       DECLARATOR@36..39
                         SINGLE_PATTERN@36..37
@@ -70,33 +34,12 @@ MODULE@0..47
                             None IDENT@36..37 "a" None
                         None EQ@37..38 "=" None
                         ERROR@38..39
-<<<<<<< HEAD
-<<<<<<< HEAD
-                          SEMICOLON@38..39 ";"
-                WHITESPACE@39..42 "\n  "
-                R_CURLY@42..43 "}"
-            SEMICOLON@43..44 ";"
-        WHITESPACE@44..45 "\n"
-        R_CURLY@45..46 "}"
-    JS_EMPTY_STATEMENT@46..47
-      SEMICOLON@46..47 ";"
-  WHITESPACE@47..48 "\n"
-=======
-                           SEMICOLON@38..39 ";" 
-                "\n  " R_CURLY@39..43 "}" 
-             SEMICOLON@43..44 ";" 
-        "\n" R_CURLY@44..46 "}" 
-    EMPTY_STMT@46..47
-       SEMICOLON@46..47 ";" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
                           None SEMICOLON@38..39 ";" None
                 Whitespace(3) R_CURLY@42..43 "}" None
             None SEMICOLON@43..44 ";" None
         Whitespace(1) R_CURLY@45..46 "}" None
-    EMPTY_STMT@46..47
+    JS_EMPTY_STATEMENT@46..47
       None SEMICOLON@46..47 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ invalid_method_recover.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -5,25 +5,26 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     CLASS_DECL@0..46
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       CLASS_BODY@6..46
-         L_CURLY@6..7 "{" 
+        None L_CURLY@6..7 "{" None
         LIST@7..44
           CLASS_PROP@7..44
             COMPUTED_PROPERTY_NAME@7..18
-              "\n  " L_BRACK@7..11 "[" 
+              Whitespace(3) L_BRACK@7..11 "[" None
               BIN_EXPR@11..16
                 LITERAL@11..13
-                   NUMBER@11..13 "1" " "
-                 PLUS@13..15 "+" " "
+                  None NUMBER@11..13 "1" Whitespace(1)
+                None PLUS@13..15 "+" Whitespace(1)
                 LITERAL@15..16
-                   NUMBER@15..16 "1" 
-               R_BRACK@16..18 "]" " "
-             EQ@18..20 "=" " "
+                  None NUMBER@15..16 "1" None
+              None R_BRACK@16..18 "]" Whitespace(1)
+            None EQ@18..20 "=" Whitespace(1)
             ARROW_EXPR@20..43
               PARAMETER_LIST@20..23
-                 L_PAREN@20..21 "(" 
+                None L_PAREN@20..21 "(" None
                 LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
                 R_PAREN@21..22 ")"
               WHITESPACE@22..23 " "
@@ -39,19 +40,28 @@ MODULE@0..47
 =======
                  R_PAREN@21..23 ")" " "
                FAT_ARROW@23..26 "=>" " "
+=======
+                None R_PAREN@21..23 ")" Whitespace(1)
+              None FAT_ARROW@23..26 "=>" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               BLOCK_STMT@26..43
-                 L_CURLY@26..27 "{" 
+                None L_CURLY@26..27 "{" None
                 LIST@27..39
                   VAR_DECL@27..39
+<<<<<<< HEAD
                     "\n    " IDENT@27..36 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                    Whitespace(5) IDENT@27..36 "let" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                     LIST@36..39
                       DECLARATOR@36..39
                         SINGLE_PATTERN@36..37
                           NAME@36..37
-                             IDENT@36..37 "a" 
-                         EQ@37..38 "=" 
+                            None IDENT@36..37 "a" None
+                        None EQ@37..38 "=" None
                         ERROR@38..39
+<<<<<<< HEAD
 <<<<<<< HEAD
                           SEMICOLON@38..39 ";"
                 WHITESPACE@39..42 "\n  "
@@ -70,6 +80,14 @@ MODULE@0..47
     EMPTY_STMT@46..47
        SEMICOLON@46..47 ";" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                          None SEMICOLON@38..39 ";" None
+                Whitespace(3) R_CURLY@39..43 "}" None
+            None SEMICOLON@43..44 ";" None
+        Whitespace(1) R_CURLY@44..46 "}" None
+    EMPTY_STMT@46..47
+      None SEMICOLON@46..47 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ invalid_method_recover.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -1,31 +1,30 @@
+<<<<<<< HEAD
 JS_MODULE@0..48
+=======
+MODULE@0..47
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     CLASS_DECL@0..46
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
+       CLASS_KW@0..6 "class" " "
       CLASS_BODY@6..46
-        L_CURLY@6..7 "{"
-        WHITESPACE@7..10 "\n  "
-        LIST@10..44
-          CLASS_PROP@10..44
-            COMPUTED_PROPERTY_NAME@10..17
-              L_BRACK@10..11 "["
+         L_CURLY@6..7 "{" 
+        LIST@7..44
+          CLASS_PROP@7..44
+            COMPUTED_PROPERTY_NAME@7..18
+              "\n  " L_BRACK@7..11 "[" 
               BIN_EXPR@11..16
-                LITERAL@11..12
-                  NUMBER@11..12 "1"
-                WHITESPACE@12..13 " "
-                PLUS@13..14 "+"
-                WHITESPACE@14..15 " "
+                LITERAL@11..13
+                   NUMBER@11..13 "1" " "
+                 PLUS@13..15 "+" " "
                 LITERAL@15..16
-                  NUMBER@15..16 "1"
-              R_BRACK@16..17 "]"
-            WHITESPACE@17..18 " "
-            EQ@18..19 "="
-            WHITESPACE@19..20 " "
+                   NUMBER@15..16 "1" 
+               R_BRACK@16..18 "]" " "
+             EQ@18..20 "=" " "
             ARROW_EXPR@20..43
-              PARAMETER_LIST@20..22
-                L_PAREN@20..21 "("
+              PARAMETER_LIST@20..23
+                 L_PAREN@20..21 "(" 
                 LIST@21..21
+<<<<<<< HEAD
                 R_PAREN@21..22 ")"
               WHITESPACE@22..23 " "
               FAT_ARROW@23..25 "=>"
@@ -37,13 +36,23 @@ JS_MODULE@0..48
                   VAR_DECL@32..39
                     IDENT@32..35 "let"
                     WHITESPACE@35..36 " "
+=======
+                 R_PAREN@21..23 ")" " "
+               FAT_ARROW@23..26 "=>" " "
+              BLOCK_STMT@26..43
+                 L_CURLY@26..27 "{" 
+                LIST@27..39
+                  VAR_DECL@27..39
+                    "\n    " IDENT@27..36 "let" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                     LIST@36..39
                       DECLARATOR@36..39
                         SINGLE_PATTERN@36..37
                           NAME@36..37
-                            IDENT@36..37 "a"
-                        EQ@37..38 "="
+                             IDENT@36..37 "a" 
+                         EQ@37..38 "=" 
                         ERROR@38..39
+<<<<<<< HEAD
                           SEMICOLON@38..39 ";"
                 WHITESPACE@39..42 "\n  "
                 R_CURLY@42..43 "}"
@@ -53,6 +62,14 @@ JS_MODULE@0..48
     JS_EMPTY_STATEMENT@46..47
       SEMICOLON@46..47 ";"
   WHITESPACE@47..48 "\n"
+=======
+                           SEMICOLON@38..39 ";" 
+                "\n  " R_CURLY@39..43 "}" 
+             SEMICOLON@43..44 ";" 
+        "\n" R_CURLY@44..46 "}" 
+    EMPTY_STMT@46..47
+       SEMICOLON@46..47 ";" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ invalid_method_recover.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -5,25 +5,26 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     CLASS_DECL@0..46
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       CLASS_BODY@6..46
         None L_CURLY@6..7 "{" None
         LIST@7..44
           CLASS_PROP@7..44
             COMPUTED_PROPERTY_NAME@7..18
-              Whitespace(3) L_BRACK@7..11 "[" None
+              Whitespace(3) L_BRACK@10..11 "[" None
               BIN_EXPR@11..16
                 LITERAL@11..13
-                  None NUMBER@11..13 "1" Whitespace(1)
-                None PLUS@13..15 "+" Whitespace(1)
+                  None NUMBER@11..12 "1" Whitespace(1)
+                None PLUS@13..14 "+" Whitespace(1)
                 LITERAL@15..16
                   None NUMBER@15..16 "1" None
-              None R_BRACK@16..18 "]" Whitespace(1)
-            None EQ@18..20 "=" Whitespace(1)
+              None R_BRACK@16..17 "]" Whitespace(1)
+            None EQ@18..19 "=" Whitespace(1)
             ARROW_EXPR@20..43
               PARAMETER_LIST@20..23
                 None L_PAREN@20..21 "(" None
                 LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                 R_PAREN@21..22 ")"
@@ -44,16 +45,24 @@ MODULE@0..47
                 None R_PAREN@21..23 ")" Whitespace(1)
               None FAT_ARROW@23..26 "=>" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                None R_PAREN@21..22 ")" Whitespace(1)
+              None FAT_ARROW@23..25 "=>" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               BLOCK_STMT@26..43
                 None L_CURLY@26..27 "{" None
                 LIST@27..39
                   VAR_DECL@27..39
+<<<<<<< HEAD
 <<<<<<< HEAD
                     "\n    " IDENT@27..36 "let" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                     Whitespace(5) IDENT@27..36 "let" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                    Whitespace(5) IDENT@32..35 "let" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                     LIST@36..39
                       DECLARATOR@36..39
                         SINGLE_PATTERN@36..37
@@ -82,9 +91,9 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                           None SEMICOLON@38..39 ";" None
-                Whitespace(3) R_CURLY@39..43 "}" None
+                Whitespace(3) R_CURLY@42..43 "}" None
             None SEMICOLON@43..44 ";" None
-        Whitespace(1) R_CURLY@44..46 "}" None
+        Whitespace(1) R_CURLY@45..46 "}" None
     EMPTY_STMT@46..47
       None SEMICOLON@46..47 ";" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..22
-=======
-MODULE@0..21
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..21
   LIST@0..21
     CLASS_DECL@0..19
       None CLASS_KW@0..5 "class" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -5,20 +5,20 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     CLASS_DECL@0..19
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..19
         None L_CURLY@10..11 "{" None
         LIST@11..18
           CLASS_PROP@11..17
             NAME@11..17
-              Whitespace(2) IDENT@11..17 "get" Whitespace(1)
+              Whitespace(2) IDENT@13..16 "get" Whitespace(1)
           ERROR@17..18
             None L_CURLY@17..18 "{" None
         None R_CURLY@18..19 "}" None
     ERROR@19..21
-      Whitespace(1) R_CURLY@19..21 "}" None
+      Whitespace(1) R_CURLY@20..21 "}" None
 --
 error[SyntaxError]: expected a semicolon for a class property, but found none
   ┌─ method_getter_err.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -1,26 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..22
+=======
+MODULE@0..21
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     CLASS_DECL@0..19
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..19
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..13 "\n "
-        LIST@13..18
-          CLASS_PROP@13..16
-            NAME@13..16
-              IDENT@13..16 "get"
-          WHITESPACE@16..17 " "
+         L_CURLY@10..11 "{" 
+        LIST@11..18
+          CLASS_PROP@11..17
+            NAME@11..17
+              "\n " IDENT@11..17 "get" " "
           ERROR@17..18
-            L_CURLY@17..18 "{"
-        R_CURLY@18..19 "}"
-    WHITESPACE@19..20 "\n"
-    ERROR@20..21
-      R_CURLY@20..21 "}"
-  WHITESPACE@21..22 "\n"
+             L_CURLY@17..18 "{" 
+         R_CURLY@18..19 "}" 
+    ERROR@19..21
+      "\n" R_CURLY@19..21 "}" 
 --
 error[SyntaxError]: expected a semicolon for a class property, but found none
   ┌─ method_getter_err.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -5,20 +5,20 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     CLASS_DECL@0..19
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..19
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..18
           CLASS_PROP@11..17
             NAME@11..17
-              "\n " IDENT@11..17 "get" " "
+              Whitespace(2) IDENT@11..17 "get" Whitespace(1)
           ERROR@17..18
-             L_CURLY@17..18 "{" 
-         R_CURLY@18..19 "}" 
+            None L_CURLY@17..18 "{" None
+        None R_CURLY@18..19 "}" None
     ERROR@19..21
-      "\n" R_CURLY@19..21 "}" 
+      Whitespace(1) R_CURLY@19..21 "}" None
 --
 error[SyntaxError]: expected a semicolon for a class property, but found none
   ┌─ method_getter_err.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -5,39 +5,39 @@ MODULE@0..39
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     VAR_DECL@0..26
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..26
         DECLARATOR@4..26
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..26
-             L_CURLY@8..10 "{" " "
+            None L_CURLY@8..10 "{" Whitespace(1)
             LIST@10..25
               LITERAL_PROP@10..25
                 ERROR@10..17
-                   REGEX@10..17 "/: 6, /" 
-                 COLON@17..19 ":" " "
+                  None REGEX@10..17 "/: 6, /" None
+                None COLON@17..19 ":" Whitespace(1)
                 LITERAL@19..25
-                   REGEX@19..25 "/foo/" " "
-             R_CURLY@25..26 "}" 
+                  None REGEX@19..25 "/foo/" Whitespace(1)
+            None R_CURLY@25..26 "}" None
     VAR_DECL@26..38
-      "\n" IDENT@26..31 "let" " "
+      Whitespace(1) IDENT@26..31 "let" Whitespace(1)
       LIST@31..38
         DECLARATOR@31..38
           SINGLE_PATTERN@31..33
             NAME@31..33
-               IDENT@31..33 "a" " "
-           EQ@33..35 "=" " "
+              None IDENT@31..33 "a" Whitespace(1)
+          None EQ@33..35 "=" Whitespace(1)
           OBJECT_EXPR@35..38
-             L_CURLY@35..36 "{" 
+            None L_CURLY@35..36 "{" None
             LIST@36..37
               ERROR@36..37
-                 L_CURLY@36..37 "{" 
-             R_CURLY@37..38 "}" 
+                None L_CURLY@36..37 "{" None
+            None R_CURLY@37..38 "}" None
     ERROR@38..39
-       R_CURLY@38..39 "}" 
+      None R_CURLY@38..39 "}" None
 --
 error[SyntaxError]: Expected an identifier or keyword
   ┌─ object_expr_error_prop_name.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..40
-=======
-MODULE@0..39
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..39
   LIST@0..39
     VAR_DECL@0..26
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -5,31 +5,31 @@ MODULE@0..39
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     VAR_DECL@0..26
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..26
         DECLARATOR@4..26
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..26
-            None L_CURLY@8..10 "{" Whitespace(1)
+            None L_CURLY@8..9 "{" Whitespace(1)
             LIST@10..25
               LITERAL_PROP@10..25
                 ERROR@10..17
                   None REGEX@10..17 "/: 6, /" None
-                None COLON@17..19 ":" Whitespace(1)
+                None COLON@17..18 ":" Whitespace(1)
                 LITERAL@19..25
-                  None REGEX@19..25 "/foo/" Whitespace(1)
+                  None REGEX@19..24 "/foo/" Whitespace(1)
             None R_CURLY@25..26 "}" None
     VAR_DECL@26..38
-      Whitespace(1) IDENT@26..31 "let" Whitespace(1)
+      Whitespace(1) IDENT@27..30 "let" Whitespace(1)
       LIST@31..38
         DECLARATOR@31..38
           SINGLE_PATTERN@31..33
             NAME@31..33
-              None IDENT@31..33 "a" Whitespace(1)
-          None EQ@33..35 "=" Whitespace(1)
+              None IDENT@31..32 "a" Whitespace(1)
+          None EQ@33..34 "=" Whitespace(1)
           OBJECT_EXPR@35..38
             None L_CURLY@35..36 "{" None
             LIST@36..37

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -1,50 +1,43 @@
+<<<<<<< HEAD
 JS_MODULE@0..40
+=======
+MODULE@0..39
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..39
     VAR_DECL@0..26
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..26
         DECLARATOR@4..26
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..26
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..10 " "
-            LIST@10..24
-              LITERAL_PROP@10..24
+             L_CURLY@8..10 "{" " "
+            LIST@10..25
+              LITERAL_PROP@10..25
                 ERROR@10..17
-                  REGEX@10..17 "/: 6, /"
-                COLON@17..18 ":"
-                WHITESPACE@18..19 " "
-                LITERAL@19..24
-                  REGEX@19..24 "/foo/"
-            WHITESPACE@24..25 " "
-            R_CURLY@25..26 "}"
-    WHITESPACE@26..27 "\n"
-    VAR_DECL@27..38
-      IDENT@27..30 "let"
-      WHITESPACE@30..31 " "
+                   REGEX@10..17 "/: 6, /" 
+                 COLON@17..19 ":" " "
+                LITERAL@19..25
+                   REGEX@19..25 "/foo/" " "
+             R_CURLY@25..26 "}" 
+    VAR_DECL@26..38
+      "\n" IDENT@26..31 "let" " "
       LIST@31..38
         DECLARATOR@31..38
-          SINGLE_PATTERN@31..32
-            NAME@31..32
-              IDENT@31..32 "a"
-          WHITESPACE@32..33 " "
-          EQ@33..34 "="
-          WHITESPACE@34..35 " "
+          SINGLE_PATTERN@31..33
+            NAME@31..33
+               IDENT@31..33 "a" " "
+           EQ@33..35 "=" " "
           OBJECT_EXPR@35..38
-            L_CURLY@35..36 "{"
+             L_CURLY@35..36 "{" 
             LIST@36..37
               ERROR@36..37
-                L_CURLY@36..37 "{"
-            R_CURLY@37..38 "}"
+                 L_CURLY@36..37 "{" 
+             R_CURLY@37..38 "}" 
     ERROR@38..39
-      R_CURLY@38..39 "}"
-  WHITESPACE@39..40 "\n"
+       R_CURLY@38..39 "}" 
 --
 error[SyntaxError]: Expected an identifier or keyword
   ┌─ object_expr_error_prop_name.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..12
-=======
-MODULE@0..11
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..11
   LIST@0..11
     VAR_DECL@0..11
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -5,20 +5,20 @@ MODULE@0..11
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     VAR_DECL@0..11
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..11
         DECLARATOR@4..11
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..11
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..10
               LITERAL_PROP@9..10
                 LITERAL@9..10
-                   NUMBER@9..10 "5" 
-             R_CURLY@10..11 "}" 
+                  None NUMBER@9..10 "5" None
+            None R_CURLY@10..11 "}" None
 --
 error[SyntaxError]: expected `:` but instead found `}`
   ┌─ object_expr_non_ident_literal_prop.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -5,13 +5,13 @@ MODULE@0..11
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     VAR_DECL@0..11
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..11
         DECLARATOR@4..11
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..11
             None L_CURLY@8..9 "{" None
             LIST@9..10

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -1,24 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..12
+=======
+MODULE@0..11
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     VAR_DECL@0..11
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..11
         DECLARATOR@4..11
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..11
-            L_CURLY@8..9 "{"
+             L_CURLY@8..9 "{" 
             LIST@9..10
               LITERAL_PROP@9..10
                 LITERAL@9..10
-                  NUMBER@9..10 "5"
-            R_CURLY@10..11 "}"
-  WHITESPACE@11..12 "\n"
+                   NUMBER@9..10 "5" 
+             R_CURLY@10..11 "}" 
 --
 error[SyntaxError]: expected `:` but instead found `}`
   ┌─ object_expr_non_ident_literal_prop.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -1,31 +1,7 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..6
       ARROW_EXPR@0..6
-<<<<<<< HEAD
-        PARAMETER_LIST@0..4
-          L_PAREN@0..1 "("
-          LIST@1..4
-            ERROR@1..2
-              NUMBER@1..2 "5"
-            WHITESPACE@2..3 " "
-            ERROR@3..4
-              PLUS@3..4 "+"
-        WHITESPACE@4..5 " "
-        NUMBER@5..6 "5"
-    ERROR@6..7
-      R_PAREN@6..7 ")"
-    WHITESPACE@7..8 " "
-    ERROR@8..10
-      FAT_ARROW@8..10 "=>"
-    WHITESPACE@10..11 " "
-    JS_BLOCK_STATEMENT@11..13
-      L_CURLY@11..12 "{"
-=======
         PARAMETER_LIST@0..5
           None L_PAREN@0..1 "(" None
           LIST@1..5
@@ -38,13 +14,8 @@ MODULE@0..13
       None R_PAREN@6..7 ")" Whitespace(1)
     ERROR@8..11
       None FAT_ARROW@8..10 "=>" Whitespace(1)
-    BLOCK_STMT@11..13
-<<<<<<< HEAD
-       L_CURLY@11..12 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+    JS_BLOCK_STATEMENT@11..13
       None L_CURLY@11..12 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       LIST@12..12
       None R_CURLY@12..13 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -30,14 +30,14 @@ MODULE@0..13
           None L_PAREN@0..1 "(" None
           LIST@1..5
             ERROR@1..3
-              None NUMBER@1..3 "5" Whitespace(1)
+              None NUMBER@1..2 "5" Whitespace(1)
             ERROR@3..5
-              None PLUS@3..5 "+" Whitespace(1)
+              None PLUS@3..4 "+" Whitespace(1)
         None NUMBER@5..6 "5" None
     ERROR@6..8
-      None R_PAREN@6..8 ")" Whitespace(1)
+      None R_PAREN@6..7 ")" Whitespace(1)
     ERROR@8..11
-      None FAT_ARROW@8..11 "=>" Whitespace(1)
+      None FAT_ARROW@8..10 "=>" Whitespace(1)
     BLOCK_STMT@11..13
 <<<<<<< HEAD
        L_CURLY@11..12 "{" 

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -1,7 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..6
       ARROW_EXPR@0..6
+<<<<<<< HEAD
         PARAMETER_LIST@0..4
           L_PAREN@0..1 "("
           LIST@1..4
@@ -20,9 +25,24 @@ JS_MODULE@0..14
     WHITESPACE@10..11 " "
     JS_BLOCK_STATEMENT@11..13
       L_CURLY@11..12 "{"
+=======
+        PARAMETER_LIST@0..5
+           L_PAREN@0..1 "(" 
+          LIST@1..5
+            ERROR@1..3
+               NUMBER@1..3 "5" " "
+            ERROR@3..5
+               PLUS@3..5 "+" " "
+         NUMBER@5..6 "5" 
+    ERROR@6..8
+       R_PAREN@6..8 ")" " "
+    ERROR@8..11
+       FAT_ARROW@8..11 "=>" " "
+    BLOCK_STMT@11..13
+       L_CURLY@11..12 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       LIST@12..12
-      R_CURLY@12..13 "}"
-  WHITESPACE@13..14 "\n"
+       R_CURLY@12..13 "}" 
 --
 error[SyntaxError]: Expected an identifier or pattern, but found none
   ┌─ paren_or_arrow_expr_invalid_params.js:1:2

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -27,22 +27,26 @@ MODULE@0..13
       L_CURLY@11..12 "{"
 =======
         PARAMETER_LIST@0..5
-           L_PAREN@0..1 "(" 
+          None L_PAREN@0..1 "(" None
           LIST@1..5
             ERROR@1..3
-               NUMBER@1..3 "5" " "
+              None NUMBER@1..3 "5" Whitespace(1)
             ERROR@3..5
-               PLUS@3..5 "+" " "
-         NUMBER@5..6 "5" 
+              None PLUS@3..5 "+" Whitespace(1)
+        None NUMBER@5..6 "5" None
     ERROR@6..8
-       R_PAREN@6..8 ")" " "
+      None R_PAREN@6..8 ")" Whitespace(1)
     ERROR@8..11
-       FAT_ARROW@8..11 "=>" " "
+      None FAT_ARROW@8..11 "=>" Whitespace(1)
     BLOCK_STMT@11..13
+<<<<<<< HEAD
        L_CURLY@11..12 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None L_CURLY@11..12 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       LIST@12..12
-       R_CURLY@12..13 "}" 
+      None R_CURLY@12..13 "}" None
 --
 error[SyntaxError]: Expected an identifier or pattern, but found none
   ┌─ paren_or_arrow_expr_invalid_params.js:1:2

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -5,14 +5,15 @@ MODULE@0..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
     VAR_DECL@0..11
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..9
         DECLARATOR@4..9
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           ERROR@8..9
+<<<<<<< HEAD
 <<<<<<< HEAD
             ERROR_TOKEN@8..9 "\\"
       SEMICOLON@9..10 ";"
@@ -21,16 +22,20 @@ MODULE@0..17
 =======
              ERROR_TOKEN@8..9 "\\" 
        SEMICOLON@9..11 ";" " "
+=======
+            None ERROR_TOKEN@8..9 "\\" None
+      None SEMICOLON@9..11 ";" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@11..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       CALL_EXPR@11..16
         NAME_REF@11..14
-           IDENT@11..14 "foo" 
+          None IDENT@11..14 "foo" None
         ARG_LIST@14..16
-           L_PAREN@14..15 "(" 
+          None L_PAREN@14..15 "(" None
           LIST@15..15
-           R_PAREN@15..16 ")" 
-       SEMICOLON@16..17 ";" 
+          None R_PAREN@15..16 ")" None
+      None SEMICOLON@16..17 ";" None
 --
 error: unexpected token `\`
   ┌─ primary_expr_invalid_recovery.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..18
-=======
-MODULE@0..17
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..17
   LIST@0..17
     VAR_DECL@0..11
       None IDENT@0..3 "let" Whitespace(1)
@@ -13,25 +9,9 @@ MODULE@0..17
               None IDENT@4..5 "a" Whitespace(1)
           None EQ@6..7 "=" Whitespace(1)
           ERROR@8..9
-<<<<<<< HEAD
-<<<<<<< HEAD
-            ERROR_TOKEN@8..9 "\\"
-      SEMICOLON@9..10 ";"
-    WHITESPACE@10..11 " "
-    JS_EXPRESSION_STATEMENT@11..17
-=======
-             ERROR_TOKEN@8..9 "\\" 
-       SEMICOLON@9..11 ";" " "
-=======
             None ERROR_TOKEN@8..9 "\\" None
-<<<<<<< HEAD
-      None SEMICOLON@9..11 ";" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
       None SEMICOLON@9..10 ";" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-    EXPR_STMT@11..17
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+    JS_EXPRESSION_STATEMENT@11..17
       CALL_EXPR@11..16
         NAME_REF@11..14
           None IDENT@11..14 "foo" None

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -1,30 +1,36 @@
+<<<<<<< HEAD
 JS_MODULE@0..18
+=======
+MODULE@0..17
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
-    VAR_DECL@0..10
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+    VAR_DECL@0..11
+       IDENT@0..4 "let" " "
       LIST@4..9
         DECLARATOR@4..9
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           ERROR@8..9
+<<<<<<< HEAD
             ERROR_TOKEN@8..9 "\\"
       SEMICOLON@9..10 ";"
     WHITESPACE@10..11 " "
     JS_EXPRESSION_STATEMENT@11..17
+=======
+             ERROR_TOKEN@8..9 "\\" 
+       SEMICOLON@9..11 ";" " "
+    EXPR_STMT@11..17
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       CALL_EXPR@11..16
         NAME_REF@11..14
-          IDENT@11..14 "foo"
+           IDENT@11..14 "foo" 
         ARG_LIST@14..16
-          L_PAREN@14..15 "("
+           L_PAREN@14..15 "(" 
           LIST@15..15
-          R_PAREN@15..16 ")"
-      SEMICOLON@16..17 ";"
-  WHITESPACE@17..18 "\n"
+           R_PAREN@15..16 ")" 
+       SEMICOLON@16..17 ";" 
 --
 error: unexpected token `\`
   ┌─ primary_expr_invalid_recovery.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -5,13 +5,13 @@ MODULE@0..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
     VAR_DECL@0..11
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..9
         DECLARATOR@4..9
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           ERROR@8..9
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -24,8 +24,12 @@ MODULE@0..17
        SEMICOLON@9..11 ";" " "
 =======
             None ERROR_TOKEN@8..9 "\\" None
+<<<<<<< HEAD
       None SEMICOLON@9..11 ";" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      None SEMICOLON@9..10 ";" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
     EXPR_STMT@11..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       CALL_EXPR@11..16

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -16,11 +16,15 @@ MODULE@0..19
       None SEMICOLON@6..7 ";" None
     RETURN_STMT@7..19
 <<<<<<< HEAD
+<<<<<<< HEAD
       "\n" RETURN_KW@7..15 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
       Whitespace(1) RETURN_KW@7..15 "return" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      Whitespace(1) RETURN_KW@8..14 "return" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NAME_REF@15..18
         None IDENT@15..18 "foo" None
       None SEMICOLON@18..19 ";" None

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..20
   LIST@0..19
     JS_RETURN_STATEMENT@0..7
@@ -7,10 +8,18 @@ JS_MODULE@0..20
     JS_RETURN_STATEMENT@8..19
       RETURN_KW@8..14 "return"
       WHITESPACE@14..15 " "
+=======
+MODULE@0..19
+  LIST@0..19
+    RETURN_STMT@0..7
+       RETURN_KW@0..6 "return" 
+       SEMICOLON@6..7 ";" 
+    RETURN_STMT@7..19
+      "\n" RETURN_KW@7..15 "return" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NAME_REF@15..18
-        IDENT@15..18 "foo"
-      SEMICOLON@18..19 ";"
-  WHITESPACE@19..20 "\n"
+         IDENT@15..18 "foo" 
+       SEMICOLON@18..19 ";" 
 --
 error[SyntaxError]: Illegal return statement outside of a function
   ┌─ return_stmt_err.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -1,30 +1,10 @@
-<<<<<<< HEAD
-JS_MODULE@0..20
+JS_MODULE@0..19
   LIST@0..19
     JS_RETURN_STATEMENT@0..7
-      RETURN_KW@0..6 "return"
-      SEMICOLON@6..7 ";"
-    WHITESPACE@7..8 "\n"
-    JS_RETURN_STATEMENT@8..19
-      RETURN_KW@8..14 "return"
-      WHITESPACE@14..15 " "
-=======
-MODULE@0..19
-  LIST@0..19
-    RETURN_STMT@0..7
       None RETURN_KW@0..6 "return" None
       None SEMICOLON@6..7 ";" None
-    RETURN_STMT@7..19
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "\n" RETURN_KW@7..15 "return" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-      Whitespace(1) RETURN_KW@7..15 "return" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+    JS_RETURN_STATEMENT@7..19
       Whitespace(1) RETURN_KW@8..14 "return" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NAME_REF@15..18
         None IDENT@15..18 "foo" None
       None SEMICOLON@18..19 ";" None

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -12,14 +12,18 @@ JS_MODULE@0..20
 MODULE@0..19
   LIST@0..19
     RETURN_STMT@0..7
-       RETURN_KW@0..6 "return" 
-       SEMICOLON@6..7 ";" 
+      None RETURN_KW@0..6 "return" None
+      None SEMICOLON@6..7 ";" None
     RETURN_STMT@7..19
+<<<<<<< HEAD
       "\n" RETURN_KW@7..15 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      Whitespace(1) RETURN_KW@7..15 "return" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       NAME_REF@15..18
-         IDENT@15..18 "foo" 
-       SEMICOLON@18..19 ";" 
+        None IDENT@15..18 "foo" None
+      None SEMICOLON@18..19 ";" None
 --
 error[SyntaxError]: Illegal return statement outside of a function
   ┌─ return_stmt_err.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..24
-  LIST@0..23
-    VAR_DECL@0..13
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
-      LIST@4..13
-        DECLARATOR@4..13
-          SINGLE_PATTERN@4..7
-            NAME@4..7
-              IDENT@4..7 "foo"
-          WHITESPACE@7..8 " "
-          EQ@8..9 "="
-          WHITESPACE@9..10 " "
-          NAME_REF@10..13
-            IDENT@10..13 "bar"
-    WHITESPACE@13..14 " "
-    JS_THROW_STATEMENT@14..23
-      THROW_KW@14..19 "throw"
-      WHITESPACE@19..20 " "
-=======
-MODULE@0..23
+JS_MODULE@0..23
   LIST@0..23
     VAR_DECL@0..14
       None IDENT@0..3 "let" Whitespace(1)
@@ -31,17 +10,8 @@ MODULE@0..23
           None EQ@8..9 "=" Whitespace(1)
           NAME_REF@10..14
             None IDENT@10..13 "bar" Whitespace(1)
-    THROW_STMT@14..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-       THROW_KW@14..20 "throw" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-      None THROW_KW@14..20 "throw" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+    JS_THROW_STATEMENT@14..23
       None THROW_KW@14..19 "throw" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NAME_REF@20..23
         None IDENT@20..23 "foo" None
 --

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..24
   LIST@0..23
     VAR_DECL@0..13
@@ -17,9 +18,24 @@ JS_MODULE@0..24
     JS_THROW_STATEMENT@14..23
       THROW_KW@14..19 "throw"
       WHITESPACE@19..20 " "
+=======
+MODULE@0..23
+  LIST@0..23
+    VAR_DECL@0..14
+       IDENT@0..4 "let" " "
+      LIST@4..14
+        DECLARATOR@4..14
+          SINGLE_PATTERN@4..8
+            NAME@4..8
+               IDENT@4..8 "foo" " "
+           EQ@8..10 "=" " "
+          NAME_REF@10..14
+             IDENT@10..14 "bar" " "
+    THROW_STMT@14..23
+       THROW_KW@14..20 "throw" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NAME_REF@20..23
-        IDENT@20..23 "foo"
-  WHITESPACE@23..24 "\n"
+         IDENT@20..23 "foo" 
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ semicolons_err.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -22,22 +22,26 @@ JS_MODULE@0..24
 MODULE@0..23
   LIST@0..23
     VAR_DECL@0..14
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..14
         DECLARATOR@4..14
           SINGLE_PATTERN@4..8
             NAME@4..8
-              None IDENT@4..8 "foo" Whitespace(1)
-          None EQ@8..10 "=" Whitespace(1)
+              None IDENT@4..7 "foo" Whitespace(1)
+          None EQ@8..9 "=" Whitespace(1)
           NAME_REF@10..14
-            None IDENT@10..14 "bar" Whitespace(1)
+            None IDENT@10..13 "bar" Whitespace(1)
     THROW_STMT@14..23
+<<<<<<< HEAD
 <<<<<<< HEAD
        THROW_KW@14..20 "throw" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
       None THROW_KW@14..20 "throw" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      None THROW_KW@14..19 "throw" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NAME_REF@20..23
         None IDENT@20..23 "foo" None
 --

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -22,20 +22,24 @@ JS_MODULE@0..24
 MODULE@0..23
   LIST@0..23
     VAR_DECL@0..14
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..14
         DECLARATOR@4..14
           SINGLE_PATTERN@4..8
             NAME@4..8
-               IDENT@4..8 "foo" " "
-           EQ@8..10 "=" " "
+              None IDENT@4..8 "foo" Whitespace(1)
+          None EQ@8..10 "=" Whitespace(1)
           NAME_REF@10..14
-             IDENT@10..14 "bar" " "
+            None IDENT@10..14 "bar" Whitespace(1)
     THROW_STMT@14..23
+<<<<<<< HEAD
        THROW_KW@14..20 "throw" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None THROW_KW@14..20 "throw" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       NAME_REF@20..23
-         IDENT@20..23 "foo" 
+        None IDENT@20..23 "foo" None
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ semicolons_err.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -7,22 +7,22 @@ JS_MODULE@0..20
             DOT_EXPR@0..10
               CALL_EXPR@0..5
                 NAME_REF@0..3
-                   IDENT@0..3 "foo" 
+                  None IDENT@0..3 "foo" None
                 ARG_LIST@3..5
-                   L_PAREN@3..4 "(" 
+                  None L_PAREN@3..4 "(" None
                   LIST@4..4
-                   R_PAREN@4..5 ")" 
-               QUESTIONDOT@5..7 "?." 
+                  None R_PAREN@4..5 ")" None
+              None QUESTIONDOT@5..7 "?." None
               NAME@7..10
-                 IDENT@7..10 "baz" 
-             L_BRACK@10..11 "[" 
-             R_BRACK@11..12 "]" 
-           DOT@12..13 "." 
+                None IDENT@7..10 "baz" None
+            None L_BRACK@10..11 "[" None
+            None R_BRACK@11..12 "]" None
+          None DOT@12..13 "." None
           NAME@13..17
-            "\n" IDENT@13..17 "BAR" 
-         BACKTICK@17..18 "`" 
+            Whitespace(1) IDENT@13..17 "BAR" None
+        None BACKTICK@17..18 "`" None
         LIST@18..20
-           TEMPLATE_CHUNK@18..20 "b\n" 
+          None TEMPLATE_CHUNK@18..20 "b\n" None
 --
 error: unterminated template literal
   ┌─ subscripts_err.js:3:1

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -7,23 +7,22 @@ JS_MODULE@0..20
             DOT_EXPR@0..10
               CALL_EXPR@0..5
                 NAME_REF@0..3
-                  IDENT@0..3 "foo"
+                   IDENT@0..3 "foo" 
                 ARG_LIST@3..5
-                  L_PAREN@3..4 "("
+                   L_PAREN@3..4 "(" 
                   LIST@4..4
-                  R_PAREN@4..5 ")"
-              QUESTIONDOT@5..7 "?."
+                   R_PAREN@4..5 ")" 
+               QUESTIONDOT@5..7 "?." 
               NAME@7..10
-                IDENT@7..10 "baz"
-            L_BRACK@10..11 "["
-            R_BRACK@11..12 "]"
-          DOT@12..13 "."
-          WHITESPACE@13..14 "\n"
-          NAME@14..17
-            IDENT@14..17 "BAR"
-        BACKTICK@17..18 "`"
+                 IDENT@7..10 "baz" 
+             L_BRACK@10..11 "[" 
+             R_BRACK@11..12 "]" 
+           DOT@12..13 "." 
+          NAME@13..17
+            "\n" IDENT@13..17 "BAR" 
+         BACKTICK@17..18 "`" 
         LIST@18..20
-          TEMPLATE_CHUNK@18..20 "b\n"
+           TEMPLATE_CHUNK@18..20 "b\n" 
 --
 error: unterminated template literal
   ┌─ subscripts_err.js:3:1

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -19,7 +19,7 @@ JS_MODULE@0..20
             None R_BRACK@11..12 "]" None
           None DOT@12..13 "." None
           NAME@13..17
-            Whitespace(1) IDENT@13..17 "BAR" None
+            Whitespace(1) IDENT@14..17 "BAR" None
         None BACKTICK@17..18 "`" None
         LIST@18..20
           None TEMPLATE_CHUNK@18..20 "b\n" None

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -1,40 +1,15 @@
-<<<<<<< HEAD
-JS_MODULE@0..24
+JS_MODULE@0..23
   LIST@0..23
     JS_SWITCH_STATEMENT@0..13
-      SWITCH_KW@0..6 "switch"
-      WHITESPACE@6..7 " "
-      NAME_REF@7..10
-        IDENT@7..10 "foo"
-      WHITESPACE@10..11 " "
-      L_CURLY@11..12 "{"
-      LIST@12..12
-      R_CURLY@12..13 "}"
-    WHITESPACE@13..14 "\n"
-    JS_SWITCH_STATEMENT@14..23
-      SWITCH_KW@14..20 "switch"
-      WHITESPACE@20..21 " "
-      L_CURLY@21..22 "{"
-=======
-MODULE@0..23
-  LIST@0..23
-    SWITCH_STMT@0..13
       None SWITCH_KW@0..6 "switch" Whitespace(1)
-      CONDITION@7..11
-        NAME_REF@7..11
-          None IDENT@7..10 "foo" Whitespace(1)
+      NAME_REF@7..11
+        None IDENT@7..10 "foo" Whitespace(1)
       None L_CURLY@11..12 "{" None
       LIST@12..12
       None R_CURLY@12..13 "}" None
-    SWITCH_STMT@13..23
+    JS_SWITCH_STATEMENT@13..23
       Whitespace(1) SWITCH_KW@14..20 "switch" Whitespace(1)
-      CONDITION@21..21
-<<<<<<< HEAD
-       L_CURLY@21..22 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
       None L_CURLY@21..22 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       LIST@22..22
       None R_CURLY@22..23 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -19,15 +19,15 @@ JS_MODULE@0..24
 MODULE@0..23
   LIST@0..23
     SWITCH_STMT@0..13
-      None SWITCH_KW@0..7 "switch" Whitespace(1)
+      None SWITCH_KW@0..6 "switch" Whitespace(1)
       CONDITION@7..11
         NAME_REF@7..11
-          None IDENT@7..11 "foo" Whitespace(1)
+          None IDENT@7..10 "foo" Whitespace(1)
       None L_CURLY@11..12 "{" None
       LIST@12..12
       None R_CURLY@12..13 "}" None
     SWITCH_STMT@13..23
-      Whitespace(1) SWITCH_KW@13..21 "switch" Whitespace(1)
+      Whitespace(1) SWITCH_KW@14..20 "switch" Whitespace(1)
       CONDITION@21..21
 <<<<<<< HEAD
        L_CURLY@21..22 "{" 

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..24
   LIST@0..23
     JS_SWITCH_STATEMENT@0..13
@@ -14,9 +15,24 @@ JS_MODULE@0..24
       SWITCH_KW@14..20 "switch"
       WHITESPACE@20..21 " "
       L_CURLY@21..22 "{"
+=======
+MODULE@0..23
+  LIST@0..23
+    SWITCH_STMT@0..13
+       SWITCH_KW@0..7 "switch" " "
+      CONDITION@7..11
+        NAME_REF@7..11
+           IDENT@7..11 "foo" " "
+       L_CURLY@11..12 "{" 
+      LIST@12..12
+       R_CURLY@12..13 "}" 
+    SWITCH_STMT@13..23
+      "\n" SWITCH_KW@13..21 "switch" " "
+      CONDITION@21..21
+       L_CURLY@21..22 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       LIST@22..22
-      R_CURLY@22..23 "}"
-  WHITESPACE@23..24 "\n"
+       R_CURLY@22..23 "}" 
 --
 error[SyntaxError]: expected `'('` but instead found `foo`
   ┌─ switch_stmt_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -19,20 +19,24 @@ JS_MODULE@0..24
 MODULE@0..23
   LIST@0..23
     SWITCH_STMT@0..13
-       SWITCH_KW@0..7 "switch" " "
+      None SWITCH_KW@0..7 "switch" Whitespace(1)
       CONDITION@7..11
         NAME_REF@7..11
-           IDENT@7..11 "foo" " "
-       L_CURLY@11..12 "{" 
+          None IDENT@7..11 "foo" Whitespace(1)
+      None L_CURLY@11..12 "{" None
       LIST@12..12
-       R_CURLY@12..13 "}" 
+      None R_CURLY@12..13 "}" None
     SWITCH_STMT@13..23
-      "\n" SWITCH_KW@13..21 "switch" " "
+      Whitespace(1) SWITCH_KW@13..21 "switch" Whitespace(1)
       CONDITION@21..21
+<<<<<<< HEAD
        L_CURLY@21..22 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None L_CURLY@21..22 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       LIST@22..22
-       R_CURLY@22..23 "}" 
+      None R_CURLY@22..23 "}" None
 --
 error[SyntaxError]: expected `'('` but instead found `foo`
   ┌─ switch_stmt_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
@@ -1,22 +1,22 @@
 JS_MODULE@0..20
   LIST@0..20
     VAR_DECL@0..20
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..20
         DECLARATOR@4..20
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           TEMPLATE@8..20
-             BACKTICK@8..9 "`" 
+            None BACKTICK@8..9 "`" None
             LIST@9..20
               TEMPLATE_ELEMENT@9..15
-                 DOLLARCURLY@9..11 "${" 
+                None DOLLARCURLY@9..11 "${" None
                 NAME_REF@11..14
-                   IDENT@11..14 "foo" 
-                 R_CURLY@14..15 "}" 
-               TEMPLATE_CHUNK@15..20 " bar\n" 
+                  None IDENT@11..14 "foo" None
+                None R_CURLY@14..15 "}" None
+              None TEMPLATE_CHUNK@15..20 " bar\n" None
 --
 error: unterminated template literal
   ┌─ template_literal_unterminated.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
@@ -1,25 +1,22 @@
 JS_MODULE@0..20
   LIST@0..20
     VAR_DECL@0..20
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..20
         DECLARATOR@4..20
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           TEMPLATE@8..20
-            BACKTICK@8..9 "`"
+             BACKTICK@8..9 "`" 
             LIST@9..20
               TEMPLATE_ELEMENT@9..15
-                DOLLARCURLY@9..11 "${"
+                 DOLLARCURLY@9..11 "${" 
                 NAME_REF@11..14
-                  IDENT@11..14 "foo"
-                R_CURLY@14..15 "}"
-              TEMPLATE_CHUNK@15..20 " bar\n"
+                   IDENT@11..14 "foo" 
+                 R_CURLY@14..15 "}" 
+               TEMPLATE_CHUNK@15..20 " bar\n" 
 --
 error: unterminated template literal
   ┌─ template_literal_unterminated.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
@@ -1,13 +1,13 @@
 JS_MODULE@0..20
   LIST@0..20
     VAR_DECL@0..20
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..20
         DECLARATOR@4..20
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           TEMPLATE@8..20
             None BACKTICK@8..9 "`" None
             LIST@9..20

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -1,30 +1,10 @@
-<<<<<<< HEAD
-JS_MODULE@0..28
+JS_MODULE@0..27
   LIST@0..27
     JS_THROW_STATEMENT@0..5
-      THROW_KW@0..5 "throw"
-    WHITESPACE@5..6 "\n"
-    JS_EXPRESSION_STATEMENT@6..27
-      NEW_EXPR@6..27
-        NEW_KW@6..9 "new"
-        WHITESPACE@9..10 " "
-=======
-MODULE@0..27
-  LIST@0..27
-    THROW_STMT@0..5
       None THROW_KW@0..5 "throw" None
-    EXPR_STMT@5..27
+    JS_EXPRESSION_STATEMENT@5..27
       NEW_EXPR@5..27
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" NEW_KW@5..10 "new" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) NEW_KW@5..10 "new" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) NEW_KW@6..9 "new" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@10..15
           None IDENT@10..15 "Error" None
         ARG_LIST@15..27

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..28
   LIST@0..27
     JS_THROW_STATEMENT@0..5
@@ -7,15 +8,23 @@ JS_MODULE@0..28
       NEW_EXPR@6..27
         NEW_KW@6..9 "new"
         WHITESPACE@9..10 " "
+=======
+MODULE@0..27
+  LIST@0..27
+    THROW_STMT@0..5
+       THROW_KW@0..5 "throw" 
+    EXPR_STMT@5..27
+      NEW_EXPR@5..27
+        "\n" NEW_KW@5..10 "new" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME_REF@10..15
-          IDENT@10..15 "Error"
+           IDENT@10..15 "Error" 
         ARG_LIST@15..27
-          L_PAREN@15..16 "("
+           L_PAREN@15..16 "(" 
           LIST@16..26
             LITERAL@16..26
-              STRING@16..26 "\"oh no :(\""
-          R_PAREN@26..27 ")"
-  WHITESPACE@27..28 "\n"
+               STRING@16..26 "\"oh no :(\"" 
+           R_PAREN@26..27 ")" 
 --
 error[SyntaxError]: Linebreaks between a throw statement and the error to be thrown are not allowed
   ┌─ throw_stmt_err.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -12,19 +12,23 @@ JS_MODULE@0..28
 MODULE@0..27
   LIST@0..27
     THROW_STMT@0..5
-       THROW_KW@0..5 "throw" 
+      None THROW_KW@0..5 "throw" None
     EXPR_STMT@5..27
       NEW_EXPR@5..27
+<<<<<<< HEAD
         "\n" NEW_KW@5..10 "new" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) NEW_KW@5..10 "new" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@10..15
-           IDENT@10..15 "Error" 
+          None IDENT@10..15 "Error" None
         ARG_LIST@15..27
-           L_PAREN@15..16 "(" 
+          None L_PAREN@15..16 "(" None
           LIST@16..26
             LITERAL@16..26
-               STRING@16..26 "\"oh no :(\"" 
-           R_PAREN@26..27 ")" 
+              None STRING@16..26 "\"oh no :(\"" None
+          None R_PAREN@26..27 ")" None
 --
 error[SyntaxError]: Linebreaks between a throw statement and the error to be thrown are not allowed
   ┌─ throw_stmt_err.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -16,11 +16,15 @@ MODULE@0..27
     EXPR_STMT@5..27
       NEW_EXPR@5..27
 <<<<<<< HEAD
+<<<<<<< HEAD
         "\n" NEW_KW@5..10 "new" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) NEW_KW@5..10 "new" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) NEW_KW@6..9 "new" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@10..15
           None IDENT@10..15 "Error" None
         ARG_LIST@15..27

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -5,13 +5,13 @@ MODULE@0..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
     VAR_DECL@0..17
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "s" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "s" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           ERROR@8..16
             None ERROR_TOKEN@8..16 "\"\\u{200\"" None
       None SEMICOLON@16..17 ";" None

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..18
-=======
-MODULE@0..17
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..17
   LIST@0..17
     VAR_DECL@0..17
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -5,16 +5,16 @@ MODULE@0..17
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
     VAR_DECL@0..17
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "s" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "s" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           ERROR@8..16
-             ERROR_TOKEN@8..16 "\"\\u{200\"" 
-       SEMICOLON@16..17 ";" 
+            None ERROR_TOKEN@8..16 "\"\\u{200\"" None
+      None SEMICOLON@16..17 ";" None
 --
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
   ┌─ unterminated_unicode_codepoint.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -1,20 +1,20 @@
+<<<<<<< HEAD
 JS_MODULE@0..18
+=======
+MODULE@0..17
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..17
     VAR_DECL@0..17
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..16
         DECLARATOR@4..16
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "s"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "s" " "
+           EQ@6..8 "=" " "
           ERROR@8..16
-            ERROR_TOKEN@8..16 "\"\\u{200\""
-      SEMICOLON@16..17 ";"
-  WHITESPACE@17..18 "\n"
+             ERROR_TOKEN@8..16 "\"\\u{200\"" 
+       SEMICOLON@16..17 ";" 
 --
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
   ┌─ unterminated_unicode_codepoint.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -5,33 +5,33 @@ MODULE@0..31
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..31
     VAR_DECL@0..8
-      None VAR_KW@0..4 "var" Whitespace(1)
+      None VAR_KW@0..3 "var" Whitespace(1)
       LIST@4..8
         DECLARATOR@4..8
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
           None EQ@6..7 "=" None
           ERROR@7..8
             None SEMICOLON@7..8 ";" None
     VAR_DECL@8..21
-      Whitespace(1) CONST_KW@8..15 "const" Whitespace(1)
+      Whitespace(1) CONST_KW@9..14 "const" Whitespace(1)
       LIST@15..21
         DECLARATOR@15..21
           SINGLE_PATTERN@15..17
             NAME@15..17
-              None IDENT@15..17 "a" Whitespace(1)
-          None EQ@17..19 "=" Whitespace(1)
+              None IDENT@15..16 "a" Whitespace(1)
+          None EQ@17..18 "=" Whitespace(1)
           LITERAL@19..21
-            None NUMBER@19..21 "5" Whitespace(1)
+            None NUMBER@19..20 "5" Whitespace(1)
     VAR_DECL@21..31
-      None IDENT@21..25 "let" Whitespace(1)
+      None IDENT@21..24 "let" Whitespace(1)
       LIST@25..30
         DECLARATOR@25..30
           SINGLE_PATTERN@25..27
             NAME@25..27
-              None IDENT@25..27 "b" Whitespace(1)
-          None EQ@27..29 "=" Whitespace(1)
+              None IDENT@25..26 "b" Whitespace(1)
+          None EQ@27..28 "=" Whitespace(1)
           LITERAL@29..30
             None NUMBER@29..30 "5" None
       None SEMICOLON@30..31 ";" None

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -5,36 +5,36 @@ MODULE@0..31
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..31
     VAR_DECL@0..8
-       VAR_KW@0..4 "var" " "
+      None VAR_KW@0..4 "var" Whitespace(1)
       LIST@4..8
         DECLARATOR@4..8
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..7 "=" 
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..7 "=" None
           ERROR@7..8
-             SEMICOLON@7..8 ";" 
+            None SEMICOLON@7..8 ";" None
     VAR_DECL@8..21
-      "\n" CONST_KW@8..15 "const" " "
+      Whitespace(1) CONST_KW@8..15 "const" Whitespace(1)
       LIST@15..21
         DECLARATOR@15..21
           SINGLE_PATTERN@15..17
             NAME@15..17
-               IDENT@15..17 "a" " "
-           EQ@17..19 "=" " "
+              None IDENT@15..17 "a" Whitespace(1)
+          None EQ@17..19 "=" Whitespace(1)
           LITERAL@19..21
-             NUMBER@19..21 "5" " "
+            None NUMBER@19..21 "5" Whitespace(1)
     VAR_DECL@21..31
-       IDENT@21..25 "let" " "
+      None IDENT@21..25 "let" Whitespace(1)
       LIST@25..30
         DECLARATOR@25..30
           SINGLE_PATTERN@25..27
             NAME@25..27
-               IDENT@25..27 "b" " "
-           EQ@27..29 "=" " "
+              None IDENT@25..27 "b" Whitespace(1)
+          None EQ@27..29 "=" Whitespace(1)
           LITERAL@29..30
-             NUMBER@29..30 "5" 
-       SEMICOLON@30..31 ";" 
+            None NUMBER@29..30 "5" None
+      None SEMICOLON@30..31 ";" None
 --
 error[SyntaxError]: expected an expression, but found `;` instead
   ┌─ var_decl_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..32
-=======
-MODULE@0..31
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..31
   LIST@0..31
     VAR_DECL@0..8
       None VAR_KW@0..3 "var" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -1,47 +1,40 @@
+<<<<<<< HEAD
 JS_MODULE@0..32
+=======
+MODULE@0..31
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..31
     VAR_DECL@0..8
-      VAR_KW@0..3 "var"
-      WHITESPACE@3..4 " "
+       VAR_KW@0..4 "var" " "
       LIST@4..8
         DECLARATOR@4..8
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..7 "=" 
           ERROR@7..8
-            SEMICOLON@7..8 ";"
-    WHITESPACE@8..9 "\n"
-    VAR_DECL@9..20
-      CONST_KW@9..14 "const"
-      WHITESPACE@14..15 " "
-      LIST@15..20
-        DECLARATOR@15..20
-          SINGLE_PATTERN@15..16
-            NAME@15..16
-              IDENT@15..16 "a"
-          WHITESPACE@16..17 " "
-          EQ@17..18 "="
-          WHITESPACE@18..19 " "
-          LITERAL@19..20
-            NUMBER@19..20 "5"
-    WHITESPACE@20..21 " "
+             SEMICOLON@7..8 ";" 
+    VAR_DECL@8..21
+      "\n" CONST_KW@8..15 "const" " "
+      LIST@15..21
+        DECLARATOR@15..21
+          SINGLE_PATTERN@15..17
+            NAME@15..17
+               IDENT@15..17 "a" " "
+           EQ@17..19 "=" " "
+          LITERAL@19..21
+             NUMBER@19..21 "5" " "
     VAR_DECL@21..31
-      IDENT@21..24 "let"
-      WHITESPACE@24..25 " "
+       IDENT@21..25 "let" " "
       LIST@25..30
         DECLARATOR@25..30
-          SINGLE_PATTERN@25..26
-            NAME@25..26
-              IDENT@25..26 "b"
-          WHITESPACE@26..27 " "
-          EQ@27..28 "="
-          WHITESPACE@28..29 " "
+          SINGLE_PATTERN@25..27
+            NAME@25..27
+               IDENT@25..27 "b" " "
+           EQ@27..29 "=" " "
           LITERAL@29..30
-            NUMBER@29..30 "5"
-      SEMICOLON@30..31 ";"
-  WHITESPACE@31..32 "\n"
+             NUMBER@29..30 "5" 
+       SEMICOLON@30..31 ";" 
 --
 error[SyntaxError]: expected an expression, but found `;` instead
   ┌─ var_decl_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -14,17 +14,21 @@ JS_MODULE@0..52
 MODULE@0..51
   LIST@0..51
     WHILE_STMT@0..13
-       WHILE_KW@0..6 "while" " "
+      None WHILE_KW@0..6 "while" Whitespace(1)
       CONDITION@6..11
         LITERAL@6..11
-           TRUE_KW@6..11 "true" " "
+          None TRUE_KW@6..11 "true" Whitespace(1)
       BLOCK_STMT@11..13
+<<<<<<< HEAD
          L_CURLY@11..12 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None L_CURLY@11..12 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@12..12
-         R_CURLY@12..13 "}" 
+        None R_CURLY@12..13 "}" None
     WHILE_STMT@13..22
-      "\n" WHILE_KW@13..20 "while" " "
+      Whitespace(1) WHILE_KW@13..20 "while" Whitespace(1)
       CONDITION@20..20
 <<<<<<< HEAD
       JS_BLOCK_STATEMENT@20..22
@@ -44,28 +48,32 @@ MODULE@0..51
         L_CURLY@35..36 "{"
 =======
       BLOCK_STMT@20..22
-         L_CURLY@20..21 "{" 
+        None L_CURLY@20..21 "{" None
         LIST@21..21
-         R_CURLY@21..22 "}" 
+        None R_CURLY@21..22 "}" None
     WHILE_STMT@22..37
-      "\n" WHILE_KW@22..29 "while" " "
+      Whitespace(1) WHILE_KW@22..29 "while" Whitespace(1)
       CONDITION@29..35
-         L_PAREN@29..30 "(" 
+        None L_PAREN@29..30 "(" None
         LITERAL@30..35
-           TRUE_KW@30..35 "true" " "
+          None TRUE_KW@30..35 "true" Whitespace(1)
       BLOCK_STMT@35..37
+<<<<<<< HEAD
          L_CURLY@35..36 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None L_CURLY@35..36 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@36..36
-         R_CURLY@36..37 "}" 
+        None R_CURLY@36..37 "}" None
     WHILE_STMT@37..51
-      "\n" WHILE_KW@37..44 "while" " "
+      Whitespace(1) WHILE_KW@37..44 "while" Whitespace(1)
       CONDITION@44..50
         LITERAL@44..48
-           TRUE_KW@44..48 "true" 
-         R_PAREN@48..50 ")" " "
+          None TRUE_KW@44..48 "true" None
+        None R_PAREN@48..50 ")" Whitespace(1)
       ERROR@50..51
-         R_CURLY@50..51 "}" 
+        None R_CURLY@50..51 "}" None
 --
 error[SyntaxError]: expected `'('` but instead found `true`
   ┌─ while_stmt_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -14,10 +14,10 @@ JS_MODULE@0..52
 MODULE@0..51
   LIST@0..51
     WHILE_STMT@0..13
-      None WHILE_KW@0..6 "while" Whitespace(1)
+      None WHILE_KW@0..5 "while" Whitespace(1)
       CONDITION@6..11
         LITERAL@6..11
-          None TRUE_KW@6..11 "true" Whitespace(1)
+          None TRUE_KW@6..10 "true" Whitespace(1)
       BLOCK_STMT@11..13
 <<<<<<< HEAD
          L_CURLY@11..12 "{" 
@@ -28,7 +28,7 @@ MODULE@0..51
         LIST@12..12
         None R_CURLY@12..13 "}" None
     WHILE_STMT@13..22
-      Whitespace(1) WHILE_KW@13..20 "while" Whitespace(1)
+      Whitespace(1) WHILE_KW@14..19 "while" Whitespace(1)
       CONDITION@20..20
 <<<<<<< HEAD
       JS_BLOCK_STATEMENT@20..22
@@ -52,11 +52,11 @@ MODULE@0..51
         LIST@21..21
         None R_CURLY@21..22 "}" None
     WHILE_STMT@22..37
-      Whitespace(1) WHILE_KW@22..29 "while" Whitespace(1)
+      Whitespace(1) WHILE_KW@23..28 "while" Whitespace(1)
       CONDITION@29..35
         None L_PAREN@29..30 "(" None
         LITERAL@30..35
-          None TRUE_KW@30..35 "true" Whitespace(1)
+          None TRUE_KW@30..34 "true" Whitespace(1)
       BLOCK_STMT@35..37
 <<<<<<< HEAD
          L_CURLY@35..36 "{" 
@@ -67,11 +67,11 @@ MODULE@0..51
         LIST@36..36
         None R_CURLY@36..37 "}" None
     WHILE_STMT@37..51
-      Whitespace(1) WHILE_KW@37..44 "while" Whitespace(1)
+      Whitespace(1) WHILE_KW@38..43 "while" Whitespace(1)
       CONDITION@44..50
         LITERAL@44..48
           None TRUE_KW@44..48 "true" None
-        None R_PAREN@48..50 ")" Whitespace(1)
+        None R_PAREN@48..49 ")" Whitespace(1)
       ERROR@50..51
         None R_CURLY@50..51 "}" None
 --

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -1,53 +1,18 @@
-<<<<<<< HEAD
-JS_MODULE@0..52
-  LIST@0..51
-    WHILE_STMT@0..13
-      WHILE_KW@0..5 "while"
-      WHITESPACE@5..6 " "
-      CONDITION@6..10
-        LITERAL@6..10
-          TRUE_KW@6..10 "true"
-      WHITESPACE@10..11 " "
-      JS_BLOCK_STATEMENT@11..13
-        L_CURLY@11..12 "{"
-=======
-MODULE@0..51
+JS_MODULE@0..51
   LIST@0..51
     WHILE_STMT@0..13
       None WHILE_KW@0..5 "while" Whitespace(1)
       CONDITION@6..11
         LITERAL@6..11
           None TRUE_KW@6..10 "true" Whitespace(1)
-      BLOCK_STMT@11..13
-<<<<<<< HEAD
-         L_CURLY@11..12 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+      JS_BLOCK_STATEMENT@11..13
         None L_CURLY@11..12 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@12..12
         None R_CURLY@12..13 "}" None
     WHILE_STMT@13..22
       Whitespace(1) WHILE_KW@14..19 "while" Whitespace(1)
       CONDITION@20..20
-<<<<<<< HEAD
       JS_BLOCK_STATEMENT@20..22
-        L_CURLY@20..21 "{"
-        LIST@21..21
-        R_CURLY@21..22 "}"
-    WHITESPACE@22..23 "\n"
-    WHILE_STMT@23..37
-      WHILE_KW@23..28 "while"
-      WHITESPACE@28..29 " "
-      CONDITION@29..34
-        L_PAREN@29..30 "("
-        LITERAL@30..34
-          TRUE_KW@30..34 "true"
-      WHITESPACE@34..35 " "
-      JS_BLOCK_STATEMENT@35..37
-        L_CURLY@35..36 "{"
-=======
-      BLOCK_STMT@20..22
         None L_CURLY@20..21 "{" None
         LIST@21..21
         None R_CURLY@21..22 "}" None
@@ -57,13 +22,8 @@ MODULE@0..51
         None L_PAREN@29..30 "(" None
         LITERAL@30..35
           None TRUE_KW@30..34 "true" Whitespace(1)
-      BLOCK_STMT@35..37
-<<<<<<< HEAD
-         L_CURLY@35..36 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+      JS_BLOCK_STATEMENT@35..37
         None L_CURLY@35..36 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@36..36
         None R_CURLY@36..37 "}" None
     WHILE_STMT@37..51

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..52
   LIST@0..51
     WHILE_STMT@0..13
@@ -9,13 +10,23 @@ JS_MODULE@0..52
       WHITESPACE@10..11 " "
       JS_BLOCK_STATEMENT@11..13
         L_CURLY@11..12 "{"
+=======
+MODULE@0..51
+  LIST@0..51
+    WHILE_STMT@0..13
+       WHILE_KW@0..6 "while" " "
+      CONDITION@6..11
+        LITERAL@6..11
+           TRUE_KW@6..11 "true" " "
+      BLOCK_STMT@11..13
+         L_CURLY@11..12 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@12..12
-        R_CURLY@12..13 "}"
-    WHITESPACE@13..14 "\n"
-    WHILE_STMT@14..22
-      WHILE_KW@14..19 "while"
-      WHITESPACE@19..20 " "
+         R_CURLY@12..13 "}" 
+    WHILE_STMT@13..22
+      "\n" WHILE_KW@13..20 "while" " "
       CONDITION@20..20
+<<<<<<< HEAD
       JS_BLOCK_STATEMENT@20..22
         L_CURLY@20..21 "{"
         LIST@21..21
@@ -31,20 +42,30 @@ JS_MODULE@0..52
       WHITESPACE@34..35 " "
       JS_BLOCK_STATEMENT@35..37
         L_CURLY@35..36 "{"
+=======
+      BLOCK_STMT@20..22
+         L_CURLY@20..21 "{" 
+        LIST@21..21
+         R_CURLY@21..22 "}" 
+    WHILE_STMT@22..37
+      "\n" WHILE_KW@22..29 "while" " "
+      CONDITION@29..35
+         L_PAREN@29..30 "(" 
+        LITERAL@30..35
+           TRUE_KW@30..35 "true" " "
+      BLOCK_STMT@35..37
+         L_CURLY@35..36 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@36..36
-        R_CURLY@36..37 "}"
-    WHITESPACE@37..38 "\n"
-    WHILE_STMT@38..51
-      WHILE_KW@38..43 "while"
-      WHITESPACE@43..44 " "
-      CONDITION@44..49
+         R_CURLY@36..37 "}" 
+    WHILE_STMT@37..51
+      "\n" WHILE_KW@37..44 "while" " "
+      CONDITION@44..50
         LITERAL@44..48
-          TRUE_KW@44..48 "true"
-        R_PAREN@48..49 ")"
-      WHITESPACE@49..50 " "
+           TRUE_KW@44..48 "true" 
+         R_PAREN@48..50 ")" " "
       ERROR@50..51
-        R_CURLY@50..51 "}"
-  WHITESPACE@51..52 "\n"
+         R_CURLY@50..51 "}" 
 --
 error[SyntaxError]: expected `'('` but instead found `true`
   ┌─ while_stmt_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -6,12 +6,13 @@ MODULE@0..64
   LIST@0..64
     JS_EXPRESSION_STATEMENT@0..11
       ARRAY_EXPR@0..10
-         L_BRACK@0..1 "[" 
+        None L_BRACK@0..1 "[" None
         LIST@1..9
           NAME_REF@1..4
-             IDENT@1..4 "foo" 
-           COMMA@4..6 "," " "
+            None IDENT@1..4 "foo" None
+          None COMMA@4..6 "," Whitespace(1)
           NAME_REF@6..9
+<<<<<<< HEAD
 <<<<<<< HEAD
             IDENT@6..9 "bar"
         R_BRACK@9..10 "]"
@@ -33,21 +34,31 @@ MODULE@0..64
              IDENT@6..9 "bar" 
          R_BRACK@9..10 "]" 
        SEMICOLON@10..11 ";" 
+=======
+            None IDENT@6..9 "bar" None
+        None R_BRACK@9..10 "]" None
+      None SEMICOLON@10..11 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@11..18
       ARRAY_EXPR@11..17
-        "\n" L_BRACK@11..13 "[" 
+        Whitespace(1) L_BRACK@11..13 "[" None
         LIST@13..16
           NAME_REF@13..16
-             IDENT@13..16 "foo" 
-         R_BRACK@16..17 "]" 
-       SEMICOLON@17..18 ";" 
+            None IDENT@13..16 "foo" None
+        None R_BRACK@16..17 "]" None
+      None SEMICOLON@17..18 ";" None
     EXPR_STMT@18..26
       ARRAY_EXPR@18..25
+<<<<<<< HEAD
         "\n" L_BRACK@18..20 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) L_BRACK@18..20 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@20..24
-           COMMA@20..21 "," 
+          None COMMA@20..21 "," None
           NAME_REF@21..24
+<<<<<<< HEAD
 <<<<<<< HEAD
             IDENT@21..24 "foo"
         R_BRACK@24..25 "]"
@@ -70,26 +81,36 @@ MODULE@0..64
              IDENT@21..24 "foo" 
          R_BRACK@24..25 "]" 
        SEMICOLON@25..26 ";" 
+=======
+            None IDENT@21..24 "foo" None
+        None R_BRACK@24..25 "]" None
+      None SEMICOLON@25..26 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@26..34
       ARRAY_EXPR@26..33
-        "\n" L_BRACK@26..28 "[" 
+        Whitespace(1) L_BRACK@26..28 "[" None
         LIST@28..32
           NAME_REF@28..31
-             IDENT@28..31 "foo" 
-           COMMA@31..32 "," 
-         R_BRACK@32..33 "]" 
-       SEMICOLON@33..34 ";" 
+            None IDENT@28..31 "foo" None
+          None COMMA@31..32 "," None
+        None R_BRACK@32..33 "]" None
+      None SEMICOLON@33..34 ";" None
     EXPR_STMT@34..50
       ARRAY_EXPR@34..49
+<<<<<<< HEAD
         "\n" L_BRACK@34..36 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) L_BRACK@34..36 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@36..48
-           COMMA@36..37 "," 
-           COMMA@37..38 "," 
-           COMMA@38..39 "," 
-           COMMA@39..40 "," 
-           COMMA@40..41 "," 
+          None COMMA@36..37 "," None
+          None COMMA@37..38 "," None
+          None COMMA@38..39 "," None
+          None COMMA@39..40 "," None
+          None COMMA@40..41 "," None
           NAME_REF@41..44
+<<<<<<< HEAD
 <<<<<<< HEAD
             IDENT@41..44 "foo"
           COMMA@44..45 ","
@@ -114,15 +135,27 @@ MODULE@0..64
       ARRAY_EXPR@50..63
         "\n" L_BRACK@50..52 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None IDENT@41..44 "foo" None
+          None COMMA@44..45 "," None
+          None COMMA@45..46 "," None
+          None COMMA@46..47 "," None
+          None COMMA@47..48 "," None
+        None R_BRACK@48..49 "]" None
+      None SEMICOLON@49..50 ";" None
+    EXPR_STMT@50..64
+      ARRAY_EXPR@50..63
+        Whitespace(1) L_BRACK@50..52 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@52..62
           SPREAD_ELEMENT@52..56
-             DOT2@52..55 "..." 
+            None DOT2@52..55 "..." None
             NAME_REF@55..56
-               IDENT@55..56 "a" 
-           COMMA@56..58 "," " "
+              None IDENT@55..56 "a" None
+          None COMMA@56..58 "," Whitespace(1)
           SPREAD_ELEMENT@58..62
-             DOT2@58..61 "..." 
+            None DOT2@58..61 "..." None
             NAME_REF@61..62
-               IDENT@61..62 "b" 
-         R_BRACK@62..63 "]" 
-       SEMICOLON@63..64 ";" 
+              None IDENT@61..62 "b" None
+        None R_BRACK@62..63 "]" None
+      None SEMICOLON@63..64 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -1,14 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..65
+=======
+MODULE@0..64
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..64
     JS_EXPRESSION_STATEMENT@0..11
       ARRAY_EXPR@0..10
-        L_BRACK@0..1 "["
+         L_BRACK@0..1 "[" 
         LIST@1..9
           NAME_REF@1..4
-            IDENT@1..4 "foo"
-          COMMA@4..5 ","
-          WHITESPACE@5..6 " "
+             IDENT@1..4 "foo" 
+           COMMA@4..6 "," " "
           NAME_REF@6..9
+<<<<<<< HEAD
             IDENT@6..9 "bar"
         R_BRACK@9..10 "]"
       SEMICOLON@10..11 ";"
@@ -25,9 +29,26 @@ JS_MODULE@0..65
     JS_EXPRESSION_STATEMENT@19..26
       ARRAY_EXPR@19..25
         L_BRACK@19..20 "["
+=======
+             IDENT@6..9 "bar" 
+         R_BRACK@9..10 "]" 
+       SEMICOLON@10..11 ";" 
+    EXPR_STMT@11..18
+      ARRAY_EXPR@11..17
+        "\n" L_BRACK@11..13 "[" 
+        LIST@13..16
+          NAME_REF@13..16
+             IDENT@13..16 "foo" 
+         R_BRACK@16..17 "]" 
+       SEMICOLON@17..18 ";" 
+    EXPR_STMT@18..26
+      ARRAY_EXPR@18..25
+        "\n" L_BRACK@18..20 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@20..24
-          COMMA@20..21 ","
+           COMMA@20..21 "," 
           NAME_REF@21..24
+<<<<<<< HEAD
             IDENT@21..24 "foo"
         R_BRACK@24..25 "]"
       SEMICOLON@25..26 ";"
@@ -45,13 +66,31 @@ JS_MODULE@0..65
     JS_EXPRESSION_STATEMENT@35..50
       ARRAY_EXPR@35..49
         L_BRACK@35..36 "["
+=======
+             IDENT@21..24 "foo" 
+         R_BRACK@24..25 "]" 
+       SEMICOLON@25..26 ";" 
+    EXPR_STMT@26..34
+      ARRAY_EXPR@26..33
+        "\n" L_BRACK@26..28 "[" 
+        LIST@28..32
+          NAME_REF@28..31
+             IDENT@28..31 "foo" 
+           COMMA@31..32 "," 
+         R_BRACK@32..33 "]" 
+       SEMICOLON@33..34 ";" 
+    EXPR_STMT@34..50
+      ARRAY_EXPR@34..49
+        "\n" L_BRACK@34..36 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@36..48
-          COMMA@36..37 ","
-          COMMA@37..38 ","
-          COMMA@38..39 ","
-          COMMA@39..40 ","
-          COMMA@40..41 ","
+           COMMA@36..37 "," 
+           COMMA@37..38 "," 
+           COMMA@38..39 "," 
+           COMMA@39..40 "," 
+           COMMA@40..41 "," 
           NAME_REF@41..44
+<<<<<<< HEAD
             IDENT@41..44 "foo"
           COMMA@44..45 ","
           COMMA@45..46 ","
@@ -63,17 +102,27 @@ JS_MODULE@0..65
     JS_EXPRESSION_STATEMENT@51..64
       ARRAY_EXPR@51..63
         L_BRACK@51..52 "["
+=======
+             IDENT@41..44 "foo" 
+           COMMA@44..45 "," 
+           COMMA@45..46 "," 
+           COMMA@46..47 "," 
+           COMMA@47..48 "," 
+         R_BRACK@48..49 "]" 
+       SEMICOLON@49..50 ";" 
+    EXPR_STMT@50..64
+      ARRAY_EXPR@50..63
+        "\n" L_BRACK@50..52 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@52..62
           SPREAD_ELEMENT@52..56
-            DOT2@52..55 "..."
+             DOT2@52..55 "..." 
             NAME_REF@55..56
-              IDENT@55..56 "a"
-          COMMA@56..57 ","
-          WHITESPACE@57..58 " "
+               IDENT@55..56 "a" 
+           COMMA@56..58 "," " "
           SPREAD_ELEMENT@58..62
-            DOT2@58..61 "..."
+             DOT2@58..61 "..." 
             NAME_REF@61..62
-              IDENT@61..62 "b"
-        R_BRACK@62..63 "]"
-      SEMICOLON@63..64 ";"
-  WHITESPACE@64..65 "\n"
+               IDENT@61..62 "b" 
+         R_BRACK@62..63 "]" 
+       SEMICOLON@63..64 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -10,7 +10,7 @@ MODULE@0..64
         LIST@1..9
           NAME_REF@1..4
             None IDENT@1..4 "foo" None
-          None COMMA@4..6 "," Whitespace(1)
+          None COMMA@4..5 "," Whitespace(1)
           NAME_REF@6..9
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -41,7 +41,7 @@ MODULE@0..64
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@11..18
       ARRAY_EXPR@11..17
-        Whitespace(1) L_BRACK@11..13 "[" None
+        Whitespace(1) L_BRACK@12..13 "[" None
         LIST@13..16
           NAME_REF@13..16
             None IDENT@13..16 "foo" None
@@ -50,11 +50,15 @@ MODULE@0..64
     EXPR_STMT@18..26
       ARRAY_EXPR@18..25
 <<<<<<< HEAD
+<<<<<<< HEAD
         "\n" L_BRACK@18..20 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) L_BRACK@18..20 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_BRACK@19..20 "[" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@20..24
           None COMMA@20..21 "," None
           NAME_REF@21..24
@@ -88,7 +92,7 @@ MODULE@0..64
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@26..34
       ARRAY_EXPR@26..33
-        Whitespace(1) L_BRACK@26..28 "[" None
+        Whitespace(1) L_BRACK@27..28 "[" None
         LIST@28..32
           NAME_REF@28..31
             None IDENT@28..31 "foo" None
@@ -98,11 +102,15 @@ MODULE@0..64
     EXPR_STMT@34..50
       ARRAY_EXPR@34..49
 <<<<<<< HEAD
+<<<<<<< HEAD
         "\n" L_BRACK@34..36 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) L_BRACK@34..36 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_BRACK@35..36 "[" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@36..48
           None COMMA@36..37 "," None
           None COMMA@37..38 "," None
@@ -145,14 +153,18 @@ MODULE@0..64
       None SEMICOLON@49..50 ";" None
     EXPR_STMT@50..64
       ARRAY_EXPR@50..63
+<<<<<<< HEAD
         Whitespace(1) L_BRACK@50..52 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_BRACK@51..52 "[" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@52..62
           SPREAD_ELEMENT@52..56
             None DOT2@52..55 "..." None
             NAME_REF@55..56
               None IDENT@55..56 "a" None
-          None COMMA@56..58 "," Whitespace(1)
+          None COMMA@56..57 "," Whitespace(1)
           SPREAD_ELEMENT@58..62
             None DOT2@58..61 "..." None
             NAME_REF@61..62

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..65
-=======
-MODULE@0..64
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..64
   LIST@0..64
     JS_EXPRESSION_STATEMENT@0..11
       ARRAY_EXPR@0..10
@@ -12,34 +8,10 @@ MODULE@0..64
             None IDENT@1..4 "foo" None
           None COMMA@4..5 "," Whitespace(1)
           NAME_REF@6..9
-<<<<<<< HEAD
-<<<<<<< HEAD
-            IDENT@6..9 "bar"
-        R_BRACK@9..10 "]"
-      SEMICOLON@10..11 ";"
-    WHITESPACE@11..12 "\n"
-    JS_EXPRESSION_STATEMENT@12..18
-      ARRAY_EXPR@12..17
-        L_BRACK@12..13 "["
-        LIST@13..16
-          NAME_REF@13..16
-            IDENT@13..16 "foo"
-        R_BRACK@16..17 "]"
-      SEMICOLON@17..18 ";"
-    WHITESPACE@18..19 "\n"
-    JS_EXPRESSION_STATEMENT@19..26
-      ARRAY_EXPR@19..25
-        L_BRACK@19..20 "["
-=======
-             IDENT@6..9 "bar" 
-         R_BRACK@9..10 "]" 
-       SEMICOLON@10..11 ";" 
-=======
             None IDENT@6..9 "bar" None
         None R_BRACK@9..10 "]" None
       None SEMICOLON@10..11 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@11..18
+    JS_EXPRESSION_STATEMENT@11..18
       ARRAY_EXPR@11..17
         Whitespace(1) L_BRACK@12..13 "[" None
         LIST@13..16
@@ -47,50 +19,16 @@ MODULE@0..64
             None IDENT@13..16 "foo" None
         None R_BRACK@16..17 "]" None
       None SEMICOLON@17..18 ";" None
-    EXPR_STMT@18..26
+    JS_EXPRESSION_STATEMENT@18..26
       ARRAY_EXPR@18..25
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" L_BRACK@18..20 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) L_BRACK@18..20 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_BRACK@19..20 "[" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@20..24
           None COMMA@20..21 "," None
           NAME_REF@21..24
-<<<<<<< HEAD
-<<<<<<< HEAD
-            IDENT@21..24 "foo"
-        R_BRACK@24..25 "]"
-      SEMICOLON@25..26 ";"
-    WHITESPACE@26..27 "\n"
-    JS_EXPRESSION_STATEMENT@27..34
-      ARRAY_EXPR@27..33
-        L_BRACK@27..28 "["
-        LIST@28..32
-          NAME_REF@28..31
-            IDENT@28..31 "foo"
-          COMMA@31..32 ","
-        R_BRACK@32..33 "]"
-      SEMICOLON@33..34 ";"
-    WHITESPACE@34..35 "\n"
-    JS_EXPRESSION_STATEMENT@35..50
-      ARRAY_EXPR@35..49
-        L_BRACK@35..36 "["
-=======
-             IDENT@21..24 "foo" 
-         R_BRACK@24..25 "]" 
-       SEMICOLON@25..26 ";" 
-=======
             None IDENT@21..24 "foo" None
         None R_BRACK@24..25 "]" None
       None SEMICOLON@25..26 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@26..34
+    JS_EXPRESSION_STATEMENT@26..34
       ARRAY_EXPR@26..33
         Whitespace(1) L_BRACK@27..28 "[" None
         LIST@28..32
@@ -99,18 +37,9 @@ MODULE@0..64
           None COMMA@31..32 "," None
         None R_BRACK@32..33 "]" None
       None SEMICOLON@33..34 ";" None
-    EXPR_STMT@34..50
+    JS_EXPRESSION_STATEMENT@34..50
       ARRAY_EXPR@34..49
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" L_BRACK@34..36 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) L_BRACK@34..36 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_BRACK@35..36 "[" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@36..48
           None COMMA@36..37 "," None
           None COMMA@37..38 "," None
@@ -118,32 +47,6 @@ MODULE@0..64
           None COMMA@39..40 "," None
           None COMMA@40..41 "," None
           NAME_REF@41..44
-<<<<<<< HEAD
-<<<<<<< HEAD
-            IDENT@41..44 "foo"
-          COMMA@44..45 ","
-          COMMA@45..46 ","
-          COMMA@46..47 ","
-          COMMA@47..48 ","
-        R_BRACK@48..49 "]"
-      SEMICOLON@49..50 ";"
-    WHITESPACE@50..51 "\n"
-    JS_EXPRESSION_STATEMENT@51..64
-      ARRAY_EXPR@51..63
-        L_BRACK@51..52 "["
-=======
-             IDENT@41..44 "foo" 
-           COMMA@44..45 "," 
-           COMMA@45..46 "," 
-           COMMA@46..47 "," 
-           COMMA@47..48 "," 
-         R_BRACK@48..49 "]" 
-       SEMICOLON@49..50 ";" 
-    EXPR_STMT@50..64
-      ARRAY_EXPR@50..63
-        "\n" L_BRACK@50..52 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None IDENT@41..44 "foo" None
           None COMMA@44..45 "," None
           None COMMA@45..46 "," None
@@ -151,14 +54,9 @@ MODULE@0..64
           None COMMA@47..48 "," None
         None R_BRACK@48..49 "]" None
       None SEMICOLON@49..50 ";" None
-    EXPR_STMT@50..64
+    JS_EXPRESSION_STATEMENT@50..64
       ARRAY_EXPR@50..63
-<<<<<<< HEAD
-        Whitespace(1) L_BRACK@50..52 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_BRACK@51..52 "[" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         LIST@52..62
           SPREAD_ELEMENT@52..56
             None DOT2@52..55 "..." None

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -52,8 +52,8 @@ MODULE@0..43
           L_CURLY@41..42 "{"
 =======
         NAME@0..4
-          None IDENT@0..4 "foo" Whitespace(1)
-        None FAT_ARROW@4..7 "=>" Whitespace(1)
+          None IDENT@0..3 "foo" Whitespace(1)
+        None FAT_ARROW@4..6 "=>" Whitespace(1)
         BLOCK_STMT@7..9
           None L_CURLY@7..8 "{" None
           LIST@8..8
@@ -61,8 +61,8 @@ MODULE@0..43
     EXPR_STMT@9..21
       ARROW_EXPR@9..21
         NAME@9..16
-          Whitespace(1) IDENT@9..16 "yield" Whitespace(1)
-        None FAT_ARROW@16..19 "=>" Whitespace(1)
+          Whitespace(1) IDENT@10..15 "yield" Whitespace(1)
+        None FAT_ARROW@16..18 "=>" Whitespace(1)
         BLOCK_STMT@19..21
           None L_CURLY@19..20 "{" None
           LIST@20..20
@@ -70,8 +70,8 @@ MODULE@0..43
     EXPR_STMT@21..33
       ARROW_EXPR@21..33
         NAME@21..28
-          Whitespace(1) IDENT@21..28 "await" Whitespace(1)
-        None FAT_ARROW@28..31 "=>" Whitespace(1)
+          Whitespace(1) IDENT@22..27 "await" Whitespace(1)
+        None FAT_ARROW@28..30 "=>" Whitespace(1)
         BLOCK_STMT@31..33
           None L_CURLY@31..32 "{" None
           LIST@32..32
@@ -79,14 +79,18 @@ MODULE@0..43
     EXPR_STMT@33..43
       ARROW_EXPR@33..43
         NAME@33..38
-          Whitespace(1) IDENT@33..38 "foo" Whitespace(1)
+          Whitespace(1) IDENT@34..37 "foo" Whitespace(1)
         None FAT_ARROW@38..40 "=>" None
         BLOCK_STMT@40..43
+<<<<<<< HEAD
 <<<<<<< HEAD
           "\n" L_CURLY@40..42 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(1) L_CURLY@40..42 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) L_CURLY@41..42 "{" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@42..42
           None R_CURLY@42..43 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -1,7 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..44
+=======
+MODULE@0..43
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..43
     JS_EXPRESSION_STATEMENT@0..9
       ARROW_EXPR@0..9
+<<<<<<< HEAD
         NAME@0..3
           IDENT@0..3 "foo"
         WHITESPACE@3..4 " "
@@ -45,6 +50,39 @@ JS_MODULE@0..44
         WHITESPACE@40..41 "\n"
         JS_BLOCK_STATEMENT@41..43
           L_CURLY@41..42 "{"
+=======
+        NAME@0..4
+           IDENT@0..4 "foo" " "
+         FAT_ARROW@4..7 "=>" " "
+        BLOCK_STMT@7..9
+           L_CURLY@7..8 "{" 
+          LIST@8..8
+           R_CURLY@8..9 "}" 
+    EXPR_STMT@9..21
+      ARROW_EXPR@9..21
+        NAME@9..16
+          "\n" IDENT@9..16 "yield" " "
+         FAT_ARROW@16..19 "=>" " "
+        BLOCK_STMT@19..21
+           L_CURLY@19..20 "{" 
+          LIST@20..20
+           R_CURLY@20..21 "}" 
+    EXPR_STMT@21..33
+      ARROW_EXPR@21..33
+        NAME@21..28
+          "\n" IDENT@21..28 "await" " "
+         FAT_ARROW@28..31 "=>" " "
+        BLOCK_STMT@31..33
+           L_CURLY@31..32 "{" 
+          LIST@32..32
+           R_CURLY@32..33 "}" 
+    EXPR_STMT@33..43
+      ARROW_EXPR@33..43
+        NAME@33..38
+          "\n" IDENT@33..38 "foo" " "
+         FAT_ARROW@38..40 "=>" 
+        BLOCK_STMT@40..43
+          "\n" L_CURLY@40..42 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@42..42
-          R_CURLY@42..43 "}"
-  WHITESPACE@43..44 "\n"
+           R_CURLY@42..43 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -1,96 +1,38 @@
-<<<<<<< HEAD
-JS_MODULE@0..44
-=======
-MODULE@0..43
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..43
   LIST@0..43
     JS_EXPRESSION_STATEMENT@0..9
       ARROW_EXPR@0..9
-<<<<<<< HEAD
-        NAME@0..3
-          IDENT@0..3 "foo"
-        WHITESPACE@3..4 " "
-        FAT_ARROW@4..6 "=>"
-        WHITESPACE@6..7 " "
-        JS_BLOCK_STATEMENT@7..9
-          L_CURLY@7..8 "{"
-          LIST@8..8
-          R_CURLY@8..9 "}"
-    WHITESPACE@9..10 "\n"
-    JS_EXPRESSION_STATEMENT@10..21
-      ARROW_EXPR@10..21
-        NAME@10..15
-          IDENT@10..15 "yield"
-        WHITESPACE@15..16 " "
-        FAT_ARROW@16..18 "=>"
-        WHITESPACE@18..19 " "
-        JS_BLOCK_STATEMENT@19..21
-          L_CURLY@19..20 "{"
-          LIST@20..20
-          R_CURLY@20..21 "}"
-    WHITESPACE@21..22 "\n"
-    JS_EXPRESSION_STATEMENT@22..33
-      ARROW_EXPR@22..33
-        NAME@22..27
-          IDENT@22..27 "await"
-        WHITESPACE@27..28 " "
-        FAT_ARROW@28..30 "=>"
-        WHITESPACE@30..31 " "
-        JS_BLOCK_STATEMENT@31..33
-          L_CURLY@31..32 "{"
-          LIST@32..32
-          R_CURLY@32..33 "}"
-    WHITESPACE@33..34 "\n"
-    JS_EXPRESSION_STATEMENT@34..43
-      ARROW_EXPR@34..43
-        NAME@34..37
-          IDENT@34..37 "foo"
-        WHITESPACE@37..38 " "
-        FAT_ARROW@38..40 "=>"
-        WHITESPACE@40..41 "\n"
-        JS_BLOCK_STATEMENT@41..43
-          L_CURLY@41..42 "{"
-=======
         NAME@0..4
           None IDENT@0..3 "foo" Whitespace(1)
         None FAT_ARROW@4..6 "=>" Whitespace(1)
-        BLOCK_STMT@7..9
+        JS_BLOCK_STATEMENT@7..9
           None L_CURLY@7..8 "{" None
           LIST@8..8
           None R_CURLY@8..9 "}" None
-    EXPR_STMT@9..21
+    JS_EXPRESSION_STATEMENT@9..21
       ARROW_EXPR@9..21
         NAME@9..16
           Whitespace(1) IDENT@10..15 "yield" Whitespace(1)
         None FAT_ARROW@16..18 "=>" Whitespace(1)
-        BLOCK_STMT@19..21
+        JS_BLOCK_STATEMENT@19..21
           None L_CURLY@19..20 "{" None
           LIST@20..20
           None R_CURLY@20..21 "}" None
-    EXPR_STMT@21..33
+    JS_EXPRESSION_STATEMENT@21..33
       ARROW_EXPR@21..33
         NAME@21..28
           Whitespace(1) IDENT@22..27 "await" Whitespace(1)
         None FAT_ARROW@28..30 "=>" Whitespace(1)
-        BLOCK_STMT@31..33
+        JS_BLOCK_STATEMENT@31..33
           None L_CURLY@31..32 "{" None
           LIST@32..32
           None R_CURLY@32..33 "}" None
-    EXPR_STMT@33..43
+    JS_EXPRESSION_STATEMENT@33..43
       ARROW_EXPR@33..43
         NAME@33..38
           Whitespace(1) IDENT@34..37 "foo" Whitespace(1)
         None FAT_ARROW@38..40 "=>" None
-        BLOCK_STMT@40..43
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" L_CURLY@40..42 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) L_CURLY@40..42 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+        JS_BLOCK_STATEMENT@40..43
           Whitespace(1) L_CURLY@41..42 "{" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@42..42
           None R_CURLY@42..43 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -52,37 +52,41 @@ MODULE@0..43
           L_CURLY@41..42 "{"
 =======
         NAME@0..4
-           IDENT@0..4 "foo" " "
-         FAT_ARROW@4..7 "=>" " "
+          None IDENT@0..4 "foo" Whitespace(1)
+        None FAT_ARROW@4..7 "=>" Whitespace(1)
         BLOCK_STMT@7..9
-           L_CURLY@7..8 "{" 
+          None L_CURLY@7..8 "{" None
           LIST@8..8
-           R_CURLY@8..9 "}" 
+          None R_CURLY@8..9 "}" None
     EXPR_STMT@9..21
       ARROW_EXPR@9..21
         NAME@9..16
-          "\n" IDENT@9..16 "yield" " "
-         FAT_ARROW@16..19 "=>" " "
+          Whitespace(1) IDENT@9..16 "yield" Whitespace(1)
+        None FAT_ARROW@16..19 "=>" Whitespace(1)
         BLOCK_STMT@19..21
-           L_CURLY@19..20 "{" 
+          None L_CURLY@19..20 "{" None
           LIST@20..20
-           R_CURLY@20..21 "}" 
+          None R_CURLY@20..21 "}" None
     EXPR_STMT@21..33
       ARROW_EXPR@21..33
         NAME@21..28
-          "\n" IDENT@21..28 "await" " "
-         FAT_ARROW@28..31 "=>" " "
+          Whitespace(1) IDENT@21..28 "await" Whitespace(1)
+        None FAT_ARROW@28..31 "=>" Whitespace(1)
         BLOCK_STMT@31..33
-           L_CURLY@31..32 "{" 
+          None L_CURLY@31..32 "{" None
           LIST@32..32
-           R_CURLY@32..33 "}" 
+          None R_CURLY@32..33 "}" None
     EXPR_STMT@33..43
       ARROW_EXPR@33..43
         NAME@33..38
-          "\n" IDENT@33..38 "foo" " "
-         FAT_ARROW@38..40 "=>" 
+          Whitespace(1) IDENT@33..38 "foo" Whitespace(1)
+        None FAT_ARROW@38..40 "=>" None
         BLOCK_STMT@40..43
+<<<<<<< HEAD
           "\n" L_CURLY@40..42 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) L_CURLY@40..42 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@42..42
-           R_CURLY@42..43 "}" 
+          None R_CURLY@42..43 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -1,25 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..101
+=======
+MODULE@0..100
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..100
     JS_EXPRESSION_STATEMENT@0..21
       ASSIGN_EXPR@0..20
-        NAME_REF@0..3
-          IDENT@0..3 "foo"
-        WHITESPACE@3..4 " "
-        PLUSEQ@4..6 "+="
-        WHITESPACE@6..7 " "
+        NAME_REF@0..4
+           IDENT@0..4 "foo" " "
+         PLUSEQ@4..7 "+=" " "
         ASSIGN_EXPR@7..20
-          NAME_REF@7..10
-            IDENT@7..10 "bar"
-          WHITESPACE@10..11 " "
-          EQ@11..12 "="
-          WHITESPACE@12..13 " "
+          NAME_REF@7..11
+             IDENT@7..11 "bar" " "
+           EQ@11..13 "=" " "
           ASSIGN_EXPR@13..20
-            NAME_REF@13..14
-              IDENT@13..14 "b"
-            WHITESPACE@14..15 " "
-            QUESTION2EQ@15..18 "??="
-            WHITESPACE@18..19 " "
+            NAME_REF@13..15
+               IDENT@13..15 "b" " "
+             QUESTION2EQ@15..19 "??=" " "
             LITERAL@19..20
+<<<<<<< HEAD
               NUMBER@19..20 "3"
       SEMICOLON@20..21 ";"
     WHITESPACE@21..22 "\n"
@@ -38,47 +37,64 @@ JS_MODULE@0..101
       ASSIGN_EXPR@34..50
         ARRAY_PATTERN@34..44
           L_BRACK@34..35 "["
+=======
+               NUMBER@19..20 "3" 
+       SEMICOLON@20..21 ";" 
+    EXPR_STMT@21..33
+      ASSIGN_EXPR@21..32
+        NAME_REF@21..26
+          "\n" IDENT@21..26 "foo" " "
+         MINUSEQ@26..29 "-=" " "
+        NAME_REF@29..32
+           IDENT@29..32 "bar" 
+       SEMICOLON@32..33 ";" 
+    EXPR_STMT@33..51
+      ASSIGN_EXPR@33..50
+        ARRAY_PATTERN@33..45
+          "\n" L_BRACK@33..35 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@35..43
             SINGLE_PATTERN@35..38
               NAME@35..38
-                IDENT@35..38 "foo"
-            COMMA@38..39 ","
-            WHITESPACE@39..40 " "
+                 IDENT@35..38 "foo" 
+             COMMA@38..40 "," " "
             SINGLE_PATTERN@40..43
               NAME@40..43
-                IDENT@40..43 "bar"
-          R_BRACK@43..44 "]"
-        WHITESPACE@44..45 " "
-        EQ@45..46 "="
-        WHITESPACE@46..47 " "
+                 IDENT@40..43 "bar" 
+           R_BRACK@43..45 "]" " "
+         EQ@45..47 "=" " "
         NAME_REF@47..50
+<<<<<<< HEAD
           IDENT@47..50 "baz"
       SEMICOLON@50..51 ";"
     WHITESPACE@51..52 "\n"
     JS_EXPRESSION_STATEMENT@52..72
       GROUPING_EXPR@52..71
         L_PAREN@52..53 "("
+=======
+           IDENT@47..50 "baz" 
+       SEMICOLON@50..51 ";" 
+    EXPR_STMT@51..72
+      GROUPING_EXPR@51..71
+        "\n" L_PAREN@51..53 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         ASSIGN_EXPR@53..70
-          OBJECT_PATTERN@53..65
-            L_CURLY@53..54 "{"
-            WHITESPACE@54..55 " "
-            LIST@55..63
+          OBJECT_PATTERN@53..66
+             L_CURLY@53..55 "{" " "
+            LIST@55..64
               SINGLE_PATTERN@55..58
                 NAME@55..58
-                  IDENT@55..58 "bar"
-              COMMA@58..59 ","
-              WHITESPACE@59..60 " "
-              SINGLE_PATTERN@60..63
-                NAME@60..63
-                  IDENT@60..63 "baz"
-            WHITESPACE@63..64 " "
-            R_CURLY@64..65 "}"
-          WHITESPACE@65..66 " "
-          EQ@66..67 "="
-          WHITESPACE@67..68 " "
+                   IDENT@55..58 "bar" 
+               COMMA@58..60 "," " "
+              SINGLE_PATTERN@60..64
+                NAME@60..64
+                   IDENT@60..64 "baz" " "
+             R_CURLY@64..66 "}" " "
+           EQ@66..68 "=" " "
           OBJECT_EXPR@68..70
-            L_CURLY@68..69 "{"
+             L_CURLY@68..69 "{" 
             LIST@69..69
+<<<<<<< HEAD
             R_CURLY@69..70 "}"
         R_PAREN@70..71 ")"
       SEMICOLON@71..72 ";"
@@ -86,37 +102,38 @@ JS_MODULE@0..101
     JS_EXPRESSION_STATEMENT@73..100
       GROUPING_EXPR@73..99
         L_PAREN@73..74 "("
+=======
+             R_CURLY@69..70 "}" 
+         R_PAREN@70..71 ")" 
+       SEMICOLON@71..72 ";" 
+    EXPR_STMT@72..100
+      GROUPING_EXPR@72..99
+        "\n" L_PAREN@72..74 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         ASSIGN_EXPR@74..98
-          OBJECT_PATTERN@74..93
-            L_CURLY@74..75 "{"
-            WHITESPACE@75..76 " "
-            LIST@76..91
+          OBJECT_PATTERN@74..94
+             L_CURLY@74..76 "{" " "
+            LIST@76..92
               KEY_VALUE_PATTERN@76..86
                 NAME@76..79
-                  IDENT@76..79 "bar"
-                COLON@79..80 ":"
-                WHITESPACE@80..81 " "
+                   IDENT@76..79 "bar" 
+                 COLON@79..81 ":" " "
                 ARRAY_PATTERN@81..86
-                  L_BRACK@81..82 "["
+                   L_BRACK@81..82 "[" 
                   LIST@82..85
                     SINGLE_PATTERN@82..85
                       NAME@82..85
-                        IDENT@82..85 "baz"
-                  R_BRACK@85..86 "]"
-              COMMA@86..87 ","
-              WHITESPACE@87..88 " "
-              SINGLE_PATTERN@88..91
-                NAME@88..91
-                  IDENT@88..91 "foo"
-            WHITESPACE@91..92 " "
-            R_CURLY@92..93 "}"
-          WHITESPACE@93..94 " "
-          EQ@94..95 "="
-          WHITESPACE@95..96 " "
+                         IDENT@82..85 "baz" 
+                   R_BRACK@85..86 "]" 
+               COMMA@86..88 "," " "
+              SINGLE_PATTERN@88..92
+                NAME@88..92
+                   IDENT@88..92 "foo" " "
+             R_CURLY@92..94 "}" " "
+           EQ@94..96 "=" " "
           OBJECT_EXPR@96..98
-            L_CURLY@96..97 "{"
+             L_CURLY@96..97 "{" 
             LIST@97..97
-            R_CURLY@97..98 "}"
-        R_PAREN@98..99 ")"
-      SEMICOLON@99..100 ";"
-  WHITESPACE@100..101 "\n"
+             R_CURLY@97..98 "}" 
+         R_PAREN@98..99 ")" 
+       SEMICOLON@99..100 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..101
-=======
-MODULE@0..100
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..100
   LIST@0..100
     JS_EXPRESSION_STATEMENT@0..21
       ASSIGN_EXPR@0..20
@@ -18,34 +14,9 @@ MODULE@0..100
               None IDENT@13..14 "b" Whitespace(1)
             None QUESTION2EQ@15..18 "??=" Whitespace(1)
             LITERAL@19..20
-<<<<<<< HEAD
-<<<<<<< HEAD
-              NUMBER@19..20 "3"
-      SEMICOLON@20..21 ";"
-    WHITESPACE@21..22 "\n"
-    JS_EXPRESSION_STATEMENT@22..33
-      ASSIGN_EXPR@22..32
-        NAME_REF@22..25
-          IDENT@22..25 "foo"
-        WHITESPACE@25..26 " "
-        MINUSEQ@26..28 "-="
-        WHITESPACE@28..29 " "
-        NAME_REF@29..32
-          IDENT@29..32 "bar"
-      SEMICOLON@32..33 ";"
-    WHITESPACE@33..34 "\n"
-    JS_EXPRESSION_STATEMENT@34..51
-      ASSIGN_EXPR@34..50
-        ARRAY_PATTERN@34..44
-          L_BRACK@34..35 "["
-=======
-               NUMBER@19..20 "3" 
-       SEMICOLON@20..21 ";" 
-=======
               None NUMBER@19..20 "3" None
       None SEMICOLON@20..21 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@21..33
+    JS_EXPRESSION_STATEMENT@21..33
       ASSIGN_EXPR@21..32
         NAME_REF@21..26
           Whitespace(1) IDENT@22..25 "foo" Whitespace(1)
@@ -53,19 +24,10 @@ MODULE@0..100
         NAME_REF@29..32
           None IDENT@29..32 "bar" None
       None SEMICOLON@32..33 ";" None
-    EXPR_STMT@33..51
+    JS_EXPRESSION_STATEMENT@33..51
       ASSIGN_EXPR@33..50
         ARRAY_PATTERN@33..45
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" L_BRACK@33..35 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) L_BRACK@33..35 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) L_BRACK@34..35 "[" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@35..43
             SINGLE_PATTERN@35..38
               NAME@35..38
@@ -77,32 +39,11 @@ MODULE@0..100
           None R_BRACK@43..44 "]" Whitespace(1)
         None EQ@45..46 "=" Whitespace(1)
         NAME_REF@47..50
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@47..50 "baz"
-      SEMICOLON@50..51 ";"
-    WHITESPACE@51..52 "\n"
-    JS_EXPRESSION_STATEMENT@52..72
-      GROUPING_EXPR@52..71
-        L_PAREN@52..53 "("
-=======
-           IDENT@47..50 "baz" 
-       SEMICOLON@50..51 ";" 
-    EXPR_STMT@51..72
-      GROUPING_EXPR@51..71
-        "\n" L_PAREN@51..53 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None IDENT@47..50 "baz" None
       None SEMICOLON@50..51 ";" None
-    EXPR_STMT@51..72
+    JS_EXPRESSION_STATEMENT@51..72
       GROUPING_EXPR@51..71
-<<<<<<< HEAD
-        Whitespace(1) L_PAREN@51..53 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_PAREN@52..53 "(" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ASSIGN_EXPR@53..70
           OBJECT_PATTERN@53..66
             None L_CURLY@53..54 "{" Whitespace(1)
@@ -119,35 +60,12 @@ MODULE@0..100
           OBJECT_EXPR@68..70
             None L_CURLY@68..69 "{" None
             LIST@69..69
-<<<<<<< HEAD
-<<<<<<< HEAD
-            R_CURLY@69..70 "}"
-        R_PAREN@70..71 ")"
-      SEMICOLON@71..72 ";"
-    WHITESPACE@72..73 "\n"
-    JS_EXPRESSION_STATEMENT@73..100
-      GROUPING_EXPR@73..99
-        L_PAREN@73..74 "("
-=======
-             R_CURLY@69..70 "}" 
-         R_PAREN@70..71 ")" 
-       SEMICOLON@71..72 ";" 
-    EXPR_STMT@72..100
-      GROUPING_EXPR@72..99
-        "\n" L_PAREN@72..74 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None R_CURLY@69..70 "}" None
         None R_PAREN@70..71 ")" None
       None SEMICOLON@71..72 ";" None
-    EXPR_STMT@72..100
+    JS_EXPRESSION_STATEMENT@72..100
       GROUPING_EXPR@72..99
-<<<<<<< HEAD
-        Whitespace(1) L_PAREN@72..74 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_PAREN@73..74 "(" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ASSIGN_EXPR@74..98
           OBJECT_PATTERN@74..94
             None L_CURLY@74..75 "{" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -7,17 +7,18 @@ MODULE@0..100
     JS_EXPRESSION_STATEMENT@0..21
       ASSIGN_EXPR@0..20
         NAME_REF@0..4
-           IDENT@0..4 "foo" " "
-         PLUSEQ@4..7 "+=" " "
+          None IDENT@0..4 "foo" Whitespace(1)
+        None PLUSEQ@4..7 "+=" Whitespace(1)
         ASSIGN_EXPR@7..20
           NAME_REF@7..11
-             IDENT@7..11 "bar" " "
-           EQ@11..13 "=" " "
+            None IDENT@7..11 "bar" Whitespace(1)
+          None EQ@11..13 "=" Whitespace(1)
           ASSIGN_EXPR@13..20
             NAME_REF@13..15
-               IDENT@13..15 "b" " "
-             QUESTION2EQ@15..19 "??=" " "
+              None IDENT@13..15 "b" Whitespace(1)
+            None QUESTION2EQ@15..19 "??=" Whitespace(1)
             LITERAL@19..20
+<<<<<<< HEAD
 <<<<<<< HEAD
               NUMBER@19..20 "3"
       SEMICOLON@20..21 ";"
@@ -40,30 +41,39 @@ MODULE@0..100
 =======
                NUMBER@19..20 "3" 
        SEMICOLON@20..21 ";" 
+=======
+              None NUMBER@19..20 "3" None
+      None SEMICOLON@20..21 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@21..33
       ASSIGN_EXPR@21..32
         NAME_REF@21..26
-          "\n" IDENT@21..26 "foo" " "
-         MINUSEQ@26..29 "-=" " "
+          Whitespace(1) IDENT@21..26 "foo" Whitespace(1)
+        None MINUSEQ@26..29 "-=" Whitespace(1)
         NAME_REF@29..32
-           IDENT@29..32 "bar" 
-       SEMICOLON@32..33 ";" 
+          None IDENT@29..32 "bar" None
+      None SEMICOLON@32..33 ";" None
     EXPR_STMT@33..51
       ASSIGN_EXPR@33..50
         ARRAY_PATTERN@33..45
+<<<<<<< HEAD
           "\n" L_BRACK@33..35 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) L_BRACK@33..35 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@35..43
             SINGLE_PATTERN@35..38
               NAME@35..38
-                 IDENT@35..38 "foo" 
-             COMMA@38..40 "," " "
+                None IDENT@35..38 "foo" None
+            None COMMA@38..40 "," Whitespace(1)
             SINGLE_PATTERN@40..43
               NAME@40..43
-                 IDENT@40..43 "bar" 
-           R_BRACK@43..45 "]" " "
-         EQ@45..47 "=" " "
+                None IDENT@40..43 "bar" None
+          None R_BRACK@43..45 "]" Whitespace(1)
+        None EQ@45..47 "=" Whitespace(1)
         NAME_REF@47..50
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@47..50 "baz"
       SEMICOLON@50..51 ";"
@@ -78,22 +88,30 @@ MODULE@0..100
       GROUPING_EXPR@51..71
         "\n" L_PAREN@51..53 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@47..50 "baz" None
+      None SEMICOLON@50..51 ";" None
+    EXPR_STMT@51..72
+      GROUPING_EXPR@51..71
+        Whitespace(1) L_PAREN@51..53 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ASSIGN_EXPR@53..70
           OBJECT_PATTERN@53..66
-             L_CURLY@53..55 "{" " "
+            None L_CURLY@53..55 "{" Whitespace(1)
             LIST@55..64
               SINGLE_PATTERN@55..58
                 NAME@55..58
-                   IDENT@55..58 "bar" 
-               COMMA@58..60 "," " "
+                  None IDENT@55..58 "bar" None
+              None COMMA@58..60 "," Whitespace(1)
               SINGLE_PATTERN@60..64
                 NAME@60..64
-                   IDENT@60..64 "baz" " "
-             R_CURLY@64..66 "}" " "
-           EQ@66..68 "=" " "
+                  None IDENT@60..64 "baz" Whitespace(1)
+            None R_CURLY@64..66 "}" Whitespace(1)
+          None EQ@66..68 "=" Whitespace(1)
           OBJECT_EXPR@68..70
-             L_CURLY@68..69 "{" 
+            None L_CURLY@68..69 "{" None
             LIST@69..69
+<<<<<<< HEAD
 <<<<<<< HEAD
             R_CURLY@69..70 "}"
         R_PAREN@70..71 ")"
@@ -110,30 +128,38 @@ MODULE@0..100
       GROUPING_EXPR@72..99
         "\n" L_PAREN@72..74 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None R_CURLY@69..70 "}" None
+        None R_PAREN@70..71 ")" None
+      None SEMICOLON@71..72 ";" None
+    EXPR_STMT@72..100
+      GROUPING_EXPR@72..99
+        Whitespace(1) L_PAREN@72..74 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         ASSIGN_EXPR@74..98
           OBJECT_PATTERN@74..94
-             L_CURLY@74..76 "{" " "
+            None L_CURLY@74..76 "{" Whitespace(1)
             LIST@76..92
               KEY_VALUE_PATTERN@76..86
                 NAME@76..79
-                   IDENT@76..79 "bar" 
-                 COLON@79..81 ":" " "
+                  None IDENT@76..79 "bar" None
+                None COLON@79..81 ":" Whitespace(1)
                 ARRAY_PATTERN@81..86
-                   L_BRACK@81..82 "[" 
+                  None L_BRACK@81..82 "[" None
                   LIST@82..85
                     SINGLE_PATTERN@82..85
                       NAME@82..85
-                         IDENT@82..85 "baz" 
-                   R_BRACK@85..86 "]" 
-               COMMA@86..88 "," " "
+                        None IDENT@82..85 "baz" None
+                  None R_BRACK@85..86 "]" None
+              None COMMA@86..88 "," Whitespace(1)
               SINGLE_PATTERN@88..92
                 NAME@88..92
-                   IDENT@88..92 "foo" " "
-             R_CURLY@92..94 "}" " "
-           EQ@94..96 "=" " "
+                  None IDENT@88..92 "foo" Whitespace(1)
+            None R_CURLY@92..94 "}" Whitespace(1)
+          None EQ@94..96 "=" Whitespace(1)
           OBJECT_EXPR@96..98
-             L_CURLY@96..97 "{" 
+            None L_CURLY@96..97 "{" None
             LIST@97..97
-             R_CURLY@97..98 "}" 
-         R_PAREN@98..99 ")" 
-       SEMICOLON@99..100 ";" 
+            None R_CURLY@97..98 "}" None
+        None R_PAREN@98..99 ")" None
+      None SEMICOLON@99..100 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -7,16 +7,16 @@ MODULE@0..100
     JS_EXPRESSION_STATEMENT@0..21
       ASSIGN_EXPR@0..20
         NAME_REF@0..4
-          None IDENT@0..4 "foo" Whitespace(1)
-        None PLUSEQ@4..7 "+=" Whitespace(1)
+          None IDENT@0..3 "foo" Whitespace(1)
+        None PLUSEQ@4..6 "+=" Whitespace(1)
         ASSIGN_EXPR@7..20
           NAME_REF@7..11
-            None IDENT@7..11 "bar" Whitespace(1)
-          None EQ@11..13 "=" Whitespace(1)
+            None IDENT@7..10 "bar" Whitespace(1)
+          None EQ@11..12 "=" Whitespace(1)
           ASSIGN_EXPR@13..20
             NAME_REF@13..15
-              None IDENT@13..15 "b" Whitespace(1)
-            None QUESTION2EQ@15..19 "??=" Whitespace(1)
+              None IDENT@13..14 "b" Whitespace(1)
+            None QUESTION2EQ@15..18 "??=" Whitespace(1)
             LITERAL@19..20
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -48,8 +48,8 @@ MODULE@0..100
     EXPR_STMT@21..33
       ASSIGN_EXPR@21..32
         NAME_REF@21..26
-          Whitespace(1) IDENT@21..26 "foo" Whitespace(1)
-        None MINUSEQ@26..29 "-=" Whitespace(1)
+          Whitespace(1) IDENT@22..25 "foo" Whitespace(1)
+        None MINUSEQ@26..28 "-=" Whitespace(1)
         NAME_REF@29..32
           None IDENT@29..32 "bar" None
       None SEMICOLON@32..33 ";" None
@@ -57,21 +57,25 @@ MODULE@0..100
       ASSIGN_EXPR@33..50
         ARRAY_PATTERN@33..45
 <<<<<<< HEAD
+<<<<<<< HEAD
           "\n" L_BRACK@33..35 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(1) L_BRACK@33..35 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) L_BRACK@34..35 "[" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@35..43
             SINGLE_PATTERN@35..38
               NAME@35..38
                 None IDENT@35..38 "foo" None
-            None COMMA@38..40 "," Whitespace(1)
+            None COMMA@38..39 "," Whitespace(1)
             SINGLE_PATTERN@40..43
               NAME@40..43
                 None IDENT@40..43 "bar" None
-          None R_BRACK@43..45 "]" Whitespace(1)
-        None EQ@45..47 "=" Whitespace(1)
+          None R_BRACK@43..44 "]" Whitespace(1)
+        None EQ@45..46 "=" Whitespace(1)
         NAME_REF@47..50
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -93,21 +97,25 @@ MODULE@0..100
       None SEMICOLON@50..51 ";" None
     EXPR_STMT@51..72
       GROUPING_EXPR@51..71
+<<<<<<< HEAD
         Whitespace(1) L_PAREN@51..53 "(" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_PAREN@52..53 "(" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ASSIGN_EXPR@53..70
           OBJECT_PATTERN@53..66
-            None L_CURLY@53..55 "{" Whitespace(1)
+            None L_CURLY@53..54 "{" Whitespace(1)
             LIST@55..64
               SINGLE_PATTERN@55..58
                 NAME@55..58
                   None IDENT@55..58 "bar" None
-              None COMMA@58..60 "," Whitespace(1)
+              None COMMA@58..59 "," Whitespace(1)
               SINGLE_PATTERN@60..64
                 NAME@60..64
-                  None IDENT@60..64 "baz" Whitespace(1)
-            None R_CURLY@64..66 "}" Whitespace(1)
-          None EQ@66..68 "=" Whitespace(1)
+                  None IDENT@60..63 "baz" Whitespace(1)
+            None R_CURLY@64..65 "}" Whitespace(1)
+          None EQ@66..67 "=" Whitespace(1)
           OBJECT_EXPR@68..70
             None L_CURLY@68..69 "{" None
             LIST@69..69
@@ -134,16 +142,20 @@ MODULE@0..100
       None SEMICOLON@71..72 ";" None
     EXPR_STMT@72..100
       GROUPING_EXPR@72..99
+<<<<<<< HEAD
         Whitespace(1) L_PAREN@72..74 "(" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_PAREN@73..74 "(" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         ASSIGN_EXPR@74..98
           OBJECT_PATTERN@74..94
-            None L_CURLY@74..76 "{" Whitespace(1)
+            None L_CURLY@74..75 "{" Whitespace(1)
             LIST@76..92
               KEY_VALUE_PATTERN@76..86
                 NAME@76..79
                   None IDENT@76..79 "bar" None
-                None COLON@79..81 ":" Whitespace(1)
+                None COLON@79..80 ":" Whitespace(1)
                 ARRAY_PATTERN@81..86
                   None L_BRACK@81..82 "[" None
                   LIST@82..85
@@ -151,12 +163,12 @@ MODULE@0..100
                       NAME@82..85
                         None IDENT@82..85 "baz" None
                   None R_BRACK@85..86 "]" None
-              None COMMA@86..88 "," Whitespace(1)
+              None COMMA@86..87 "," Whitespace(1)
               SINGLE_PATTERN@88..92
                 NAME@88..92
-                  None IDENT@88..92 "foo" Whitespace(1)
-            None R_CURLY@92..94 "}" Whitespace(1)
-          None EQ@94..96 "=" Whitespace(1)
+                  None IDENT@88..91 "foo" Whitespace(1)
+            None R_CURLY@92..93 "}" Whitespace(1)
+          None EQ@94..95 "=" Whitespace(1)
           OBJECT_EXPR@96..98
             None L_CURLY@96..97 "{" None
             LIST@97..97

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -5,14 +5,15 @@ MODULE@0..81
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..81
     VAR_DECL@0..23
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..23
         DECLARATOR@4..23
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           ARROW_EXPR@8..23
+<<<<<<< HEAD
 <<<<<<< HEAD
             ASYNC_KW@8..13 "async"
             WHITESPACE@13..14 " "
@@ -25,29 +26,37 @@ MODULE@0..81
               L_CURLY@21..22 "{"
 =======
              ASYNC_KW@8..14 "async" " "
+=======
+            None ASYNC_KW@8..14 "async" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
             NAME@14..18
-               IDENT@14..18 "foo" " "
-             FAT_ARROW@18..21 "=>" " "
+              None IDENT@14..18 "foo" Whitespace(1)
+            None FAT_ARROW@18..21 "=>" Whitespace(1)
             BLOCK_STMT@21..23
+<<<<<<< HEAD
                L_CURLY@21..22 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None L_CURLY@21..22 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@22..22
-               R_CURLY@22..23 "}" 
+              None R_CURLY@22..23 "}" None
     VAR_DECL@23..49
-      "\n" IDENT@23..28 "let" " "
+      Whitespace(1) IDENT@23..28 "let" Whitespace(1)
       LIST@28..49
         DECLARATOR@28..49
           SINGLE_PATTERN@28..30
             NAME@28..30
-               IDENT@28..30 "b" " "
-           EQ@30..32 "=" " "
+              None IDENT@28..30 "b" Whitespace(1)
+          None EQ@30..32 "=" Whitespace(1)
           ARROW_EXPR@32..49
-             ASYNC_KW@32..38 "async" " "
+            None ASYNC_KW@32..38 "async" Whitespace(1)
             PARAMETER_LIST@38..44
-               L_PAREN@38..39 "(" 
+              None L_PAREN@38..39 "(" None
               LIST@39..42
                 SINGLE_PATTERN@39..42
                   NAME@39..42
+<<<<<<< HEAD
 <<<<<<< HEAD
                     IDENT@39..42 "bar"
               R_PAREN@42..43 ")"
@@ -69,31 +78,40 @@ MODULE@0..81
                      IDENT@39..42 "bar" 
                R_PAREN@42..44 ")" " "
              FAT_ARROW@44..47 "=>" " "
+=======
+                    None IDENT@39..42 "bar" None
+              None R_PAREN@42..44 ")" Whitespace(1)
+            None FAT_ARROW@44..47 "=>" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
             BLOCK_STMT@47..49
-               L_CURLY@47..48 "{" 
+              None L_CURLY@47..48 "{" None
               LIST@48..48
-               R_CURLY@48..49 "}" 
+              None R_CURLY@48..49 "}" None
     EXPR_STMT@49..81
       ARROW_EXPR@49..81
-        "\n" ASYNC_KW@49..56 "async" " "
+        Whitespace(1) ASYNC_KW@49..56 "async" Whitespace(1)
         PARAMETER_LIST@56..75
+<<<<<<< HEAD
            L_PAREN@56..57 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None L_PAREN@56..57 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@57..73
             SINGLE_PATTERN@57..60
               NAME@57..60
-                 IDENT@57..60 "foo" 
-             COMMA@60..62 "," " "
+                None IDENT@57..60 "foo" None
+            None COMMA@60..62 "," Whitespace(1)
             SINGLE_PATTERN@62..65
               NAME@62..65
-                 IDENT@62..65 "bar" 
-             COMMA@65..67 "," " "
+                None IDENT@62..65 "bar" None
+            None COMMA@65..67 "," Whitespace(1)
             REST_PATTERN@67..73
-               DOT2@67..70 "..." 
+              None DOT2@67..70 "..." None
               SINGLE_PATTERN@70..73
                 NAME@70..73
-                   IDENT@70..73 "baz" 
-           R_PAREN@73..75 ")" " "
-         FAT_ARROW@75..78 "=>" " "
+                  None IDENT@70..73 "baz" None
+          None R_PAREN@73..75 ")" Whitespace(1)
+        None FAT_ARROW@75..78 "=>" Whitespace(1)
         NAME_REF@78..81
-           IDENT@78..81 "foo" 
+          None IDENT@78..81 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..82
-=======
-MODULE@0..81
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..81
   LIST@0..81
     VAR_DECL@0..23
       None IDENT@0..3 "let" Whitespace(1)
@@ -13,36 +9,12 @@ MODULE@0..81
               None IDENT@4..5 "a" Whitespace(1)
           None EQ@6..7 "=" Whitespace(1)
           ARROW_EXPR@8..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            ASYNC_KW@8..13 "async"
-            WHITESPACE@13..14 " "
-            NAME@14..17
-              IDENT@14..17 "foo"
-            WHITESPACE@17..18 " "
-            FAT_ARROW@18..20 "=>"
-            WHITESPACE@20..21 " "
-            JS_BLOCK_STATEMENT@21..23
-              L_CURLY@21..22 "{"
-=======
-             ASYNC_KW@8..14 "async" " "
-=======
-            None ASYNC_KW@8..14 "async" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
             None ASYNC_KW@8..13 "async" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             NAME@14..18
               None IDENT@14..17 "foo" Whitespace(1)
             None FAT_ARROW@18..20 "=>" Whitespace(1)
-            BLOCK_STMT@21..23
-<<<<<<< HEAD
-               L_CURLY@21..22 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+            JS_BLOCK_STATEMENT@21..23
               None L_CURLY@21..22 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@22..22
               None R_CURLY@22..23 "}" None
     VAR_DECL@23..49
@@ -60,52 +32,18 @@ MODULE@0..81
               LIST@39..42
                 SINGLE_PATTERN@39..42
                   NAME@39..42
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    IDENT@39..42 "bar"
-              R_PAREN@42..43 ")"
-            WHITESPACE@43..44 " "
-            FAT_ARROW@44..46 "=>"
-            WHITESPACE@46..47 " "
-            JS_BLOCK_STATEMENT@47..49
-              L_CURLY@47..48 "{"
-              LIST@48..48
-              R_CURLY@48..49 "}"
-    WHITESPACE@49..50 "\n"
-    JS_EXPRESSION_STATEMENT@50..81
-      ARROW_EXPR@50..81
-        ASYNC_KW@50..55 "async"
-        WHITESPACE@55..56 " "
-        PARAMETER_LIST@56..74
-          L_PAREN@56..57 "("
-=======
-                     IDENT@39..42 "bar" 
-               R_PAREN@42..44 ")" " "
-             FAT_ARROW@44..47 "=>" " "
-=======
                     None IDENT@39..42 "bar" None
-<<<<<<< HEAD
-              None R_PAREN@42..44 ")" Whitespace(1)
-            None FAT_ARROW@44..47 "=>" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               None R_PAREN@42..43 ")" Whitespace(1)
             None FAT_ARROW@44..46 "=>" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@47..49
+            JS_BLOCK_STATEMENT@47..49
               None L_CURLY@47..48 "{" None
               LIST@48..48
               None R_CURLY@48..49 "}" None
-    EXPR_STMT@49..81
+    JS_EXPRESSION_STATEMENT@49..81
       ARROW_EXPR@49..81
         Whitespace(1) ASYNC_KW@50..55 "async" Whitespace(1)
         PARAMETER_LIST@56..75
-<<<<<<< HEAD
-           L_PAREN@56..57 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None L_PAREN@56..57 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@57..73
             SINGLE_PATTERN@57..60
               NAME@57..60

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -1,17 +1,19 @@
+<<<<<<< HEAD
 JS_MODULE@0..82
+=======
+MODULE@0..81
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..81
     VAR_DECL@0..23
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..23
         DECLARATOR@4..23
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           ARROW_EXPR@8..23
+<<<<<<< HEAD
             ASYNC_KW@8..13 "async"
             WHITESPACE@13..14 " "
             NAME@14..17
@@ -21,28 +23,32 @@ JS_MODULE@0..82
             WHITESPACE@20..21 " "
             JS_BLOCK_STATEMENT@21..23
               L_CURLY@21..22 "{"
+=======
+             ASYNC_KW@8..14 "async" " "
+            NAME@14..18
+               IDENT@14..18 "foo" " "
+             FAT_ARROW@18..21 "=>" " "
+            BLOCK_STMT@21..23
+               L_CURLY@21..22 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@22..22
-              R_CURLY@22..23 "}"
-    WHITESPACE@23..24 "\n"
-    VAR_DECL@24..49
-      IDENT@24..27 "let"
-      WHITESPACE@27..28 " "
+               R_CURLY@22..23 "}" 
+    VAR_DECL@23..49
+      "\n" IDENT@23..28 "let" " "
       LIST@28..49
         DECLARATOR@28..49
-          SINGLE_PATTERN@28..29
-            NAME@28..29
-              IDENT@28..29 "b"
-          WHITESPACE@29..30 " "
-          EQ@30..31 "="
-          WHITESPACE@31..32 " "
+          SINGLE_PATTERN@28..30
+            NAME@28..30
+               IDENT@28..30 "b" " "
+           EQ@30..32 "=" " "
           ARROW_EXPR@32..49
-            ASYNC_KW@32..37 "async"
-            WHITESPACE@37..38 " "
-            PARAMETER_LIST@38..43
-              L_PAREN@38..39 "("
+             ASYNC_KW@32..38 "async" " "
+            PARAMETER_LIST@38..44
+               L_PAREN@38..39 "(" 
               LIST@39..42
                 SINGLE_PATTERN@39..42
                   NAME@39..42
+<<<<<<< HEAD
                     IDENT@39..42 "bar"
               R_PAREN@42..43 ")"
             WHITESPACE@43..44 " "
@@ -59,26 +65,35 @@ JS_MODULE@0..82
         WHITESPACE@55..56 " "
         PARAMETER_LIST@56..74
           L_PAREN@56..57 "("
+=======
+                     IDENT@39..42 "bar" 
+               R_PAREN@42..44 ")" " "
+             FAT_ARROW@44..47 "=>" " "
+            BLOCK_STMT@47..49
+               L_CURLY@47..48 "{" 
+              LIST@48..48
+               R_CURLY@48..49 "}" 
+    EXPR_STMT@49..81
+      ARROW_EXPR@49..81
+        "\n" ASYNC_KW@49..56 "async" " "
+        PARAMETER_LIST@56..75
+           L_PAREN@56..57 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@57..73
             SINGLE_PATTERN@57..60
               NAME@57..60
-                IDENT@57..60 "foo"
-            COMMA@60..61 ","
-            WHITESPACE@61..62 " "
+                 IDENT@57..60 "foo" 
+             COMMA@60..62 "," " "
             SINGLE_PATTERN@62..65
               NAME@62..65
-                IDENT@62..65 "bar"
-            COMMA@65..66 ","
-            WHITESPACE@66..67 " "
+                 IDENT@62..65 "bar" 
+             COMMA@65..67 "," " "
             REST_PATTERN@67..73
-              DOT2@67..70 "..."
+               DOT2@67..70 "..." 
               SINGLE_PATTERN@70..73
                 NAME@70..73
-                  IDENT@70..73 "baz"
-          R_PAREN@73..74 ")"
-        WHITESPACE@74..75 " "
-        FAT_ARROW@75..77 "=>"
-        WHITESPACE@77..78 " "
+                   IDENT@70..73 "baz" 
+           R_PAREN@73..75 ")" " "
+         FAT_ARROW@75..78 "=>" " "
         NAME_REF@78..81
-          IDENT@78..81 "foo"
-  WHITESPACE@81..82 "\n"
+           IDENT@78..81 "foo" 

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -5,14 +5,15 @@ MODULE@0..81
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..81
     VAR_DECL@0..23
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..23
         DECLARATOR@4..23
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           ARROW_EXPR@8..23
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
             ASYNC_KW@8..13 "async"
@@ -29,9 +30,12 @@ MODULE@0..81
 =======
             None ASYNC_KW@8..14 "async" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            None ASYNC_KW@8..13 "async" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             NAME@14..18
-              None IDENT@14..18 "foo" Whitespace(1)
-            None FAT_ARROW@18..21 "=>" Whitespace(1)
+              None IDENT@14..17 "foo" Whitespace(1)
+            None FAT_ARROW@18..20 "=>" Whitespace(1)
             BLOCK_STMT@21..23
 <<<<<<< HEAD
                L_CURLY@21..22 "{" 
@@ -42,15 +46,15 @@ MODULE@0..81
               LIST@22..22
               None R_CURLY@22..23 "}" None
     VAR_DECL@23..49
-      Whitespace(1) IDENT@23..28 "let" Whitespace(1)
+      Whitespace(1) IDENT@24..27 "let" Whitespace(1)
       LIST@28..49
         DECLARATOR@28..49
           SINGLE_PATTERN@28..30
             NAME@28..30
-              None IDENT@28..30 "b" Whitespace(1)
-          None EQ@30..32 "=" Whitespace(1)
+              None IDENT@28..29 "b" Whitespace(1)
+          None EQ@30..31 "=" Whitespace(1)
           ARROW_EXPR@32..49
-            None ASYNC_KW@32..38 "async" Whitespace(1)
+            None ASYNC_KW@32..37 "async" Whitespace(1)
             PARAMETER_LIST@38..44
               None L_PAREN@38..39 "(" None
               LIST@39..42
@@ -80,16 +84,21 @@ MODULE@0..81
              FAT_ARROW@44..47 "=>" " "
 =======
                     None IDENT@39..42 "bar" None
+<<<<<<< HEAD
               None R_PAREN@42..44 ")" Whitespace(1)
             None FAT_ARROW@44..47 "=>" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              None R_PAREN@42..43 ")" Whitespace(1)
+            None FAT_ARROW@44..46 "=>" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@47..49
               None L_CURLY@47..48 "{" None
               LIST@48..48
               None R_CURLY@48..49 "}" None
     EXPR_STMT@49..81
       ARROW_EXPR@49..81
-        Whitespace(1) ASYNC_KW@49..56 "async" Whitespace(1)
+        Whitespace(1) ASYNC_KW@50..55 "async" Whitespace(1)
         PARAMETER_LIST@56..75
 <<<<<<< HEAD
            L_PAREN@56..57 "(" 
@@ -101,17 +110,17 @@ MODULE@0..81
             SINGLE_PATTERN@57..60
               NAME@57..60
                 None IDENT@57..60 "foo" None
-            None COMMA@60..62 "," Whitespace(1)
+            None COMMA@60..61 "," Whitespace(1)
             SINGLE_PATTERN@62..65
               NAME@62..65
                 None IDENT@62..65 "bar" None
-            None COMMA@65..67 "," Whitespace(1)
+            None COMMA@65..66 "," Whitespace(1)
             REST_PATTERN@67..73
               None DOT2@67..70 "..." None
               SINGLE_PATTERN@70..73
                 NAME@70..73
                   None IDENT@70..73 "baz" None
-          None R_PAREN@73..75 ")" Whitespace(1)
-        None FAT_ARROW@75..78 "=>" Whitespace(1)
+          None R_PAREN@73..74 ")" Whitespace(1)
+        None FAT_ARROW@75..77 "=>" Whitespace(1)
         NAME_REF@78..81
           None IDENT@78..81 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -1,57 +1,62 @@
+<<<<<<< HEAD
 JS_MODULE@0..62
+=======
+MODULE@0..61
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..61
     VAR_DECL@0..28
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..27
         DECLARATOR@4..27
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           FN_EXPR@8..27
-            ASYNC_KW@8..13 "async"
-            WHITESPACE@13..14 " "
-            FUNCTION_KW@14..22 "function"
-            PARAMETER_LIST@22..24
-              L_PAREN@22..23 "("
+             ASYNC_KW@8..14 "async" " "
+             FUNCTION_KW@14..22 "function" 
+            PARAMETER_LIST@22..25
+               L_PAREN@22..23 "(" 
               LIST@23..23
+<<<<<<< HEAD
               R_PAREN@23..24 ")"
             WHITESPACE@24..25 " "
             JS_BLOCK_STATEMENT@25..27
               L_CURLY@25..26 "{"
+=======
+               R_PAREN@23..25 ")" " "
+            BLOCK_STMT@25..27
+               L_CURLY@25..26 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@26..26
-              R_CURLY@26..27 "}"
-      SEMICOLON@27..28 ";"
-    WHITESPACE@28..29 "\n"
-    VAR_DECL@29..61
-      IDENT@29..32 "let"
-      WHITESPACE@32..33 " "
+               R_CURLY@26..27 "}" 
+       SEMICOLON@27..28 ";" 
+    VAR_DECL@28..61
+      "\n" IDENT@28..33 "let" " "
       LIST@33..60
         DECLARATOR@33..60
-          SINGLE_PATTERN@33..34
-            NAME@33..34
-              IDENT@33..34 "b"
-          WHITESPACE@34..35 " "
-          EQ@35..36 "="
-          WHITESPACE@36..37 " "
+          SINGLE_PATTERN@33..35
+            NAME@33..35
+               IDENT@33..35 "b" " "
+           EQ@35..37 "=" " "
           FN_EXPR@37..60
-            ASYNC_KW@37..42 "async"
-            WHITESPACE@42..43 " "
-            FUNCTION_KW@43..51 "function"
-            WHITESPACE@51..52 " "
+             ASYNC_KW@37..43 "async" " "
+             FUNCTION_KW@43..52 "function" " "
             NAME@52..55
-              IDENT@52..55 "foo"
-            PARAMETER_LIST@55..57
-              L_PAREN@55..56 "("
+               IDENT@52..55 "foo" 
+            PARAMETER_LIST@55..58
+               L_PAREN@55..56 "(" 
               LIST@56..56
+<<<<<<< HEAD
               R_PAREN@56..57 ")"
             WHITESPACE@57..58 " "
             JS_BLOCK_STATEMENT@58..60
               L_CURLY@58..59 "{"
+=======
+               R_PAREN@56..58 ")" " "
+            BLOCK_STMT@58..60
+               L_CURLY@58..59 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@59..59
-              R_CURLY@59..60 "}"
-      SEMICOLON@60..61 ";"
-  WHITESPACE@61..62 "\n"
+               R_CURLY@59..60 "}" 
+       SEMICOLON@60..61 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -5,19 +5,20 @@ MODULE@0..61
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..61
     VAR_DECL@0..28
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..27
         DECLARATOR@4..27
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           FN_EXPR@8..27
-            None ASYNC_KW@8..14 "async" Whitespace(1)
+            None ASYNC_KW@8..13 "async" Whitespace(1)
             None FUNCTION_KW@14..22 "function" None
             PARAMETER_LIST@22..25
               None L_PAREN@22..23 "(" None
               LIST@23..23
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@23..24 ")"
@@ -31,6 +32,9 @@ MODULE@0..61
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@23..25 ")" Whitespace(1)
+=======
+              None R_PAREN@23..24 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@25..27
               None L_CURLY@25..26 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
@@ -38,21 +42,22 @@ MODULE@0..61
               None R_CURLY@26..27 "}" None
       None SEMICOLON@27..28 ";" None
     VAR_DECL@28..61
-      Whitespace(1) IDENT@28..33 "let" Whitespace(1)
+      Whitespace(1) IDENT@29..32 "let" Whitespace(1)
       LIST@33..60
         DECLARATOR@33..60
           SINGLE_PATTERN@33..35
             NAME@33..35
-              None IDENT@33..35 "b" Whitespace(1)
-          None EQ@35..37 "=" Whitespace(1)
+              None IDENT@33..34 "b" Whitespace(1)
+          None EQ@35..36 "=" Whitespace(1)
           FN_EXPR@37..60
-            None ASYNC_KW@37..43 "async" Whitespace(1)
-            None FUNCTION_KW@43..52 "function" Whitespace(1)
+            None ASYNC_KW@37..42 "async" Whitespace(1)
+            None FUNCTION_KW@43..51 "function" Whitespace(1)
             NAME@52..55
               None IDENT@52..55 "foo" None
             PARAMETER_LIST@55..58
               None L_PAREN@55..56 "(" None
               LIST@56..56
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@56..57 ")"
@@ -66,6 +71,9 @@ MODULE@0..61
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@56..58 ")" Whitespace(1)
+=======
+              None R_PAREN@56..57 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@58..60
               None L_CURLY@58..59 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -5,19 +5,20 @@ MODULE@0..61
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..61
     VAR_DECL@0..28
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..27
         DECLARATOR@4..27
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           FN_EXPR@8..27
-             ASYNC_KW@8..14 "async" " "
-             FUNCTION_KW@14..22 "function" 
+            None ASYNC_KW@8..14 "async" Whitespace(1)
+            None FUNCTION_KW@14..22 "function" None
             PARAMETER_LIST@22..25
-               L_PAREN@22..23 "(" 
+              None L_PAREN@22..23 "(" None
               LIST@23..23
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@23..24 ")"
             WHITESPACE@24..25 " "
@@ -28,25 +29,31 @@ MODULE@0..61
             BLOCK_STMT@25..27
                L_CURLY@25..26 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@23..25 ")" Whitespace(1)
+            BLOCK_STMT@25..27
+              None L_CURLY@25..26 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@26..26
-               R_CURLY@26..27 "}" 
-       SEMICOLON@27..28 ";" 
+              None R_CURLY@26..27 "}" None
+      None SEMICOLON@27..28 ";" None
     VAR_DECL@28..61
-      "\n" IDENT@28..33 "let" " "
+      Whitespace(1) IDENT@28..33 "let" Whitespace(1)
       LIST@33..60
         DECLARATOR@33..60
           SINGLE_PATTERN@33..35
             NAME@33..35
-               IDENT@33..35 "b" " "
-           EQ@35..37 "=" " "
+              None IDENT@33..35 "b" Whitespace(1)
+          None EQ@35..37 "=" Whitespace(1)
           FN_EXPR@37..60
-             ASYNC_KW@37..43 "async" " "
-             FUNCTION_KW@43..52 "function" " "
+            None ASYNC_KW@37..43 "async" Whitespace(1)
+            None FUNCTION_KW@43..52 "function" Whitespace(1)
             NAME@52..55
-               IDENT@52..55 "foo" 
+              None IDENT@52..55 "foo" None
             PARAMETER_LIST@55..58
-               L_PAREN@55..56 "(" 
+              None L_PAREN@55..56 "(" None
               LIST@56..56
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@56..57 ")"
             WHITESPACE@57..58 " "
@@ -57,6 +64,11 @@ MODULE@0..61
             BLOCK_STMT@58..60
                L_CURLY@58..59 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@56..58 ")" Whitespace(1)
+            BLOCK_STMT@58..60
+              None L_CURLY@58..59 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@59..59
-               R_CURLY@59..60 "}" 
-       SEMICOLON@60..61 ";" 
+              None R_CURLY@59..60 "}" None
+      None SEMICOLON@60..61 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..62
-=======
-MODULE@0..61
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..61
   LIST@0..61
     VAR_DECL@0..28
       None IDENT@0..3 "let" Whitespace(1)
@@ -18,26 +14,9 @@ MODULE@0..61
             PARAMETER_LIST@22..25
               None L_PAREN@22..23 "(" None
               LIST@23..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@23..24 ")"
-            WHITESPACE@24..25 " "
-            JS_BLOCK_STATEMENT@25..27
-              L_CURLY@25..26 "{"
-=======
-               R_PAREN@23..25 ")" " "
-            BLOCK_STMT@25..27
-               L_CURLY@25..26 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@23..25 ")" Whitespace(1)
-=======
               None R_PAREN@23..24 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@25..27
+            JS_BLOCK_STATEMENT@25..27
               None L_CURLY@25..26 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@26..26
               None R_CURLY@26..27 "}" None
       None SEMICOLON@27..28 ";" None
@@ -57,26 +36,9 @@ MODULE@0..61
             PARAMETER_LIST@55..58
               None L_PAREN@55..56 "(" None
               LIST@56..56
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@56..57 ")"
-            WHITESPACE@57..58 " "
-            JS_BLOCK_STATEMENT@58..60
-              L_CURLY@58..59 "{"
-=======
-               R_PAREN@56..58 ")" " "
-            BLOCK_STMT@58..60
-               L_CURLY@58..59 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@56..58 ")" Whitespace(1)
-=======
               None R_PAREN@56..57 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@58..60
+            JS_BLOCK_STATEMENT@58..60
               None L_CURLY@58..59 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@59..59
               None R_CURLY@59..60 "}" None
       None SEMICOLON@60..61 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -5,13 +5,13 @@ MODULE@0..14
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..14
     VAR_DECL@0..14
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           NAME_REF@8..13
-             IDENT@8..13 "async" 
-       SEMICOLON@13..14 ";" 
+            None IDENT@8..13 "async" None
+      None SEMICOLON@13..14 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -5,13 +5,13 @@ MODULE@0..14
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..14
     VAR_DECL@0..14
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           NAME_REF@8..13
             None IDENT@8..13 "async" None
       None SEMICOLON@13..14 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..15
-=======
-MODULE@0..14
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..14
   LIST@0..14
     VAR_DECL@0..14
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -1,17 +1,17 @@
+<<<<<<< HEAD
 JS_MODULE@0..15
+=======
+MODULE@0..14
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..14
     VAR_DECL@0..14
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..13
         DECLARATOR@4..13
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           NAME_REF@8..13
-            IDENT@8..13 "async"
-      SEMICOLON@13..14 ";"
-  WHITESPACE@14..15 "\n"
+             IDENT@8..13 "async" 
+       SEMICOLON@13..14 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..47
-=======
-MODULE@0..46
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..46
   LIST@0..46
     CLASS_DECL@0..46
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -18,26 +14,9 @@ MODULE@0..46
             PARAMETER_LIST@22..25
               None L_PAREN@22..23 "(" None
               LIST@23..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@23..24 ")"
-            WHITESPACE@24..25 " "
-            JS_BLOCK_STATEMENT@25..27
-              L_CURLY@25..26 "{"
-=======
-               R_PAREN@23..25 ")" " "
-            BLOCK_STMT@25..27
-               L_CURLY@25..26 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@23..25 ")" Whitespace(1)
-=======
               None R_PAREN@23..24 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@25..27
+            JS_BLOCK_STATEMENT@25..27
               None L_CURLY@25..26 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@26..26
               None R_CURLY@26..27 "}" None
           METHOD@27..44
@@ -48,26 +27,9 @@ MODULE@0..46
             PARAMETER_LIST@39..42
               None L_PAREN@39..40 "(" None
               LIST@40..40
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@40..41 ")"
-            WHITESPACE@41..42 " "
-            JS_BLOCK_STATEMENT@42..44
-              L_CURLY@42..43 "{"
-=======
-               R_PAREN@40..42 ")" " "
-            BLOCK_STMT@42..44
-               L_CURLY@42..43 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@40..42 ")" Whitespace(1)
-=======
               None R_PAREN@40..41 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@42..44
+            JS_BLOCK_STATEMENT@42..44
               None L_CURLY@42..43 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@43..43
               None R_CURLY@43..44 "}" None
         Whitespace(1) R_CURLY@45..46 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -5,19 +5,20 @@ MODULE@0..46
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..46
     CLASS_DECL@0..46
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..46
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..44
           METHOD@11..27
-            "\n " ASYNC_KW@11..19 "async" " "
+            Whitespace(2) ASYNC_KW@11..19 "async" Whitespace(1)
             NAME@19..22
-               IDENT@19..22 "foo" 
+              None IDENT@19..22 "foo" None
             PARAMETER_LIST@22..25
-               L_PAREN@22..23 "(" 
+              None L_PAREN@22..23 "(" None
               LIST@23..23
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@23..24 ")"
             WHITESPACE@24..25 " "
@@ -28,16 +29,22 @@ MODULE@0..46
             BLOCK_STMT@25..27
                L_CURLY@25..26 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@23..25 ")" Whitespace(1)
+            BLOCK_STMT@25..27
+              None L_CURLY@25..26 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@26..26
-               R_CURLY@26..27 "}" 
+              None R_CURLY@26..27 "}" None
           METHOD@27..44
-            "\n " ASYNC_KW@27..35 "async" " "
-             STAR@35..36 "*" 
+            Whitespace(2) ASYNC_KW@27..35 "async" Whitespace(1)
+            None STAR@35..36 "*" None
             NAME@36..39
-               IDENT@36..39 "foo" 
+              None IDENT@36..39 "foo" None
             PARAMETER_LIST@39..42
-               L_PAREN@39..40 "(" 
+              None L_PAREN@39..40 "(" None
               LIST@40..40
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@40..41 ")"
             WHITESPACE@41..42 " "
@@ -48,6 +55,11 @@ MODULE@0..46
             BLOCK_STMT@42..44
                L_CURLY@42..43 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@40..42 ")" Whitespace(1)
+            BLOCK_STMT@42..44
+              None L_CURLY@42..43 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@43..43
-               R_CURLY@43..44 "}" 
-        "\n" R_CURLY@44..46 "}" 
+              None R_CURLY@43..44 "}" None
+        Whitespace(1) R_CURLY@44..46 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -1,45 +1,53 @@
+<<<<<<< HEAD
 JS_MODULE@0..47
+=======
+MODULE@0..46
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..46
     CLASS_DECL@0..46
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..46
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..13 "\n "
-        LIST@13..44
-          METHOD@13..27
-            ASYNC_KW@13..18 "async"
-            WHITESPACE@18..19 " "
+         L_CURLY@10..11 "{" 
+        LIST@11..44
+          METHOD@11..27
+            "\n " ASYNC_KW@11..19 "async" " "
             NAME@19..22
-              IDENT@19..22 "foo"
-            PARAMETER_LIST@22..24
-              L_PAREN@22..23 "("
+               IDENT@19..22 "foo" 
+            PARAMETER_LIST@22..25
+               L_PAREN@22..23 "(" 
               LIST@23..23
+<<<<<<< HEAD
               R_PAREN@23..24 ")"
             WHITESPACE@24..25 " "
             JS_BLOCK_STATEMENT@25..27
               L_CURLY@25..26 "{"
+=======
+               R_PAREN@23..25 ")" " "
+            BLOCK_STMT@25..27
+               L_CURLY@25..26 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@26..26
-              R_CURLY@26..27 "}"
-          WHITESPACE@27..29 "\n "
-          METHOD@29..44
-            ASYNC_KW@29..34 "async"
-            WHITESPACE@34..35 " "
-            STAR@35..36 "*"
+               R_CURLY@26..27 "}" 
+          METHOD@27..44
+            "\n " ASYNC_KW@27..35 "async" " "
+             STAR@35..36 "*" 
             NAME@36..39
-              IDENT@36..39 "foo"
-            PARAMETER_LIST@39..41
-              L_PAREN@39..40 "("
+               IDENT@36..39 "foo" 
+            PARAMETER_LIST@39..42
+               L_PAREN@39..40 "(" 
               LIST@40..40
+<<<<<<< HEAD
               R_PAREN@40..41 ")"
             WHITESPACE@41..42 " "
             JS_BLOCK_STATEMENT@42..44
               L_CURLY@42..43 "{"
+=======
+               R_PAREN@40..42 ")" " "
+            BLOCK_STMT@42..44
+               L_CURLY@42..43 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@43..43
-              R_CURLY@43..44 "}"
-        WHITESPACE@44..45 "\n"
-        R_CURLY@45..46 "}"
-  WHITESPACE@46..47 "\n"
+               R_CURLY@43..44 "}" 
+        "\n" R_CURLY@44..46 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -5,19 +5,20 @@ MODULE@0..46
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..46
     CLASS_DECL@0..46
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..46
         None L_CURLY@10..11 "{" None
         LIST@11..44
           METHOD@11..27
-            Whitespace(2) ASYNC_KW@11..19 "async" Whitespace(1)
+            Whitespace(2) ASYNC_KW@13..18 "async" Whitespace(1)
             NAME@19..22
               None IDENT@19..22 "foo" None
             PARAMETER_LIST@22..25
               None L_PAREN@22..23 "(" None
               LIST@23..23
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@23..24 ")"
@@ -31,19 +32,23 @@ MODULE@0..46
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@23..25 ")" Whitespace(1)
+=======
+              None R_PAREN@23..24 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@25..27
               None L_CURLY@25..26 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@26..26
               None R_CURLY@26..27 "}" None
           METHOD@27..44
-            Whitespace(2) ASYNC_KW@27..35 "async" Whitespace(1)
+            Whitespace(2) ASYNC_KW@29..34 "async" Whitespace(1)
             None STAR@35..36 "*" None
             NAME@36..39
               None IDENT@36..39 "foo" None
             PARAMETER_LIST@39..42
               None L_PAREN@39..40 "(" None
               LIST@40..40
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@40..41 ")"
@@ -57,9 +62,12 @@ MODULE@0..46
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@40..42 ")" Whitespace(1)
+=======
+              None R_PAREN@40..41 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@42..44
               None L_CURLY@42..43 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@43..43
               None R_CURLY@43..44 "}" None
-        Whitespace(1) R_CURLY@44..46 "}" None
+        Whitespace(1) R_CURLY@45..46 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..125
-=======
-MODULE@0..124
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..124
   LIST@0..124
     JS_EXPRESSION_STATEMENT@0..5
       BIN_EXPR@0..5
@@ -10,75 +6,23 @@ MODULE@0..124
           None NUMBER@0..1 "5" Whitespace(1)
         None STAR@2..3 "*" Whitespace(1)
         LITERAL@4..5
-<<<<<<< HEAD
-<<<<<<< HEAD
-          NUMBER@4..5 "5"
-    WHITESPACE@5..6 "\n"
-    JS_EXPRESSION_STATEMENT@6..17
-      BIN_EXPR@6..17
-        LITERAL@6..7
-          NUMBER@6..7 "6"
-        WHITESPACE@7..8 " "
-        STAR2@8..10 "**"
-        WHITESPACE@10..11 " "
-=======
-           NUMBER@4..5 "5" 
-    EXPR_STMT@5..17
-      BIN_EXPR@5..17
-        LITERAL@5..8
-          "\n" NUMBER@5..8 "6" " "
-         STAR2@8..11 "**" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None NUMBER@4..5 "5" None
-    EXPR_STMT@5..17
+    JS_EXPRESSION_STATEMENT@5..17
       BIN_EXPR@5..17
         LITERAL@5..8
-<<<<<<< HEAD
-          Whitespace(1) NUMBER@5..8 "6" Whitespace(1)
-        None STAR2@8..11 "**" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) NUMBER@6..7 "6" Whitespace(1)
         None STAR2@8..10 "**" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@11..17
           LITERAL@11..13
             None NUMBER@11..12 "6" Whitespace(1)
           None STAR2@13..15 "**" Whitespace(1)
           LITERAL@16..17
-<<<<<<< HEAD
-<<<<<<< HEAD
-            NUMBER@16..17 "7"
-    WHITESPACE@17..18 "\n"
-    JS_EXPRESSION_STATEMENT@18..39
-      BIN_EXPR@18..39
-        LITERAL@18..19
-          NUMBER@18..19 "1"
-        WHITESPACE@19..20 " "
-        PLUS@20..21 "+"
-        WHITESPACE@21..22 " "
-=======
-             NUMBER@16..17 "7" 
-    EXPR_STMT@17..39
-      BIN_EXPR@17..39
-        LITERAL@17..20
-          "\n" NUMBER@17..20 "1" " "
-         PLUS@20..22 "+" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None NUMBER@16..17 "7" None
-    EXPR_STMT@17..39
+    JS_EXPRESSION_STATEMENT@17..39
       BIN_EXPR@17..39
         LITERAL@17..20
-<<<<<<< HEAD
-          Whitespace(1) NUMBER@17..20 "1" Whitespace(1)
-        None PLUS@20..22 "+" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) NUMBER@18..19 "1" Whitespace(1)
         None PLUS@20..21 "+" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@22..39
           BIN_EXPR@22..36
             LITERAL@22..24
@@ -99,119 +43,36 @@ MODULE@0..124
                 None R_PAREN@34..35 ")" Whitespace(1)
           None STAR@36..37 "*" Whitespace(1)
           LITERAL@38..39
-<<<<<<< HEAD
-<<<<<<< HEAD
-            NUMBER@38..39 "3"
-    WHITESPACE@39..40 "\n"
-    JS_EXPRESSION_STATEMENT@40..45
-      BIN_EXPR@40..45
-        LITERAL@40..41
-          NUMBER@40..41 "1"
-        WHITESPACE@41..42 " "
-        SLASH@42..43 "/"
-        WHITESPACE@43..44 " "
-        LITERAL@44..45
-          NUMBER@44..45 "2"
-    WHITESPACE@45..46 "\n"
-    JS_EXPRESSION_STATEMENT@46..55
-      BIN_EXPR@46..55
-        LITERAL@46..48
-          NUMBER@46..48 "74"
-        WHITESPACE@48..49 " "
-        IN_KW@49..51 "in"
-        WHITESPACE@51..52 " "
-        NAME_REF@52..55
-          IDENT@52..55 "foo"
-    WHITESPACE@55..56 "\n"
-    JS_EXPRESSION_STATEMENT@56..76
-      BIN_EXPR@56..76
-        NAME_REF@56..59
-          IDENT@56..59 "foo"
-        WHITESPACE@59..60 " "
-        INSTANCEOF_KW@60..70 "instanceof"
-        WHITESPACE@70..71 " "
-        NAME_REF@71..76
-          IDENT@71..76 "Array"
-    WHITESPACE@76..77 "\n"
-    JS_EXPRESSION_STATEMENT@77..87
-      BIN_EXPR@77..87
-        NAME_REF@77..80
-          IDENT@77..80 "foo"
-        WHITESPACE@80..81 " "
-        QUESTION2@81..83 "??"
-        WHITESPACE@83..84 " "
-        NAME_REF@84..87
-          IDENT@84..87 "bar"
-    WHITESPACE@87..88 "\n"
-    JS_EXPRESSION_STATEMENT@88..101
-      BIN_EXPR@88..101
-        BIN_EXPR@88..97
-          BIN_EXPR@88..93
-            LITERAL@88..89
-              NUMBER@88..89 "1"
-            WHITESPACE@89..90 " "
-            PLUS@90..91 "+"
-            WHITESPACE@91..92 " "
-            LITERAL@92..93
-              NUMBER@92..93 "1"
-          WHITESPACE@93..94 " "
-          PLUS@94..95 "+"
-          WHITESPACE@95..96 " "
-          LITERAL@96..97
-            NUMBER@96..97 "1"
-        WHITESPACE@97..98 " "
-        PLUS@98..99 "+"
-        WHITESPACE@99..100 " "
-        LITERAL@100..101
-          NUMBER@100..101 "1"
-    WHITESPACE@101..102 "\n"
-    JS_EXPRESSION_STATEMENT@102..124
-      BIN_EXPR@102..124
-        BIN_EXPR@102..107
-          LITERAL@102..103
-            NUMBER@102..103 "5"
-          WHITESPACE@103..104 " "
-          PLUS@104..105 "+"
-          WHITESPACE@105..106 " "
-          LITERAL@106..107
-            NUMBER@106..107 "6"
-        WHITESPACE@107..108 " "
-        MINUS@108..109 "-"
-        WHITESPACE@109..110 " "
-=======
-             NUMBER@38..39 "3" 
-=======
             None NUMBER@38..39 "3" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@39..45
+    JS_EXPRESSION_STATEMENT@39..45
       BIN_EXPR@39..45
         LITERAL@39..42
           Whitespace(1) NUMBER@40..41 "1" Whitespace(1)
         None SLASH@42..43 "/" Whitespace(1)
         LITERAL@44..45
           None NUMBER@44..45 "2" None
-    EXPR_STMT@45..55
+    JS_EXPRESSION_STATEMENT@45..55
       BIN_EXPR@45..55
         LITERAL@45..49
           Whitespace(1) NUMBER@46..48 "74" Whitespace(1)
         None IN_KW@49..51 "in" Whitespace(1)
         NAME_REF@52..55
           None IDENT@52..55 "foo" None
-    EXPR_STMT@55..76
+    JS_EXPRESSION_STATEMENT@55..76
       BIN_EXPR@55..76
         NAME_REF@55..60
           Whitespace(1) IDENT@56..59 "foo" Whitespace(1)
         None INSTANCEOF_KW@60..70 "instanceof" Whitespace(1)
         NAME_REF@71..76
           None IDENT@71..76 "Array" None
-    EXPR_STMT@76..87
+    JS_EXPRESSION_STATEMENT@76..87
       BIN_EXPR@76..87
         NAME_REF@76..81
           Whitespace(1) IDENT@77..80 "foo" Whitespace(1)
         None QUESTION2@81..83 "??" Whitespace(1)
         NAME_REF@84..87
           None IDENT@84..87 "bar" None
-    EXPR_STMT@87..101
+    JS_EXPRESSION_STATEMENT@87..101
       BIN_EXPR@87..101
         BIN_EXPR@87..98
           BIN_EXPR@87..94
@@ -226,26 +87,15 @@ MODULE@0..124
         None PLUS@98..99 "+" Whitespace(1)
         LITERAL@100..101
           None NUMBER@100..101 "1" None
-    EXPR_STMT@101..124
+    JS_EXPRESSION_STATEMENT@101..124
       BIN_EXPR@101..124
         BIN_EXPR@101..108
           LITERAL@101..104
             Whitespace(1) NUMBER@102..103 "5" Whitespace(1)
           None PLUS@104..105 "+" Whitespace(1)
           LITERAL@106..108
-<<<<<<< HEAD
-<<<<<<< HEAD
-             NUMBER@106..108 "6" " "
-         MINUS@108..110 "-" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            None NUMBER@106..108 "6" Whitespace(1)
-        None MINUS@108..110 "-" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
             None NUMBER@106..107 "6" Whitespace(1)
         None MINUS@108..109 "-" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@110..124
           BIN_EXPR@110..116
             LITERAL@110..112

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -7,8 +7,8 @@ MODULE@0..124
     JS_EXPRESSION_STATEMENT@0..5
       BIN_EXPR@0..5
         LITERAL@0..2
-          None NUMBER@0..2 "5" Whitespace(1)
-        None STAR@2..4 "*" Whitespace(1)
+          None NUMBER@0..1 "5" Whitespace(1)
+        None STAR@2..3 "*" Whitespace(1)
         LITERAL@4..5
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -34,13 +34,18 @@ MODULE@0..124
     EXPR_STMT@5..17
       BIN_EXPR@5..17
         LITERAL@5..8
+<<<<<<< HEAD
           Whitespace(1) NUMBER@5..8 "6" Whitespace(1)
         None STAR2@8..11 "**" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) NUMBER@6..7 "6" Whitespace(1)
+        None STAR2@8..10 "**" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@11..17
           LITERAL@11..13
-            None NUMBER@11..13 "6" Whitespace(1)
-          None STAR2@13..16 "**" Whitespace(1)
+            None NUMBER@11..12 "6" Whitespace(1)
+          None STAR2@13..15 "**" Whitespace(1)
           LITERAL@16..17
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -66,28 +71,33 @@ MODULE@0..124
     EXPR_STMT@17..39
       BIN_EXPR@17..39
         LITERAL@17..20
+<<<<<<< HEAD
           Whitespace(1) NUMBER@17..20 "1" Whitespace(1)
         None PLUS@20..22 "+" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) NUMBER@18..19 "1" Whitespace(1)
+        None PLUS@20..21 "+" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@22..39
           BIN_EXPR@22..36
             LITERAL@22..24
-              None NUMBER@22..24 "2" Whitespace(1)
-            None STAR@24..26 "*" Whitespace(1)
+              None NUMBER@22..23 "2" Whitespace(1)
+            None STAR@24..25 "*" Whitespace(1)
             CALL_EXPR@26..36
               LITERAL@26..27
                 None NUMBER@26..27 "3" None
               ARG_LIST@27..36
-                Whitespace(1) L_PAREN@27..29 "(" None
+                Whitespace(1) L_PAREN@28..29 "(" None
                 LIST@29..34
                   BIN_EXPR@29..34
                     LITERAL@29..31
-                      None NUMBER@29..31 "1" Whitespace(1)
-                    None PLUS@31..33 "+" Whitespace(1)
+                      None NUMBER@29..30 "1" Whitespace(1)
+                    None PLUS@31..32 "+" Whitespace(1)
                     LITERAL@33..34
                       None NUMBER@33..34 "2" None
-                None R_PAREN@34..36 ")" Whitespace(1)
-          None STAR@36..38 "*" Whitespace(1)
+                None R_PAREN@34..35 ")" Whitespace(1)
+          None STAR@36..37 "*" Whitespace(1)
           LITERAL@38..39
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -176,29 +186,29 @@ MODULE@0..124
     EXPR_STMT@39..45
       BIN_EXPR@39..45
         LITERAL@39..42
-          Whitespace(1) NUMBER@39..42 "1" Whitespace(1)
-        None SLASH@42..44 "/" Whitespace(1)
+          Whitespace(1) NUMBER@40..41 "1" Whitespace(1)
+        None SLASH@42..43 "/" Whitespace(1)
         LITERAL@44..45
           None NUMBER@44..45 "2" None
     EXPR_STMT@45..55
       BIN_EXPR@45..55
         LITERAL@45..49
-          Whitespace(1) NUMBER@45..49 "74" Whitespace(1)
-        None IN_KW@49..52 "in" Whitespace(1)
+          Whitespace(1) NUMBER@46..48 "74" Whitespace(1)
+        None IN_KW@49..51 "in" Whitespace(1)
         NAME_REF@52..55
           None IDENT@52..55 "foo" None
     EXPR_STMT@55..76
       BIN_EXPR@55..76
         NAME_REF@55..60
-          Whitespace(1) IDENT@55..60 "foo" Whitespace(1)
-        None INSTANCEOF_KW@60..71 "instanceof" Whitespace(1)
+          Whitespace(1) IDENT@56..59 "foo" Whitespace(1)
+        None INSTANCEOF_KW@60..70 "instanceof" Whitespace(1)
         NAME_REF@71..76
           None IDENT@71..76 "Array" None
     EXPR_STMT@76..87
       BIN_EXPR@76..87
         NAME_REF@76..81
-          Whitespace(1) IDENT@76..81 "foo" Whitespace(1)
-        None QUESTION2@81..84 "??" Whitespace(1)
+          Whitespace(1) IDENT@77..80 "foo" Whitespace(1)
+        None QUESTION2@81..83 "??" Whitespace(1)
         NAME_REF@84..87
           None IDENT@84..87 "bar" None
     EXPR_STMT@87..101
@@ -206,23 +216,24 @@ MODULE@0..124
         BIN_EXPR@87..98
           BIN_EXPR@87..94
             LITERAL@87..90
-              Whitespace(1) NUMBER@87..90 "1" Whitespace(1)
-            None PLUS@90..92 "+" Whitespace(1)
+              Whitespace(1) NUMBER@88..89 "1" Whitespace(1)
+            None PLUS@90..91 "+" Whitespace(1)
             LITERAL@92..94
-              None NUMBER@92..94 "1" Whitespace(1)
-          None PLUS@94..96 "+" Whitespace(1)
+              None NUMBER@92..93 "1" Whitespace(1)
+          None PLUS@94..95 "+" Whitespace(1)
           LITERAL@96..98
-            None NUMBER@96..98 "1" Whitespace(1)
-        None PLUS@98..100 "+" Whitespace(1)
+            None NUMBER@96..97 "1" Whitespace(1)
+        None PLUS@98..99 "+" Whitespace(1)
         LITERAL@100..101
           None NUMBER@100..101 "1" None
     EXPR_STMT@101..124
       BIN_EXPR@101..124
         BIN_EXPR@101..108
           LITERAL@101..104
-            Whitespace(1) NUMBER@101..104 "5" Whitespace(1)
-          None PLUS@104..106 "+" Whitespace(1)
+            Whitespace(1) NUMBER@102..103 "5" Whitespace(1)
+          None PLUS@104..105 "+" Whitespace(1)
           LITERAL@106..108
+<<<<<<< HEAD
 <<<<<<< HEAD
              NUMBER@106..108 "6" " "
          MINUS@108..110 "-" " "
@@ -231,17 +242,21 @@ MODULE@0..124
             None NUMBER@106..108 "6" Whitespace(1)
         None MINUS@108..110 "-" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            None NUMBER@106..107 "6" Whitespace(1)
+        None MINUS@108..109 "-" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@110..124
           BIN_EXPR@110..116
             LITERAL@110..112
-              None NUMBER@110..112 "1" Whitespace(1)
-            None STAR@112..114 "*" Whitespace(1)
+              None NUMBER@110..111 "1" Whitespace(1)
+            None STAR@112..113 "*" Whitespace(1)
             LITERAL@114..116
-              None NUMBER@114..116 "2" Whitespace(1)
-          None SLASH@116..118 "/" Whitespace(1)
+              None NUMBER@114..115 "2" Whitespace(1)
+          None SLASH@116..117 "/" Whitespace(1)
           BIN_EXPR@118..124
             LITERAL@118..120
-              None NUMBER@118..120 "1" Whitespace(1)
-            None STAR2@120..123 "**" Whitespace(1)
+              None NUMBER@118..119 "1" Whitespace(1)
+            None STAR2@120..122 "**" Whitespace(1)
             LITERAL@123..124
               None NUMBER@123..124 "6" None

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -7,9 +7,10 @@ MODULE@0..124
     JS_EXPRESSION_STATEMENT@0..5
       BIN_EXPR@0..5
         LITERAL@0..2
-           NUMBER@0..2 "5" " "
-         STAR@2..4 "*" " "
+          None NUMBER@0..2 "5" Whitespace(1)
+        None STAR@2..4 "*" Whitespace(1)
         LITERAL@4..5
+<<<<<<< HEAD
 <<<<<<< HEAD
           NUMBER@4..5 "5"
     WHITESPACE@5..6 "\n"
@@ -28,11 +29,20 @@ MODULE@0..124
           "\n" NUMBER@5..8 "6" " "
          STAR2@8..11 "**" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None NUMBER@4..5 "5" None
+    EXPR_STMT@5..17
+      BIN_EXPR@5..17
+        LITERAL@5..8
+          Whitespace(1) NUMBER@5..8 "6" Whitespace(1)
+        None STAR2@8..11 "**" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@11..17
           LITERAL@11..13
-             NUMBER@11..13 "6" " "
-           STAR2@13..16 "**" " "
+            None NUMBER@11..13 "6" Whitespace(1)
+          None STAR2@13..16 "**" Whitespace(1)
           LITERAL@16..17
+<<<<<<< HEAD
 <<<<<<< HEAD
             NUMBER@16..17 "7"
     WHITESPACE@17..18 "\n"
@@ -51,26 +61,35 @@ MODULE@0..124
           "\n" NUMBER@17..20 "1" " "
          PLUS@20..22 "+" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None NUMBER@16..17 "7" None
+    EXPR_STMT@17..39
+      BIN_EXPR@17..39
+        LITERAL@17..20
+          Whitespace(1) NUMBER@17..20 "1" Whitespace(1)
+        None PLUS@20..22 "+" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@22..39
           BIN_EXPR@22..36
             LITERAL@22..24
-               NUMBER@22..24 "2" " "
-             STAR@24..26 "*" " "
+              None NUMBER@22..24 "2" Whitespace(1)
+            None STAR@24..26 "*" Whitespace(1)
             CALL_EXPR@26..36
               LITERAL@26..27
-                 NUMBER@26..27 "3" 
+                None NUMBER@26..27 "3" None
               ARG_LIST@27..36
-                "\n" L_PAREN@27..29 "(" 
+                Whitespace(1) L_PAREN@27..29 "(" None
                 LIST@29..34
                   BIN_EXPR@29..34
                     LITERAL@29..31
-                       NUMBER@29..31 "1" " "
-                     PLUS@31..33 "+" " "
+                      None NUMBER@29..31 "1" Whitespace(1)
+                    None PLUS@31..33 "+" Whitespace(1)
                     LITERAL@33..34
-                       NUMBER@33..34 "2" 
-                 R_PAREN@34..36 ")" " "
-           STAR@36..38 "*" " "
+                      None NUMBER@33..34 "2" None
+                None R_PAREN@34..36 ")" Whitespace(1)
+          None STAR@36..38 "*" Whitespace(1)
           LITERAL@38..39
+<<<<<<< HEAD
 <<<<<<< HEAD
             NUMBER@38..39 "3"
     WHITESPACE@39..40 "\n"
@@ -151,70 +170,78 @@ MODULE@0..124
         WHITESPACE@109..110 " "
 =======
              NUMBER@38..39 "3" 
+=======
+            None NUMBER@38..39 "3" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@39..45
       BIN_EXPR@39..45
         LITERAL@39..42
-          "\n" NUMBER@39..42 "1" " "
-         SLASH@42..44 "/" " "
+          Whitespace(1) NUMBER@39..42 "1" Whitespace(1)
+        None SLASH@42..44 "/" Whitespace(1)
         LITERAL@44..45
-           NUMBER@44..45 "2" 
+          None NUMBER@44..45 "2" None
     EXPR_STMT@45..55
       BIN_EXPR@45..55
         LITERAL@45..49
-          "\n" NUMBER@45..49 "74" " "
-         IN_KW@49..52 "in" " "
+          Whitespace(1) NUMBER@45..49 "74" Whitespace(1)
+        None IN_KW@49..52 "in" Whitespace(1)
         NAME_REF@52..55
-           IDENT@52..55 "foo" 
+          None IDENT@52..55 "foo" None
     EXPR_STMT@55..76
       BIN_EXPR@55..76
         NAME_REF@55..60
-          "\n" IDENT@55..60 "foo" " "
-         INSTANCEOF_KW@60..71 "instanceof" " "
+          Whitespace(1) IDENT@55..60 "foo" Whitespace(1)
+        None INSTANCEOF_KW@60..71 "instanceof" Whitespace(1)
         NAME_REF@71..76
-           IDENT@71..76 "Array" 
+          None IDENT@71..76 "Array" None
     EXPR_STMT@76..87
       BIN_EXPR@76..87
         NAME_REF@76..81
-          "\n" IDENT@76..81 "foo" " "
-         QUESTION2@81..84 "??" " "
+          Whitespace(1) IDENT@76..81 "foo" Whitespace(1)
+        None QUESTION2@81..84 "??" Whitespace(1)
         NAME_REF@84..87
-           IDENT@84..87 "bar" 
+          None IDENT@84..87 "bar" None
     EXPR_STMT@87..101
       BIN_EXPR@87..101
         BIN_EXPR@87..98
           BIN_EXPR@87..94
             LITERAL@87..90
-              "\n" NUMBER@87..90 "1" " "
-             PLUS@90..92 "+" " "
+              Whitespace(1) NUMBER@87..90 "1" Whitespace(1)
+            None PLUS@90..92 "+" Whitespace(1)
             LITERAL@92..94
-               NUMBER@92..94 "1" " "
-           PLUS@94..96 "+" " "
+              None NUMBER@92..94 "1" Whitespace(1)
+          None PLUS@94..96 "+" Whitespace(1)
           LITERAL@96..98
-             NUMBER@96..98 "1" " "
-         PLUS@98..100 "+" " "
+            None NUMBER@96..98 "1" Whitespace(1)
+        None PLUS@98..100 "+" Whitespace(1)
         LITERAL@100..101
-           NUMBER@100..101 "1" 
+          None NUMBER@100..101 "1" None
     EXPR_STMT@101..124
       BIN_EXPR@101..124
         BIN_EXPR@101..108
           LITERAL@101..104
-            "\n" NUMBER@101..104 "5" " "
-           PLUS@104..106 "+" " "
+            Whitespace(1) NUMBER@101..104 "5" Whitespace(1)
+          None PLUS@104..106 "+" Whitespace(1)
           LITERAL@106..108
+<<<<<<< HEAD
              NUMBER@106..108 "6" " "
          MINUS@108..110 "-" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None NUMBER@106..108 "6" Whitespace(1)
+        None MINUS@108..110 "-" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@110..124
           BIN_EXPR@110..116
             LITERAL@110..112
-               NUMBER@110..112 "1" " "
-             STAR@112..114 "*" " "
+              None NUMBER@110..112 "1" Whitespace(1)
+            None STAR@112..114 "*" Whitespace(1)
             LITERAL@114..116
-               NUMBER@114..116 "2" " "
-           SLASH@116..118 "/" " "
+              None NUMBER@114..116 "2" Whitespace(1)
+          None SLASH@116..118 "/" Whitespace(1)
           BIN_EXPR@118..124
             LITERAL@118..120
-               NUMBER@118..120 "1" " "
-             STAR2@120..123 "**" " "
+              None NUMBER@118..120 "1" Whitespace(1)
+            None STAR2@120..123 "**" Whitespace(1)
             LITERAL@123..124
-               NUMBER@123..124 "6" 
+              None NUMBER@123..124 "6" None

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -1,13 +1,16 @@
+<<<<<<< HEAD
 JS_MODULE@0..125
+=======
+MODULE@0..124
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..124
     JS_EXPRESSION_STATEMENT@0..5
       BIN_EXPR@0..5
-        LITERAL@0..1
-          NUMBER@0..1 "5"
-        WHITESPACE@1..2 " "
-        STAR@2..3 "*"
-        WHITESPACE@3..4 " "
+        LITERAL@0..2
+           NUMBER@0..2 "5" " "
+         STAR@2..4 "*" " "
         LITERAL@4..5
+<<<<<<< HEAD
           NUMBER@4..5 "5"
     WHITESPACE@5..6 "\n"
     JS_EXPRESSION_STATEMENT@6..17
@@ -17,13 +20,20 @@ JS_MODULE@0..125
         WHITESPACE@7..8 " "
         STAR2@8..10 "**"
         WHITESPACE@10..11 " "
+=======
+           NUMBER@4..5 "5" 
+    EXPR_STMT@5..17
+      BIN_EXPR@5..17
+        LITERAL@5..8
+          "\n" NUMBER@5..8 "6" " "
+         STAR2@8..11 "**" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@11..17
-          LITERAL@11..12
-            NUMBER@11..12 "6"
-          WHITESPACE@12..13 " "
-          STAR2@13..15 "**"
-          WHITESPACE@15..16 " "
+          LITERAL@11..13
+             NUMBER@11..13 "6" " "
+           STAR2@13..16 "**" " "
           LITERAL@16..17
+<<<<<<< HEAD
             NUMBER@16..17 "7"
     WHITESPACE@17..18 "\n"
     JS_EXPRESSION_STATEMENT@18..39
@@ -33,33 +43,35 @@ JS_MODULE@0..125
         WHITESPACE@19..20 " "
         PLUS@20..21 "+"
         WHITESPACE@21..22 " "
+=======
+             NUMBER@16..17 "7" 
+    EXPR_STMT@17..39
+      BIN_EXPR@17..39
+        LITERAL@17..20
+          "\n" NUMBER@17..20 "1" " "
+         PLUS@20..22 "+" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@22..39
-          BIN_EXPR@22..35
-            LITERAL@22..23
-              NUMBER@22..23 "2"
-            WHITESPACE@23..24 " "
-            STAR@24..25 "*"
-            WHITESPACE@25..26 " "
-            CALL_EXPR@26..35
+          BIN_EXPR@22..36
+            LITERAL@22..24
+               NUMBER@22..24 "2" " "
+             STAR@24..26 "*" " "
+            CALL_EXPR@26..36
               LITERAL@26..27
-                NUMBER@26..27 "3"
-              WHITESPACE@27..28 "\n"
-              ARG_LIST@28..35
-                L_PAREN@28..29 "("
+                 NUMBER@26..27 "3" 
+              ARG_LIST@27..36
+                "\n" L_PAREN@27..29 "(" 
                 LIST@29..34
                   BIN_EXPR@29..34
-                    LITERAL@29..30
-                      NUMBER@29..30 "1"
-                    WHITESPACE@30..31 " "
-                    PLUS@31..32 "+"
-                    WHITESPACE@32..33 " "
+                    LITERAL@29..31
+                       NUMBER@29..31 "1" " "
+                     PLUS@31..33 "+" " "
                     LITERAL@33..34
-                      NUMBER@33..34 "2"
-                R_PAREN@34..35 ")"
-          WHITESPACE@35..36 " "
-          STAR@36..37 "*"
-          WHITESPACE@37..38 " "
+                       NUMBER@33..34 "2" 
+                 R_PAREN@34..36 ")" " "
+           STAR@36..38 "*" " "
           LITERAL@38..39
+<<<<<<< HEAD
             NUMBER@38..39 "3"
     WHITESPACE@39..40 "\n"
     JS_EXPRESSION_STATEMENT@40..45
@@ -137,24 +149,72 @@ JS_MODULE@0..125
         WHITESPACE@107..108 " "
         MINUS@108..109 "-"
         WHITESPACE@109..110 " "
+=======
+             NUMBER@38..39 "3" 
+    EXPR_STMT@39..45
+      BIN_EXPR@39..45
+        LITERAL@39..42
+          "\n" NUMBER@39..42 "1" " "
+         SLASH@42..44 "/" " "
+        LITERAL@44..45
+           NUMBER@44..45 "2" 
+    EXPR_STMT@45..55
+      BIN_EXPR@45..55
+        LITERAL@45..49
+          "\n" NUMBER@45..49 "74" " "
+         IN_KW@49..52 "in" " "
+        NAME_REF@52..55
+           IDENT@52..55 "foo" 
+    EXPR_STMT@55..76
+      BIN_EXPR@55..76
+        NAME_REF@55..60
+          "\n" IDENT@55..60 "foo" " "
+         INSTANCEOF_KW@60..71 "instanceof" " "
+        NAME_REF@71..76
+           IDENT@71..76 "Array" 
+    EXPR_STMT@76..87
+      BIN_EXPR@76..87
+        NAME_REF@76..81
+          "\n" IDENT@76..81 "foo" " "
+         QUESTION2@81..84 "??" " "
+        NAME_REF@84..87
+           IDENT@84..87 "bar" 
+    EXPR_STMT@87..101
+      BIN_EXPR@87..101
+        BIN_EXPR@87..98
+          BIN_EXPR@87..94
+            LITERAL@87..90
+              "\n" NUMBER@87..90 "1" " "
+             PLUS@90..92 "+" " "
+            LITERAL@92..94
+               NUMBER@92..94 "1" " "
+           PLUS@94..96 "+" " "
+          LITERAL@96..98
+             NUMBER@96..98 "1" " "
+         PLUS@98..100 "+" " "
+        LITERAL@100..101
+           NUMBER@100..101 "1" 
+    EXPR_STMT@101..124
+      BIN_EXPR@101..124
+        BIN_EXPR@101..108
+          LITERAL@101..104
+            "\n" NUMBER@101..104 "5" " "
+           PLUS@104..106 "+" " "
+          LITERAL@106..108
+             NUMBER@106..108 "6" " "
+         MINUS@108..110 "-" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@110..124
-          BIN_EXPR@110..115
-            LITERAL@110..111
-              NUMBER@110..111 "1"
-            WHITESPACE@111..112 " "
-            STAR@112..113 "*"
-            WHITESPACE@113..114 " "
-            LITERAL@114..115
-              NUMBER@114..115 "2"
-          WHITESPACE@115..116 " "
-          SLASH@116..117 "/"
-          WHITESPACE@117..118 " "
+          BIN_EXPR@110..116
+            LITERAL@110..112
+               NUMBER@110..112 "1" " "
+             STAR@112..114 "*" " "
+            LITERAL@114..116
+               NUMBER@114..116 "2" " "
+           SLASH@116..118 "/" " "
           BIN_EXPR@118..124
-            LITERAL@118..119
-              NUMBER@118..119 "1"
-            WHITESPACE@119..120 " "
-            STAR2@120..122 "**"
-            WHITESPACE@122..123 " "
+            LITERAL@118..120
+               NUMBER@118..120 "1" " "
+             STAR2@120..123 "**" " "
             LITERAL@123..124
-              NUMBER@123..124 "6"
-  WHITESPACE@124..125 "\n"
+               NUMBER@123..124 "6" 

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -32,35 +32,35 @@ JS_MODULE@0..27
 MODULE@0..26
   LIST@0..26
     BLOCK_STMT@0..2
-       L_CURLY@0..1 "{" 
+      None L_CURLY@0..1 "{" None
       LIST@1..1
-       R_CURLY@1..2 "}" 
+      None R_CURLY@1..2 "}" None
     BLOCK_STMT@2..11
-      "\n" L_CURLY@2..4 "{" 
+      Whitespace(1) L_CURLY@2..4 "{" None
       LIST@4..10
         BLOCK_STMT@4..10
-           L_CURLY@4..5 "{" 
+          None L_CURLY@4..5 "{" None
           LIST@5..9
             BLOCK_STMT@5..9
-               L_CURLY@5..6 "{" 
+              None L_CURLY@5..6 "{" None
               LIST@6..8
                 BLOCK_STMT@6..8
-                   L_CURLY@6..7 "{" 
+                  None L_CURLY@6..7 "{" None
                   LIST@7..7
-                   R_CURLY@7..8 "}" 
-               R_CURLY@8..9 "}" 
-           R_CURLY@9..10 "}" 
-       R_CURLY@10..11 "}" 
+                  None R_CURLY@7..8 "}" None
+              None R_CURLY@8..9 "}" None
+          None R_CURLY@9..10 "}" None
+      None R_CURLY@10..11 "}" None
     BLOCK_STMT@11..26
-      "\n" L_CURLY@11..14 "{" " "
+      Whitespace(1) L_CURLY@11..14 "{" Whitespace(1)
       LIST@14..25
         EXPR_STMT@14..25
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           ASSIGN_EXPR@14..23
             NAME_REF@14..18
-               IDENT@14..18 "foo" " "
-             EQ@18..20 "=" " "
+              None IDENT@14..18 "foo" Whitespace(1)
+            None EQ@18..20 "=" Whitespace(1)
             NAME_REF@20..23
-               IDENT@20..23 "bar" 
-           SEMICOLON@23..25 ";" " "
-       R_CURLY@25..26 "}" 
+              None IDENT@20..23 "bar" None
+          None SEMICOLON@23..25 ";" Whitespace(1)
+      None R_CURLY@25..26 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -1,61 +1,29 @@
-<<<<<<< HEAD
-JS_MODULE@0..27
+JS_MODULE@0..26
   LIST@0..26
     JS_BLOCK_STATEMENT@0..2
-      L_CURLY@0..1 "{"
-      LIST@1..1
-      R_CURLY@1..2 "}"
-    WHITESPACE@2..3 "\n"
-    JS_BLOCK_STATEMENT@3..11
-      L_CURLY@3..4 "{"
-      LIST@4..10
-        JS_BLOCK_STATEMENT@4..10
-          L_CURLY@4..5 "{"
-          LIST@5..9
-            JS_BLOCK_STATEMENT@5..9
-              L_CURLY@5..6 "{"
-              LIST@6..8
-                JS_BLOCK_STATEMENT@6..8
-                  L_CURLY@6..7 "{"
-                  LIST@7..7
-                  R_CURLY@7..8 "}"
-              R_CURLY@8..9 "}"
-          R_CURLY@9..10 "}"
-      R_CURLY@10..11 "}"
-    WHITESPACE@11..12 "\n"
-    JS_BLOCK_STATEMENT@12..26
-      L_CURLY@12..13 "{"
-      WHITESPACE@13..14 " "
-      LIST@14..24
-        JS_EXPRESSION_STATEMENT@14..24
-=======
-MODULE@0..26
-  LIST@0..26
-    BLOCK_STMT@0..2
       None L_CURLY@0..1 "{" None
       LIST@1..1
       None R_CURLY@1..2 "}" None
-    BLOCK_STMT@2..11
+    JS_BLOCK_STATEMENT@2..11
       Whitespace(1) L_CURLY@3..4 "{" None
       LIST@4..10
-        BLOCK_STMT@4..10
+        JS_BLOCK_STATEMENT@4..10
           None L_CURLY@4..5 "{" None
           LIST@5..9
-            BLOCK_STMT@5..9
+            JS_BLOCK_STATEMENT@5..9
               None L_CURLY@5..6 "{" None
               LIST@6..8
-                BLOCK_STMT@6..8
+                JS_BLOCK_STATEMENT@6..8
                   None L_CURLY@6..7 "{" None
                   LIST@7..7
                   None R_CURLY@7..8 "}" None
               None R_CURLY@8..9 "}" None
           None R_CURLY@9..10 "}" None
       None R_CURLY@10..11 "}" None
-    BLOCK_STMT@11..26
+    JS_BLOCK_STATEMENT@11..26
       Whitespace(1) L_CURLY@12..13 "{" Whitespace(1)
       LIST@14..25
-        EXPR_STMT@14..25
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+        JS_EXPRESSION_STATEMENT@14..25
           ASSIGN_EXPR@14..23
             NAME_REF@14..18
               None IDENT@14..17 "foo" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -36,7 +36,7 @@ MODULE@0..26
       LIST@1..1
       None R_CURLY@1..2 "}" None
     BLOCK_STMT@2..11
-      Whitespace(1) L_CURLY@2..4 "{" None
+      Whitespace(1) L_CURLY@3..4 "{" None
       LIST@4..10
         BLOCK_STMT@4..10
           None L_CURLY@4..5 "{" None
@@ -52,15 +52,15 @@ MODULE@0..26
           None R_CURLY@9..10 "}" None
       None R_CURLY@10..11 "}" None
     BLOCK_STMT@11..26
-      Whitespace(1) L_CURLY@11..14 "{" Whitespace(1)
+      Whitespace(1) L_CURLY@12..13 "{" Whitespace(1)
       LIST@14..25
         EXPR_STMT@14..25
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           ASSIGN_EXPR@14..23
             NAME_REF@14..18
-              None IDENT@14..18 "foo" Whitespace(1)
-            None EQ@18..20 "=" Whitespace(1)
+              None IDENT@14..17 "foo" Whitespace(1)
+            None EQ@18..19 "=" Whitespace(1)
             NAME_REF@20..23
               None IDENT@20..23 "bar" None
-          None SEMICOLON@23..25 ";" Whitespace(1)
+          None SEMICOLON@23..24 ";" Whitespace(1)
       None R_CURLY@25..26 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..27
   LIST@0..26
     JS_BLOCK_STATEMENT@0..2
@@ -27,15 +28,39 @@ JS_MODULE@0..27
       WHITESPACE@13..14 " "
       LIST@14..24
         JS_EXPRESSION_STATEMENT@14..24
+=======
+MODULE@0..26
+  LIST@0..26
+    BLOCK_STMT@0..2
+       L_CURLY@0..1 "{" 
+      LIST@1..1
+       R_CURLY@1..2 "}" 
+    BLOCK_STMT@2..11
+      "\n" L_CURLY@2..4 "{" 
+      LIST@4..10
+        BLOCK_STMT@4..10
+           L_CURLY@4..5 "{" 
+          LIST@5..9
+            BLOCK_STMT@5..9
+               L_CURLY@5..6 "{" 
+              LIST@6..8
+                BLOCK_STMT@6..8
+                   L_CURLY@6..7 "{" 
+                  LIST@7..7
+                   R_CURLY@7..8 "}" 
+               R_CURLY@8..9 "}" 
+           R_CURLY@9..10 "}" 
+       R_CURLY@10..11 "}" 
+    BLOCK_STMT@11..26
+      "\n" L_CURLY@11..14 "{" " "
+      LIST@14..25
+        EXPR_STMT@14..25
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           ASSIGN_EXPR@14..23
-            NAME_REF@14..17
-              IDENT@14..17 "foo"
-            WHITESPACE@17..18 " "
-            EQ@18..19 "="
-            WHITESPACE@19..20 " "
+            NAME_REF@14..18
+               IDENT@14..18 "foo" " "
+             EQ@18..20 "=" " "
             NAME_REF@20..23
-              IDENT@20..23 "bar"
-          SEMICOLON@23..24 ";"
-      WHITESPACE@24..25 " "
-      R_CURLY@25..26 "}"
-  WHITESPACE@26..27 "\n"
+               IDENT@20..23 "bar" 
+           SEMICOLON@23..25 ";" " "
+       R_CURLY@25..26 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -1,11 +1,16 @@
+<<<<<<< HEAD
 JS_MODULE@0..56
+=======
+MODULE@0..55
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..55
     JS_EXPRESSION_STATEMENT@0..8
       BRACKET_EXPR@0..8
         NAME_REF@0..3
-          IDENT@0..3 "foo"
-        L_BRACK@3..4 "["
+           IDENT@0..3 "foo" 
+         L_BRACK@3..4 "[" 
         NAME_REF@4..7
+<<<<<<< HEAD
           IDENT@4..7 "bar"
         R_BRACK@7..8 "]"
     WHITESPACE@8..9 "\n"
@@ -14,13 +19,21 @@ JS_MODULE@0..56
         NAME_REF@9..12
           IDENT@9..12 "foo"
         L_BRACK@12..13 "["
+=======
+           IDENT@4..7 "bar" 
+         R_BRACK@7..8 "]" 
+    EXPR_STMT@8..19
+      BRACKET_EXPR@8..19
+        NAME_REF@8..12
+          "\n" IDENT@8..12 "foo" 
+         L_BRACK@12..13 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@13..18
-          LITERAL@13..14
-            NUMBER@13..14 "5"
-          WHITESPACE@14..15 " "
-          PLUS@15..16 "+"
-          WHITESPACE@16..17 " "
+          LITERAL@13..15
+             NUMBER@13..15 "5" " "
+           PLUS@15..17 "+" " "
           LITERAL@17..18
+<<<<<<< HEAD
             NUMBER@17..18 "5"
         R_BRACK@18..19 "]"
     WHITESPACE@19..20 "\n"
@@ -39,11 +52,30 @@ JS_MODULE@0..56
           NAME_REF@31..34
             IDENT@31..34 "foo"
           L_BRACK@34..35 "["
+=======
+             NUMBER@17..18 "5" 
+         R_BRACK@18..19 "]" 
+    EXPR_STMT@19..30
+      BRACKET_EXPR@19..30
+        NAME_REF@19..23
+          "\n" IDENT@19..23 "foo" 
+         L_BRACK@23..24 "[" 
+        LITERAL@24..29
+           STRING@24..29 "\"bar\"" 
+         R_BRACK@29..30 "]" 
+    EXPR_STMT@30..44
+      BRACKET_EXPR@30..44
+        BRACKET_EXPR@30..39
+          NAME_REF@30..34
+            "\n" IDENT@30..34 "foo" 
+           L_BRACK@34..35 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           NAME_REF@35..38
-            IDENT@35..38 "bar"
-          R_BRACK@38..39 "]"
-        L_BRACK@39..40 "["
+             IDENT@35..38 "bar" 
+           R_BRACK@38..39 "]" 
+         L_BRACK@39..40 "[" 
         NAME_REF@40..43
+<<<<<<< HEAD
           IDENT@40..43 "baz"
         R_BRACK@43..44 "]"
     WHITESPACE@44..45 "\n"
@@ -53,7 +85,16 @@ JS_MODULE@0..56
           IDENT@45..48 "foo"
         QUESTIONDOT@48..50 "?."
         L_BRACK@50..51 "["
+=======
+           IDENT@40..43 "baz" 
+         R_BRACK@43..44 "]" 
+    EXPR_STMT@44..55
+      BRACKET_EXPR@44..55
+        NAME_REF@44..48
+          "\n" IDENT@44..48 "foo" 
+         QUESTIONDOT@48..50 "?." 
+         L_BRACK@50..51 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME_REF@51..54
-          IDENT@51..54 "bar"
-        R_BRACK@54..55 "]"
-  WHITESPACE@55..56 "\n"
+           IDENT@51..54 "bar" 
+         R_BRACK@54..55 "]" 

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..56
-=======
-MODULE@0..55
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..55
   LIST@0..55
     JS_EXPRESSION_STATEMENT@0..8
       BRACKET_EXPR@0..8
@@ -10,67 +6,21 @@ MODULE@0..55
           None IDENT@0..3 "foo" None
         None L_BRACK@3..4 "[" None
         NAME_REF@4..7
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@4..7 "bar"
-        R_BRACK@7..8 "]"
-    WHITESPACE@8..9 "\n"
-    JS_EXPRESSION_STATEMENT@9..19
-      BRACKET_EXPR@9..19
-        NAME_REF@9..12
-          IDENT@9..12 "foo"
-        L_BRACK@12..13 "["
-=======
-           IDENT@4..7 "bar" 
-         R_BRACK@7..8 "]" 
-    EXPR_STMT@8..19
-      BRACKET_EXPR@8..19
-        NAME_REF@8..12
-          "\n" IDENT@8..12 "foo" 
-         L_BRACK@12..13 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None IDENT@4..7 "bar" None
         None R_BRACK@7..8 "]" None
-    EXPR_STMT@8..19
+    JS_EXPRESSION_STATEMENT@8..19
       BRACKET_EXPR@8..19
         NAME_REF@8..12
           Whitespace(1) IDENT@9..12 "foo" None
         None L_BRACK@12..13 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@13..18
           LITERAL@13..15
             None NUMBER@13..14 "5" Whitespace(1)
           None PLUS@15..16 "+" Whitespace(1)
           LITERAL@17..18
-<<<<<<< HEAD
-<<<<<<< HEAD
-            NUMBER@17..18 "5"
-        R_BRACK@18..19 "]"
-    WHITESPACE@19..20 "\n"
-    JS_EXPRESSION_STATEMENT@20..30
-      BRACKET_EXPR@20..30
-        NAME_REF@20..23
-          IDENT@20..23 "foo"
-        L_BRACK@23..24 "["
-        LITERAL@24..29
-          STRING@24..29 "\"bar\""
-        R_BRACK@29..30 "]"
-    WHITESPACE@30..31 "\n"
-    JS_EXPRESSION_STATEMENT@31..44
-      BRACKET_EXPR@31..44
-        BRACKET_EXPR@31..39
-          NAME_REF@31..34
-            IDENT@31..34 "foo"
-          L_BRACK@34..35 "["
-=======
-             NUMBER@17..18 "5" 
-         R_BRACK@18..19 "]" 
-=======
             None NUMBER@17..18 "5" None
         None R_BRACK@18..19 "]" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@19..30
+    JS_EXPRESSION_STATEMENT@19..30
       BRACKET_EXPR@19..30
         NAME_REF@19..23
           Whitespace(1) IDENT@20..23 "foo" None
@@ -78,58 +28,25 @@ MODULE@0..55
         LITERAL@24..29
           None STRING@24..29 "\"bar\"" None
         None R_BRACK@29..30 "]" None
-    EXPR_STMT@30..44
+    JS_EXPRESSION_STATEMENT@30..44
       BRACKET_EXPR@30..44
         BRACKET_EXPR@30..39
           NAME_REF@30..34
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "\n" IDENT@30..34 "foo" 
-           L_BRACK@34..35 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            Whitespace(1) IDENT@30..34 "foo" None
-=======
             Whitespace(1) IDENT@31..34 "foo" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           None L_BRACK@34..35 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           NAME_REF@35..38
             None IDENT@35..38 "bar" None
           None R_BRACK@38..39 "]" None
         None L_BRACK@39..40 "[" None
         NAME_REF@40..43
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@40..43 "baz"
-        R_BRACK@43..44 "]"
-    WHITESPACE@44..45 "\n"
-    JS_EXPRESSION_STATEMENT@45..55
-      BRACKET_EXPR@45..55
-        NAME_REF@45..48
-          IDENT@45..48 "foo"
-        QUESTIONDOT@48..50 "?."
-        L_BRACK@50..51 "["
-=======
-           IDENT@40..43 "baz" 
-         R_BRACK@43..44 "]" 
-    EXPR_STMT@44..55
-      BRACKET_EXPR@44..55
-        NAME_REF@44..48
-          "\n" IDENT@44..48 "foo" 
-         QUESTIONDOT@48..50 "?." 
-         L_BRACK@50..51 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None IDENT@40..43 "baz" None
         None R_BRACK@43..44 "]" None
-    EXPR_STMT@44..55
+    JS_EXPRESSION_STATEMENT@44..55
       BRACKET_EXPR@44..55
         NAME_REF@44..48
           Whitespace(1) IDENT@45..48 "foo" None
         None QUESTIONDOT@48..50 "?." None
         None L_BRACK@50..51 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@51..54
           None IDENT@51..54 "bar" None
         None R_BRACK@54..55 "]" None

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -7,9 +7,10 @@ MODULE@0..55
     JS_EXPRESSION_STATEMENT@0..8
       BRACKET_EXPR@0..8
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
-         L_BRACK@3..4 "[" 
+          None IDENT@0..3 "foo" None
+        None L_BRACK@3..4 "[" None
         NAME_REF@4..7
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@4..7 "bar"
         R_BRACK@7..8 "]"
@@ -28,11 +29,21 @@ MODULE@0..55
           "\n" IDENT@8..12 "foo" 
          L_BRACK@12..13 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@4..7 "bar" None
+        None R_BRACK@7..8 "]" None
+    EXPR_STMT@8..19
+      BRACKET_EXPR@8..19
+        NAME_REF@8..12
+          Whitespace(1) IDENT@8..12 "foo" None
+        None L_BRACK@12..13 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@13..18
           LITERAL@13..15
-             NUMBER@13..15 "5" " "
-           PLUS@15..17 "+" " "
+            None NUMBER@13..15 "5" Whitespace(1)
+          None PLUS@15..17 "+" Whitespace(1)
           LITERAL@17..18
+<<<<<<< HEAD
 <<<<<<< HEAD
             NUMBER@17..18 "5"
         R_BRACK@18..19 "]"
@@ -55,26 +66,36 @@ MODULE@0..55
 =======
              NUMBER@17..18 "5" 
          R_BRACK@18..19 "]" 
+=======
+            None NUMBER@17..18 "5" None
+        None R_BRACK@18..19 "]" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@19..30
       BRACKET_EXPR@19..30
         NAME_REF@19..23
-          "\n" IDENT@19..23 "foo" 
-         L_BRACK@23..24 "[" 
+          Whitespace(1) IDENT@19..23 "foo" None
+        None L_BRACK@23..24 "[" None
         LITERAL@24..29
-           STRING@24..29 "\"bar\"" 
-         R_BRACK@29..30 "]" 
+          None STRING@24..29 "\"bar\"" None
+        None R_BRACK@29..30 "]" None
     EXPR_STMT@30..44
       BRACKET_EXPR@30..44
         BRACKET_EXPR@30..39
           NAME_REF@30..34
+<<<<<<< HEAD
             "\n" IDENT@30..34 "foo" 
            L_BRACK@34..35 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            Whitespace(1) IDENT@30..34 "foo" None
+          None L_BRACK@34..35 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           NAME_REF@35..38
-             IDENT@35..38 "bar" 
-           R_BRACK@38..39 "]" 
-         L_BRACK@39..40 "[" 
+            None IDENT@35..38 "bar" None
+          None R_BRACK@38..39 "]" None
+        None L_BRACK@39..40 "[" None
         NAME_REF@40..43
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@40..43 "baz"
         R_BRACK@43..44 "]"
@@ -95,6 +116,16 @@ MODULE@0..55
          QUESTIONDOT@48..50 "?." 
          L_BRACK@50..51 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@40..43 "baz" None
+        None R_BRACK@43..44 "]" None
+    EXPR_STMT@44..55
+      BRACKET_EXPR@44..55
+        NAME_REF@44..48
+          Whitespace(1) IDENT@44..48 "foo" None
+        None QUESTIONDOT@48..50 "?." None
+        None L_BRACK@50..51 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@51..54
-           IDENT@51..54 "bar" 
-         R_BRACK@54..55 "]" 
+          None IDENT@51..54 "bar" None
+        None R_BRACK@54..55 "]" None

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -35,13 +35,13 @@ MODULE@0..55
     EXPR_STMT@8..19
       BRACKET_EXPR@8..19
         NAME_REF@8..12
-          Whitespace(1) IDENT@8..12 "foo" None
+          Whitespace(1) IDENT@9..12 "foo" None
         None L_BRACK@12..13 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@13..18
           LITERAL@13..15
-            None NUMBER@13..15 "5" Whitespace(1)
-          None PLUS@15..17 "+" Whitespace(1)
+            None NUMBER@13..14 "5" Whitespace(1)
+          None PLUS@15..16 "+" Whitespace(1)
           LITERAL@17..18
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -73,7 +73,7 @@ MODULE@0..55
     EXPR_STMT@19..30
       BRACKET_EXPR@19..30
         NAME_REF@19..23
-          Whitespace(1) IDENT@19..23 "foo" None
+          Whitespace(1) IDENT@20..23 "foo" None
         None L_BRACK@23..24 "[" None
         LITERAL@24..29
           None STRING@24..29 "\"bar\"" None
@@ -83,11 +83,15 @@ MODULE@0..55
         BRACKET_EXPR@30..39
           NAME_REF@30..34
 <<<<<<< HEAD
+<<<<<<< HEAD
             "\n" IDENT@30..34 "foo" 
            L_BRACK@34..35 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             Whitespace(1) IDENT@30..34 "foo" None
+=======
+            Whitespace(1) IDENT@31..34 "foo" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           None L_BRACK@34..35 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           NAME_REF@35..38
@@ -122,7 +126,7 @@ MODULE@0..55
     EXPR_STMT@44..55
       BRACKET_EXPR@44..55
         NAME_REF@44..48
-          Whitespace(1) IDENT@44..48 "foo" None
+          Whitespace(1) IDENT@45..48 "foo" None
         None QUESTIONDOT@48..50 "?." None
         None L_BRACK@50..51 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -22,15 +22,15 @@ MODULE@0..45
     LABELLED_STMT@0..7
       NAME@0..3
         None IDENT@0..3 "foo" None
-      None COLON@3..5 ":" Whitespace(1)
+      None COLON@3..4 ":" Whitespace(1)
       BLOCK_STMT@5..7
         None L_CURLY@5..6 "{" None
         LIST@6..6
         None R_CURLY@6..7 "}" None
     LABELLED_STMT@7..16
       NAME@7..12
-        Whitespace(1) IDENT@7..12 "rust" None
-      None COLON@12..14 ":" Whitespace(1)
+        Whitespace(1) IDENT@8..12 "rust" None
+      None COLON@12..13 ":" Whitespace(1)
       BLOCK_STMT@14..16
 <<<<<<< HEAD
          L_CURLY@14..15 "{" 
@@ -41,14 +41,14 @@ MODULE@0..45
         LIST@15..15
         None R_CURLY@15..16 "}" None
     BREAK_STMT@16..23
-      Whitespace(1) BREAK_KW@16..22 "break" None
+      Whitespace(1) BREAK_KW@17..22 "break" None
       None SEMICOLON@22..23 ";" None
     BREAK_STMT@23..34
-      Whitespace(1) BREAK_KW@23..30 "break" Whitespace(1)
+      Whitespace(1) BREAK_KW@24..29 "break" Whitespace(1)
       NAME_REF@30..33
         None IDENT@30..33 "foo" None
       None SEMICOLON@33..34 ";" None
     BREAK_STMT@34..45
-      Whitespace(1) BREAK_KW@34..41 "break" Whitespace(1)
+      Whitespace(1) BREAK_KW@35..40 "break" Whitespace(1)
       NAME_REF@41..45
         None IDENT@41..45 "rust" None

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -1,43 +1,17 @@
-<<<<<<< HEAD
-JS_MODULE@0..46
+JS_MODULE@0..45
   LIST@0..45
     JS_LABELED_STATEMENT@0..7
-      IDENT@0..3 "foo"
-      COLON@3..4 ":"
-      WHITESPACE@4..5 " "
-      JS_BLOCK_STATEMENT@5..7
-        L_CURLY@5..6 "{"
-        LIST@6..6
-        R_CURLY@6..7 "}"
-    WHITESPACE@7..8 "\n"
-    JS_LABELED_STATEMENT@8..16
-      IDENT@8..12 "rust"
-      COLON@12..13 ":"
-      WHITESPACE@13..14 " "
-      JS_BLOCK_STATEMENT@14..16
-        L_CURLY@14..15 "{"
-=======
-MODULE@0..45
-  LIST@0..45
-    LABELLED_STMT@0..7
-      NAME@0..3
-        None IDENT@0..3 "foo" None
+      None IDENT@0..3 "foo" None
       None COLON@3..4 ":" Whitespace(1)
-      BLOCK_STMT@5..7
+      JS_BLOCK_STATEMENT@5..7
         None L_CURLY@5..6 "{" None
         LIST@6..6
         None R_CURLY@6..7 "}" None
-    LABELLED_STMT@7..16
-      NAME@7..12
-        Whitespace(1) IDENT@8..12 "rust" None
+    JS_LABELED_STATEMENT@7..16
+      Whitespace(1) IDENT@8..12 "rust" None
       None COLON@12..13 ":" Whitespace(1)
-      BLOCK_STMT@14..16
-<<<<<<< HEAD
-         L_CURLY@14..15 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+      JS_BLOCK_STATEMENT@14..16
         None L_CURLY@14..15 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@15..15
         None R_CURLY@15..16 "}" None
     BREAK_STMT@16..23

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -21,30 +21,34 @@ MODULE@0..45
   LIST@0..45
     LABELLED_STMT@0..7
       NAME@0..3
-         IDENT@0..3 "foo" 
-       COLON@3..5 ":" " "
+        None IDENT@0..3 "foo" None
+      None COLON@3..5 ":" Whitespace(1)
       BLOCK_STMT@5..7
-         L_CURLY@5..6 "{" 
+        None L_CURLY@5..6 "{" None
         LIST@6..6
-         R_CURLY@6..7 "}" 
+        None R_CURLY@6..7 "}" None
     LABELLED_STMT@7..16
       NAME@7..12
-        "\n" IDENT@7..12 "rust" 
-       COLON@12..14 ":" " "
+        Whitespace(1) IDENT@7..12 "rust" None
+      None COLON@12..14 ":" Whitespace(1)
       BLOCK_STMT@14..16
+<<<<<<< HEAD
          L_CURLY@14..15 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None L_CURLY@14..15 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@15..15
-         R_CURLY@15..16 "}" 
+        None R_CURLY@15..16 "}" None
     BREAK_STMT@16..23
-      "\n" BREAK_KW@16..22 "break" 
-       SEMICOLON@22..23 ";" 
+      Whitespace(1) BREAK_KW@16..22 "break" None
+      None SEMICOLON@22..23 ";" None
     BREAK_STMT@23..34
-      "\n" BREAK_KW@23..30 "break" " "
+      Whitespace(1) BREAK_KW@23..30 "break" Whitespace(1)
       NAME_REF@30..33
-         IDENT@30..33 "foo" 
-       SEMICOLON@33..34 ";" 
+        None IDENT@30..33 "foo" None
+      None SEMICOLON@33..34 ";" None
     BREAK_STMT@34..45
-      "\n" BREAK_KW@34..41 "break" " "
+      Whitespace(1) BREAK_KW@34..41 "break" Whitespace(1)
       NAME_REF@41..45
-         IDENT@41..45 "rust" 
+        None IDENT@41..45 "rust" None

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..46
   LIST@0..45
     JS_LABELED_STATEMENT@0..7
@@ -15,23 +16,35 @@ JS_MODULE@0..46
       WHITESPACE@13..14 " "
       JS_BLOCK_STATEMENT@14..16
         L_CURLY@14..15 "{"
+=======
+MODULE@0..45
+  LIST@0..45
+    LABELLED_STMT@0..7
+      NAME@0..3
+         IDENT@0..3 "foo" 
+       COLON@3..5 ":" " "
+      BLOCK_STMT@5..7
+         L_CURLY@5..6 "{" 
+        LIST@6..6
+         R_CURLY@6..7 "}" 
+    LABELLED_STMT@7..16
+      NAME@7..12
+        "\n" IDENT@7..12 "rust" 
+       COLON@12..14 ":" " "
+      BLOCK_STMT@14..16
+         L_CURLY@14..15 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@15..15
-        R_CURLY@15..16 "}"
-    WHITESPACE@16..17 "\n"
-    BREAK_STMT@17..23
-      BREAK_KW@17..22 "break"
-      SEMICOLON@22..23 ";"
-    WHITESPACE@23..24 "\n"
-    BREAK_STMT@24..34
-      BREAK_KW@24..29 "break"
-      WHITESPACE@29..30 " "
+         R_CURLY@15..16 "}" 
+    BREAK_STMT@16..23
+      "\n" BREAK_KW@16..22 "break" 
+       SEMICOLON@22..23 ";" 
+    BREAK_STMT@23..34
+      "\n" BREAK_KW@23..30 "break" " "
       NAME_REF@30..33
-        IDENT@30..33 "foo"
-      SEMICOLON@33..34 ";"
-    WHITESPACE@34..35 "\n"
-    BREAK_STMT@35..45
-      BREAK_KW@35..40 "break"
-      WHITESPACE@40..41 " "
+         IDENT@30..33 "foo" 
+       SEMICOLON@33..34 ";" 
+    BREAK_STMT@34..45
+      "\n" BREAK_KW@34..41 "break" " "
       NAME_REF@41..45
-        IDENT@41..45 "rust"
-  WHITESPACE@45..46 "\n"
+         IDENT@41..45 "rust" 

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -1,49 +1,40 @@
+<<<<<<< HEAD
 JS_MODULE@0..67
+=======
+MODULE@0..66
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     CLASS_DECL@0..12
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..12
-        L_CURLY@10..11 "{"
+         L_CURLY@10..11 "{" 
         LIST@11..11
-        R_CURLY@11..12 "}"
-    WHITESPACE@12..13 "\n"
-    CLASS_DECL@13..37
-      CLASS_KW@13..18 "class"
-      WHITESPACE@18..19 " "
-      NAME@19..22
-        IDENT@19..22 "foo"
-      WHITESPACE@22..23 " "
-      EXTENDS_KW@23..30 "extends"
-      WHITESPACE@30..31 " "
-      NAME_REF@31..34
-        IDENT@31..34 "bar"
-      WHITESPACE@34..35 " "
+         R_CURLY@11..12 "}" 
+    CLASS_DECL@12..37
+      "\n" CLASS_KW@12..19 "class" " "
+      NAME@19..23
+         IDENT@19..23 "foo" " "
+       EXTENDS_KW@23..31 "extends" " "
+      NAME_REF@31..35
+         IDENT@31..35 "bar" " "
       CLASS_BODY@35..37
-        L_CURLY@35..36 "{"
+         L_CURLY@35..36 "{" 
         LIST@36..36
-        R_CURLY@36..37 "}"
-    WHITESPACE@37..38 "\n"
-    CLASS_DECL@38..66
-      CLASS_KW@38..43 "class"
-      WHITESPACE@43..44 " "
-      NAME@44..47
-        IDENT@44..47 "foo"
-      WHITESPACE@47..48 " "
-      EXTENDS_KW@48..55 "extends"
-      WHITESPACE@55..56 " "
-      DOT_EXPR@56..63
+         R_CURLY@36..37 "}" 
+    CLASS_DECL@37..66
+      "\n" CLASS_KW@37..44 "class" " "
+      NAME@44..48
+         IDENT@44..48 "foo" " "
+       EXTENDS_KW@48..56 "extends" " "
+      DOT_EXPR@56..64
         NAME_REF@56..59
-          IDENT@56..59 "foo"
-        DOT@59..60 "."
-        NAME@60..63
-          IDENT@60..63 "bar"
-      WHITESPACE@63..64 " "
+           IDENT@56..59 "foo" 
+         DOT@59..60 "." 
+        NAME@60..64
+           IDENT@60..64 "bar" " "
       CLASS_BODY@64..66
-        L_CURLY@64..65 "{"
+         L_CURLY@64..65 "{" 
         LIST@65..65
-        R_CURLY@65..66 "}"
-  WHITESPACE@66..67 "\n"
+         R_CURLY@65..66 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -5,35 +5,35 @@ MODULE@0..66
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     CLASS_DECL@0..12
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..12
         None L_CURLY@10..11 "{" None
         LIST@11..11
         None R_CURLY@11..12 "}" None
     CLASS_DECL@12..37
-      Whitespace(1) CLASS_KW@12..19 "class" Whitespace(1)
+      Whitespace(1) CLASS_KW@13..18 "class" Whitespace(1)
       NAME@19..23
-        None IDENT@19..23 "foo" Whitespace(1)
-      None EXTENDS_KW@23..31 "extends" Whitespace(1)
+        None IDENT@19..22 "foo" Whitespace(1)
+      None EXTENDS_KW@23..30 "extends" Whitespace(1)
       NAME_REF@31..35
-        None IDENT@31..35 "bar" Whitespace(1)
+        None IDENT@31..34 "bar" Whitespace(1)
       CLASS_BODY@35..37
         None L_CURLY@35..36 "{" None
         LIST@36..36
         None R_CURLY@36..37 "}" None
     CLASS_DECL@37..66
-      Whitespace(1) CLASS_KW@37..44 "class" Whitespace(1)
+      Whitespace(1) CLASS_KW@38..43 "class" Whitespace(1)
       NAME@44..48
-        None IDENT@44..48 "foo" Whitespace(1)
-      None EXTENDS_KW@48..56 "extends" Whitespace(1)
+        None IDENT@44..47 "foo" Whitespace(1)
+      None EXTENDS_KW@48..55 "extends" Whitespace(1)
       DOT_EXPR@56..64
         NAME_REF@56..59
           None IDENT@56..59 "foo" None
         None DOT@59..60 "." None
         NAME@60..64
-          None IDENT@60..64 "bar" Whitespace(1)
+          None IDENT@60..63 "bar" Whitespace(1)
       CLASS_BODY@64..66
         None L_CURLY@64..65 "{" None
         LIST@65..65

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -5,36 +5,36 @@ MODULE@0..66
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     CLASS_DECL@0..12
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..12
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..11
-         R_CURLY@11..12 "}" 
+        None R_CURLY@11..12 "}" None
     CLASS_DECL@12..37
-      "\n" CLASS_KW@12..19 "class" " "
+      Whitespace(1) CLASS_KW@12..19 "class" Whitespace(1)
       NAME@19..23
-         IDENT@19..23 "foo" " "
-       EXTENDS_KW@23..31 "extends" " "
+        None IDENT@19..23 "foo" Whitespace(1)
+      None EXTENDS_KW@23..31 "extends" Whitespace(1)
       NAME_REF@31..35
-         IDENT@31..35 "bar" " "
+        None IDENT@31..35 "bar" Whitespace(1)
       CLASS_BODY@35..37
-         L_CURLY@35..36 "{" 
+        None L_CURLY@35..36 "{" None
         LIST@36..36
-         R_CURLY@36..37 "}" 
+        None R_CURLY@36..37 "}" None
     CLASS_DECL@37..66
-      "\n" CLASS_KW@37..44 "class" " "
+      Whitespace(1) CLASS_KW@37..44 "class" Whitespace(1)
       NAME@44..48
-         IDENT@44..48 "foo" " "
-       EXTENDS_KW@48..56 "extends" " "
+        None IDENT@44..48 "foo" Whitespace(1)
+      None EXTENDS_KW@48..56 "extends" Whitespace(1)
       DOT_EXPR@56..64
         NAME_REF@56..59
-           IDENT@56..59 "foo" 
-         DOT@59..60 "." 
+          None IDENT@56..59 "foo" None
+        None DOT@59..60 "." None
         NAME@60..64
-           IDENT@60..64 "bar" " "
+          None IDENT@60..64 "bar" Whitespace(1)
       CLASS_BODY@64..66
-         L_CURLY@64..65 "{" 
+        None L_CURLY@64..65 "{" None
         LIST@65..65
-         R_CURLY@65..66 "}" 
+        None R_CURLY@65..66 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..67
-=======
-MODULE@0..66
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..66
   LIST@0..66
     CLASS_DECL@0..12
       None CLASS_KW@0..5 "class" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -1,15 +1,17 @@
+<<<<<<< HEAD
 JS_MODULE@0..41
+=======
+MODULE@0..40
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..40
     CLASS_DECL@0..40
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..40
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..12 " "
+         L_CURLY@10..12 "{" " "
         LIST@12..39
+<<<<<<< HEAD
           JS_EMPTY_STATEMENT@12..13
             SEMICOLON@12..13 ";"
           JS_EMPTY_STATEMENT@13..14
@@ -31,14 +33,36 @@ JS_MODULE@0..41
           JS_EMPTY_STATEMENT@21..22
             SEMICOLON@21..22 ";"
           WHITESPACE@22..23 " "
+=======
+          EMPTY_STMT@12..13
+             SEMICOLON@12..13 ";" 
+          EMPTY_STMT@13..14
+             SEMICOLON@13..14 ";" 
+          EMPTY_STMT@14..15
+             SEMICOLON@14..15 ";" 
+          EMPTY_STMT@15..16
+             SEMICOLON@15..16 ";" 
+          EMPTY_STMT@16..17
+             SEMICOLON@16..17 ";" 
+          EMPTY_STMT@17..18
+             SEMICOLON@17..18 ";" 
+          EMPTY_STMT@18..19
+             SEMICOLON@18..19 ";" 
+          EMPTY_STMT@19..20
+             SEMICOLON@19..20 ";" 
+          EMPTY_STMT@20..21
+             SEMICOLON@20..21 ";" 
+          EMPTY_STMT@21..23
+             SEMICOLON@21..23 ";" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           GETTER@23..35
-            GET_KW@23..26 "get"
-            WHITESPACE@26..27 " "
+             GET_KW@23..27 "get" " "
             NAME@27..30
-              IDENT@27..30 "foo"
-            PARAMETER_LIST@30..32
-              L_PAREN@30..31 "("
+               IDENT@27..30 "foo" 
+            PARAMETER_LIST@30..33
+               L_PAREN@30..31 "(" 
               LIST@31..31
+<<<<<<< HEAD
               R_PAREN@31..32 ")"
             WHITESPACE@32..33 " "
             JS_BLOCK_STATEMENT@33..35
@@ -55,3 +79,19 @@ JS_MODULE@0..41
             SEMICOLON@38..39 ";"
         R_CURLY@39..40 "}"
   WHITESPACE@40..41 "\n"
+=======
+               R_PAREN@31..33 ")" " "
+            BLOCK_STMT@33..35
+               L_CURLY@33..34 "{" 
+              LIST@34..34
+               R_CURLY@34..35 "}" 
+          EMPTY_STMT@35..36
+             SEMICOLON@35..36 ";" 
+          EMPTY_STMT@36..37
+             SEMICOLON@36..37 ";" 
+          EMPTY_STMT@37..38
+             SEMICOLON@37..38 ";" 
+          EMPTY_STMT@38..39
+             SEMICOLON@38..39 ";" 
+         R_CURLY@39..40 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -5,11 +5,11 @@ MODULE@0..40
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..40
     CLASS_DECL@0..40
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..40
-         L_CURLY@10..12 "{" " "
+        None L_CURLY@10..12 "{" Whitespace(1)
         LIST@12..39
 <<<<<<< HEAD
           JS_EMPTY_STATEMENT@12..13
@@ -35,33 +35,38 @@ MODULE@0..40
           WHITESPACE@22..23 " "
 =======
           EMPTY_STMT@12..13
-             SEMICOLON@12..13 ";" 
+            None SEMICOLON@12..13 ";" None
           EMPTY_STMT@13..14
-             SEMICOLON@13..14 ";" 
+            None SEMICOLON@13..14 ";" None
           EMPTY_STMT@14..15
-             SEMICOLON@14..15 ";" 
+            None SEMICOLON@14..15 ";" None
           EMPTY_STMT@15..16
-             SEMICOLON@15..16 ";" 
+            None SEMICOLON@15..16 ";" None
           EMPTY_STMT@16..17
-             SEMICOLON@16..17 ";" 
+            None SEMICOLON@16..17 ";" None
           EMPTY_STMT@17..18
-             SEMICOLON@17..18 ";" 
+            None SEMICOLON@17..18 ";" None
           EMPTY_STMT@18..19
-             SEMICOLON@18..19 ";" 
+            None SEMICOLON@18..19 ";" None
           EMPTY_STMT@19..20
-             SEMICOLON@19..20 ";" 
+            None SEMICOLON@19..20 ";" None
           EMPTY_STMT@20..21
-             SEMICOLON@20..21 ";" 
+            None SEMICOLON@20..21 ";" None
           EMPTY_STMT@21..23
+<<<<<<< HEAD
              SEMICOLON@21..23 ";" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None SEMICOLON@21..23 ";" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           GETTER@23..35
-             GET_KW@23..27 "get" " "
+            None GET_KW@23..27 "get" Whitespace(1)
             NAME@27..30
-               IDENT@27..30 "foo" 
+              None IDENT@27..30 "foo" None
             PARAMETER_LIST@30..33
-               L_PAREN@30..31 "(" 
+              None L_PAREN@30..31 "(" None
               LIST@31..31
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@31..32 ")"
             WHITESPACE@32..33 " "
@@ -81,17 +86,25 @@ MODULE@0..40
   WHITESPACE@40..41 "\n"
 =======
                R_PAREN@31..33 ")" " "
+=======
+              None R_PAREN@31..33 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
             BLOCK_STMT@33..35
-               L_CURLY@33..34 "{" 
+              None L_CURLY@33..34 "{" None
               LIST@34..34
-               R_CURLY@34..35 "}" 
+              None R_CURLY@34..35 "}" None
           EMPTY_STMT@35..36
-             SEMICOLON@35..36 ";" 
+            None SEMICOLON@35..36 ";" None
           EMPTY_STMT@36..37
-             SEMICOLON@36..37 ";" 
+            None SEMICOLON@36..37 ";" None
           EMPTY_STMT@37..38
-             SEMICOLON@37..38 ";" 
+            None SEMICOLON@37..38 ";" None
           EMPTY_STMT@38..39
+<<<<<<< HEAD
              SEMICOLON@38..39 ";" 
          R_CURLY@39..40 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None SEMICOLON@38..39 ";" None
+        None R_CURLY@39..40 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -5,11 +5,11 @@ MODULE@0..40
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..40
     CLASS_DECL@0..40
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..40
-        None L_CURLY@10..12 "{" Whitespace(1)
+        None L_CURLY@10..11 "{" Whitespace(1)
         LIST@12..39
 <<<<<<< HEAD
           JS_EMPTY_STATEMENT@12..13
@@ -54,18 +54,23 @@ MODULE@0..40
             None SEMICOLON@20..21 ";" None
           EMPTY_STMT@21..23
 <<<<<<< HEAD
+<<<<<<< HEAD
              SEMICOLON@21..23 ";" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             None SEMICOLON@21..23 ";" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            None SEMICOLON@21..22 ";" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           GETTER@23..35
-            None GET_KW@23..27 "get" Whitespace(1)
+            None GET_KW@23..26 "get" Whitespace(1)
             NAME@27..30
               None IDENT@27..30 "foo" None
             PARAMETER_LIST@30..33
               None L_PAREN@30..31 "(" None
               LIST@31..31
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@31..32 ")"
@@ -89,6 +94,9 @@ MODULE@0..40
 =======
               None R_PAREN@31..33 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              None R_PAREN@31..32 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@33..35
               None L_CURLY@33..34 "{" None
               LIST@34..34

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..41
-=======
-MODULE@0..40
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..40
   LIST@0..40
     CLASS_DECL@0..40
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -11,58 +7,26 @@ MODULE@0..40
       CLASS_BODY@10..40
         None L_CURLY@10..11 "{" Whitespace(1)
         LIST@12..39
-<<<<<<< HEAD
           JS_EMPTY_STATEMENT@12..13
-            SEMICOLON@12..13 ";"
-          JS_EMPTY_STATEMENT@13..14
-            SEMICOLON@13..14 ";"
-          JS_EMPTY_STATEMENT@14..15
-            SEMICOLON@14..15 ";"
-          JS_EMPTY_STATEMENT@15..16
-            SEMICOLON@15..16 ";"
-          JS_EMPTY_STATEMENT@16..17
-            SEMICOLON@16..17 ";"
-          JS_EMPTY_STATEMENT@17..18
-            SEMICOLON@17..18 ";"
-          JS_EMPTY_STATEMENT@18..19
-            SEMICOLON@18..19 ";"
-          JS_EMPTY_STATEMENT@19..20
-            SEMICOLON@19..20 ";"
-          JS_EMPTY_STATEMENT@20..21
-            SEMICOLON@20..21 ";"
-          JS_EMPTY_STATEMENT@21..22
-            SEMICOLON@21..22 ";"
-          WHITESPACE@22..23 " "
-=======
-          EMPTY_STMT@12..13
             None SEMICOLON@12..13 ";" None
-          EMPTY_STMT@13..14
+          JS_EMPTY_STATEMENT@13..14
             None SEMICOLON@13..14 ";" None
-          EMPTY_STMT@14..15
+          JS_EMPTY_STATEMENT@14..15
             None SEMICOLON@14..15 ";" None
-          EMPTY_STMT@15..16
+          JS_EMPTY_STATEMENT@15..16
             None SEMICOLON@15..16 ";" None
-          EMPTY_STMT@16..17
+          JS_EMPTY_STATEMENT@16..17
             None SEMICOLON@16..17 ";" None
-          EMPTY_STMT@17..18
+          JS_EMPTY_STATEMENT@17..18
             None SEMICOLON@17..18 ";" None
-          EMPTY_STMT@18..19
+          JS_EMPTY_STATEMENT@18..19
             None SEMICOLON@18..19 ";" None
-          EMPTY_STMT@19..20
+          JS_EMPTY_STATEMENT@19..20
             None SEMICOLON@19..20 ";" None
-          EMPTY_STMT@20..21
+          JS_EMPTY_STATEMENT@20..21
             None SEMICOLON@20..21 ";" None
-          EMPTY_STMT@21..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-             SEMICOLON@21..23 ";" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            None SEMICOLON@21..23 ";" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+          JS_EMPTY_STATEMENT@21..23
             None SEMICOLON@21..22 ";" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           GETTER@23..35
             None GET_KW@23..26 "get" Whitespace(1)
             NAME@27..30
@@ -70,49 +34,17 @@ MODULE@0..40
             PARAMETER_LIST@30..33
               None L_PAREN@30..31 "(" None
               LIST@31..31
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@31..32 ")"
-            WHITESPACE@32..33 " "
-            JS_BLOCK_STATEMENT@33..35
-              L_CURLY@33..34 "{"
-              LIST@34..34
-              R_CURLY@34..35 "}"
-          JS_EMPTY_STATEMENT@35..36
-            SEMICOLON@35..36 ";"
-          JS_EMPTY_STATEMENT@36..37
-            SEMICOLON@36..37 ";"
-          JS_EMPTY_STATEMENT@37..38
-            SEMICOLON@37..38 ";"
-          JS_EMPTY_STATEMENT@38..39
-            SEMICOLON@38..39 ";"
-        R_CURLY@39..40 "}"
-  WHITESPACE@40..41 "\n"
-=======
-               R_PAREN@31..33 ")" " "
-=======
-              None R_PAREN@31..33 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               None R_PAREN@31..32 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@33..35
+            JS_BLOCK_STATEMENT@33..35
               None L_CURLY@33..34 "{" None
               LIST@34..34
               None R_CURLY@34..35 "}" None
-          EMPTY_STMT@35..36
+          JS_EMPTY_STATEMENT@35..36
             None SEMICOLON@35..36 ";" None
-          EMPTY_STMT@36..37
+          JS_EMPTY_STATEMENT@36..37
             None SEMICOLON@36..37 ";" None
-          EMPTY_STMT@37..38
+          JS_EMPTY_STATEMENT@37..38
             None SEMICOLON@37..38 ";" None
-          EMPTY_STMT@38..39
-<<<<<<< HEAD
-             SEMICOLON@38..39 ";" 
-         R_CURLY@39..40 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+          JS_EMPTY_STATEMENT@38..39
             None SEMICOLON@38..39 ";" None
         None R_CURLY@39..40 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -5,41 +5,42 @@ MODULE@0..71
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..71
     VAR_DECL@0..17
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           CLASS_EXPR@8..16
-             CLASS_KW@8..14 "class" " "
+            None CLASS_KW@8..14 "class" Whitespace(1)
             CLASS_BODY@14..16
-               L_CURLY@14..15 "{" 
+              None L_CURLY@14..15 "{" None
               LIST@15..15
-               R_CURLY@15..16 "}" 
-       SEMICOLON@16..17 ";" 
+              None R_CURLY@15..16 "}" None
+      None SEMICOLON@16..17 ";" None
     VAR_DECL@17..57
-      "\n" IDENT@17..22 "let" " "
+      Whitespace(1) IDENT@17..22 "let" Whitespace(1)
       LIST@22..57
         DECLARATOR@22..57
           SINGLE_PATTERN@22..24
             NAME@22..24
-               IDENT@22..24 "a" " "
-           EQ@24..26 "=" " "
+              None IDENT@22..24 "a" Whitespace(1)
+          None EQ@24..26 "=" Whitespace(1)
           CLASS_EXPR@26..57
-             CLASS_KW@26..32 "class" " "
+            None CLASS_KW@26..32 "class" Whitespace(1)
             NAME@32..36
-               IDENT@32..36 "foo" " "
+              None IDENT@32..36 "foo" Whitespace(1)
             CLASS_BODY@36..57
-               L_CURLY@36..37 "{" 
+              None L_CURLY@36..37 "{" None
               LIST@37..55
                 CONSTRUCTOR@37..55
                   NAME@37..50
-                    "\n " IDENT@37..50 "constructor" 
+                    Whitespace(2) IDENT@37..50 "constructor" None
                   PARAMETER_LIST@50..53
-                     L_PAREN@50..51 "(" 
+                    None L_PAREN@50..51 "(" None
                     LIST@51..51
+<<<<<<< HEAD
 <<<<<<< HEAD
                     R_PAREN@51..52 ")"
                   WHITESPACE@52..53 " "
@@ -57,21 +58,29 @@ MODULE@0..71
         L_BRACK@61..62 "["
 =======
                      R_PAREN@51..53 ")" " "
+=======
+                    None R_PAREN@51..53 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   BLOCK_STMT@53..55
-                     L_CURLY@53..54 "{" 
+                    None L_CURLY@53..54 "{" None
                     LIST@54..54
-                     R_CURLY@54..55 "}" 
-              "\n" R_CURLY@55..57 "}" 
+                    None R_CURLY@54..55 "}" None
+              Whitespace(1) R_CURLY@55..57 "}" None
     EXPR_STMT@57..71
       BRACKET_EXPR@57..71
         NAME_REF@57..61
+<<<<<<< HEAD
           "\n" IDENT@57..61 "foo" 
          L_BRACK@61..62 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) IDENT@57..61 "foo" None
+        None L_BRACK@61..62 "[" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         CLASS_EXPR@62..70
-           CLASS_KW@62..68 "class" " "
+          None CLASS_KW@62..68 "class" Whitespace(1)
           CLASS_BODY@68..70
-             L_CURLY@68..69 "{" 
+            None L_CURLY@68..69 "{" None
             LIST@69..69
-             R_CURLY@69..70 "}" 
-         R_BRACK@70..71 "]" 
+            None R_CURLY@69..70 "}" None
+        None R_BRACK@70..71 "]" None

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -5,41 +5,42 @@ MODULE@0..71
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..71
     VAR_DECL@0..17
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           CLASS_EXPR@8..16
-            None CLASS_KW@8..14 "class" Whitespace(1)
+            None CLASS_KW@8..13 "class" Whitespace(1)
             CLASS_BODY@14..16
               None L_CURLY@14..15 "{" None
               LIST@15..15
               None R_CURLY@15..16 "}" None
       None SEMICOLON@16..17 ";" None
     VAR_DECL@17..57
-      Whitespace(1) IDENT@17..22 "let" Whitespace(1)
+      Whitespace(1) IDENT@18..21 "let" Whitespace(1)
       LIST@22..57
         DECLARATOR@22..57
           SINGLE_PATTERN@22..24
             NAME@22..24
-              None IDENT@22..24 "a" Whitespace(1)
-          None EQ@24..26 "=" Whitespace(1)
+              None IDENT@22..23 "a" Whitespace(1)
+          None EQ@24..25 "=" Whitespace(1)
           CLASS_EXPR@26..57
-            None CLASS_KW@26..32 "class" Whitespace(1)
+            None CLASS_KW@26..31 "class" Whitespace(1)
             NAME@32..36
-              None IDENT@32..36 "foo" Whitespace(1)
+              None IDENT@32..35 "foo" Whitespace(1)
             CLASS_BODY@36..57
               None L_CURLY@36..37 "{" None
               LIST@37..55
                 CONSTRUCTOR@37..55
                   NAME@37..50
-                    Whitespace(2) IDENT@37..50 "constructor" None
+                    Whitespace(2) IDENT@39..50 "constructor" None
                   PARAMETER_LIST@50..53
                     None L_PAREN@50..51 "(" None
                     LIST@51..51
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                     R_PAREN@51..52 ")"
@@ -61,24 +62,31 @@ MODULE@0..71
 =======
                     None R_PAREN@51..53 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                    None R_PAREN@51..52 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                   BLOCK_STMT@53..55
                     None L_CURLY@53..54 "{" None
                     LIST@54..54
                     None R_CURLY@54..55 "}" None
-              Whitespace(1) R_CURLY@55..57 "}" None
+              Whitespace(1) R_CURLY@56..57 "}" None
     EXPR_STMT@57..71
       BRACKET_EXPR@57..71
         NAME_REF@57..61
+<<<<<<< HEAD
 <<<<<<< HEAD
           "\n" IDENT@57..61 "foo" 
          L_BRACK@61..62 "[" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(1) IDENT@57..61 "foo" None
+=======
+          Whitespace(1) IDENT@58..61 "foo" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None L_BRACK@61..62 "[" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         CLASS_EXPR@62..70
-          None CLASS_KW@62..68 "class" Whitespace(1)
+          None CLASS_KW@62..67 "class" Whitespace(1)
           CLASS_BODY@68..70
             None L_CURLY@68..69 "{" None
             LIST@69..69

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -1,52 +1,46 @@
+<<<<<<< HEAD
 JS_MODULE@0..72
+=======
+MODULE@0..71
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..71
     VAR_DECL@0..17
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..16
         DECLARATOR@4..16
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           CLASS_EXPR@8..16
-            CLASS_KW@8..13 "class"
-            WHITESPACE@13..14 " "
+             CLASS_KW@8..14 "class" " "
             CLASS_BODY@14..16
-              L_CURLY@14..15 "{"
+               L_CURLY@14..15 "{" 
               LIST@15..15
-              R_CURLY@15..16 "}"
-      SEMICOLON@16..17 ";"
-    WHITESPACE@17..18 "\n"
-    VAR_DECL@18..57
-      IDENT@18..21 "let"
-      WHITESPACE@21..22 " "
+               R_CURLY@15..16 "}" 
+       SEMICOLON@16..17 ";" 
+    VAR_DECL@17..57
+      "\n" IDENT@17..22 "let" " "
       LIST@22..57
         DECLARATOR@22..57
-          SINGLE_PATTERN@22..23
-            NAME@22..23
-              IDENT@22..23 "a"
-          WHITESPACE@23..24 " "
-          EQ@24..25 "="
-          WHITESPACE@25..26 " "
+          SINGLE_PATTERN@22..24
+            NAME@22..24
+               IDENT@22..24 "a" " "
+           EQ@24..26 "=" " "
           CLASS_EXPR@26..57
-            CLASS_KW@26..31 "class"
-            WHITESPACE@31..32 " "
-            NAME@32..35
-              IDENT@32..35 "foo"
-            WHITESPACE@35..36 " "
+             CLASS_KW@26..32 "class" " "
+            NAME@32..36
+               IDENT@32..36 "foo" " "
             CLASS_BODY@36..57
-              L_CURLY@36..37 "{"
-              WHITESPACE@37..39 "\n "
-              LIST@39..55
-                CONSTRUCTOR@39..55
-                  NAME@39..50
-                    IDENT@39..50 "constructor"
-                  PARAMETER_LIST@50..52
-                    L_PAREN@50..51 "("
+               L_CURLY@36..37 "{" 
+              LIST@37..55
+                CONSTRUCTOR@37..55
+                  NAME@37..50
+                    "\n " IDENT@37..50 "constructor" 
+                  PARAMETER_LIST@50..53
+                     L_PAREN@50..51 "(" 
                     LIST@51..51
+<<<<<<< HEAD
                     R_PAREN@51..52 ")"
                   WHITESPACE@52..53 " "
                   JS_BLOCK_STATEMENT@53..55
@@ -61,12 +55,23 @@ JS_MODULE@0..72
         NAME_REF@58..61
           IDENT@58..61 "foo"
         L_BRACK@61..62 "["
+=======
+                     R_PAREN@51..53 ")" " "
+                  BLOCK_STMT@53..55
+                     L_CURLY@53..54 "{" 
+                    LIST@54..54
+                     R_CURLY@54..55 "}" 
+              "\n" R_CURLY@55..57 "}" 
+    EXPR_STMT@57..71
+      BRACKET_EXPR@57..71
+        NAME_REF@57..61
+          "\n" IDENT@57..61 "foo" 
+         L_BRACK@61..62 "[" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         CLASS_EXPR@62..70
-          CLASS_KW@62..67 "class"
-          WHITESPACE@67..68 " "
+           CLASS_KW@62..68 "class" " "
           CLASS_BODY@68..70
-            L_CURLY@68..69 "{"
+             L_CURLY@68..69 "{" 
             LIST@69..69
-            R_CURLY@69..70 "}"
-        R_BRACK@70..71 "]"
-  WHITESPACE@71..72 "\n"
+             R_CURLY@69..70 "}" 
+         R_BRACK@70..71 "]" 

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..72
-=======
-MODULE@0..71
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..71
   LIST@0..71
     VAR_DECL@0..17
       None IDENT@0..3 "let" Whitespace(1)
@@ -40,51 +36,17 @@ MODULE@0..71
                   PARAMETER_LIST@50..53
                     None L_PAREN@50..51 "(" None
                     LIST@51..51
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    R_PAREN@51..52 ")"
-                  WHITESPACE@52..53 " "
-                  JS_BLOCK_STATEMENT@53..55
-                    L_CURLY@53..54 "{"
-                    LIST@54..54
-                    R_CURLY@54..55 "}"
-              WHITESPACE@55..56 "\n"
-              R_CURLY@56..57 "}"
-    WHITESPACE@57..58 "\n"
-    JS_EXPRESSION_STATEMENT@58..71
-      BRACKET_EXPR@58..71
-        NAME_REF@58..61
-          IDENT@58..61 "foo"
-        L_BRACK@61..62 "["
-=======
-                     R_PAREN@51..53 ")" " "
-=======
-                    None R_PAREN@51..53 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                     None R_PAREN@51..52 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                  BLOCK_STMT@53..55
+                  JS_BLOCK_STATEMENT@53..55
                     None L_CURLY@53..54 "{" None
                     LIST@54..54
                     None R_CURLY@54..55 "}" None
               Whitespace(1) R_CURLY@56..57 "}" None
-    EXPR_STMT@57..71
+    JS_EXPRESSION_STATEMENT@57..71
       BRACKET_EXPR@57..71
         NAME_REF@57..61
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" IDENT@57..61 "foo" 
-         L_BRACK@61..62 "[" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) IDENT@57..61 "foo" None
-=======
           Whitespace(1) IDENT@58..61 "foo" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None L_BRACK@61..62 "[" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         CLASS_EXPR@62..70
           None CLASS_KW@62..67 "class" Whitespace(1)
           CLASS_BODY@68..70

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -7,12 +7,13 @@ MODULE@0..43
     JS_EXPRESSION_STATEMENT@0..15
       COND_EXPR@0..15
         NAME_REF@0..4
-           IDENT@0..4 "foo" " "
-         QUESTION@4..6 "?" " "
+          None IDENT@0..4 "foo" Whitespace(1)
+        None QUESTION@4..6 "?" Whitespace(1)
         NAME_REF@6..10
-           IDENT@6..10 "bar" " "
-         COLON@10..12 ":" " "
+          None IDENT@6..10 "bar" Whitespace(1)
+        None COLON@10..12 ":" Whitespace(1)
         NAME_REF@12..15
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@12..15 "baz"
     WHITESPACE@15..16 "\n"
@@ -30,21 +31,29 @@ MODULE@0..43
         WHITESPACE@27..28 " "
 =======
            IDENT@12..15 "baz" 
+=======
+          None IDENT@12..15 "baz" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@15..43
       COND_EXPR@15..43
         NAME_REF@15..20
-          "\n" IDENT@15..20 "foo" " "
-         QUESTION@20..22 "?" " "
+          Whitespace(1) IDENT@15..20 "foo" Whitespace(1)
+        None QUESTION@20..22 "?" Whitespace(1)
         NAME_REF@22..26
+<<<<<<< HEAD
            IDENT@22..26 "bar" " "
          COLON@26..28 ":" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@22..26 "bar" Whitespace(1)
+        None COLON@26..28 ":" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         COND_EXPR@28..43
           NAME_REF@28..32
-             IDENT@28..32 "baz" " "
-           QUESTION@32..34 "?" " "
+            None IDENT@28..32 "baz" Whitespace(1)
+          None QUESTION@32..34 "?" Whitespace(1)
           NAME_REF@34..38
-             IDENT@34..38 "bar" " "
-           COLON@38..40 ":" " "
+            None IDENT@34..38 "bar" Whitespace(1)
+          None COLON@38..40 ":" Whitespace(1)
           NAME_REF@40..43
-             IDENT@40..43 "baz" 
+            None IDENT@40..43 "baz" None

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -7,11 +7,11 @@ MODULE@0..43
     JS_EXPRESSION_STATEMENT@0..15
       COND_EXPR@0..15
         NAME_REF@0..4
-          None IDENT@0..4 "foo" Whitespace(1)
-        None QUESTION@4..6 "?" Whitespace(1)
+          None IDENT@0..3 "foo" Whitespace(1)
+        None QUESTION@4..5 "?" Whitespace(1)
         NAME_REF@6..10
-          None IDENT@6..10 "bar" Whitespace(1)
-        None COLON@10..12 ":" Whitespace(1)
+          None IDENT@6..9 "bar" Whitespace(1)
+        None COLON@10..11 ":" Whitespace(1)
         NAME_REF@12..15
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -37,9 +37,10 @@ MODULE@0..43
     EXPR_STMT@15..43
       COND_EXPR@15..43
         NAME_REF@15..20
-          Whitespace(1) IDENT@15..20 "foo" Whitespace(1)
-        None QUESTION@20..22 "?" Whitespace(1)
+          Whitespace(1) IDENT@16..19 "foo" Whitespace(1)
+        None QUESTION@20..21 "?" Whitespace(1)
         NAME_REF@22..26
+<<<<<<< HEAD
 <<<<<<< HEAD
            IDENT@22..26 "bar" " "
          COLON@26..28 ":" " "
@@ -48,12 +49,16 @@ MODULE@0..43
           None IDENT@22..26 "bar" Whitespace(1)
         None COLON@26..28 ":" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          None IDENT@22..25 "bar" Whitespace(1)
+        None COLON@26..27 ":" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         COND_EXPR@28..43
           NAME_REF@28..32
-            None IDENT@28..32 "baz" Whitespace(1)
-          None QUESTION@32..34 "?" Whitespace(1)
+            None IDENT@28..31 "baz" Whitespace(1)
+          None QUESTION@32..33 "?" Whitespace(1)
           NAME_REF@34..38
-            None IDENT@34..38 "bar" Whitespace(1)
-          None COLON@38..40 ":" Whitespace(1)
+            None IDENT@34..37 "bar" Whitespace(1)
+          None COLON@38..39 ":" Whitespace(1)
           NAME_REF@40..43
             None IDENT@40..43 "baz" None

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -1,18 +1,19 @@
+<<<<<<< HEAD
 JS_MODULE@0..44
+=======
+MODULE@0..43
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..43
     JS_EXPRESSION_STATEMENT@0..15
       COND_EXPR@0..15
-        NAME_REF@0..3
-          IDENT@0..3 "foo"
-        WHITESPACE@3..4 " "
-        QUESTION@4..5 "?"
-        WHITESPACE@5..6 " "
-        NAME_REF@6..9
-          IDENT@6..9 "bar"
-        WHITESPACE@9..10 " "
-        COLON@10..11 ":"
-        WHITESPACE@11..12 " "
+        NAME_REF@0..4
+           IDENT@0..4 "foo" " "
+         QUESTION@4..6 "?" " "
+        NAME_REF@6..10
+           IDENT@6..10 "bar" " "
+         COLON@10..12 ":" " "
         NAME_REF@12..15
+<<<<<<< HEAD
           IDENT@12..15 "baz"
     WHITESPACE@15..16 "\n"
     JS_EXPRESSION_STATEMENT@16..43
@@ -27,17 +28,23 @@ JS_MODULE@0..44
         WHITESPACE@25..26 " "
         COLON@26..27 ":"
         WHITESPACE@27..28 " "
+=======
+           IDENT@12..15 "baz" 
+    EXPR_STMT@15..43
+      COND_EXPR@15..43
+        NAME_REF@15..20
+          "\n" IDENT@15..20 "foo" " "
+         QUESTION@20..22 "?" " "
+        NAME_REF@22..26
+           IDENT@22..26 "bar" " "
+         COLON@26..28 ":" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         COND_EXPR@28..43
-          NAME_REF@28..31
-            IDENT@28..31 "baz"
-          WHITESPACE@31..32 " "
-          QUESTION@32..33 "?"
-          WHITESPACE@33..34 " "
-          NAME_REF@34..37
-            IDENT@34..37 "bar"
-          WHITESPACE@37..38 " "
-          COLON@38..39 ":"
-          WHITESPACE@39..40 " "
+          NAME_REF@28..32
+             IDENT@28..32 "baz" " "
+           QUESTION@32..34 "?" " "
+          NAME_REF@34..38
+             IDENT@34..38 "bar" " "
+           COLON@38..40 ":" " "
           NAME_REF@40..43
-            IDENT@40..43 "baz"
-  WHITESPACE@43..44 "\n"
+             IDENT@40..43 "baz" 

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..44
-=======
-MODULE@0..43
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..43
   LIST@0..43
     JS_EXPRESSION_STATEMENT@0..15
       COND_EXPR@0..15
@@ -13,46 +9,15 @@ MODULE@0..43
           None IDENT@6..9 "bar" Whitespace(1)
         None COLON@10..11 ":" Whitespace(1)
         NAME_REF@12..15
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@12..15 "baz"
-    WHITESPACE@15..16 "\n"
-    JS_EXPRESSION_STATEMENT@16..43
-      COND_EXPR@16..43
-        NAME_REF@16..19
-          IDENT@16..19 "foo"
-        WHITESPACE@19..20 " "
-        QUESTION@20..21 "?"
-        WHITESPACE@21..22 " "
-        NAME_REF@22..25
-          IDENT@22..25 "bar"
-        WHITESPACE@25..26 " "
-        COLON@26..27 ":"
-        WHITESPACE@27..28 " "
-=======
-           IDENT@12..15 "baz" 
-=======
           None IDENT@12..15 "baz" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@15..43
+    JS_EXPRESSION_STATEMENT@15..43
       COND_EXPR@15..43
         NAME_REF@15..20
           Whitespace(1) IDENT@16..19 "foo" Whitespace(1)
         None QUESTION@20..21 "?" Whitespace(1)
         NAME_REF@22..26
-<<<<<<< HEAD
-<<<<<<< HEAD
-           IDENT@22..26 "bar" " "
-         COLON@26..28 ":" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          None IDENT@22..26 "bar" Whitespace(1)
-        None COLON@26..28 ":" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           None IDENT@22..25 "bar" Whitespace(1)
         None COLON@26..27 ":" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         COND_EXPR@28..43
           NAME_REF@28..32
             None IDENT@28..31 "baz" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..64
   LIST@0..63
     JS_LABELED_STATEMENT@0..7
@@ -6,15 +7,24 @@ JS_MODULE@0..64
       WHITESPACE@4..5 " "
       JS_BLOCK_STATEMENT@5..7
         L_CURLY@5..6 "{"
+=======
+MODULE@0..63
+  LIST@0..63
+    LABELLED_STMT@0..7
+      NAME@0..3
+         IDENT@0..3 "foo" 
+       COLON@3..5 ":" " "
+      BLOCK_STMT@5..7
+         L_CURLY@5..6 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@6..6
-        R_CURLY@6..7 "}"
-    WHITESPACE@7..8 "\n"
-    WHILE_STMT@8..63
-      WHILE_KW@8..13 "while"
-      WHITESPACE@13..14 " "
-      CONDITION@14..20
-        L_PAREN@14..15 "("
+         R_CURLY@6..7 "}" 
+    WHILE_STMT@7..63
+      "\n" WHILE_KW@7..14 "while" " "
+      CONDITION@14..21
+         L_PAREN@14..15 "(" 
         LITERAL@15..19
+<<<<<<< HEAD
           TRUE_KW@15..19 "true"
         R_PAREN@19..20 ")"
       WHITESPACE@20..21 " "
@@ -29,12 +39,21 @@ JS_MODULE@0..64
           CONTINUE_STMT@37..50
             CONTINUE_KW@37..45 "continue"
             WHITESPACE@45..46 " "
+=======
+           TRUE_KW@15..19 "true" 
+         R_PAREN@19..21 ")" " "
+      BLOCK_STMT@21..63
+         L_CURLY@21..22 "{" 
+        LIST@22..61
+          CONTINUE_STMT@22..34
+            "\n  " CONTINUE_KW@22..33 "continue" 
+             SEMICOLON@33..34 ";" 
+          CONTINUE_STMT@34..50
+            "\n  " CONTINUE_KW@34..46 "continue" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
             NAME_REF@46..49
-              IDENT@46..49 "foo"
-            SEMICOLON@49..50 ";"
-          WHITESPACE@50..53 "\n  "
-          CONTINUE_STMT@53..61
-            CONTINUE_KW@53..61 "continue"
-        WHITESPACE@61..62 "\n"
-        R_CURLY@62..63 "}"
-  WHITESPACE@63..64 "\n"
+               IDENT@46..49 "foo" 
+             SEMICOLON@49..50 ";" 
+          CONTINUE_STMT@50..61
+            "\n  " CONTINUE_KW@50..61 "continue" 
+        "\n" R_CURLY@61..63 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -13,7 +13,7 @@ MODULE@0..63
     LABELLED_STMT@0..7
       NAME@0..3
         None IDENT@0..3 "foo" None
-      None COLON@3..5 ":" Whitespace(1)
+      None COLON@3..4 ":" Whitespace(1)
       BLOCK_STMT@5..7
 <<<<<<< HEAD
          L_CURLY@5..6 "{" 
@@ -24,7 +24,7 @@ MODULE@0..63
         LIST@6..6
         None R_CURLY@6..7 "}" None
     WHILE_STMT@7..63
-      Whitespace(1) WHILE_KW@7..14 "while" Whitespace(1)
+      Whitespace(1) WHILE_KW@8..13 "while" Whitespace(1)
       CONDITION@14..21
         None L_PAREN@14..15 "(" None
         LITERAL@15..19
@@ -49,24 +49,32 @@ MODULE@0..63
          R_PAREN@19..21 ")" " "
 =======
           None TRUE_KW@15..19 "true" None
+<<<<<<< HEAD
         None R_PAREN@19..21 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@19..20 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@21..63
         None L_CURLY@21..22 "{" None
         LIST@22..61
           CONTINUE_STMT@22..34
-            Whitespace(3) CONTINUE_KW@22..33 "continue" None
+            Whitespace(3) CONTINUE_KW@25..33 "continue" None
             None SEMICOLON@33..34 ";" None
           CONTINUE_STMT@34..50
+<<<<<<< HEAD
 <<<<<<< HEAD
             "\n  " CONTINUE_KW@34..46 "continue" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
             Whitespace(3) CONTINUE_KW@34..46 "continue" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+            Whitespace(3) CONTINUE_KW@37..45 "continue" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             NAME_REF@46..49
               None IDENT@46..49 "foo" None
             None SEMICOLON@49..50 ";" None
           CONTINUE_STMT@50..61
-            Whitespace(3) CONTINUE_KW@50..61 "continue" None
-        Whitespace(1) R_CURLY@61..63 "}" None
+            Whitespace(3) CONTINUE_KW@53..61 "continue" None
+        Whitespace(1) R_CURLY@62..63 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -1,26 +1,10 @@
-<<<<<<< HEAD
-JS_MODULE@0..64
+JS_MODULE@0..63
   LIST@0..63
     JS_LABELED_STATEMENT@0..7
-      IDENT@0..3 "foo"
-      COLON@3..4 ":"
-      WHITESPACE@4..5 " "
-      JS_BLOCK_STATEMENT@5..7
-        L_CURLY@5..6 "{"
-=======
-MODULE@0..63
-  LIST@0..63
-    LABELLED_STMT@0..7
-      NAME@0..3
-        None IDENT@0..3 "foo" None
+      None IDENT@0..3 "foo" None
       None COLON@3..4 ":" Whitespace(1)
-      BLOCK_STMT@5..7
-<<<<<<< HEAD
-         L_CURLY@5..6 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+      JS_BLOCK_STATEMENT@5..7
         None L_CURLY@5..6 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@6..6
         None R_CURLY@6..7 "}" None
     WHILE_STMT@7..63
@@ -28,50 +12,16 @@ MODULE@0..63
       CONDITION@14..21
         None L_PAREN@14..15 "(" None
         LITERAL@15..19
-<<<<<<< HEAD
-<<<<<<< HEAD
-          TRUE_KW@15..19 "true"
-        R_PAREN@19..20 ")"
-      WHITESPACE@20..21 " "
-      JS_BLOCK_STATEMENT@21..63
-        L_CURLY@21..22 "{"
-        WHITESPACE@22..25 "\n  "
-        LIST@25..61
-          CONTINUE_STMT@25..34
-            CONTINUE_KW@25..33 "continue"
-            SEMICOLON@33..34 ";"
-          WHITESPACE@34..37 "\n  "
-          CONTINUE_STMT@37..50
-            CONTINUE_KW@37..45 "continue"
-            WHITESPACE@45..46 " "
-=======
-           TRUE_KW@15..19 "true" 
-         R_PAREN@19..21 ")" " "
-=======
           None TRUE_KW@15..19 "true" None
-<<<<<<< HEAD
-        None R_PAREN@19..21 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@19..20 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@21..63
+      JS_BLOCK_STATEMENT@21..63
         None L_CURLY@21..22 "{" None
         LIST@22..61
           CONTINUE_STMT@22..34
             Whitespace(3) CONTINUE_KW@25..33 "continue" None
             None SEMICOLON@33..34 ";" None
           CONTINUE_STMT@34..50
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "\n  " CONTINUE_KW@34..46 "continue" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-            Whitespace(3) CONTINUE_KW@34..46 "continue" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
             Whitespace(3) CONTINUE_KW@37..45 "continue" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             NAME_REF@46..49
               None IDENT@46..49 "foo" None
             None SEMICOLON@49..50 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -12,18 +12,23 @@ MODULE@0..63
   LIST@0..63
     LABELLED_STMT@0..7
       NAME@0..3
-         IDENT@0..3 "foo" 
-       COLON@3..5 ":" " "
+        None IDENT@0..3 "foo" None
+      None COLON@3..5 ":" Whitespace(1)
       BLOCK_STMT@5..7
+<<<<<<< HEAD
          L_CURLY@5..6 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None L_CURLY@5..6 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@6..6
-         R_CURLY@6..7 "}" 
+        None R_CURLY@6..7 "}" None
     WHILE_STMT@7..63
-      "\n" WHILE_KW@7..14 "while" " "
+      Whitespace(1) WHILE_KW@7..14 "while" Whitespace(1)
       CONDITION@14..21
-         L_PAREN@14..15 "(" 
+        None L_PAREN@14..15 "(" None
         LITERAL@15..19
+<<<<<<< HEAD
 <<<<<<< HEAD
           TRUE_KW@15..19 "true"
         R_PAREN@19..20 ")"
@@ -42,18 +47,26 @@ MODULE@0..63
 =======
            TRUE_KW@15..19 "true" 
          R_PAREN@19..21 ")" " "
+=======
+          None TRUE_KW@15..19 "true" None
+        None R_PAREN@19..21 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@21..63
-         L_CURLY@21..22 "{" 
+        None L_CURLY@21..22 "{" None
         LIST@22..61
           CONTINUE_STMT@22..34
-            "\n  " CONTINUE_KW@22..33 "continue" 
-             SEMICOLON@33..34 ";" 
+            Whitespace(3) CONTINUE_KW@22..33 "continue" None
+            None SEMICOLON@33..34 ";" None
           CONTINUE_STMT@34..50
+<<<<<<< HEAD
             "\n  " CONTINUE_KW@34..46 "continue" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            Whitespace(3) CONTINUE_KW@34..46 "continue" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
             NAME_REF@46..49
-               IDENT@46..49 "foo" 
-             SEMICOLON@49..50 ";" 
+              None IDENT@46..49 "foo" None
+            None SEMICOLON@49..50 ";" None
           CONTINUE_STMT@50..61
-            "\n  " CONTINUE_KW@50..61 "continue" 
-        "\n" R_CURLY@61..63 "}" 
+            Whitespace(3) CONTINUE_KW@50..61 "continue" None
+        Whitespace(1) R_CURLY@61..63 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -9,6 +9,11 @@ JS_MODULE@0..10
 MODULE@0..9
   LIST@0..9
     DEBUGGER_STMT@0..9
+<<<<<<< HEAD
        DEBUGGER_KW@0..8 "debugger" 
        SEMICOLON@8..9 ";" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None DEBUGGER_KW@0..8 "debugger" None
+      None SEMICOLON@8..9 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -1,19 +1,5 @@
-<<<<<<< HEAD
-JS_MODULE@0..10
+JS_MODULE@0..9
   LIST@0..9
     JS_DEBUGGER_STATEMENT@0..9
-      DEBUGGER_KW@0..8 "debugger"
-      SEMICOLON@8..9 ";"
-  WHITESPACE@9..10 "\n"
-=======
-MODULE@0..9
-  LIST@0..9
-    DEBUGGER_STMT@0..9
-<<<<<<< HEAD
-       DEBUGGER_KW@0..8 "debugger" 
-       SEMICOLON@8..9 ";" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
       None DEBUGGER_KW@0..8 "debugger" None
       None SEMICOLON@8..9 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -1,6 +1,14 @@
+<<<<<<< HEAD
 JS_MODULE@0..10
   LIST@0..9
     JS_DEBUGGER_STATEMENT@0..9
       DEBUGGER_KW@0..8 "debugger"
       SEMICOLON@8..9 ";"
   WHITESPACE@9..10 "\n"
+=======
+MODULE@0..9
+  LIST@0..9
+    DEBUGGER_STMT@0..9
+       DEBUGGER_KW@0..8 "debugger" 
+       SEMICOLON@8..9 ";" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -7,9 +7,10 @@ MODULE@0..53
     JS_EXPRESSION_STATEMENT@0..7
       DOT_EXPR@0..7
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
-         DOT@3..4 "." 
+          None IDENT@0..3 "foo" None
+        None DOT@3..4 "." None
         NAME@4..7
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@4..7 "bar"
     WHITESPACE@7..8 "\n"
@@ -52,39 +53,47 @@ MODULE@0..53
         QUESTIONDOT@48..50 "?."
 =======
            IDENT@4..7 "bar" 
+=======
+          None IDENT@4..7 "bar" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@7..17
       DOT_EXPR@7..17
         NAME_REF@7..11
-          "\n" IDENT@7..11 "foo" 
-         DOT@11..12 "." 
+          Whitespace(1) IDENT@7..11 "foo" None
+        None DOT@11..12 "." None
         NAME@12..17
-           IDENT@12..17 "await" 
+          None IDENT@12..17 "await" None
     EXPR_STMT@17..27
       DOT_EXPR@17..27
         NAME_REF@17..21
-          "\n" IDENT@17..21 "foo" 
-         DOT@21..22 "." 
+          Whitespace(1) IDENT@17..21 "foo" None
+        None DOT@21..22 "." None
         NAME@22..27
-           IDENT@22..27 "yield" 
+          None IDENT@22..27 "yield" None
     EXPR_STMT@27..35
       DOT_EXPR@27..35
         NAME_REF@27..31
-          "\n" IDENT@27..31 "foo" 
-         DOT@31..32 "." 
+          Whitespace(1) IDENT@27..31 "foo" None
+        None DOT@31..32 "." None
         NAME@32..35
-           IDENT@32..35 "for" 
+          None IDENT@32..35 "for" None
     EXPR_STMT@35..44
       DOT_EXPR@35..44
         NAME_REF@35..39
-          "\n" IDENT@35..39 "foo" 
-         QUESTIONDOT@39..41 "?." 
+          Whitespace(1) IDENT@35..39 "foo" None
+        None QUESTIONDOT@39..41 "?." None
         NAME@41..44
-           IDENT@41..44 "for" 
+          None IDENT@41..44 "for" None
     EXPR_STMT@44..53
       DOT_EXPR@44..53
         NAME_REF@44..48
+<<<<<<< HEAD
           "\n" IDENT@44..48 "foo" 
          QUESTIONDOT@48..50 "?." 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) IDENT@44..48 "foo" None
+        None QUESTIONDOT@48..50 "?." None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@50..53
-           IDENT@50..53 "bar" 
+          None IDENT@50..53 "bar" None

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..54
-=======
-MODULE@0..53
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..53
   LIST@0..53
     JS_EXPRESSION_STATEMENT@0..7
       DOT_EXPR@0..7
@@ -10,94 +6,39 @@ MODULE@0..53
           None IDENT@0..3 "foo" None
         None DOT@3..4 "." None
         NAME@4..7
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@4..7 "bar"
-    WHITESPACE@7..8 "\n"
-    JS_EXPRESSION_STATEMENT@8..17
-      DOT_EXPR@8..17
-        NAME_REF@8..11
-          IDENT@8..11 "foo"
-        DOT@11..12 "."
-        NAME@12..17
-          IDENT@12..17 "await"
-    WHITESPACE@17..18 "\n"
-    JS_EXPRESSION_STATEMENT@18..27
-      DOT_EXPR@18..27
-        NAME_REF@18..21
-          IDENT@18..21 "foo"
-        DOT@21..22 "."
-        NAME@22..27
-          IDENT@22..27 "yield"
-    WHITESPACE@27..28 "\n"
-    JS_EXPRESSION_STATEMENT@28..35
-      DOT_EXPR@28..35
-        NAME_REF@28..31
-          IDENT@28..31 "foo"
-        DOT@31..32 "."
-        NAME@32..35
-          IDENT@32..35 "for"
-    WHITESPACE@35..36 "\n"
-    JS_EXPRESSION_STATEMENT@36..44
-      DOT_EXPR@36..44
-        NAME_REF@36..39
-          IDENT@36..39 "foo"
-        QUESTIONDOT@39..41 "?."
-        NAME@41..44
-          IDENT@41..44 "for"
-    WHITESPACE@44..45 "\n"
-    JS_EXPRESSION_STATEMENT@45..53
-      DOT_EXPR@45..53
-        NAME_REF@45..48
-          IDENT@45..48 "foo"
-        QUESTIONDOT@48..50 "?."
-=======
-           IDENT@4..7 "bar" 
-=======
           None IDENT@4..7 "bar" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@7..17
+    JS_EXPRESSION_STATEMENT@7..17
       DOT_EXPR@7..17
         NAME_REF@7..11
           Whitespace(1) IDENT@8..11 "foo" None
         None DOT@11..12 "." None
         NAME@12..17
           None IDENT@12..17 "await" None
-    EXPR_STMT@17..27
+    JS_EXPRESSION_STATEMENT@17..27
       DOT_EXPR@17..27
         NAME_REF@17..21
           Whitespace(1) IDENT@18..21 "foo" None
         None DOT@21..22 "." None
         NAME@22..27
           None IDENT@22..27 "yield" None
-    EXPR_STMT@27..35
+    JS_EXPRESSION_STATEMENT@27..35
       DOT_EXPR@27..35
         NAME_REF@27..31
           Whitespace(1) IDENT@28..31 "foo" None
         None DOT@31..32 "." None
         NAME@32..35
           None IDENT@32..35 "for" None
-    EXPR_STMT@35..44
+    JS_EXPRESSION_STATEMENT@35..44
       DOT_EXPR@35..44
         NAME_REF@35..39
           Whitespace(1) IDENT@36..39 "foo" None
         None QUESTIONDOT@39..41 "?." None
         NAME@41..44
           None IDENT@41..44 "for" None
-    EXPR_STMT@44..53
+    JS_EXPRESSION_STATEMENT@44..53
       DOT_EXPR@44..53
         NAME_REF@44..48
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" IDENT@44..48 "foo" 
-         QUESTIONDOT@48..50 "?." 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) IDENT@44..48 "foo" None
-=======
           Whitespace(1) IDENT@45..48 "foo" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None QUESTIONDOT@48..50 "?." None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@50..53
           None IDENT@50..53 "bar" None

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -59,28 +59,28 @@ MODULE@0..53
     EXPR_STMT@7..17
       DOT_EXPR@7..17
         NAME_REF@7..11
-          Whitespace(1) IDENT@7..11 "foo" None
+          Whitespace(1) IDENT@8..11 "foo" None
         None DOT@11..12 "." None
         NAME@12..17
           None IDENT@12..17 "await" None
     EXPR_STMT@17..27
       DOT_EXPR@17..27
         NAME_REF@17..21
-          Whitespace(1) IDENT@17..21 "foo" None
+          Whitespace(1) IDENT@18..21 "foo" None
         None DOT@21..22 "." None
         NAME@22..27
           None IDENT@22..27 "yield" None
     EXPR_STMT@27..35
       DOT_EXPR@27..35
         NAME_REF@27..31
-          Whitespace(1) IDENT@27..31 "foo" None
+          Whitespace(1) IDENT@28..31 "foo" None
         None DOT@31..32 "." None
         NAME@32..35
           None IDENT@32..35 "for" None
     EXPR_STMT@35..44
       DOT_EXPR@35..44
         NAME_REF@35..39
-          Whitespace(1) IDENT@35..39 "foo" None
+          Whitespace(1) IDENT@36..39 "foo" None
         None QUESTIONDOT@39..41 "?." None
         NAME@41..44
           None IDENT@41..44 "for" None
@@ -88,11 +88,15 @@ MODULE@0..53
       DOT_EXPR@44..53
         NAME_REF@44..48
 <<<<<<< HEAD
+<<<<<<< HEAD
           "\n" IDENT@44..48 "foo" 
          QUESTIONDOT@48..50 "?." 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(1) IDENT@44..48 "foo" None
+=======
+          Whitespace(1) IDENT@45..48 "foo" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None QUESTIONDOT@48..50 "?." None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@50..53

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -1,11 +1,16 @@
+<<<<<<< HEAD
 JS_MODULE@0..54
+=======
+MODULE@0..53
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..53
     JS_EXPRESSION_STATEMENT@0..7
       DOT_EXPR@0..7
         NAME_REF@0..3
-          IDENT@0..3 "foo"
-        DOT@3..4 "."
+           IDENT@0..3 "foo" 
+         DOT@3..4 "." 
         NAME@4..7
+<<<<<<< HEAD
           IDENT@4..7 "bar"
     WHITESPACE@7..8 "\n"
     JS_EXPRESSION_STATEMENT@8..17
@@ -45,6 +50,41 @@ JS_MODULE@0..54
         NAME_REF@45..48
           IDENT@45..48 "foo"
         QUESTIONDOT@48..50 "?."
+=======
+           IDENT@4..7 "bar" 
+    EXPR_STMT@7..17
+      DOT_EXPR@7..17
+        NAME_REF@7..11
+          "\n" IDENT@7..11 "foo" 
+         DOT@11..12 "." 
+        NAME@12..17
+           IDENT@12..17 "await" 
+    EXPR_STMT@17..27
+      DOT_EXPR@17..27
+        NAME_REF@17..21
+          "\n" IDENT@17..21 "foo" 
+         DOT@21..22 "." 
+        NAME@22..27
+           IDENT@22..27 "yield" 
+    EXPR_STMT@27..35
+      DOT_EXPR@27..35
+        NAME_REF@27..31
+          "\n" IDENT@27..31 "foo" 
+         DOT@31..32 "." 
+        NAME@32..35
+           IDENT@32..35 "for" 
+    EXPR_STMT@35..44
+      DOT_EXPR@35..44
+        NAME_REF@35..39
+          "\n" IDENT@35..39 "foo" 
+         QUESTIONDOT@39..41 "?." 
+        NAME@41..44
+           IDENT@41..44 "for" 
+    EXPR_STMT@44..53
+      DOT_EXPR@44..53
+        NAME_REF@44..48
+          "\n" IDENT@44..48 "foo" 
+         QUESTIONDOT@48..50 "?." 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME@50..53
-          IDENT@50..53 "bar"
-  WHITESPACE@53..54 "\n"
+           IDENT@50..53 "bar" 

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -8,5 +8,9 @@ JS_MODULE@0..2
 MODULE@0..1
   LIST@0..1
     EMPTY_STMT@0..1
+<<<<<<< HEAD
        SEMICOLON@0..1 ";" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None SEMICOLON@0..1 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -1,5 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..2
   LIST@0..1
     JS_EMPTY_STATEMENT@0..1
       SEMICOLON@0..1 ";"
   WHITESPACE@1..2 "\n"
+=======
+MODULE@0..1
+  LIST@0..1
+    EMPTY_STMT@0..1
+       SEMICOLON@0..1 ";" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -1,16 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..2
+JS_MODULE@0..1
   LIST@0..1
     JS_EMPTY_STATEMENT@0..1
-      SEMICOLON@0..1 ";"
-  WHITESPACE@1..2 "\n"
-=======
-MODULE@0..1
-  LIST@0..1
-    EMPTY_STMT@0..1
-<<<<<<< HEAD
-       SEMICOLON@0..1 ";" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
       None SEMICOLON@0..1 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -5,15 +5,15 @@ MODULE@0..26
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     EXPORT_DECL@0..26
-       EXPORT_KW@0..7 "export" " "
+      None EXPORT_KW@0..7 "export" Whitespace(1)
       EXPORT_NAMED@7..26
-         L_CURLY@7..9 "{" " "
+        None L_CURLY@7..9 "{" Whitespace(1)
         LIST@9..13
           SPECIFIER@9..13
             NAME@9..13
-               IDENT@9..13 "foo" " "
-         R_CURLY@13..15 "}" " "
-         FROM_KW@15..20 "from" " "
+              None IDENT@9..13 "foo" Whitespace(1)
+        None R_CURLY@13..15 "}" Whitespace(1)
+        None FROM_KW@15..20 "from" Whitespace(1)
         LITERAL@20..25
-           STRING@20..25 "\"bla\"" 
-         SEMICOLON@25..26 ";" 
+          None STRING@20..25 "\"bla\"" None
+        None SEMICOLON@25..26 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -5,15 +5,15 @@ MODULE@0..26
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     EXPORT_DECL@0..26
-      None EXPORT_KW@0..7 "export" Whitespace(1)
+      None EXPORT_KW@0..6 "export" Whitespace(1)
       EXPORT_NAMED@7..26
-        None L_CURLY@7..9 "{" Whitespace(1)
+        None L_CURLY@7..8 "{" Whitespace(1)
         LIST@9..13
           SPECIFIER@9..13
             NAME@9..13
-              None IDENT@9..13 "foo" Whitespace(1)
-        None R_CURLY@13..15 "}" Whitespace(1)
-        None FROM_KW@15..20 "from" Whitespace(1)
+              None IDENT@9..12 "foo" Whitespace(1)
+        None R_CURLY@13..14 "}" Whitespace(1)
+        None FROM_KW@15..19 "from" Whitespace(1)
         LITERAL@20..25
           None STRING@20..25 "\"bla\"" None
         None SEMICOLON@25..26 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..27
-=======
-MODULE@0..26
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..26
   LIST@0..26
     EXPORT_DECL@0..26
       None EXPORT_KW@0..6 "export" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -1,21 +1,19 @@
+<<<<<<< HEAD
 JS_MODULE@0..27
+=======
+MODULE@0..26
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     EXPORT_DECL@0..26
-      EXPORT_KW@0..6 "export"
-      WHITESPACE@6..7 " "
+       EXPORT_KW@0..7 "export" " "
       EXPORT_NAMED@7..26
-        L_CURLY@7..8 "{"
-        WHITESPACE@8..9 " "
-        LIST@9..12
-          SPECIFIER@9..12
-            NAME@9..12
-              IDENT@9..12 "foo"
-        WHITESPACE@12..13 " "
-        R_CURLY@13..14 "}"
-        WHITESPACE@14..15 " "
-        FROM_KW@15..19 "from"
-        WHITESPACE@19..20 " "
+         L_CURLY@7..9 "{" " "
+        LIST@9..13
+          SPECIFIER@9..13
+            NAME@9..13
+               IDENT@9..13 "foo" " "
+         R_CURLY@13..15 "}" " "
+         FROM_KW@15..20 "from" " "
         LITERAL@20..25
-          STRING@20..25 "\"bla\""
-        SEMICOLON@25..26 ";"
-  WHITESPACE@26..27 "\n"
+           STRING@20..25 "\"bla\"" 
+         SEMICOLON@25..26 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..95
-=======
-MODULE@0..94
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..94
   LIST@0..94
     FOR_STMT@0..31
       None FOR_KW@0..3 "for" Whitespace(1)
@@ -30,28 +26,11 @@ MODULE@0..94
       FOR_STMT_UPDATE@24..27
         POST_UPDATE_EXPRESSION@24..27
           NAME_REF@24..25
-<<<<<<< HEAD
-<<<<<<< HEAD
-            IDENT@24..25 "i"
-          PLUS2@25..27 "++"
-      R_PAREN@27..28 ")"
-      WHITESPACE@28..29 " "
-      JS_BLOCK_STATEMENT@29..31
-        L_CURLY@29..30 "{"
-=======
-             IDENT@24..25 "i" 
-           PLUS2@25..27 "++" 
-       R_PAREN@27..29 ")" " "
-      BLOCK_STMT@29..31
-         L_CURLY@29..30 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None IDENT@24..25 "i" None
           None PLUS2@25..27 "++" None
       None R_PAREN@27..28 ")" Whitespace(1)
-      BLOCK_STMT@29..31
+      JS_BLOCK_STATEMENT@29..31
         None L_CURLY@29..30 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@30..30
         None R_CURLY@30..31 "}" None
     FOR_OF_STMT@31..63
@@ -77,25 +56,10 @@ MODULE@0..94
       OBJECT_EXPR@57..59
         None L_CURLY@57..58 "{" None
         LIST@58..58
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_CURLY@58..59 "}"
-      R_PAREN@59..60 ")"
-      WHITESPACE@60..61 " "
-      JS_BLOCK_STATEMENT@61..63
-        L_CURLY@61..62 "{"
-=======
-         R_CURLY@58..59 "}" 
-       R_PAREN@59..61 ")" " "
-      BLOCK_STMT@61..63
-         L_CURLY@61..62 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
         None R_CURLY@58..59 "}" None
       None R_PAREN@59..60 ")" Whitespace(1)
-      BLOCK_STMT@61..63
+      JS_BLOCK_STATEMENT@61..63
         None L_CURLY@61..62 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@62..62
         None R_CURLY@62..63 "}" None
     FOR_IN_STMT@63..82
@@ -108,38 +72,9 @@ MODULE@0..94
       OBJECT_EXPR@76..78
         None L_CURLY@76..77 "{" None
         LIST@77..77
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_CURLY@77..78 "}"
-      R_PAREN@78..79 ")"
-      WHITESPACE@79..80 " "
-      JS_BLOCK_STATEMENT@80..82
-        L_CURLY@80..81 "{"
-        LIST@81..81
-        R_CURLY@81..82 "}"
-    WHITESPACE@82..83 "\n"
-    FOR_STMT@83..94
-      FOR_KW@83..86 "for"
-      WHITESPACE@86..87 " "
-      L_PAREN@87..88 "("
-      SEMICOLON@88..89 ";"
-      SEMICOLON@89..90 ";"
-      R_PAREN@90..91 ")"
-      WHITESPACE@91..92 " "
-      JS_BLOCK_STATEMENT@92..94
-        L_CURLY@92..93 "{"
-=======
-         R_CURLY@77..78 "}" 
-       R_PAREN@78..80 ")" " "
-=======
         None R_CURLY@77..78 "}" None
-<<<<<<< HEAD
-      None R_PAREN@78..80 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
       None R_PAREN@78..79 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@80..82
+      JS_BLOCK_STATEMENT@80..82
         None L_CURLY@80..81 "{" None
         LIST@81..81
         None R_CURLY@81..82 "}" None
@@ -149,12 +84,7 @@ MODULE@0..94
       None SEMICOLON@88..89 ";" None
       None SEMICOLON@89..90 ";" None
       None R_PAREN@90..91 ")" Whitespace(1)
-      BLOCK_STMT@92..94
-<<<<<<< HEAD
-         L_CURLY@92..93 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
+      JS_BLOCK_STATEMENT@92..94
         None L_CURLY@92..93 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@93..93
         None R_CURLY@93..94 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -5,28 +5,28 @@ MODULE@0..94
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..94
     FOR_STMT@0..31
-      None FOR_KW@0..4 "for" Whitespace(1)
+      None FOR_KW@0..3 "for" Whitespace(1)
       None L_PAREN@4..5 "(" None
       FOR_STMT_INIT@5..14
         VAR_DECL@5..14
-          None IDENT@5..9 "let" Whitespace(1)
+          None IDENT@5..8 "let" Whitespace(1)
           LIST@9..14
             DECLARATOR@9..14
               SINGLE_PATTERN@9..11
                 NAME@9..11
-                  None IDENT@9..11 "i" Whitespace(1)
-              None EQ@11..13 "=" Whitespace(1)
+                  None IDENT@9..10 "i" Whitespace(1)
+              None EQ@11..12 "=" Whitespace(1)
               LITERAL@13..14
                 None NUMBER@13..14 "5" None
-      None SEMICOLON@14..16 ";" Whitespace(1)
+      None SEMICOLON@14..15 ";" Whitespace(1)
       FOR_STMT_TEST@16..22
         BIN_EXPR@16..22
           NAME_REF@16..18
-            None IDENT@16..18 "i" Whitespace(1)
-          None L_ANGLE@18..20 "<" Whitespace(1)
+            None IDENT@16..17 "i" Whitespace(1)
+          None L_ANGLE@18..19 "<" Whitespace(1)
           LITERAL@20..22
             None NUMBER@20..22 "10" None
-      None SEMICOLON@22..24 ";" Whitespace(1)
+      None SEMICOLON@22..23 ";" Whitespace(1)
       FOR_STMT_UPDATE@24..27
         POST_UPDATE_EXPRESSION@24..27
           NAME_REF@24..25
@@ -48,32 +48,32 @@ MODULE@0..94
 =======
             None IDENT@24..25 "i" None
           None PLUS2@25..27 "++" None
-      None R_PAREN@27..29 ")" Whitespace(1)
+      None R_PAREN@27..28 ")" Whitespace(1)
       BLOCK_STMT@29..31
         None L_CURLY@29..30 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@30..30
         None R_CURLY@30..31 "}" None
     FOR_OF_STMT@31..63
-      Whitespace(1) FOR_KW@31..36 "for" Whitespace(1)
+      Whitespace(1) FOR_KW@32..35 "for" Whitespace(1)
       None L_PAREN@36..37 "(" None
       FOR_STMT_INIT@37..54
         VAR_DECL@37..54
-          None IDENT@37..41 "let" Whitespace(1)
+          None IDENT@37..40 "let" Whitespace(1)
           LIST@41..54
             DECLARATOR@41..54
               OBJECT_PATTERN@41..54
-                None L_CURLY@41..43 "{" Whitespace(1)
+                None L_CURLY@41..42 "{" Whitespace(1)
                 LIST@43..52
                   SINGLE_PATTERN@43..46
                     NAME@43..46
                       None IDENT@43..46 "foo" None
-                  None COMMA@46..48 "," Whitespace(1)
+                  None COMMA@46..47 "," Whitespace(1)
                   SINGLE_PATTERN@48..52
                     NAME@48..52
-                      None IDENT@48..52 "bar" Whitespace(1)
-                None R_CURLY@52..54 "}" Whitespace(1)
-      None IDENT@54..57 "of" Whitespace(1)
+                      None IDENT@48..51 "bar" Whitespace(1)
+                None R_CURLY@52..53 "}" Whitespace(1)
+      None IDENT@54..56 "of" Whitespace(1)
       OBJECT_EXPR@57..59
         None L_CURLY@57..58 "{" None
         LIST@58..58
@@ -92,19 +92,19 @@ MODULE@0..94
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_CURLY@58..59 "}" None
-      None R_PAREN@59..61 ")" Whitespace(1)
+      None R_PAREN@59..60 ")" Whitespace(1)
       BLOCK_STMT@61..63
         None L_CURLY@61..62 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@62..62
         None R_CURLY@62..63 "}" None
     FOR_IN_STMT@63..82
-      Whitespace(1) FOR_KW@63..68 "for" Whitespace(1)
+      Whitespace(1) FOR_KW@64..67 "for" Whitespace(1)
       None L_PAREN@68..69 "(" None
       FOR_STMT_INIT@69..73
         NAME_REF@69..73
-          None IDENT@69..73 "foo" Whitespace(1)
-      None IN_KW@73..76 "in" Whitespace(1)
+          None IDENT@69..72 "foo" Whitespace(1)
+      None IN_KW@73..75 "in" Whitespace(1)
       OBJECT_EXPR@76..78
         None L_CURLY@76..77 "{" None
         LIST@77..77
@@ -133,18 +133,22 @@ MODULE@0..94
        R_PAREN@78..80 ")" " "
 =======
         None R_CURLY@77..78 "}" None
+<<<<<<< HEAD
       None R_PAREN@78..80 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      None R_PAREN@78..79 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@80..82
         None L_CURLY@80..81 "{" None
         LIST@81..81
         None R_CURLY@81..82 "}" None
     FOR_STMT@82..94
-      Whitespace(1) FOR_KW@82..87 "for" Whitespace(1)
+      Whitespace(1) FOR_KW@83..86 "for" Whitespace(1)
       None L_PAREN@87..88 "(" None
       None SEMICOLON@88..89 ";" None
       None SEMICOLON@89..90 ";" None
-      None R_PAREN@90..92 ")" Whitespace(1)
+      None R_PAREN@90..91 ")" Whitespace(1)
       BLOCK_STMT@92..94
 <<<<<<< HEAD
          L_CURLY@92..93 "{" 

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -1,99 +1,99 @@
+<<<<<<< HEAD
 JS_MODULE@0..95
+=======
+MODULE@0..94
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..94
     FOR_STMT@0..31
-      FOR_KW@0..3 "for"
-      WHITESPACE@3..4 " "
-      L_PAREN@4..5 "("
+       FOR_KW@0..4 "for" " "
+       L_PAREN@4..5 "(" 
       FOR_STMT_INIT@5..14
         VAR_DECL@5..14
-          IDENT@5..8 "let"
-          WHITESPACE@8..9 " "
+           IDENT@5..9 "let" " "
           LIST@9..14
             DECLARATOR@9..14
-              SINGLE_PATTERN@9..10
-                NAME@9..10
-                  IDENT@9..10 "i"
-              WHITESPACE@10..11 " "
-              EQ@11..12 "="
-              WHITESPACE@12..13 " "
+              SINGLE_PATTERN@9..11
+                NAME@9..11
+                   IDENT@9..11 "i" " "
+               EQ@11..13 "=" " "
               LITERAL@13..14
-                NUMBER@13..14 "5"
-      SEMICOLON@14..15 ";"
-      WHITESPACE@15..16 " "
+                 NUMBER@13..14 "5" 
+       SEMICOLON@14..16 ";" " "
       FOR_STMT_TEST@16..22
         BIN_EXPR@16..22
-          NAME_REF@16..17
-            IDENT@16..17 "i"
-          WHITESPACE@17..18 " "
-          L_ANGLE@18..19 "<"
-          WHITESPACE@19..20 " "
+          NAME_REF@16..18
+             IDENT@16..18 "i" " "
+           L_ANGLE@18..20 "<" " "
           LITERAL@20..22
-            NUMBER@20..22 "10"
-      SEMICOLON@22..23 ";"
-      WHITESPACE@23..24 " "
+             NUMBER@20..22 "10" 
+       SEMICOLON@22..24 ";" " "
       FOR_STMT_UPDATE@24..27
         POST_UPDATE_EXPRESSION@24..27
           NAME_REF@24..25
+<<<<<<< HEAD
             IDENT@24..25 "i"
           PLUS2@25..27 "++"
       R_PAREN@27..28 ")"
       WHITESPACE@28..29 " "
       JS_BLOCK_STATEMENT@29..31
         L_CURLY@29..30 "{"
+=======
+             IDENT@24..25 "i" 
+           PLUS2@25..27 "++" 
+       R_PAREN@27..29 ")" " "
+      BLOCK_STMT@29..31
+         L_CURLY@29..30 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@30..30
-        R_CURLY@30..31 "}"
-    WHITESPACE@31..32 "\n"
-    FOR_OF_STMT@32..63
-      FOR_KW@32..35 "for"
-      WHITESPACE@35..36 " "
-      L_PAREN@36..37 "("
-      FOR_STMT_INIT@37..53
-        VAR_DECL@37..53
-          IDENT@37..40 "let"
-          WHITESPACE@40..41 " "
-          LIST@41..53
-            DECLARATOR@41..53
-              OBJECT_PATTERN@41..53
-                L_CURLY@41..42 "{"
-                WHITESPACE@42..43 " "
-                LIST@43..51
+         R_CURLY@30..31 "}" 
+    FOR_OF_STMT@31..63
+      "\n" FOR_KW@31..36 "for" " "
+       L_PAREN@36..37 "(" 
+      FOR_STMT_INIT@37..54
+        VAR_DECL@37..54
+           IDENT@37..41 "let" " "
+          LIST@41..54
+            DECLARATOR@41..54
+              OBJECT_PATTERN@41..54
+                 L_CURLY@41..43 "{" " "
+                LIST@43..52
                   SINGLE_PATTERN@43..46
                     NAME@43..46
-                      IDENT@43..46 "foo"
-                  COMMA@46..47 ","
-                  WHITESPACE@47..48 " "
-                  SINGLE_PATTERN@48..51
-                    NAME@48..51
-                      IDENT@48..51 "bar"
-                WHITESPACE@51..52 " "
-                R_CURLY@52..53 "}"
-      WHITESPACE@53..54 " "
-      IDENT@54..56 "of"
-      WHITESPACE@56..57 " "
+                       IDENT@43..46 "foo" 
+                   COMMA@46..48 "," " "
+                  SINGLE_PATTERN@48..52
+                    NAME@48..52
+                       IDENT@48..52 "bar" " "
+                 R_CURLY@52..54 "}" " "
+       IDENT@54..57 "of" " "
       OBJECT_EXPR@57..59
-        L_CURLY@57..58 "{"
+         L_CURLY@57..58 "{" 
         LIST@58..58
+<<<<<<< HEAD
         R_CURLY@58..59 "}"
       R_PAREN@59..60 ")"
       WHITESPACE@60..61 " "
       JS_BLOCK_STATEMENT@61..63
         L_CURLY@61..62 "{"
+=======
+         R_CURLY@58..59 "}" 
+       R_PAREN@59..61 ")" " "
+      BLOCK_STMT@61..63
+         L_CURLY@61..62 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@62..62
-        R_CURLY@62..63 "}"
-    WHITESPACE@63..64 "\n"
-    FOR_IN_STMT@64..82
-      FOR_KW@64..67 "for"
-      WHITESPACE@67..68 " "
-      L_PAREN@68..69 "("
-      FOR_STMT_INIT@69..72
-        NAME_REF@69..72
-          IDENT@69..72 "foo"
-      WHITESPACE@72..73 " "
-      IN_KW@73..75 "in"
-      WHITESPACE@75..76 " "
+         R_CURLY@62..63 "}" 
+    FOR_IN_STMT@63..82
+      "\n" FOR_KW@63..68 "for" " "
+       L_PAREN@68..69 "(" 
+      FOR_STMT_INIT@69..73
+        NAME_REF@69..73
+           IDENT@69..73 "foo" " "
+       IN_KW@73..76 "in" " "
       OBJECT_EXPR@76..78
-        L_CURLY@76..77 "{"
+         L_CURLY@76..77 "{" 
         LIST@77..77
+<<<<<<< HEAD
         R_CURLY@77..78 "}"
       R_PAREN@78..79 ")"
       WHITESPACE@79..80 " "
@@ -112,6 +112,21 @@ JS_MODULE@0..95
       WHITESPACE@91..92 " "
       JS_BLOCK_STATEMENT@92..94
         L_CURLY@92..93 "{"
+=======
+         R_CURLY@77..78 "}" 
+       R_PAREN@78..80 ")" " "
+      BLOCK_STMT@80..82
+         L_CURLY@80..81 "{" 
+        LIST@81..81
+         R_CURLY@81..82 "}" 
+    FOR_STMT@82..94
+      "\n" FOR_KW@82..87 "for" " "
+       L_PAREN@87..88 "(" 
+       SEMICOLON@88..89 ";" 
+       SEMICOLON@89..90 ";" 
+       R_PAREN@90..92 ")" " "
+      BLOCK_STMT@92..94
+         L_CURLY@92..93 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@93..93
-        R_CURLY@93..94 "}"
-  WHITESPACE@94..95 "\n"
+         R_CURLY@93..94 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -5,31 +5,32 @@ MODULE@0..94
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..94
     FOR_STMT@0..31
-       FOR_KW@0..4 "for" " "
-       L_PAREN@4..5 "(" 
+      None FOR_KW@0..4 "for" Whitespace(1)
+      None L_PAREN@4..5 "(" None
       FOR_STMT_INIT@5..14
         VAR_DECL@5..14
-           IDENT@5..9 "let" " "
+          None IDENT@5..9 "let" Whitespace(1)
           LIST@9..14
             DECLARATOR@9..14
               SINGLE_PATTERN@9..11
                 NAME@9..11
-                   IDENT@9..11 "i" " "
-               EQ@11..13 "=" " "
+                  None IDENT@9..11 "i" Whitespace(1)
+              None EQ@11..13 "=" Whitespace(1)
               LITERAL@13..14
-                 NUMBER@13..14 "5" 
-       SEMICOLON@14..16 ";" " "
+                None NUMBER@13..14 "5" None
+      None SEMICOLON@14..16 ";" Whitespace(1)
       FOR_STMT_TEST@16..22
         BIN_EXPR@16..22
           NAME_REF@16..18
-             IDENT@16..18 "i" " "
-           L_ANGLE@18..20 "<" " "
+            None IDENT@16..18 "i" Whitespace(1)
+          None L_ANGLE@18..20 "<" Whitespace(1)
           LITERAL@20..22
-             NUMBER@20..22 "10" 
-       SEMICOLON@22..24 ";" " "
+            None NUMBER@20..22 "10" None
+      None SEMICOLON@22..24 ";" Whitespace(1)
       FOR_STMT_UPDATE@24..27
         POST_UPDATE_EXPRESSION@24..27
           NAME_REF@24..25
+<<<<<<< HEAD
 <<<<<<< HEAD
             IDENT@24..25 "i"
           PLUS2@25..27 "++"
@@ -44,31 +45,39 @@ MODULE@0..94
       BLOCK_STMT@29..31
          L_CURLY@29..30 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None IDENT@24..25 "i" None
+          None PLUS2@25..27 "++" None
+      None R_PAREN@27..29 ")" Whitespace(1)
+      BLOCK_STMT@29..31
+        None L_CURLY@29..30 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@30..30
-         R_CURLY@30..31 "}" 
+        None R_CURLY@30..31 "}" None
     FOR_OF_STMT@31..63
-      "\n" FOR_KW@31..36 "for" " "
-       L_PAREN@36..37 "(" 
+      Whitespace(1) FOR_KW@31..36 "for" Whitespace(1)
+      None L_PAREN@36..37 "(" None
       FOR_STMT_INIT@37..54
         VAR_DECL@37..54
-           IDENT@37..41 "let" " "
+          None IDENT@37..41 "let" Whitespace(1)
           LIST@41..54
             DECLARATOR@41..54
               OBJECT_PATTERN@41..54
-                 L_CURLY@41..43 "{" " "
+                None L_CURLY@41..43 "{" Whitespace(1)
                 LIST@43..52
                   SINGLE_PATTERN@43..46
                     NAME@43..46
-                       IDENT@43..46 "foo" 
-                   COMMA@46..48 "," " "
+                      None IDENT@43..46 "foo" None
+                  None COMMA@46..48 "," Whitespace(1)
                   SINGLE_PATTERN@48..52
                     NAME@48..52
-                       IDENT@48..52 "bar" " "
-                 R_CURLY@52..54 "}" " "
-       IDENT@54..57 "of" " "
+                      None IDENT@48..52 "bar" Whitespace(1)
+                None R_CURLY@52..54 "}" Whitespace(1)
+      None IDENT@54..57 "of" Whitespace(1)
       OBJECT_EXPR@57..59
-         L_CURLY@57..58 "{" 
+        None L_CURLY@57..58 "{" None
         LIST@58..58
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_CURLY@58..59 "}"
       R_PAREN@59..60 ")"
@@ -81,18 +90,25 @@ MODULE@0..94
       BLOCK_STMT@61..63
          L_CURLY@61..62 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_CURLY@58..59 "}" None
+      None R_PAREN@59..61 ")" Whitespace(1)
+      BLOCK_STMT@61..63
+        None L_CURLY@61..62 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@62..62
-         R_CURLY@62..63 "}" 
+        None R_CURLY@62..63 "}" None
     FOR_IN_STMT@63..82
-      "\n" FOR_KW@63..68 "for" " "
-       L_PAREN@68..69 "(" 
+      Whitespace(1) FOR_KW@63..68 "for" Whitespace(1)
+      None L_PAREN@68..69 "(" None
       FOR_STMT_INIT@69..73
         NAME_REF@69..73
-           IDENT@69..73 "foo" " "
-       IN_KW@73..76 "in" " "
+          None IDENT@69..73 "foo" Whitespace(1)
+      None IN_KW@73..76 "in" Whitespace(1)
       OBJECT_EXPR@76..78
-         L_CURLY@76..77 "{" 
+        None L_CURLY@76..77 "{" None
         LIST@77..77
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_CURLY@77..78 "}"
       R_PAREN@78..79 ")"
@@ -115,18 +131,26 @@ MODULE@0..94
 =======
          R_CURLY@77..78 "}" 
        R_PAREN@78..80 ")" " "
+=======
+        None R_CURLY@77..78 "}" None
+      None R_PAREN@78..80 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@80..82
-         L_CURLY@80..81 "{" 
+        None L_CURLY@80..81 "{" None
         LIST@81..81
-         R_CURLY@81..82 "}" 
+        None R_CURLY@81..82 "}" None
     FOR_STMT@82..94
-      "\n" FOR_KW@82..87 "for" " "
-       L_PAREN@87..88 "(" 
-       SEMICOLON@88..89 ";" 
-       SEMICOLON@89..90 ";" 
-       R_PAREN@90..92 ")" " "
+      Whitespace(1) FOR_KW@82..87 "for" Whitespace(1)
+      None L_PAREN@87..88 "(" None
+      None SEMICOLON@88..89 ";" None
+      None SEMICOLON@89..90 ";" None
+      None R_PAREN@90..92 ")" Whitespace(1)
       BLOCK_STMT@92..94
+<<<<<<< HEAD
          L_CURLY@92..93 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None L_CURLY@92..93 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@93..93
-         R_CURLY@93..94 "}" 
+        None R_CURLY@93..94 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..142
-=======
-MODULE@0..141
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..141
   LIST@0..141
     FN_DECL@0..17
       None FUNCTION_KW@0..8 "function" Whitespace(1)
@@ -11,26 +7,9 @@ MODULE@0..141
       PARAMETER_LIST@12..15
         None L_PAREN@12..13 "(" None
         LIST@13..13
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@13..14 ")"
-      WHITESPACE@14..15 " "
-      JS_BLOCK_STATEMENT@15..17
-        L_CURLY@15..16 "{"
-=======
-         R_PAREN@13..15 ")" " "
-      BLOCK_STMT@15..17
-         L_CURLY@15..16 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@13..15 ")" Whitespace(1)
-=======
         None R_PAREN@13..14 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@15..17
+      JS_BLOCK_STATEMENT@15..17
         None L_CURLY@15..16 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@16..16
         None R_CURLY@16..17 "}" None
     FN_DECL@17..36
@@ -41,26 +20,9 @@ MODULE@0..141
       PARAMETER_LIST@31..34
         None L_PAREN@31..32 "(" None
         LIST@32..32
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@32..33 ")"
-      WHITESPACE@33..34 " "
-      JS_BLOCK_STATEMENT@34..36
-        L_CURLY@34..35 "{"
-=======
-         R_PAREN@32..34 ")" " "
-      BLOCK_STMT@34..36
-         L_CURLY@34..35 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@32..34 ")" Whitespace(1)
-=======
         None R_PAREN@32..33 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@34..36
+      JS_BLOCK_STATEMENT@34..36
         None L_CURLY@34..35 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@35..35
         None R_CURLY@35..36 "}" None
     FN_DECL@36..59
@@ -72,25 +34,10 @@ MODULE@0..141
         LIST@50..55
           SINGLE_PATTERN@50..55
             NAME@50..55
-<<<<<<< HEAD
-<<<<<<< HEAD
-              IDENT@50..55 "await"
-        R_PAREN@55..56 ")"
-      WHITESPACE@56..57 " "
-      JS_BLOCK_STATEMENT@57..59
-        L_CURLY@57..58 "{"
-=======
-               IDENT@50..55 "await" 
-         R_PAREN@55..57 ")" " "
-      BLOCK_STMT@57..59
-         L_CURLY@57..58 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
               None IDENT@50..55 "await" None
         None R_PAREN@55..56 ")" Whitespace(1)
-      BLOCK_STMT@57..59
+      JS_BLOCK_STATEMENT@57..59
         None L_CURLY@57..58 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@58..58
         None R_CURLY@58..59 "}" None
     FN_DECL@59..84
@@ -102,26 +49,9 @@ MODULE@0..141
       PARAMETER_LIST@79..82
         None L_PAREN@79..80 "(" None
         LIST@80..80
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@80..81 ")"
-      WHITESPACE@81..82 " "
-      JS_BLOCK_STATEMENT@82..84
-        L_CURLY@82..83 "{"
-=======
-         R_PAREN@80..82 ")" " "
-      BLOCK_STMT@82..84
-         L_CURLY@82..83 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@80..82 ")" Whitespace(1)
-=======
         None R_PAREN@80..81 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@82..84
+      JS_BLOCK_STATEMENT@82..84
         None L_CURLY@82..83 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@83..83
         None R_CURLY@83..84 "}" None
     FN_DECL@84..108
@@ -132,26 +62,9 @@ MODULE@0..141
       PARAMETER_LIST@103..106
         None L_PAREN@103..104 "(" None
         LIST@104..104
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@104..105 ")"
-      WHITESPACE@105..106 " "
-      JS_BLOCK_STATEMENT@106..108
-        L_CURLY@106..107 "{"
-=======
-         R_PAREN@104..106 ")" " "
-      BLOCK_STMT@106..108
-         L_CURLY@106..107 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        None R_PAREN@104..106 ")" Whitespace(1)
-=======
         None R_PAREN@104..105 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@106..108
+      JS_BLOCK_STATEMENT@106..108
         None L_CURLY@106..107 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@107..107
         None R_CURLY@107..108 "}" None
     FN_DECL@108..141
@@ -162,42 +75,13 @@ MODULE@0..141
       PARAMETER_LIST@122..125
         None L_PAREN@122..123 "(" None
         LIST@123..123
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@123..124 ")"
-      WHITESPACE@124..125 " "
-      JS_BLOCK_STATEMENT@125..141
-        L_CURLY@125..126 "{"
-        WHITESPACE@126..129 "\n  "
-        LIST@129..139
-          JS_EXPRESSION_STATEMENT@129..139
-            YIELD_EXPR@129..138
-              YIELD_KW@129..134 "yield"
-              WHITESPACE@134..135 " "
-=======
-         R_PAREN@123..125 ")" " "
-=======
-        None R_PAREN@123..125 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@123..124 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@125..141
+      JS_BLOCK_STATEMENT@125..141
         None L_CURLY@125..126 "{" None
         LIST@126..139
-          EXPR_STMT@126..139
+          JS_EXPRESSION_STATEMENT@126..139
             YIELD_EXPR@126..138
-<<<<<<< HEAD
-<<<<<<< HEAD
-              "\n  " YIELD_KW@126..135 "yield" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              Whitespace(3) YIELD_KW@126..135 "yield" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               Whitespace(3) YIELD_KW@129..134 "yield" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               NAME_REF@135..138
                 None IDENT@135..138 "foo" None
             None SEMICOLON@138..139 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -1,98 +1,121 @@
+<<<<<<< HEAD
 JS_MODULE@0..142
+=======
+MODULE@0..141
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..141
     FN_DECL@0..17
-      FUNCTION_KW@0..8 "function"
-      WHITESPACE@8..9 " "
+       FUNCTION_KW@0..9 "function" " "
       NAME@9..12
-        IDENT@9..12 "foo"
-      PARAMETER_LIST@12..14
-        L_PAREN@12..13 "("
+         IDENT@9..12 "foo" 
+      PARAMETER_LIST@12..15
+         L_PAREN@12..13 "(" 
         LIST@13..13
+<<<<<<< HEAD
         R_PAREN@13..14 ")"
       WHITESPACE@14..15 " "
       JS_BLOCK_STATEMENT@15..17
         L_CURLY@15..16 "{"
+=======
+         R_PAREN@13..15 ")" " "
+      BLOCK_STMT@15..17
+         L_CURLY@15..16 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@16..16
-        R_CURLY@16..17 "}"
-    WHITESPACE@17..18 "\n"
-    FN_DECL@18..36
-      FUNCTION_KW@18..26 "function"
-      WHITESPACE@26..27 " "
-      STAR@27..28 "*"
+         R_CURLY@16..17 "}" 
+    FN_DECL@17..36
+      "\n" FUNCTION_KW@17..27 "function" " "
+       STAR@27..28 "*" 
       NAME@28..31
-        IDENT@28..31 "foo"
-      PARAMETER_LIST@31..33
-        L_PAREN@31..32 "("
+         IDENT@28..31 "foo" 
+      PARAMETER_LIST@31..34
+         L_PAREN@31..32 "(" 
         LIST@32..32
+<<<<<<< HEAD
         R_PAREN@32..33 ")"
       WHITESPACE@33..34 " "
       JS_BLOCK_STATEMENT@34..36
         L_CURLY@34..35 "{"
+=======
+         R_PAREN@32..34 ")" " "
+      BLOCK_STMT@34..36
+         L_CURLY@34..35 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@35..35
-        R_CURLY@35..36 "}"
-    WHITESPACE@36..37 "\n"
-    FN_DECL@37..59
-      FUNCTION_KW@37..45 "function"
-      WHITESPACE@45..46 " "
+         R_CURLY@35..36 "}" 
+    FN_DECL@36..59
+      "\n" FUNCTION_KW@36..46 "function" " "
       NAME@46..49
-        IDENT@46..49 "foo"
-      PARAMETER_LIST@49..56
-        L_PAREN@49..50 "("
+         IDENT@46..49 "foo" 
+      PARAMETER_LIST@49..57
+         L_PAREN@49..50 "(" 
         LIST@50..55
           SINGLE_PATTERN@50..55
             NAME@50..55
+<<<<<<< HEAD
               IDENT@50..55 "await"
         R_PAREN@55..56 ")"
       WHITESPACE@56..57 " "
       JS_BLOCK_STATEMENT@57..59
         L_CURLY@57..58 "{"
+=======
+               IDENT@50..55 "await" 
+         R_PAREN@55..57 ")" " "
+      BLOCK_STMT@57..59
+         L_CURLY@57..58 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@58..58
-        R_CURLY@58..59 "}"
-    WHITESPACE@59..60 "\n"
-    FN_DECL@60..84
-      IDENT@60..65 "async"
-      WHITESPACE@65..66 " "
-      FUNCTION_KW@66..74 "function"
-      WHITESPACE@74..75 " "
-      STAR@75..76 "*"
+         R_CURLY@58..59 "}" 
+    FN_DECL@59..84
+      "\n" IDENT@59..66 "async" " "
+       FUNCTION_KW@66..75 "function" " "
+       STAR@75..76 "*" 
       NAME@76..79
-        IDENT@76..79 "foo"
-      PARAMETER_LIST@79..81
-        L_PAREN@79..80 "("
+         IDENT@76..79 "foo" 
+      PARAMETER_LIST@79..82
+         L_PAREN@79..80 "(" 
         LIST@80..80
+<<<<<<< HEAD
         R_PAREN@80..81 ")"
       WHITESPACE@81..82 " "
       JS_BLOCK_STATEMENT@82..84
         L_CURLY@82..83 "{"
+=======
+         R_PAREN@80..82 ")" " "
+      BLOCK_STMT@82..84
+         L_CURLY@82..83 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@83..83
-        R_CURLY@83..84 "}"
-    WHITESPACE@84..85 "\n"
-    FN_DECL@85..108
-      IDENT@85..90 "async"
-      WHITESPACE@90..91 " "
-      FUNCTION_KW@91..99 "function"
-      WHITESPACE@99..100 " "
+         R_CURLY@83..84 "}" 
+    FN_DECL@84..108
+      "\n" IDENT@84..91 "async" " "
+       FUNCTION_KW@91..100 "function" " "
       NAME@100..103
-        IDENT@100..103 "foo"
-      PARAMETER_LIST@103..105
-        L_PAREN@103..104 "("
+         IDENT@100..103 "foo" 
+      PARAMETER_LIST@103..106
+         L_PAREN@103..104 "(" 
         LIST@104..104
+<<<<<<< HEAD
         R_PAREN@104..105 ")"
       WHITESPACE@105..106 " "
       JS_BLOCK_STATEMENT@106..108
         L_CURLY@106..107 "{"
+=======
+         R_PAREN@104..106 ")" " "
+      BLOCK_STMT@106..108
+         L_CURLY@106..107 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@107..107
-        R_CURLY@107..108 "}"
-    WHITESPACE@108..109 "\n"
-    FN_DECL@109..141
-      FUNCTION_KW@109..117 "function"
-      WHITESPACE@117..118 " "
-      STAR@118..119 "*"
+         R_CURLY@107..108 "}" 
+    FN_DECL@108..141
+      "\n" FUNCTION_KW@108..118 "function" " "
+       STAR@118..119 "*" 
       NAME@119..122
-        IDENT@119..122 "foo"
-      PARAMETER_LIST@122..124
-        L_PAREN@122..123 "("
+         IDENT@119..122 "foo" 
+      PARAMETER_LIST@122..125
+         L_PAREN@122..123 "(" 
         LIST@123..123
+<<<<<<< HEAD
         R_PAREN@123..124 ")"
       WHITESPACE@124..125 " "
       JS_BLOCK_STATEMENT@125..141
@@ -103,9 +126,16 @@ JS_MODULE@0..142
             YIELD_EXPR@129..138
               YIELD_KW@129..134 "yield"
               WHITESPACE@134..135 " "
+=======
+         R_PAREN@123..125 ")" " "
+      BLOCK_STMT@125..141
+         L_CURLY@125..126 "{" 
+        LIST@126..139
+          EXPR_STMT@126..139
+            YIELD_EXPR@126..138
+              "\n  " YIELD_KW@126..135 "yield" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               NAME_REF@135..138
-                IDENT@135..138 "foo"
-            SEMICOLON@138..139 ";"
-        WHITESPACE@139..140 "\n"
-        R_CURLY@140..141 "}"
-  WHITESPACE@141..142 "\n"
+                 IDENT@135..138 "foo" 
+             SEMICOLON@138..139 ";" 
+        "\n" R_CURLY@139..141 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -5,12 +5,13 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..141
     FN_DECL@0..17
-      None FUNCTION_KW@0..9 "function" Whitespace(1)
+      None FUNCTION_KW@0..8 "function" Whitespace(1)
       NAME@9..12
         None IDENT@9..12 "foo" None
       PARAMETER_LIST@12..15
         None L_PAREN@12..13 "(" None
         LIST@13..13
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@13..14 ")"
@@ -24,19 +25,23 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@13..15 ")" Whitespace(1)
+=======
+        None R_PAREN@13..14 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@15..17
         None L_CURLY@15..16 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@16..16
         None R_CURLY@16..17 "}" None
     FN_DECL@17..36
-      Whitespace(1) FUNCTION_KW@17..27 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@18..26 "function" Whitespace(1)
       None STAR@27..28 "*" None
       NAME@28..31
         None IDENT@28..31 "foo" None
       PARAMETER_LIST@31..34
         None L_PAREN@31..32 "(" None
         LIST@32..32
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@32..33 ")"
@@ -50,13 +55,16 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@32..34 ")" Whitespace(1)
+=======
+        None R_PAREN@32..33 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@34..36
         None L_CURLY@34..35 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@35..35
         None R_CURLY@35..36 "}" None
     FN_DECL@36..59
-      Whitespace(1) FUNCTION_KW@36..46 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@37..45 "function" Whitespace(1)
       NAME@46..49
         None IDENT@46..49 "foo" None
       PARAMETER_LIST@49..57
@@ -79,21 +87,22 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None IDENT@50..55 "await" None
-        None R_PAREN@55..57 ")" Whitespace(1)
+        None R_PAREN@55..56 ")" Whitespace(1)
       BLOCK_STMT@57..59
         None L_CURLY@57..58 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@58..58
         None R_CURLY@58..59 "}" None
     FN_DECL@59..84
-      Whitespace(1) IDENT@59..66 "async" Whitespace(1)
-      None FUNCTION_KW@66..75 "function" Whitespace(1)
+      Whitespace(1) IDENT@60..65 "async" Whitespace(1)
+      None FUNCTION_KW@66..74 "function" Whitespace(1)
       None STAR@75..76 "*" None
       NAME@76..79
         None IDENT@76..79 "foo" None
       PARAMETER_LIST@79..82
         None L_PAREN@79..80 "(" None
         LIST@80..80
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@80..81 ")"
@@ -107,19 +116,23 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@80..82 ")" Whitespace(1)
+=======
+        None R_PAREN@80..81 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@82..84
         None L_CURLY@82..83 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@83..83
         None R_CURLY@83..84 "}" None
     FN_DECL@84..108
-      Whitespace(1) IDENT@84..91 "async" Whitespace(1)
-      None FUNCTION_KW@91..100 "function" Whitespace(1)
+      Whitespace(1) IDENT@85..90 "async" Whitespace(1)
+      None FUNCTION_KW@91..99 "function" Whitespace(1)
       NAME@100..103
         None IDENT@100..103 "foo" None
       PARAMETER_LIST@103..106
         None L_PAREN@103..104 "(" None
         LIST@104..104
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@104..105 ")"
@@ -133,19 +146,23 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         None R_PAREN@104..106 ")" Whitespace(1)
+=======
+        None R_PAREN@104..105 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@106..108
         None L_CURLY@106..107 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@107..107
         None R_CURLY@107..108 "}" None
     FN_DECL@108..141
-      Whitespace(1) FUNCTION_KW@108..118 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@109..117 "function" Whitespace(1)
       None STAR@118..119 "*" None
       NAME@119..122
         None IDENT@119..122 "foo" None
       PARAMETER_LIST@122..125
         None L_PAREN@122..123 "(" None
         LIST@123..123
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@123..124 ")"
@@ -163,18 +180,25 @@ MODULE@0..141
 =======
         None R_PAREN@123..125 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@123..124 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@125..141
         None L_CURLY@125..126 "{" None
         LIST@126..139
           EXPR_STMT@126..139
             YIELD_EXPR@126..138
 <<<<<<< HEAD
+<<<<<<< HEAD
               "\n  " YIELD_KW@126..135 "yield" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               Whitespace(3) YIELD_KW@126..135 "yield" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              Whitespace(3) YIELD_KW@129..134 "yield" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               NAME_REF@135..138
                 None IDENT@135..138 "foo" None
             None SEMICOLON@138..139 ";" None
-        Whitespace(1) R_CURLY@139..141 "}" None
+        Whitespace(1) R_CURLY@140..141 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -5,12 +5,13 @@ MODULE@0..141
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..141
     FN_DECL@0..17
-       FUNCTION_KW@0..9 "function" " "
+      None FUNCTION_KW@0..9 "function" Whitespace(1)
       NAME@9..12
-         IDENT@9..12 "foo" 
+        None IDENT@9..12 "foo" None
       PARAMETER_LIST@12..15
-         L_PAREN@12..13 "(" 
+        None L_PAREN@12..13 "(" None
         LIST@13..13
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@13..14 ")"
       WHITESPACE@14..15 " "
@@ -21,16 +22,22 @@ MODULE@0..141
       BLOCK_STMT@15..17
          L_CURLY@15..16 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@13..15 ")" Whitespace(1)
+      BLOCK_STMT@15..17
+        None L_CURLY@15..16 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@16..16
-         R_CURLY@16..17 "}" 
+        None R_CURLY@16..17 "}" None
     FN_DECL@17..36
-      "\n" FUNCTION_KW@17..27 "function" " "
-       STAR@27..28 "*" 
+      Whitespace(1) FUNCTION_KW@17..27 "function" Whitespace(1)
+      None STAR@27..28 "*" None
       NAME@28..31
-         IDENT@28..31 "foo" 
+        None IDENT@28..31 "foo" None
       PARAMETER_LIST@31..34
-         L_PAREN@31..32 "(" 
+        None L_PAREN@31..32 "(" None
         LIST@32..32
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@32..33 ")"
       WHITESPACE@33..34 " "
@@ -41,17 +48,23 @@ MODULE@0..141
       BLOCK_STMT@34..36
          L_CURLY@34..35 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@32..34 ")" Whitespace(1)
+      BLOCK_STMT@34..36
+        None L_CURLY@34..35 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@35..35
-         R_CURLY@35..36 "}" 
+        None R_CURLY@35..36 "}" None
     FN_DECL@36..59
-      "\n" FUNCTION_KW@36..46 "function" " "
+      Whitespace(1) FUNCTION_KW@36..46 "function" Whitespace(1)
       NAME@46..49
-         IDENT@46..49 "foo" 
+        None IDENT@46..49 "foo" None
       PARAMETER_LIST@49..57
-         L_PAREN@49..50 "(" 
+        None L_PAREN@49..50 "(" None
         LIST@50..55
           SINGLE_PATTERN@50..55
             NAME@50..55
+<<<<<<< HEAD
 <<<<<<< HEAD
               IDENT@50..55 "await"
         R_PAREN@55..56 ")"
@@ -64,17 +77,24 @@ MODULE@0..141
       BLOCK_STMT@57..59
          L_CURLY@57..58 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None IDENT@50..55 "await" None
+        None R_PAREN@55..57 ")" Whitespace(1)
+      BLOCK_STMT@57..59
+        None L_CURLY@57..58 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@58..58
-         R_CURLY@58..59 "}" 
+        None R_CURLY@58..59 "}" None
     FN_DECL@59..84
-      "\n" IDENT@59..66 "async" " "
-       FUNCTION_KW@66..75 "function" " "
-       STAR@75..76 "*" 
+      Whitespace(1) IDENT@59..66 "async" Whitespace(1)
+      None FUNCTION_KW@66..75 "function" Whitespace(1)
+      None STAR@75..76 "*" None
       NAME@76..79
-         IDENT@76..79 "foo" 
+        None IDENT@76..79 "foo" None
       PARAMETER_LIST@79..82
-         L_PAREN@79..80 "(" 
+        None L_PAREN@79..80 "(" None
         LIST@80..80
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@80..81 ")"
       WHITESPACE@81..82 " "
@@ -85,16 +105,22 @@ MODULE@0..141
       BLOCK_STMT@82..84
          L_CURLY@82..83 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@80..82 ")" Whitespace(1)
+      BLOCK_STMT@82..84
+        None L_CURLY@82..83 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@83..83
-         R_CURLY@83..84 "}" 
+        None R_CURLY@83..84 "}" None
     FN_DECL@84..108
-      "\n" IDENT@84..91 "async" " "
-       FUNCTION_KW@91..100 "function" " "
+      Whitespace(1) IDENT@84..91 "async" Whitespace(1)
+      None FUNCTION_KW@91..100 "function" Whitespace(1)
       NAME@100..103
-         IDENT@100..103 "foo" 
+        None IDENT@100..103 "foo" None
       PARAMETER_LIST@103..106
-         L_PAREN@103..104 "(" 
+        None L_PAREN@103..104 "(" None
         LIST@104..104
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@104..105 ")"
       WHITESPACE@105..106 " "
@@ -105,16 +131,22 @@ MODULE@0..141
       BLOCK_STMT@106..108
          L_CURLY@106..107 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None R_PAREN@104..106 ")" Whitespace(1)
+      BLOCK_STMT@106..108
+        None L_CURLY@106..107 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@107..107
-         R_CURLY@107..108 "}" 
+        None R_CURLY@107..108 "}" None
     FN_DECL@108..141
-      "\n" FUNCTION_KW@108..118 "function" " "
-       STAR@118..119 "*" 
+      Whitespace(1) FUNCTION_KW@108..118 "function" Whitespace(1)
+      None STAR@118..119 "*" None
       NAME@119..122
-         IDENT@119..122 "foo" 
+        None IDENT@119..122 "foo" None
       PARAMETER_LIST@122..125
-         L_PAREN@122..123 "(" 
+        None L_PAREN@122..123 "(" None
         LIST@123..123
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@123..124 ")"
       WHITESPACE@124..125 " "
@@ -128,14 +160,21 @@ MODULE@0..141
               WHITESPACE@134..135 " "
 =======
          R_PAREN@123..125 ")" " "
+=======
+        None R_PAREN@123..125 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@125..141
-         L_CURLY@125..126 "{" 
+        None L_CURLY@125..126 "{" None
         LIST@126..139
           EXPR_STMT@126..139
             YIELD_EXPR@126..138
+<<<<<<< HEAD
               "\n  " YIELD_KW@126..135 "yield" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              Whitespace(3) YIELD_KW@126..135 "yield" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               NAME_REF@135..138
-                 IDENT@135..138 "foo" 
-             SEMICOLON@138..139 ";" 
-        "\n" R_CURLY@139..141 "}" 
+                None IDENT@135..138 "foo" None
+            None SEMICOLON@138..139 ";" None
+        Whitespace(1) R_CURLY@139..141 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..48
-=======
-MODULE@0..47
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..47
   LIST@0..47
     VAR_DECL@0..21
       None IDENT@0..3 "let" Whitespace(1)
@@ -17,26 +13,9 @@ MODULE@0..47
             PARAMETER_LIST@16..19
               None L_PAREN@16..17 "(" None
               LIST@17..17
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@17..18 ")"
-            WHITESPACE@18..19 " "
-            JS_BLOCK_STATEMENT@19..21
-              L_CURLY@19..20 "{"
-=======
-               R_PAREN@17..19 ")" " "
-            BLOCK_STMT@19..21
-               L_CURLY@19..20 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@17..19 ")" Whitespace(1)
-=======
               None R_PAREN@17..18 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@19..21
+            JS_BLOCK_STATEMENT@19..21
               None L_CURLY@19..20 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@20..20
               None R_CURLY@20..21 "}" None
     VAR_DECL@21..47
@@ -54,25 +33,8 @@ MODULE@0..47
             PARAMETER_LIST@42..45
               None L_PAREN@42..43 "(" None
               LIST@43..43
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@43..44 ")"
-            WHITESPACE@44..45 " "
-            JS_BLOCK_STATEMENT@45..47
-              L_CURLY@45..46 "{"
-=======
-               R_PAREN@43..45 ")" " "
-            BLOCK_STMT@45..47
-               L_CURLY@45..46 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@43..45 ")" Whitespace(1)
-=======
               None R_PAREN@43..44 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@45..47
+            JS_BLOCK_STATEMENT@45..47
               None L_CURLY@45..46 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@46..46
               None R_CURLY@46..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -5,18 +5,19 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..21
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..21
         DECLARATOR@4..21
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           FN_EXPR@8..21
             None FUNCTION_KW@8..16 "function" None
             PARAMETER_LIST@16..19
               None L_PAREN@16..17 "(" None
               LIST@17..17
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@17..18 ")"
@@ -30,26 +31,30 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@17..19 ")" Whitespace(1)
+=======
+              None R_PAREN@17..18 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@19..21
               None L_CURLY@19..20 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@20..20
               None R_CURLY@20..21 "}" None
     VAR_DECL@21..47
-      Whitespace(1) IDENT@21..26 "let" Whitespace(1)
+      Whitespace(1) IDENT@22..25 "let" Whitespace(1)
       LIST@26..47
         DECLARATOR@26..47
           SINGLE_PATTERN@26..28
             NAME@26..28
-              None IDENT@26..28 "b" Whitespace(1)
-          None EQ@28..30 "=" Whitespace(1)
+              None IDENT@26..27 "b" Whitespace(1)
+          None EQ@28..29 "=" Whitespace(1)
           FN_EXPR@30..47
-            None FUNCTION_KW@30..39 "function" Whitespace(1)
+            None FUNCTION_KW@30..38 "function" Whitespace(1)
             NAME@39..42
               None IDENT@39..42 "foo" None
             PARAMETER_LIST@42..45
               None L_PAREN@42..43 "(" None
               LIST@43..43
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@43..44 ")"
@@ -63,6 +68,9 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@43..45 ")" Whitespace(1)
+=======
+              None R_PAREN@43..44 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@45..47
               None L_CURLY@45..46 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -5,18 +5,19 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..21
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..21
         DECLARATOR@4..21
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           FN_EXPR@8..21
-             FUNCTION_KW@8..16 "function" 
+            None FUNCTION_KW@8..16 "function" None
             PARAMETER_LIST@16..19
-               L_PAREN@16..17 "(" 
+              None L_PAREN@16..17 "(" None
               LIST@17..17
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@17..18 ")"
             WHITESPACE@18..19 " "
@@ -27,23 +28,29 @@ MODULE@0..47
             BLOCK_STMT@19..21
                L_CURLY@19..20 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@17..19 ")" Whitespace(1)
+            BLOCK_STMT@19..21
+              None L_CURLY@19..20 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@20..20
-               R_CURLY@20..21 "}" 
+              None R_CURLY@20..21 "}" None
     VAR_DECL@21..47
-      "\n" IDENT@21..26 "let" " "
+      Whitespace(1) IDENT@21..26 "let" Whitespace(1)
       LIST@26..47
         DECLARATOR@26..47
           SINGLE_PATTERN@26..28
             NAME@26..28
-               IDENT@26..28 "b" " "
-           EQ@28..30 "=" " "
+              None IDENT@26..28 "b" Whitespace(1)
+          None EQ@28..30 "=" Whitespace(1)
           FN_EXPR@30..47
-             FUNCTION_KW@30..39 "function" " "
+            None FUNCTION_KW@30..39 "function" Whitespace(1)
             NAME@39..42
-               IDENT@39..42 "foo" 
+              None IDENT@39..42 "foo" None
             PARAMETER_LIST@42..45
-               L_PAREN@42..43 "(" 
+              None L_PAREN@42..43 "(" None
               LIST@43..43
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@43..44 ")"
             WHITESPACE@44..45 " "
@@ -54,5 +61,10 @@ MODULE@0..47
             BLOCK_STMT@45..47
                L_CURLY@45..46 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@43..45 ")" Whitespace(1)
+            BLOCK_STMT@45..47
+              None L_CURLY@45..46 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@46..46
-               R_CURLY@46..47 "}" 
+              None R_CURLY@46..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -1,51 +1,58 @@
+<<<<<<< HEAD
 JS_MODULE@0..48
+=======
+MODULE@0..47
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..21
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..21
         DECLARATOR@4..21
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           FN_EXPR@8..21
-            FUNCTION_KW@8..16 "function"
-            PARAMETER_LIST@16..18
-              L_PAREN@16..17 "("
+             FUNCTION_KW@8..16 "function" 
+            PARAMETER_LIST@16..19
+               L_PAREN@16..17 "(" 
               LIST@17..17
+<<<<<<< HEAD
               R_PAREN@17..18 ")"
             WHITESPACE@18..19 " "
             JS_BLOCK_STATEMENT@19..21
               L_CURLY@19..20 "{"
+=======
+               R_PAREN@17..19 ")" " "
+            BLOCK_STMT@19..21
+               L_CURLY@19..20 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@20..20
-              R_CURLY@20..21 "}"
-    WHITESPACE@21..22 "\n"
-    VAR_DECL@22..47
-      IDENT@22..25 "let"
-      WHITESPACE@25..26 " "
+               R_CURLY@20..21 "}" 
+    VAR_DECL@21..47
+      "\n" IDENT@21..26 "let" " "
       LIST@26..47
         DECLARATOR@26..47
-          SINGLE_PATTERN@26..27
-            NAME@26..27
-              IDENT@26..27 "b"
-          WHITESPACE@27..28 " "
-          EQ@28..29 "="
-          WHITESPACE@29..30 " "
+          SINGLE_PATTERN@26..28
+            NAME@26..28
+               IDENT@26..28 "b" " "
+           EQ@28..30 "=" " "
           FN_EXPR@30..47
-            FUNCTION_KW@30..38 "function"
-            WHITESPACE@38..39 " "
+             FUNCTION_KW@30..39 "function" " "
             NAME@39..42
-              IDENT@39..42 "foo"
-            PARAMETER_LIST@42..44
-              L_PAREN@42..43 "("
+               IDENT@39..42 "foo" 
+            PARAMETER_LIST@42..45
+               L_PAREN@42..43 "(" 
               LIST@43..43
+<<<<<<< HEAD
               R_PAREN@43..44 ")"
             WHITESPACE@44..45 " "
             JS_BLOCK_STATEMENT@45..47
               L_CURLY@45..46 "{"
+=======
+               R_PAREN@43..45 ")" " "
+            BLOCK_STMT@45..47
+               L_CURLY@45..46 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@46..46
-              R_CURLY@46..47 "}"
-  WHITESPACE@47..48 "\n"
+               R_CURLY@46..47 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       CALL_EXPR@0..13

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -1,20 +1,22 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       CALL_EXPR@0..13
         GROUPING_EXPR@0..7
-          L_PAREN@0..1 "("
+           L_PAREN@0..1 "(" 
           GROUPING_EXPR@1..6
-            L_PAREN@1..2 "("
+             L_PAREN@1..2 "(" 
             NAME_REF@2..5
-              IDENT@2..5 "foo"
-            R_PAREN@5..6 ")"
-          R_PAREN@6..7 ")"
-        WHITESPACE@7..8 "\n"
-        ARG_LIST@8..13
-          L_PAREN@8..9 "("
+               IDENT@2..5 "foo" 
+             R_PAREN@5..6 ")" 
+           R_PAREN@6..7 ")" 
+        ARG_LIST@7..13
+          "\n" L_PAREN@7..9 "(" 
           LIST@9..12
             NAME_REF@9..12
-              IDENT@9..12 "foo"
-          R_PAREN@12..13 ")"
-  WHITESPACE@13..14 "\n"
+               IDENT@9..12 "foo" 
+           R_PAREN@12..13 ")" 

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -15,7 +15,7 @@ MODULE@0..13
             None R_PAREN@5..6 ")" None
           None R_PAREN@6..7 ")" None
         ARG_LIST@7..13
-          Whitespace(1) L_PAREN@7..9 "(" None
+          Whitespace(1) L_PAREN@8..9 "(" None
           LIST@9..12
             NAME_REF@9..12
               None IDENT@9..12 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -7,16 +7,16 @@ MODULE@0..13
     JS_EXPRESSION_STATEMENT@0..13
       CALL_EXPR@0..13
         GROUPING_EXPR@0..7
-           L_PAREN@0..1 "(" 
+          None L_PAREN@0..1 "(" None
           GROUPING_EXPR@1..6
-             L_PAREN@1..2 "(" 
+            None L_PAREN@1..2 "(" None
             NAME_REF@2..5
-               IDENT@2..5 "foo" 
-             R_PAREN@5..6 ")" 
-           R_PAREN@6..7 ")" 
+              None IDENT@2..5 "foo" None
+            None R_PAREN@5..6 ")" None
+          None R_PAREN@6..7 ")" None
         ARG_LIST@7..13
-          "\n" L_PAREN@7..9 "(" 
+          Whitespace(1) L_PAREN@7..9 "(" None
           LIST@9..12
             NAME_REF@9..12
-               IDENT@9..12 "foo" 
-           R_PAREN@12..13 ")" 
+              None IDENT@9..12 "foo" None
+          None R_PAREN@12..13 ")" None

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -7,6 +7,7 @@ MODULE@0..18
     JS_EXPRESSION_STATEMENT@0..4
       NAME_REF@0..3
 <<<<<<< HEAD
+<<<<<<< HEAD
         IDENT@0..3 "foo"
       SEMICOLON@3..4 ";"
     WHITESPACE@4..5 "\n"
@@ -23,12 +24,21 @@ MODULE@0..18
 =======
          IDENT@0..3 "foo" 
        SEMICOLON@3..4 ";" 
+=======
+        None IDENT@0..3 "foo" None
+      None SEMICOLON@3..4 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@4..11
       NAME_REF@4..10
-        "\n" IDENT@4..10 "yield" 
-       SEMICOLON@10..11 ";" 
+        Whitespace(1) IDENT@4..10 "yield" None
+      None SEMICOLON@10..11 ";" None
     EXPR_STMT@11..18
       NAME_REF@11..17
+<<<<<<< HEAD
         "\n" IDENT@11..17 "await" 
        SEMICOLON@17..18 ";" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) IDENT@11..17 "await" None
+      None SEMICOLON@17..18 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -1,48 +1,14 @@
-<<<<<<< HEAD
-JS_MODULE@0..19
-=======
-MODULE@0..18
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..18
   LIST@0..18
     JS_EXPRESSION_STATEMENT@0..4
       NAME_REF@0..3
-<<<<<<< HEAD
-<<<<<<< HEAD
-        IDENT@0..3 "foo"
-      SEMICOLON@3..4 ";"
-    WHITESPACE@4..5 "\n"
-    JS_EXPRESSION_STATEMENT@5..11
-      NAME_REF@5..10
-        IDENT@5..10 "yield"
-      SEMICOLON@10..11 ";"
-    WHITESPACE@11..12 "\n"
-    JS_EXPRESSION_STATEMENT@12..18
-      NAME_REF@12..17
-        IDENT@12..17 "await"
-      SEMICOLON@17..18 ";"
-  WHITESPACE@18..19 "\n"
-=======
-         IDENT@0..3 "foo" 
-       SEMICOLON@3..4 ";" 
-=======
         None IDENT@0..3 "foo" None
       None SEMICOLON@3..4 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@4..11
+    JS_EXPRESSION_STATEMENT@4..11
       NAME_REF@4..10
         Whitespace(1) IDENT@5..10 "yield" None
       None SEMICOLON@10..11 ";" None
-    EXPR_STMT@11..18
+    JS_EXPRESSION_STATEMENT@11..18
       NAME_REF@11..17
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" IDENT@11..17 "await" 
-       SEMICOLON@17..18 ";" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) IDENT@11..17 "await" None
-=======
         Whitespace(1) IDENT@12..17 "await" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       None SEMICOLON@17..18 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -30,15 +30,19 @@ MODULE@0..18
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@4..11
       NAME_REF@4..10
-        Whitespace(1) IDENT@4..10 "yield" None
+        Whitespace(1) IDENT@5..10 "yield" None
       None SEMICOLON@10..11 ";" None
     EXPR_STMT@11..18
       NAME_REF@11..17
+<<<<<<< HEAD
 <<<<<<< HEAD
         "\n" IDENT@11..17 "await" 
        SEMICOLON@17..18 ";" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) IDENT@11..17 "await" None
+=======
+        Whitespace(1) IDENT@12..17 "await" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       None SEMICOLON@17..18 ";" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -1,7 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..19
+=======
+MODULE@0..18
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..18
     JS_EXPRESSION_STATEMENT@0..4
       NAME_REF@0..3
+<<<<<<< HEAD
         IDENT@0..3 "foo"
       SEMICOLON@3..4 ";"
     WHITESPACE@4..5 "\n"
@@ -15,3 +20,15 @@ JS_MODULE@0..19
         IDENT@12..17 "await"
       SEMICOLON@17..18 ";"
   WHITESPACE@18..19 "\n"
+=======
+         IDENT@0..3 "foo" 
+       SEMICOLON@3..4 ";" 
+    EXPR_STMT@4..11
+      NAME_REF@4..10
+        "\n" IDENT@4..10 "yield" 
+       SEMICOLON@10..11 ";" 
+    EXPR_STMT@11..18
+      NAME_REF@11..17
+        "\n" IDENT@11..17 "await" 
+       SEMICOLON@17..18 ";" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -88,68 +88,72 @@ JS_MODULE@0..88
 MODULE@0..87
   LIST@0..87
     IF_STMT@0..20
-       IF_KW@0..3 "if" " "
+      None IF_KW@0..3 "if" Whitespace(1)
       CONDITION@3..10
-         L_PAREN@3..4 "(" 
+        None L_PAREN@3..4 "(" None
         LITERAL@4..8
-           TRUE_KW@4..8 "true" 
-         R_PAREN@8..10 ")" " "
+          None TRUE_KW@4..8 "true" None
+        None R_PAREN@8..10 ")" Whitespace(1)
       BLOCK_STMT@10..13
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..11
-         R_CURLY@11..13 "}" " "
-       ELSE_KW@13..18 "else" " "
+        None R_CURLY@11..13 "}" Whitespace(1)
+      None ELSE_KW@13..18 "else" Whitespace(1)
       BLOCK_STMT@18..20
-         L_CURLY@18..19 "{" 
+        None L_CURLY@18..19 "{" None
         LIST@19..19
-         R_CURLY@19..20 "}" 
+        None R_CURLY@19..20 "}" None
     IF_STMT@20..33
-      "\n" IF_KW@20..24 "if" " "
+      Whitespace(1) IF_KW@20..24 "if" Whitespace(1)
       CONDITION@24..31
-         L_PAREN@24..25 "(" 
+        None L_PAREN@24..25 "(" None
         LITERAL@25..29
-           TRUE_KW@25..29 "true" 
-         R_PAREN@29..31 ")" " "
+          None TRUE_KW@25..29 "true" None
+        None R_PAREN@29..31 ")" Whitespace(1)
       BLOCK_STMT@31..33
-         L_CURLY@31..32 "{" 
+        None L_CURLY@31..32 "{" None
         LIST@32..32
-         R_CURLY@32..33 "}" 
+        None R_CURLY@32..33 "}" None
     IF_STMT@33..49
-      "\n" IF_KW@33..37 "if" " "
+      Whitespace(1) IF_KW@33..37 "if" Whitespace(1)
       CONDITION@37..44
-         L_PAREN@37..38 "(" 
+        None L_PAREN@37..38 "(" None
         LITERAL@38..42
-           TRUE_KW@38..42 "true" 
-         R_PAREN@42..44 ")" " "
+          None TRUE_KW@38..42 "true" None
+        None R_PAREN@42..44 ")" Whitespace(1)
       EXPR_STMT@44..49
         LITERAL@44..49
-           FALSE_KW@44..49 "false" 
+          None FALSE_KW@44..49 "false" None
     IF_STMT@49..87
-      "\n" IF_KW@49..53 "if" " "
+      Whitespace(1) IF_KW@49..53 "if" Whitespace(1)
       CONDITION@53..59
-         L_PAREN@53..54 "(" 
+        None L_PAREN@53..54 "(" None
         NAME_REF@54..57
-           IDENT@54..57 "bar" 
-         R_PAREN@57..59 ")" " "
+          None IDENT@54..57 "bar" None
+        None R_PAREN@57..59 ")" Whitespace(1)
       BLOCK_STMT@59..62
-         L_CURLY@59..60 "{" 
+        None L_CURLY@59..60 "{" None
         LIST@60..60
-         R_CURLY@60..62 "}" " "
-       ELSE_KW@62..67 "else" " "
+        None R_CURLY@60..62 "}" Whitespace(1)
+      None ELSE_KW@62..67 "else" Whitespace(1)
       IF_STMT@67..87
-         IF_KW@67..70 "if" " "
+        None IF_KW@67..70 "if" Whitespace(1)
         CONDITION@70..77
-           L_PAREN@70..71 "(" 
+          None L_PAREN@70..71 "(" None
           LITERAL@71..75
-             TRUE_KW@71..75 "true" 
-           R_PAREN@75..77 ")" " "
+            None TRUE_KW@71..75 "true" None
+          None R_PAREN@75..77 ")" Whitespace(1)
         BLOCK_STMT@77..80
-           L_CURLY@77..78 "{" 
+          None L_CURLY@77..78 "{" None
           LIST@78..78
-           R_CURLY@78..80 "}" " "
-         ELSE_KW@80..85 "else" " "
+          None R_CURLY@78..80 "}" Whitespace(1)
+        None ELSE_KW@80..85 "else" Whitespace(1)
         BLOCK_STMT@85..87
-           L_CURLY@85..86 "{" 
+          None L_CURLY@85..86 "{" None
           LIST@86..86
+<<<<<<< HEAD
            R_CURLY@86..87 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None R_CURLY@86..87 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -88,66 +88,66 @@ JS_MODULE@0..88
 MODULE@0..87
   LIST@0..87
     IF_STMT@0..20
-      None IF_KW@0..3 "if" Whitespace(1)
+      None IF_KW@0..2 "if" Whitespace(1)
       CONDITION@3..10
         None L_PAREN@3..4 "(" None
         LITERAL@4..8
           None TRUE_KW@4..8 "true" None
-        None R_PAREN@8..10 ")" Whitespace(1)
+        None R_PAREN@8..9 ")" Whitespace(1)
       BLOCK_STMT@10..13
         None L_CURLY@10..11 "{" None
         LIST@11..11
-        None R_CURLY@11..13 "}" Whitespace(1)
-      None ELSE_KW@13..18 "else" Whitespace(1)
+        None R_CURLY@11..12 "}" Whitespace(1)
+      None ELSE_KW@13..17 "else" Whitespace(1)
       BLOCK_STMT@18..20
         None L_CURLY@18..19 "{" None
         LIST@19..19
         None R_CURLY@19..20 "}" None
     IF_STMT@20..33
-      Whitespace(1) IF_KW@20..24 "if" Whitespace(1)
+      Whitespace(1) IF_KW@21..23 "if" Whitespace(1)
       CONDITION@24..31
         None L_PAREN@24..25 "(" None
         LITERAL@25..29
           None TRUE_KW@25..29 "true" None
-        None R_PAREN@29..31 ")" Whitespace(1)
+        None R_PAREN@29..30 ")" Whitespace(1)
       BLOCK_STMT@31..33
         None L_CURLY@31..32 "{" None
         LIST@32..32
         None R_CURLY@32..33 "}" None
     IF_STMT@33..49
-      Whitespace(1) IF_KW@33..37 "if" Whitespace(1)
+      Whitespace(1) IF_KW@34..36 "if" Whitespace(1)
       CONDITION@37..44
         None L_PAREN@37..38 "(" None
         LITERAL@38..42
           None TRUE_KW@38..42 "true" None
-        None R_PAREN@42..44 ")" Whitespace(1)
+        None R_PAREN@42..43 ")" Whitespace(1)
       EXPR_STMT@44..49
         LITERAL@44..49
           None FALSE_KW@44..49 "false" None
     IF_STMT@49..87
-      Whitespace(1) IF_KW@49..53 "if" Whitespace(1)
+      Whitespace(1) IF_KW@50..52 "if" Whitespace(1)
       CONDITION@53..59
         None L_PAREN@53..54 "(" None
         NAME_REF@54..57
           None IDENT@54..57 "bar" None
-        None R_PAREN@57..59 ")" Whitespace(1)
+        None R_PAREN@57..58 ")" Whitespace(1)
       BLOCK_STMT@59..62
         None L_CURLY@59..60 "{" None
         LIST@60..60
-        None R_CURLY@60..62 "}" Whitespace(1)
-      None ELSE_KW@62..67 "else" Whitespace(1)
+        None R_CURLY@60..61 "}" Whitespace(1)
+      None ELSE_KW@62..66 "else" Whitespace(1)
       IF_STMT@67..87
-        None IF_KW@67..70 "if" Whitespace(1)
+        None IF_KW@67..69 "if" Whitespace(1)
         CONDITION@70..77
           None L_PAREN@70..71 "(" None
           LITERAL@71..75
             None TRUE_KW@71..75 "true" None
-          None R_PAREN@75..77 ")" Whitespace(1)
+          None R_PAREN@75..76 ")" Whitespace(1)
         BLOCK_STMT@77..80
           None L_CURLY@77..78 "{" None
           LIST@78..78
-          None R_CURLY@78..80 "}" Whitespace(1)
-        None ELSE_KW@80..85 "else" Whitespace(1)
+          None R_CURLY@78..79 "}" Whitespace(1)
+        None ELSE_KW@80..84 "else" Whitespace(1)
         BLOCK_STMT@85..87
           None L_CURLY@85..86 "{" None
           LIST@86..86

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..88
   LIST@0..87
     JS_IF_STATEMENT@0..20
@@ -83,3 +84,72 @@ JS_MODULE@0..88
               LIST@86..86
               R_CURLY@86..87 "}"
   WHITESPACE@87..88 "\n"
+=======
+MODULE@0..87
+  LIST@0..87
+    IF_STMT@0..20
+       IF_KW@0..3 "if" " "
+      CONDITION@3..10
+         L_PAREN@3..4 "(" 
+        LITERAL@4..8
+           TRUE_KW@4..8 "true" 
+         R_PAREN@8..10 ")" " "
+      BLOCK_STMT@10..13
+         L_CURLY@10..11 "{" 
+        LIST@11..11
+         R_CURLY@11..13 "}" " "
+       ELSE_KW@13..18 "else" " "
+      BLOCK_STMT@18..20
+         L_CURLY@18..19 "{" 
+        LIST@19..19
+         R_CURLY@19..20 "}" 
+    IF_STMT@20..33
+      "\n" IF_KW@20..24 "if" " "
+      CONDITION@24..31
+         L_PAREN@24..25 "(" 
+        LITERAL@25..29
+           TRUE_KW@25..29 "true" 
+         R_PAREN@29..31 ")" " "
+      BLOCK_STMT@31..33
+         L_CURLY@31..32 "{" 
+        LIST@32..32
+         R_CURLY@32..33 "}" 
+    IF_STMT@33..49
+      "\n" IF_KW@33..37 "if" " "
+      CONDITION@37..44
+         L_PAREN@37..38 "(" 
+        LITERAL@38..42
+           TRUE_KW@38..42 "true" 
+         R_PAREN@42..44 ")" " "
+      EXPR_STMT@44..49
+        LITERAL@44..49
+           FALSE_KW@44..49 "false" 
+    IF_STMT@49..87
+      "\n" IF_KW@49..53 "if" " "
+      CONDITION@53..59
+         L_PAREN@53..54 "(" 
+        NAME_REF@54..57
+           IDENT@54..57 "bar" 
+         R_PAREN@57..59 ")" " "
+      BLOCK_STMT@59..62
+         L_CURLY@59..60 "{" 
+        LIST@60..60
+         R_CURLY@60..62 "}" " "
+       ELSE_KW@62..67 "else" " "
+      IF_STMT@67..87
+         IF_KW@67..70 "if" " "
+        CONDITION@70..77
+           L_PAREN@70..71 "(" 
+          LITERAL@71..75
+             TRUE_KW@71..75 "true" 
+           R_PAREN@75..77 ")" " "
+        BLOCK_STMT@77..80
+           L_CURLY@77..78 "{" 
+          LIST@78..78
+           R_CURLY@78..80 "}" " "
+         ELSE_KW@80..85 "else" " "
+        BLOCK_STMT@85..87
+           L_CURLY@85..86 "{" 
+          LIST@86..86
+           R_CURLY@86..87 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -1,159 +1,65 @@
-<<<<<<< HEAD
-JS_MODULE@0..88
+JS_MODULE@0..87
   LIST@0..87
     JS_IF_STATEMENT@0..20
-      IF_KW@0..2 "if"
-      WHITESPACE@2..3 " "
-      L_PAREN@3..4 "("
-      LITERAL@4..8
-        TRUE_KW@4..8 "true"
-      R_PAREN@8..9 ")"
-      WHITESPACE@9..10 " "
-      JS_BLOCK_STATEMENT@10..12
-        L_CURLY@10..11 "{"
-        LIST@11..11
-        R_CURLY@11..12 "}"
-      WHITESPACE@12..13 " "
-      JS_ELSE_CLAUSE@13..20
-        ELSE_KW@13..17 "else"
-        WHITESPACE@17..18 " "
-        JS_BLOCK_STATEMENT@18..20
-          L_CURLY@18..19 "{"
-          LIST@19..19
-          R_CURLY@19..20 "}"
-    WHITESPACE@20..21 "\n"
-    JS_IF_STATEMENT@21..33
-      IF_KW@21..23 "if"
-      WHITESPACE@23..24 " "
-      L_PAREN@24..25 "("
-      LITERAL@25..29
-        TRUE_KW@25..29 "true"
-      R_PAREN@29..30 ")"
-      WHITESPACE@30..31 " "
-      JS_BLOCK_STATEMENT@31..33
-        L_CURLY@31..32 "{"
-        LIST@32..32
-        R_CURLY@32..33 "}"
-    WHITESPACE@33..34 "\n"
-    JS_IF_STATEMENT@34..49
-      IF_KW@34..36 "if"
-      WHITESPACE@36..37 " "
-      L_PAREN@37..38 "("
-      LITERAL@38..42
-        TRUE_KW@38..42 "true"
-      R_PAREN@42..43 ")"
-      WHITESPACE@43..44 " "
-      JS_EXPRESSION_STATEMENT@44..49
-        LITERAL@44..49
-          FALSE_KW@44..49 "false"
-    WHITESPACE@49..50 "\n"
-    JS_IF_STATEMENT@50..87
-      IF_KW@50..52 "if"
-      WHITESPACE@52..53 " "
-      L_PAREN@53..54 "("
-      NAME_REF@54..57
-        IDENT@54..57 "bar"
-      R_PAREN@57..58 ")"
-      WHITESPACE@58..59 " "
-      JS_BLOCK_STATEMENT@59..61
-        L_CURLY@59..60 "{"
-        LIST@60..60
-        R_CURLY@60..61 "}"
-      WHITESPACE@61..62 " "
-      JS_ELSE_CLAUSE@62..87
-        ELSE_KW@62..66 "else"
-        WHITESPACE@66..67 " "
-        JS_IF_STATEMENT@67..87
-          IF_KW@67..69 "if"
-          WHITESPACE@69..70 " "
-          L_PAREN@70..71 "("
-          LITERAL@71..75
-            TRUE_KW@71..75 "true"
-          R_PAREN@75..76 ")"
-          WHITESPACE@76..77 " "
-          JS_BLOCK_STATEMENT@77..79
-            L_CURLY@77..78 "{"
-            LIST@78..78
-            R_CURLY@78..79 "}"
-          WHITESPACE@79..80 " "
-          JS_ELSE_CLAUSE@80..87
-            ELSE_KW@80..84 "else"
-            WHITESPACE@84..85 " "
-            JS_BLOCK_STATEMENT@85..87
-              L_CURLY@85..86 "{"
-              LIST@86..86
-              R_CURLY@86..87 "}"
-  WHITESPACE@87..88 "\n"
-=======
-MODULE@0..87
-  LIST@0..87
-    IF_STMT@0..20
       None IF_KW@0..2 "if" Whitespace(1)
-      CONDITION@3..10
-        None L_PAREN@3..4 "(" None
-        LITERAL@4..8
-          None TRUE_KW@4..8 "true" None
-        None R_PAREN@8..9 ")" Whitespace(1)
-      BLOCK_STMT@10..13
+      None L_PAREN@3..4 "(" None
+      LITERAL@4..8
+        None TRUE_KW@4..8 "true" None
+      None R_PAREN@8..9 ")" Whitespace(1)
+      JS_BLOCK_STATEMENT@10..13
         None L_CURLY@10..11 "{" None
         LIST@11..11
         None R_CURLY@11..12 "}" Whitespace(1)
-      None ELSE_KW@13..17 "else" Whitespace(1)
-      BLOCK_STMT@18..20
-        None L_CURLY@18..19 "{" None
-        LIST@19..19
-        None R_CURLY@19..20 "}" None
-    IF_STMT@20..33
+      JS_ELSE_CLAUSE@13..20
+        None ELSE_KW@13..17 "else" Whitespace(1)
+        JS_BLOCK_STATEMENT@18..20
+          None L_CURLY@18..19 "{" None
+          LIST@19..19
+          None R_CURLY@19..20 "}" None
+    JS_IF_STATEMENT@20..33
       Whitespace(1) IF_KW@21..23 "if" Whitespace(1)
-      CONDITION@24..31
-        None L_PAREN@24..25 "(" None
-        LITERAL@25..29
-          None TRUE_KW@25..29 "true" None
-        None R_PAREN@29..30 ")" Whitespace(1)
-      BLOCK_STMT@31..33
+      None L_PAREN@24..25 "(" None
+      LITERAL@25..29
+        None TRUE_KW@25..29 "true" None
+      None R_PAREN@29..30 ")" Whitespace(1)
+      JS_BLOCK_STATEMENT@31..33
         None L_CURLY@31..32 "{" None
         LIST@32..32
         None R_CURLY@32..33 "}" None
-    IF_STMT@33..49
+    JS_IF_STATEMENT@33..49
       Whitespace(1) IF_KW@34..36 "if" Whitespace(1)
-      CONDITION@37..44
-        None L_PAREN@37..38 "(" None
-        LITERAL@38..42
-          None TRUE_KW@38..42 "true" None
-        None R_PAREN@42..43 ")" Whitespace(1)
-      EXPR_STMT@44..49
+      None L_PAREN@37..38 "(" None
+      LITERAL@38..42
+        None TRUE_KW@38..42 "true" None
+      None R_PAREN@42..43 ")" Whitespace(1)
+      JS_EXPRESSION_STATEMENT@44..49
         LITERAL@44..49
           None FALSE_KW@44..49 "false" None
-    IF_STMT@49..87
+    JS_IF_STATEMENT@49..87
       Whitespace(1) IF_KW@50..52 "if" Whitespace(1)
-      CONDITION@53..59
-        None L_PAREN@53..54 "(" None
-        NAME_REF@54..57
-          None IDENT@54..57 "bar" None
-        None R_PAREN@57..58 ")" Whitespace(1)
-      BLOCK_STMT@59..62
+      None L_PAREN@53..54 "(" None
+      NAME_REF@54..57
+        None IDENT@54..57 "bar" None
+      None R_PAREN@57..58 ")" Whitespace(1)
+      JS_BLOCK_STATEMENT@59..62
         None L_CURLY@59..60 "{" None
         LIST@60..60
         None R_CURLY@60..61 "}" Whitespace(1)
-      None ELSE_KW@62..66 "else" Whitespace(1)
-      IF_STMT@67..87
-        None IF_KW@67..69 "if" Whitespace(1)
-        CONDITION@70..77
+      JS_ELSE_CLAUSE@62..87
+        None ELSE_KW@62..66 "else" Whitespace(1)
+        JS_IF_STATEMENT@67..87
+          None IF_KW@67..69 "if" Whitespace(1)
           None L_PAREN@70..71 "(" None
           LITERAL@71..75
             None TRUE_KW@71..75 "true" None
           None R_PAREN@75..76 ")" Whitespace(1)
-        BLOCK_STMT@77..80
-          None L_CURLY@77..78 "{" None
-          LIST@78..78
-          None R_CURLY@78..79 "}" Whitespace(1)
-        None ELSE_KW@80..84 "else" Whitespace(1)
-        BLOCK_STMT@85..87
-          None L_CURLY@85..86 "{" None
-          LIST@86..86
-<<<<<<< HEAD
-           R_CURLY@86..87 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          None R_CURLY@86..87 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+          JS_BLOCK_STATEMENT@77..80
+            None L_CURLY@77..78 "{" None
+            LIST@78..78
+            None R_CURLY@78..79 "}" Whitespace(1)
+          JS_ELSE_CLAUSE@80..87
+            None ELSE_KW@80..84 "else" Whitespace(1)
+            JS_BLOCK_STATEMENT@85..87
+              None L_CURLY@85..86 "{" None
+              LIST@86..86
+              None R_CURLY@86..87 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -1,10 +1,13 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       IMPORT_CALL@0..13
-        IMPORT_KW@0..6 "import"
-        L_PAREN@6..7 "("
+         IMPORT_KW@0..6 "import" 
+         L_PAREN@6..7 "(" 
         LITERAL@7..12
-          STRING@7..12 "\"foo\""
-        R_PAREN@12..13 ")"
-  WHITESPACE@13..14 "\n"
+           STRING@7..12 "\"foo\"" 
+         R_PAREN@12..13 ")" 

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -6,8 +6,8 @@ MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       IMPORT_CALL@0..13
-         IMPORT_KW@0..6 "import" 
-         L_PAREN@6..7 "(" 
+        None IMPORT_KW@0..6 "import" None
+        None L_PAREN@6..7 "(" None
         LITERAL@7..12
-           STRING@7..12 "\"foo\"" 
-         R_PAREN@12..13 ")" 
+          None STRING@7..12 "\"foo\"" None
+        None R_PAREN@12..13 ")" None

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       IMPORT_CALL@0..13

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..28
-=======
-MODULE@0..27
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..27
   LIST@0..27
     IMPORT_DECL@0..27
       None IMPORT_KW@0..6 "import" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -1,20 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..28
+=======
+MODULE@0..27
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     IMPORT_DECL@0..27
-      IMPORT_KW@0..6 "import"
-      WHITESPACE@6..7 " "
-      LIST@7..15
-        WILDCARD_IMPORT@7..15
-          STAR@7..8 "*"
-          WHITESPACE@8..9 " "
-          AS_KW@9..11 "as"
-          WHITESPACE@11..12 " "
-          NAME@12..15
-            IDENT@12..15 "foo"
-      WHITESPACE@15..16 " "
-      FROM_KW@16..20 "from"
-      WHITESPACE@20..21 " "
+       IMPORT_KW@0..7 "import" " "
+      LIST@7..16
+        WILDCARD_IMPORT@7..16
+           STAR@7..9 "*" " "
+           AS_KW@9..12 "as" " "
+          NAME@12..16
+             IDENT@12..16 "foo" " "
+       FROM_KW@16..21 "from" " "
       LITERAL@21..26
-        STRING@21..26 "\"bla\""
-      SEMICOLON@26..27 ";"
-  WHITESPACE@27..28 "\n"
+         STRING@21..26 "\"bla\"" 
+       SEMICOLON@26..27 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -5,14 +5,14 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     IMPORT_DECL@0..27
-      None IMPORT_KW@0..7 "import" Whitespace(1)
+      None IMPORT_KW@0..6 "import" Whitespace(1)
       LIST@7..16
         WILDCARD_IMPORT@7..16
-          None STAR@7..9 "*" Whitespace(1)
-          None AS_KW@9..12 "as" Whitespace(1)
+          None STAR@7..8 "*" Whitespace(1)
+          None AS_KW@9..11 "as" Whitespace(1)
           NAME@12..16
-            None IDENT@12..16 "foo" Whitespace(1)
-      None FROM_KW@16..21 "from" Whitespace(1)
+            None IDENT@12..15 "foo" Whitespace(1)
+      None FROM_KW@16..20 "from" Whitespace(1)
       LITERAL@21..26
         None STRING@21..26 "\"bla\"" None
       None SEMICOLON@26..27 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -5,14 +5,14 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     IMPORT_DECL@0..27
-       IMPORT_KW@0..7 "import" " "
+      None IMPORT_KW@0..7 "import" Whitespace(1)
       LIST@7..16
         WILDCARD_IMPORT@7..16
-           STAR@7..9 "*" " "
-           AS_KW@9..12 "as" " "
+          None STAR@7..9 "*" Whitespace(1)
+          None AS_KW@9..12 "as" Whitespace(1)
           NAME@12..16
-             IDENT@12..16 "foo" " "
-       FROM_KW@16..21 "from" " "
+            None IDENT@12..16 "foo" Whitespace(1)
+      None FROM_KW@16..21 "from" Whitespace(1)
       LITERAL@21..26
-         STRING@21..26 "\"bla\"" 
-       SEMICOLON@26..27 ";" 
+        None STRING@21..26 "\"bla\"" None
+      None SEMICOLON@26..27 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..12
-=======
-MODULE@0..11
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..11
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..11
       IMPORT_META@0..11

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -6,6 +6,6 @@ MODULE@0..11
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..11
       IMPORT_META@0..11
-         IMPORT_KW@0..6 "import" 
-         DOT@6..7 "." 
-         IDENT@7..11 "meta" 
+        None IMPORT_KW@0..6 "import" None
+        None DOT@6..7 "." None
+        None IDENT@7..11 "meta" None

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -1,8 +1,11 @@
+<<<<<<< HEAD
 JS_MODULE@0..12
+=======
+MODULE@0..11
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..11
       IMPORT_META@0..11
-        IMPORT_KW@0..6 "import"
-        DOT@6..7 "."
-        IDENT@7..11 "meta"
-  WHITESPACE@11..12 "\n"
+         IMPORT_KW@0..6 "import" 
+         DOT@6..7 "." 
+         IDENT@7..11 "meta" 

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -41,24 +41,28 @@ MODULE@0..32
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@1..6
       LITERAL@1..6
-        Whitespace(1) TRUE_KW@1..6 "true" None
+        Whitespace(1) TRUE_KW@2..6 "true" None
     EXPR_STMT@6..12
       LITERAL@6..12
-        Whitespace(1) FALSE_KW@6..12 "false" None
+        Whitespace(1) FALSE_KW@7..12 "false" None
     EXPR_STMT@12..15
       LITERAL@12..15
-        Whitespace(1) NUMBER@12..15 "5n" None
+        Whitespace(1) NUMBER@13..15 "5n" None
     EXPR_STMT@15..21
       LITERAL@15..21
-        Whitespace(1) STRING@15..21 "\"foo\"" None
+        Whitespace(1) STRING@16..21 "\"foo\"" None
     EXPR_STMT@21..27
       LITERAL@21..27
-        Whitespace(1) STRING@21..27 "'bar'" None
+        Whitespace(1) STRING@22..27 "'bar'" None
     EXPR_STMT@27..32
       LITERAL@27..32
+<<<<<<< HEAD
 <<<<<<< HEAD
         "\n" NULL_KW@27..32 "null" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) NULL_KW@27..32 "null" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) NULL_KW@28..32 "null" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -7,6 +7,7 @@ MODULE@0..32
     JS_EXPRESSION_STATEMENT@0..1
       LITERAL@0..1
 <<<<<<< HEAD
+<<<<<<< HEAD
         NUMBER@0..1 "5"
     WHITESPACE@1..2 "\n"
     JS_EXPRESSION_STATEMENT@2..6
@@ -35,22 +36,29 @@ MODULE@0..32
   WHITESPACE@32..33 "\n"
 =======
          NUMBER@0..1 "5" 
+=======
+        None NUMBER@0..1 "5" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@1..6
       LITERAL@1..6
-        "\n" TRUE_KW@1..6 "true" 
+        Whitespace(1) TRUE_KW@1..6 "true" None
     EXPR_STMT@6..12
       LITERAL@6..12
-        "\n" FALSE_KW@6..12 "false" 
+        Whitespace(1) FALSE_KW@6..12 "false" None
     EXPR_STMT@12..15
       LITERAL@12..15
-        "\n" NUMBER@12..15 "5n" 
+        Whitespace(1) NUMBER@12..15 "5n" None
     EXPR_STMT@15..21
       LITERAL@15..21
-        "\n" STRING@15..21 "\"foo\"" 
+        Whitespace(1) STRING@15..21 "\"foo\"" None
     EXPR_STMT@21..27
       LITERAL@21..27
-        "\n" STRING@21..27 "'bar'" 
+        Whitespace(1) STRING@21..27 "'bar'" None
     EXPR_STMT@27..32
       LITERAL@27..32
+<<<<<<< HEAD
         "\n" NULL_KW@27..32 "null" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) NULL_KW@27..32 "null" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -1,68 +1,23 @@
-<<<<<<< HEAD
-JS_MODULE@0..33
-=======
-MODULE@0..32
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..32
   LIST@0..32
     JS_EXPRESSION_STATEMENT@0..1
       LITERAL@0..1
-<<<<<<< HEAD
-<<<<<<< HEAD
-        NUMBER@0..1 "5"
-    WHITESPACE@1..2 "\n"
-    JS_EXPRESSION_STATEMENT@2..6
-      LITERAL@2..6
-        TRUE_KW@2..6 "true"
-    WHITESPACE@6..7 "\n"
-    JS_EXPRESSION_STATEMENT@7..12
-      LITERAL@7..12
-        FALSE_KW@7..12 "false"
-    WHITESPACE@12..13 "\n"
-    JS_EXPRESSION_STATEMENT@13..15
-      LITERAL@13..15
-        NUMBER@13..15 "5n"
-    WHITESPACE@15..16 "\n"
-    JS_EXPRESSION_STATEMENT@16..21
-      LITERAL@16..21
-        STRING@16..21 "\"foo\""
-    WHITESPACE@21..22 "\n"
-    JS_EXPRESSION_STATEMENT@22..27
-      LITERAL@22..27
-        STRING@22..27 "'bar'"
-    WHITESPACE@27..28 "\n"
-    JS_EXPRESSION_STATEMENT@28..32
-      LITERAL@28..32
-        NULL_KW@28..32 "null"
-  WHITESPACE@32..33 "\n"
-=======
-         NUMBER@0..1 "5" 
-=======
         None NUMBER@0..1 "5" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@1..6
+    JS_EXPRESSION_STATEMENT@1..6
       LITERAL@1..6
         Whitespace(1) TRUE_KW@2..6 "true" None
-    EXPR_STMT@6..12
+    JS_EXPRESSION_STATEMENT@6..12
       LITERAL@6..12
         Whitespace(1) FALSE_KW@7..12 "false" None
-    EXPR_STMT@12..15
+    JS_EXPRESSION_STATEMENT@12..15
       LITERAL@12..15
         Whitespace(1) NUMBER@13..15 "5n" None
-    EXPR_STMT@15..21
+    JS_EXPRESSION_STATEMENT@15..21
       LITERAL@15..21
         Whitespace(1) STRING@16..21 "\"foo\"" None
-    EXPR_STMT@21..27
+    JS_EXPRESSION_STATEMENT@21..27
       LITERAL@21..27
         Whitespace(1) STRING@22..27 "'bar'" None
-    EXPR_STMT@27..32
+    JS_EXPRESSION_STATEMENT@27..32
       LITERAL@27..32
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" NULL_KW@27..32 "null" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) NULL_KW@27..32 "null" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) NULL_KW@28..32 "null" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -1,7 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..33
+=======
+MODULE@0..32
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..32
     JS_EXPRESSION_STATEMENT@0..1
       LITERAL@0..1
+<<<<<<< HEAD
         NUMBER@0..1 "5"
     WHITESPACE@1..2 "\n"
     JS_EXPRESSION_STATEMENT@2..6
@@ -28,3 +33,24 @@ JS_MODULE@0..33
       LITERAL@28..32
         NULL_KW@28..32 "null"
   WHITESPACE@32..33 "\n"
+=======
+         NUMBER@0..1 "5" 
+    EXPR_STMT@1..6
+      LITERAL@1..6
+        "\n" TRUE_KW@1..6 "true" 
+    EXPR_STMT@6..12
+      LITERAL@6..12
+        "\n" FALSE_KW@6..12 "false" 
+    EXPR_STMT@12..15
+      LITERAL@12..15
+        "\n" NUMBER@12..15 "5n" 
+    EXPR_STMT@15..21
+      LITERAL@15..21
+        "\n" STRING@15..21 "\"foo\"" 
+    EXPR_STMT@21..27
+      LITERAL@21..27
+        "\n" STRING@21..27 "'bar'" 
+    EXPR_STMT@27..32
+      LITERAL@27..32
+        "\n" NULL_KW@27..32 "null" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..28
-=======
-MODULE@0..27
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..27
   LIST@0..27
     CLASS_DECL@0..27
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -18,26 +14,9 @@ MODULE@0..27
             PARAMETER_LIST@20..23
               None L_PAREN@20..21 "(" None
               LIST@21..21
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@21..22 ")"
-            WHITESPACE@22..23 " "
-            JS_BLOCK_STATEMENT@23..25
-              L_CURLY@23..24 "{"
-=======
-               R_PAREN@21..23 ")" " "
-            BLOCK_STMT@23..25
-               L_CURLY@23..24 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@21..23 ")" Whitespace(1)
-=======
               None R_PAREN@21..22 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@23..25
+            JS_BLOCK_STATEMENT@23..25
               None L_CURLY@23..24 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
               None R_CURLY@24..25 "}" None
         Whitespace(1) R_CURLY@26..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -5,19 +5,20 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..27
         None L_CURLY@10..11 "{" None
         LIST@11..25
           GETTER@11..25
-            Whitespace(2) GET_KW@11..17 "get" Whitespace(1)
+            Whitespace(2) GET_KW@13..16 "get" Whitespace(1)
             NAME@17..20
               None IDENT@17..20 "bar" None
             PARAMETER_LIST@20..23
               None L_PAREN@20..21 "(" None
               LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@21..22 ")"
@@ -31,9 +32,12 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@21..23 ")" Whitespace(1)
+=======
+              None R_PAREN@21..22 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@23..25
               None L_CURLY@23..24 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
               None R_CURLY@24..25 "}" None
-        Whitespace(1) R_CURLY@25..27 "}" None
+        Whitespace(1) R_CURLY@26..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -5,19 +5,20 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..27
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..25
           GETTER@11..25
-            "\n " GET_KW@11..17 "get" " "
+            Whitespace(2) GET_KW@11..17 "get" Whitespace(1)
             NAME@17..20
-               IDENT@17..20 "bar" 
+              None IDENT@17..20 "bar" None
             PARAMETER_LIST@20..23
-               L_PAREN@20..21 "(" 
+              None L_PAREN@20..21 "(" None
               LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@21..22 ")"
             WHITESPACE@22..23 " "
@@ -28,6 +29,11 @@ MODULE@0..27
             BLOCK_STMT@23..25
                L_CURLY@23..24 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@21..23 ")" Whitespace(1)
+            BLOCK_STMT@23..25
+              None L_CURLY@23..24 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
-               R_CURLY@24..25 "}" 
-        "\n" R_CURLY@25..27 "}" 
+              None R_CURLY@24..25 "}" None
+        Whitespace(1) R_CURLY@25..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -1,29 +1,33 @@
+<<<<<<< HEAD
 JS_MODULE@0..28
+=======
+MODULE@0..27
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..27
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..13 "\n "
-        LIST@13..25
-          GETTER@13..25
-            GET_KW@13..16 "get"
-            WHITESPACE@16..17 " "
+         L_CURLY@10..11 "{" 
+        LIST@11..25
+          GETTER@11..25
+            "\n " GET_KW@11..17 "get" " "
             NAME@17..20
-              IDENT@17..20 "bar"
-            PARAMETER_LIST@20..22
-              L_PAREN@20..21 "("
+               IDENT@17..20 "bar" 
+            PARAMETER_LIST@20..23
+               L_PAREN@20..21 "(" 
               LIST@21..21
+<<<<<<< HEAD
               R_PAREN@21..22 ")"
             WHITESPACE@22..23 " "
             JS_BLOCK_STATEMENT@23..25
               L_CURLY@23..24 "{"
+=======
+               R_PAREN@21..23 ")" " "
+            BLOCK_STMT@23..25
+               L_CURLY@23..24 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@24..24
-              R_CURLY@24..25 "}"
-        WHITESPACE@25..26 "\n"
-        R_CURLY@26..27 "}"
-  WHITESPACE@27..28 "\n"
+               R_CURLY@24..25 "}" 
+        "\n" R_CURLY@25..27 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -5,19 +5,20 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..27
         None L_CURLY@10..11 "{" None
         LIST@11..25
           SETTER@11..25
-            Whitespace(2) SET_KW@11..17 "set" Whitespace(1)
+            Whitespace(2) SET_KW@13..16 "set" Whitespace(1)
             NAME@17..20
               None IDENT@17..20 "bar" None
             PARAMETER_LIST@20..23
               None L_PAREN@20..21 "(" None
               LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@21..22 ")"
@@ -31,9 +32,12 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@21..23 ")" Whitespace(1)
+=======
+              None R_PAREN@21..22 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@23..25
               None L_CURLY@23..24 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
               None R_CURLY@24..25 "}" None
-        Whitespace(1) R_CURLY@25..27 "}" None
+        Whitespace(1) R_CURLY@26..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -1,29 +1,33 @@
+<<<<<<< HEAD
 JS_MODULE@0..28
+=======
+MODULE@0..27
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..27
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..13 "\n "
-        LIST@13..25
-          SETTER@13..25
-            SET_KW@13..16 "set"
-            WHITESPACE@16..17 " "
+         L_CURLY@10..11 "{" 
+        LIST@11..25
+          SETTER@11..25
+            "\n " SET_KW@11..17 "set" " "
             NAME@17..20
-              IDENT@17..20 "bar"
-            PARAMETER_LIST@20..22
-              L_PAREN@20..21 "("
+               IDENT@17..20 "bar" 
+            PARAMETER_LIST@20..23
+               L_PAREN@20..21 "(" 
               LIST@21..21
+<<<<<<< HEAD
               R_PAREN@21..22 ")"
             WHITESPACE@22..23 " "
             JS_BLOCK_STATEMENT@23..25
               L_CURLY@23..24 "{"
+=======
+               R_PAREN@21..23 ")" " "
+            BLOCK_STMT@23..25
+               L_CURLY@23..24 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@24..24
-              R_CURLY@24..25 "}"
-        WHITESPACE@25..26 "\n"
-        R_CURLY@26..27 "}"
-  WHITESPACE@27..28 "\n"
+               R_CURLY@24..25 "}" 
+        "\n" R_CURLY@25..27 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -5,19 +5,20 @@ MODULE@0..27
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..27
     CLASS_DECL@0..27
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..27
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..25
           SETTER@11..25
-            "\n " SET_KW@11..17 "set" " "
+            Whitespace(2) SET_KW@11..17 "set" Whitespace(1)
             NAME@17..20
-               IDENT@17..20 "bar" 
+              None IDENT@17..20 "bar" None
             PARAMETER_LIST@20..23
-               L_PAREN@20..21 "(" 
+              None L_PAREN@20..21 "(" None
               LIST@21..21
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@21..22 ")"
             WHITESPACE@22..23 " "
@@ -28,6 +29,11 @@ MODULE@0..27
             BLOCK_STMT@23..25
                L_CURLY@23..24 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@21..23 ")" Whitespace(1)
+            BLOCK_STMT@23..25
+              None L_CURLY@23..24 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
-               R_CURLY@24..25 "}" 
-        "\n" R_CURLY@25..27 "}" 
+              None R_CURLY@24..25 "}" None
+        Whitespace(1) R_CURLY@25..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..28
-=======
-MODULE@0..27
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..27
   LIST@0..27
     CLASS_DECL@0..27
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -18,26 +14,9 @@ MODULE@0..27
             PARAMETER_LIST@20..23
               None L_PAREN@20..21 "(" None
               LIST@21..21
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@21..22 ")"
-            WHITESPACE@22..23 " "
-            JS_BLOCK_STATEMENT@23..25
-              L_CURLY@23..24 "{"
-=======
-               R_PAREN@21..23 ")" " "
-            BLOCK_STMT@23..25
-               L_CURLY@23..24 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@21..23 ")" Whitespace(1)
-=======
               None R_PAREN@21..22 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@23..25
+            JS_BLOCK_STATEMENT@23..25
               None L_CURLY@23..24 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@24..24
               None R_CURLY@24..25 "}" None
         Whitespace(1) R_CURLY@26..27 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -1,14 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..113
+=======
+MODULE@0..112
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..112
     JS_EXPRESSION_STATEMENT@0..9
       NEW_EXPR@0..9
-        NEW_KW@0..3 "new"
-        WHITESPACE@3..4 " "
+         NEW_KW@0..4 "new" " "
         NAME_REF@4..7
-          IDENT@4..7 "Foo"
+           IDENT@4..7 "Foo" 
         ARG_LIST@7..9
-          L_PAREN@7..8 "("
+           L_PAREN@7..8 "(" 
           LIST@8..8
+<<<<<<< HEAD
           R_PAREN@8..9 ")"
     WHITESPACE@9..10 "\n"
     JS_EXPRESSION_STATEMENT@10..18
@@ -29,20 +33,35 @@ JS_MODULE@0..113
       NEW_EXPR@30..51
         NEW_KW@30..33 "new"
         WHITESPACE@33..34 " "
+=======
+           R_PAREN@8..9 ")" 
+    EXPR_STMT@9..18
+      NEW_EXPR@9..17
+        "\n" NEW_KW@9..14 "new" " "
+        NAME_REF@14..17
+           IDENT@14..17 "foo" 
+       SEMICOLON@17..18 ";" 
+    EXPR_STMT@18..29
+      NEW_TARGET@18..29
+        "\n" NEW_KW@18..22 "new" 
+         DOT@22..23 "." 
+         IDENT@23..29 "target" 
+    EXPR_STMT@29..52
+      NEW_EXPR@29..51
+        "\n" NEW_KW@29..34 "new" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NEW_EXPR@34..51
-          NEW_KW@34..37 "new"
-          WHITESPACE@37..38 " "
+           NEW_KW@34..38 "new" " "
           NEW_EXPR@38..51
-            NEW_KW@38..41 "new"
-            WHITESPACE@41..42 " "
+             NEW_KW@38..42 "new" " "
             NEW_EXPR@42..51
-              NEW_KW@42..45 "new"
-              WHITESPACE@45..46 " "
+               NEW_KW@42..46 "new" " "
               NAME_REF@46..49
-                IDENT@46..49 "Foo"
+                 IDENT@46..49 "Foo" 
               ARG_LIST@49..51
-                L_PAREN@49..50 "("
+                 L_PAREN@49..50 "(" 
                 LIST@50..50
+<<<<<<< HEAD
                 R_PAREN@50..51 ")"
       SEMICOLON@51..52 ";"
     WHITESPACE@52..53 "\n"
@@ -50,47 +69,48 @@ JS_MODULE@0..113
       NEW_EXPR@53..112
         NEW_KW@53..56 "new"
         WHITESPACE@56..57 " "
+=======
+                 R_PAREN@50..51 ")" 
+       SEMICOLON@51..52 ";" 
+    EXPR_STMT@52..112
+      NEW_EXPR@52..112
+        "\n" NEW_KW@52..57 "new" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME_REF@57..60
-          IDENT@57..60 "Foo"
+           IDENT@57..60 "Foo" 
         ARG_LIST@60..112
-          L_PAREN@60..61 "("
+           L_PAREN@60..61 "(" 
           LIST@61..111
             NAME_REF@61..64
-              IDENT@61..64 "bar"
-            COMMA@64..65 ","
-            WHITESPACE@65..66 " "
+               IDENT@61..64 "bar" 
+             COMMA@64..66 "," " "
             NAME_REF@66..69
-              IDENT@66..69 "baz"
-            COMMA@69..70 ","
-            WHITESPACE@70..71 " "
+               IDENT@66..69 "baz" 
+             COMMA@69..71 "," " "
             BIN_EXPR@71..76
-              LITERAL@71..72
-                NUMBER@71..72 "6"
-              WHITESPACE@72..73 " "
-              PLUS@73..74 "+"
-              WHITESPACE@74..75 " "
+              LITERAL@71..73
+                 NUMBER@71..73 "6" " "
+               PLUS@73..75 "+" " "
               LITERAL@75..76
-                NUMBER@75..76 "6"
-            COMMA@76..77 ","
-            WHITESPACE@77..78 " "
+                 NUMBER@75..76 "6" 
+             COMMA@76..78 "," " "
             BIN_EXPR@78..111
-              BRACKET_EXPR@78..86
+              BRACKET_EXPR@78..87
                 NAME_REF@78..81
-                  IDENT@78..81 "foo"
-                L_BRACK@81..82 "["
+                   IDENT@78..81 "foo" 
+                 L_BRACK@81..82 "[" 
                 NAME_REF@82..85
-                  IDENT@82..85 "bar"
-                R_BRACK@85..86 "]"
-              WHITESPACE@86..87 " "
-              PLUS@87..88 "+"
-              WHITESPACE@88..89 " "
+                   IDENT@82..85 "bar" 
+                 R_BRACK@85..87 "]" " "
+               PLUS@87..89 "+" " "
               BIN_EXPR@89..111
-                ARROW_EXPR@89..100
-                  PARAMETER_LIST@89..94
-                    L_PAREN@89..90 "("
+                ARROW_EXPR@89..101
+                  PARAMETER_LIST@89..95
+                     L_PAREN@89..90 "(" 
                     LIST@90..93
                       SINGLE_PATTERN@90..93
                         NAME@90..93
+<<<<<<< HEAD
                           IDENT@90..93 "foo"
                     R_PAREN@93..94 ")"
                   WHITESPACE@94..95 " "
@@ -98,16 +118,20 @@ JS_MODULE@0..113
                   WHITESPACE@97..98 " "
                   JS_BLOCK_STATEMENT@98..100
                     L_CURLY@98..99 "{"
+=======
+                           IDENT@90..93 "foo" 
+                     R_PAREN@93..95 ")" " "
+                   FAT_ARROW@95..98 "=>" " "
+                  BLOCK_STMT@98..101
+                     L_CURLY@98..99 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                     LIST@99..99
-                    R_CURLY@99..100 "}"
-                WHITESPACE@100..101 " "
-                STAR@101..102 "*"
-                WHITESPACE@102..103 " "
+                     R_CURLY@99..101 "}" " "
+                 STAR@101..103 "*" " "
                 DOT_EXPR@103..111
                   NAME_REF@103..106
-                    IDENT@103..106 "foo"
-                  QUESTIONDOT@106..108 "?."
+                     IDENT@103..106 "foo" 
+                   QUESTIONDOT@106..108 "?." 
                   NAME@108..111
-                    IDENT@108..111 "bar"
-          R_PAREN@111..112 ")"
-  WHITESPACE@112..113 "\n"
+                     IDENT@108..111 "bar" 
+           R_PAREN@111..112 ")" 

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -6,12 +6,13 @@ MODULE@0..112
   LIST@0..112
     JS_EXPRESSION_STATEMENT@0..9
       NEW_EXPR@0..9
-         NEW_KW@0..4 "new" " "
+        None NEW_KW@0..4 "new" Whitespace(1)
         NAME_REF@4..7
-           IDENT@4..7 "Foo" 
+          None IDENT@4..7 "Foo" None
         ARG_LIST@7..9
-           L_PAREN@7..8 "(" 
+          None L_PAREN@7..8 "(" None
           LIST@8..8
+<<<<<<< HEAD
 <<<<<<< HEAD
           R_PAREN@8..9 ")"
     WHITESPACE@9..10 "\n"
@@ -35,32 +36,40 @@ MODULE@0..112
         WHITESPACE@33..34 " "
 =======
            R_PAREN@8..9 ")" 
+=======
+          None R_PAREN@8..9 ")" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@9..18
       NEW_EXPR@9..17
-        "\n" NEW_KW@9..14 "new" " "
+        Whitespace(1) NEW_KW@9..14 "new" Whitespace(1)
         NAME_REF@14..17
-           IDENT@14..17 "foo" 
-       SEMICOLON@17..18 ";" 
+          None IDENT@14..17 "foo" None
+      None SEMICOLON@17..18 ";" None
     EXPR_STMT@18..29
       NEW_TARGET@18..29
-        "\n" NEW_KW@18..22 "new" 
-         DOT@22..23 "." 
-         IDENT@23..29 "target" 
+        Whitespace(1) NEW_KW@18..22 "new" None
+        None DOT@22..23 "." None
+        None IDENT@23..29 "target" None
     EXPR_STMT@29..52
       NEW_EXPR@29..51
+<<<<<<< HEAD
         "\n" NEW_KW@29..34 "new" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) NEW_KW@29..34 "new" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NEW_EXPR@34..51
-           NEW_KW@34..38 "new" " "
+          None NEW_KW@34..38 "new" Whitespace(1)
           NEW_EXPR@38..51
-             NEW_KW@38..42 "new" " "
+            None NEW_KW@38..42 "new" Whitespace(1)
             NEW_EXPR@42..51
-               NEW_KW@42..46 "new" " "
+              None NEW_KW@42..46 "new" Whitespace(1)
               NAME_REF@46..49
-                 IDENT@46..49 "Foo" 
+                None IDENT@46..49 "Foo" None
               ARG_LIST@49..51
-                 L_PAREN@49..50 "(" 
+                None L_PAREN@49..50 "(" None
                 LIST@50..50
+<<<<<<< HEAD
 <<<<<<< HEAD
                 R_PAREN@50..51 ")"
       SEMICOLON@51..52 ";"
@@ -76,40 +85,48 @@ MODULE@0..112
       NEW_EXPR@52..112
         "\n" NEW_KW@52..57 "new" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                None R_PAREN@50..51 ")" None
+      None SEMICOLON@51..52 ";" None
+    EXPR_STMT@52..112
+      NEW_EXPR@52..112
+        Whitespace(1) NEW_KW@52..57 "new" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@57..60
-           IDENT@57..60 "Foo" 
+          None IDENT@57..60 "Foo" None
         ARG_LIST@60..112
-           L_PAREN@60..61 "(" 
+          None L_PAREN@60..61 "(" None
           LIST@61..111
             NAME_REF@61..64
-               IDENT@61..64 "bar" 
-             COMMA@64..66 "," " "
+              None IDENT@61..64 "bar" None
+            None COMMA@64..66 "," Whitespace(1)
             NAME_REF@66..69
-               IDENT@66..69 "baz" 
-             COMMA@69..71 "," " "
+              None IDENT@66..69 "baz" None
+            None COMMA@69..71 "," Whitespace(1)
             BIN_EXPR@71..76
               LITERAL@71..73
-                 NUMBER@71..73 "6" " "
-               PLUS@73..75 "+" " "
+                None NUMBER@71..73 "6" Whitespace(1)
+              None PLUS@73..75 "+" Whitespace(1)
               LITERAL@75..76
-                 NUMBER@75..76 "6" 
-             COMMA@76..78 "," " "
+                None NUMBER@75..76 "6" None
+            None COMMA@76..78 "," Whitespace(1)
             BIN_EXPR@78..111
               BRACKET_EXPR@78..87
                 NAME_REF@78..81
-                   IDENT@78..81 "foo" 
-                 L_BRACK@81..82 "[" 
+                  None IDENT@78..81 "foo" None
+                None L_BRACK@81..82 "[" None
                 NAME_REF@82..85
-                   IDENT@82..85 "bar" 
-                 R_BRACK@85..87 "]" " "
-               PLUS@87..89 "+" " "
+                  None IDENT@82..85 "bar" None
+                None R_BRACK@85..87 "]" Whitespace(1)
+              None PLUS@87..89 "+" Whitespace(1)
               BIN_EXPR@89..111
                 ARROW_EXPR@89..101
                   PARAMETER_LIST@89..95
-                     L_PAREN@89..90 "(" 
+                    None L_PAREN@89..90 "(" None
                     LIST@90..93
                       SINGLE_PATTERN@90..93
                         NAME@90..93
+<<<<<<< HEAD
 <<<<<<< HEAD
                           IDENT@90..93 "foo"
                     R_PAREN@93..94 ")"
@@ -125,13 +142,20 @@ MODULE@0..112
                   BLOCK_STMT@98..101
                      L_CURLY@98..99 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                          None IDENT@90..93 "foo" None
+                    None R_PAREN@93..95 ")" Whitespace(1)
+                  None FAT_ARROW@95..98 "=>" Whitespace(1)
+                  BLOCK_STMT@98..101
+                    None L_CURLY@98..99 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                     LIST@99..99
-                     R_CURLY@99..101 "}" " "
-                 STAR@101..103 "*" " "
+                    None R_CURLY@99..101 "}" Whitespace(1)
+                None STAR@101..103 "*" Whitespace(1)
                 DOT_EXPR@103..111
                   NAME_REF@103..106
-                     IDENT@103..106 "foo" 
-                   QUESTIONDOT@106..108 "?." 
+                    None IDENT@103..106 "foo" None
+                  None QUESTIONDOT@106..108 "?." None
                   NAME@108..111
-                     IDENT@108..111 "bar" 
-           R_PAREN@111..112 ")" 
+                    None IDENT@108..111 "bar" None
+          None R_PAREN@111..112 ")" None

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -6,7 +6,7 @@ MODULE@0..112
   LIST@0..112
     JS_EXPRESSION_STATEMENT@0..9
       NEW_EXPR@0..9
-        None NEW_KW@0..4 "new" Whitespace(1)
+        None NEW_KW@0..3 "new" Whitespace(1)
         NAME_REF@4..7
           None IDENT@4..7 "Foo" None
         ARG_LIST@7..9
@@ -41,29 +41,33 @@ MODULE@0..112
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@9..18
       NEW_EXPR@9..17
-        Whitespace(1) NEW_KW@9..14 "new" Whitespace(1)
+        Whitespace(1) NEW_KW@10..13 "new" Whitespace(1)
         NAME_REF@14..17
           None IDENT@14..17 "foo" None
       None SEMICOLON@17..18 ";" None
     EXPR_STMT@18..29
       NEW_TARGET@18..29
-        Whitespace(1) NEW_KW@18..22 "new" None
+        Whitespace(1) NEW_KW@19..22 "new" None
         None DOT@22..23 "." None
         None IDENT@23..29 "target" None
     EXPR_STMT@29..52
       NEW_EXPR@29..51
+<<<<<<< HEAD
 <<<<<<< HEAD
         "\n" NEW_KW@29..34 "new" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) NEW_KW@29..34 "new" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) NEW_KW@30..33 "new" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NEW_EXPR@34..51
-          None NEW_KW@34..38 "new" Whitespace(1)
+          None NEW_KW@34..37 "new" Whitespace(1)
           NEW_EXPR@38..51
-            None NEW_KW@38..42 "new" Whitespace(1)
+            None NEW_KW@38..41 "new" Whitespace(1)
             NEW_EXPR@42..51
-              None NEW_KW@42..46 "new" Whitespace(1)
+              None NEW_KW@42..45 "new" Whitespace(1)
               NAME_REF@46..49
                 None IDENT@46..49 "Foo" None
               ARG_LIST@49..51
@@ -90,8 +94,12 @@ MODULE@0..112
       None SEMICOLON@51..52 ";" None
     EXPR_STMT@52..112
       NEW_EXPR@52..112
+<<<<<<< HEAD
         Whitespace(1) NEW_KW@52..57 "new" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) NEW_KW@53..56 "new" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@57..60
           None IDENT@57..60 "Foo" None
         ARG_LIST@60..112
@@ -99,17 +107,17 @@ MODULE@0..112
           LIST@61..111
             NAME_REF@61..64
               None IDENT@61..64 "bar" None
-            None COMMA@64..66 "," Whitespace(1)
+            None COMMA@64..65 "," Whitespace(1)
             NAME_REF@66..69
               None IDENT@66..69 "baz" None
-            None COMMA@69..71 "," Whitespace(1)
+            None COMMA@69..70 "," Whitespace(1)
             BIN_EXPR@71..76
               LITERAL@71..73
-                None NUMBER@71..73 "6" Whitespace(1)
-              None PLUS@73..75 "+" Whitespace(1)
+                None NUMBER@71..72 "6" Whitespace(1)
+              None PLUS@73..74 "+" Whitespace(1)
               LITERAL@75..76
                 None NUMBER@75..76 "6" None
-            None COMMA@76..78 "," Whitespace(1)
+            None COMMA@76..77 "," Whitespace(1)
             BIN_EXPR@78..111
               BRACKET_EXPR@78..87
                 NAME_REF@78..81
@@ -117,8 +125,8 @@ MODULE@0..112
                 None L_BRACK@81..82 "[" None
                 NAME_REF@82..85
                   None IDENT@82..85 "bar" None
-                None R_BRACK@85..87 "]" Whitespace(1)
-              None PLUS@87..89 "+" Whitespace(1)
+                None R_BRACK@85..86 "]" Whitespace(1)
+              None PLUS@87..88 "+" Whitespace(1)
               BIN_EXPR@89..111
                 ARROW_EXPR@89..101
                   PARAMETER_LIST@89..95
@@ -144,14 +152,14 @@ MODULE@0..112
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                           None IDENT@90..93 "foo" None
-                    None R_PAREN@93..95 ")" Whitespace(1)
-                  None FAT_ARROW@95..98 "=>" Whitespace(1)
+                    None R_PAREN@93..94 ")" Whitespace(1)
+                  None FAT_ARROW@95..97 "=>" Whitespace(1)
                   BLOCK_STMT@98..101
                     None L_CURLY@98..99 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                     LIST@99..99
-                    None R_CURLY@99..101 "}" Whitespace(1)
-                None STAR@101..103 "*" Whitespace(1)
+                    None R_CURLY@99..100 "}" Whitespace(1)
+                None STAR@101..102 "*" Whitespace(1)
                 DOT_EXPR@103..111
                   NAME_REF@103..106
                     None IDENT@103..106 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..113
-=======
-MODULE@0..112
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..112
   LIST@0..112
     JS_EXPRESSION_STATEMENT@0..9
       NEW_EXPR@0..9
@@ -12,56 +8,21 @@ MODULE@0..112
         ARG_LIST@7..9
           None L_PAREN@7..8 "(" None
           LIST@8..8
-<<<<<<< HEAD
-<<<<<<< HEAD
-          R_PAREN@8..9 ")"
-    WHITESPACE@9..10 "\n"
-    JS_EXPRESSION_STATEMENT@10..18
-      NEW_EXPR@10..17
-        NEW_KW@10..13 "new"
-        WHITESPACE@13..14 " "
-        NAME_REF@14..17
-          IDENT@14..17 "foo"
-      SEMICOLON@17..18 ";"
-    WHITESPACE@18..19 "\n"
-    JS_EXPRESSION_STATEMENT@19..29
-      NEW_TARGET@19..29
-        NEW_KW@19..22 "new"
-        DOT@22..23 "."
-        IDENT@23..29 "target"
-    WHITESPACE@29..30 "\n"
-    JS_EXPRESSION_STATEMENT@30..52
-      NEW_EXPR@30..51
-        NEW_KW@30..33 "new"
-        WHITESPACE@33..34 " "
-=======
-           R_PAREN@8..9 ")" 
-=======
           None R_PAREN@8..9 ")" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@9..18
+    JS_EXPRESSION_STATEMENT@9..18
       NEW_EXPR@9..17
         Whitespace(1) NEW_KW@10..13 "new" Whitespace(1)
         NAME_REF@14..17
           None IDENT@14..17 "foo" None
       None SEMICOLON@17..18 ";" None
-    EXPR_STMT@18..29
+    JS_EXPRESSION_STATEMENT@18..29
       NEW_TARGET@18..29
         Whitespace(1) NEW_KW@19..22 "new" None
         None DOT@22..23 "." None
         None IDENT@23..29 "target" None
-    EXPR_STMT@29..52
+    JS_EXPRESSION_STATEMENT@29..52
       NEW_EXPR@29..51
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" NEW_KW@29..34 "new" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) NEW_KW@29..34 "new" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) NEW_KW@30..33 "new" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NEW_EXPR@34..51
           None NEW_KW@34..37 "new" Whitespace(1)
           NEW_EXPR@38..51
@@ -73,33 +34,11 @@ MODULE@0..112
               ARG_LIST@49..51
                 None L_PAREN@49..50 "(" None
                 LIST@50..50
-<<<<<<< HEAD
-<<<<<<< HEAD
-                R_PAREN@50..51 ")"
-      SEMICOLON@51..52 ";"
-    WHITESPACE@52..53 "\n"
-    JS_EXPRESSION_STATEMENT@53..112
-      NEW_EXPR@53..112
-        NEW_KW@53..56 "new"
-        WHITESPACE@56..57 " "
-=======
-                 R_PAREN@50..51 ")" 
-       SEMICOLON@51..52 ";" 
-    EXPR_STMT@52..112
-      NEW_EXPR@52..112
-        "\n" NEW_KW@52..57 "new" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
                 None R_PAREN@50..51 ")" None
       None SEMICOLON@51..52 ";" None
-    EXPR_STMT@52..112
+    JS_EXPRESSION_STATEMENT@52..112
       NEW_EXPR@52..112
-<<<<<<< HEAD
-        Whitespace(1) NEW_KW@52..57 "new" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) NEW_KW@53..56 "new" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@57..60
           None IDENT@57..60 "Foo" None
         ARG_LIST@60..112
@@ -134,29 +73,11 @@ MODULE@0..112
                     LIST@90..93
                       SINGLE_PATTERN@90..93
                         NAME@90..93
-<<<<<<< HEAD
-<<<<<<< HEAD
-                          IDENT@90..93 "foo"
-                    R_PAREN@93..94 ")"
-                  WHITESPACE@94..95 " "
-                  FAT_ARROW@95..97 "=>"
-                  WHITESPACE@97..98 " "
-                  JS_BLOCK_STATEMENT@98..100
-                    L_CURLY@98..99 "{"
-=======
-                           IDENT@90..93 "foo" 
-                     R_PAREN@93..95 ")" " "
-                   FAT_ARROW@95..98 "=>" " "
-                  BLOCK_STMT@98..101
-                     L_CURLY@98..99 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
                           None IDENT@90..93 "foo" None
                     None R_PAREN@93..94 ")" Whitespace(1)
                   None FAT_ARROW@95..97 "=>" Whitespace(1)
-                  BLOCK_STMT@98..101
+                  JS_BLOCK_STATEMENT@98..101
                     None L_CURLY@98..99 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                     LIST@99..99
                     None R_CURLY@99..100 "}" Whitespace(1)
                 None STAR@101..102 "*" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..59
-=======
-MODULE@0..58
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..58
   LIST@0..58
     VAR_DECL@0..30
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -5,50 +5,50 @@ MODULE@0..58
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..58
     VAR_DECL@0..30
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..30
         DECLARATOR@4..30
           OBJECT_PATTERN@4..26
-             L_CURLY@4..6 "{" " "
+            None L_CURLY@4..6 "{" Whitespace(1)
             LIST@6..24
               KEY_VALUE_PATTERN@6..18
                 NAME@6..13
-                   IDENT@6..13 "default" 
-                 COLON@13..15 ":" " "
+                  None IDENT@6..13 "default" None
+                None COLON@13..15 ":" Whitespace(1)
                 SINGLE_PATTERN@15..18
                   NAME@15..18
-                     IDENT@15..18 "foo" 
-               COMMA@18..20 "," " "
+                    None IDENT@15..18 "foo" None
+              None COMMA@18..20 "," Whitespace(1)
               SINGLE_PATTERN@20..24
                 NAME@20..24
-                   IDENT@20..24 "bar" " "
-             R_CURLY@24..26 "}" " "
-           EQ@26..28 "=" " "
+                  None IDENT@20..24 "bar" Whitespace(1)
+            None R_CURLY@24..26 "}" Whitespace(1)
+          None EQ@26..28 "=" Whitespace(1)
           OBJECT_EXPR@28..30
-             L_CURLY@28..29 "{" 
+            None L_CURLY@28..29 "{" None
             LIST@29..29
-             R_CURLY@29..30 "}" 
+            None R_CURLY@29..30 "}" None
     VAR_DECL@30..58
-      "\n" IDENT@30..35 "let" " "
+      Whitespace(1) IDENT@30..35 "let" Whitespace(1)
       LIST@35..58
         DECLARATOR@35..58
           OBJECT_PATTERN@35..54
-             L_CURLY@35..37 "{" " "
+            None L_CURLY@35..37 "{" Whitespace(1)
             LIST@37..52
               ASSIGN_PATTERN@37..46
                 SINGLE_PATTERN@37..41
                   NAME@37..41
-                     IDENT@37..41 "foo" " "
-                 EQ@41..43 "=" " "
+                    None IDENT@37..41 "foo" Whitespace(1)
+                None EQ@41..43 "=" Whitespace(1)
                 NAME_REF@43..46
-                   IDENT@43..46 "bar" 
-               COMMA@46..48 "," " "
+                  None IDENT@43..46 "bar" None
+              None COMMA@46..48 "," Whitespace(1)
               SINGLE_PATTERN@48..52
                 NAME@48..52
-                   IDENT@48..52 "baz" " "
-             R_CURLY@52..54 "}" " "
-           EQ@54..56 "=" " "
+                  None IDENT@48..52 "baz" Whitespace(1)
+            None R_CURLY@52..54 "}" Whitespace(1)
+          None EQ@54..56 "=" Whitespace(1)
           OBJECT_EXPR@56..58
-             L_CURLY@56..57 "{" 
+            None L_CURLY@56..57 "{" None
             LIST@57..57
-             R_CURLY@57..58 "}" 
+            None R_CURLY@57..58 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -5,49 +5,49 @@ MODULE@0..58
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..58
     VAR_DECL@0..30
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..30
         DECLARATOR@4..30
           OBJECT_PATTERN@4..26
-            None L_CURLY@4..6 "{" Whitespace(1)
+            None L_CURLY@4..5 "{" Whitespace(1)
             LIST@6..24
               KEY_VALUE_PATTERN@6..18
                 NAME@6..13
                   None IDENT@6..13 "default" None
-                None COLON@13..15 ":" Whitespace(1)
+                None COLON@13..14 ":" Whitespace(1)
                 SINGLE_PATTERN@15..18
                   NAME@15..18
                     None IDENT@15..18 "foo" None
-              None COMMA@18..20 "," Whitespace(1)
+              None COMMA@18..19 "," Whitespace(1)
               SINGLE_PATTERN@20..24
                 NAME@20..24
-                  None IDENT@20..24 "bar" Whitespace(1)
-            None R_CURLY@24..26 "}" Whitespace(1)
-          None EQ@26..28 "=" Whitespace(1)
+                  None IDENT@20..23 "bar" Whitespace(1)
+            None R_CURLY@24..25 "}" Whitespace(1)
+          None EQ@26..27 "=" Whitespace(1)
           OBJECT_EXPR@28..30
             None L_CURLY@28..29 "{" None
             LIST@29..29
             None R_CURLY@29..30 "}" None
     VAR_DECL@30..58
-      Whitespace(1) IDENT@30..35 "let" Whitespace(1)
+      Whitespace(1) IDENT@31..34 "let" Whitespace(1)
       LIST@35..58
         DECLARATOR@35..58
           OBJECT_PATTERN@35..54
-            None L_CURLY@35..37 "{" Whitespace(1)
+            None L_CURLY@35..36 "{" Whitespace(1)
             LIST@37..52
               ASSIGN_PATTERN@37..46
                 SINGLE_PATTERN@37..41
                   NAME@37..41
-                    None IDENT@37..41 "foo" Whitespace(1)
-                None EQ@41..43 "=" Whitespace(1)
+                    None IDENT@37..40 "foo" Whitespace(1)
+                None EQ@41..42 "=" Whitespace(1)
                 NAME_REF@43..46
                   None IDENT@43..46 "bar" None
-              None COMMA@46..48 "," Whitespace(1)
+              None COMMA@46..47 "," Whitespace(1)
               SINGLE_PATTERN@48..52
                 NAME@48..52
-                  None IDENT@48..52 "baz" Whitespace(1)
-            None R_CURLY@52..54 "}" Whitespace(1)
-          None EQ@54..56 "=" Whitespace(1)
+                  None IDENT@48..51 "baz" Whitespace(1)
+            None R_CURLY@52..53 "}" Whitespace(1)
+          None EQ@54..55 "=" Whitespace(1)
           OBJECT_EXPR@56..58
             None L_CURLY@56..57 "{" None
             LIST@57..57

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -1,67 +1,54 @@
+<<<<<<< HEAD
 JS_MODULE@0..59
+=======
+MODULE@0..58
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..58
     VAR_DECL@0..30
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..30
         DECLARATOR@4..30
-          OBJECT_PATTERN@4..25
-            L_CURLY@4..5 "{"
-            WHITESPACE@5..6 " "
-            LIST@6..23
+          OBJECT_PATTERN@4..26
+             L_CURLY@4..6 "{" " "
+            LIST@6..24
               KEY_VALUE_PATTERN@6..18
                 NAME@6..13
-                  IDENT@6..13 "default"
-                COLON@13..14 ":"
-                WHITESPACE@14..15 " "
+                   IDENT@6..13 "default" 
+                 COLON@13..15 ":" " "
                 SINGLE_PATTERN@15..18
                   NAME@15..18
-                    IDENT@15..18 "foo"
-              COMMA@18..19 ","
-              WHITESPACE@19..20 " "
-              SINGLE_PATTERN@20..23
-                NAME@20..23
-                  IDENT@20..23 "bar"
-            WHITESPACE@23..24 " "
-            R_CURLY@24..25 "}"
-          WHITESPACE@25..26 " "
-          EQ@26..27 "="
-          WHITESPACE@27..28 " "
+                     IDENT@15..18 "foo" 
+               COMMA@18..20 "," " "
+              SINGLE_PATTERN@20..24
+                NAME@20..24
+                   IDENT@20..24 "bar" " "
+             R_CURLY@24..26 "}" " "
+           EQ@26..28 "=" " "
           OBJECT_EXPR@28..30
-            L_CURLY@28..29 "{"
+             L_CURLY@28..29 "{" 
             LIST@29..29
-            R_CURLY@29..30 "}"
-    WHITESPACE@30..31 "\n"
-    VAR_DECL@31..58
-      IDENT@31..34 "let"
-      WHITESPACE@34..35 " "
+             R_CURLY@29..30 "}" 
+    VAR_DECL@30..58
+      "\n" IDENT@30..35 "let" " "
       LIST@35..58
         DECLARATOR@35..58
-          OBJECT_PATTERN@35..53
-            L_CURLY@35..36 "{"
-            WHITESPACE@36..37 " "
-            LIST@37..51
+          OBJECT_PATTERN@35..54
+             L_CURLY@35..37 "{" " "
+            LIST@37..52
               ASSIGN_PATTERN@37..46
-                SINGLE_PATTERN@37..40
-                  NAME@37..40
-                    IDENT@37..40 "foo"
-                WHITESPACE@40..41 " "
-                EQ@41..42 "="
-                WHITESPACE@42..43 " "
+                SINGLE_PATTERN@37..41
+                  NAME@37..41
+                     IDENT@37..41 "foo" " "
+                 EQ@41..43 "=" " "
                 NAME_REF@43..46
-                  IDENT@43..46 "bar"
-              COMMA@46..47 ","
-              WHITESPACE@47..48 " "
-              SINGLE_PATTERN@48..51
-                NAME@48..51
-                  IDENT@48..51 "baz"
-            WHITESPACE@51..52 " "
-            R_CURLY@52..53 "}"
-          WHITESPACE@53..54 " "
-          EQ@54..55 "="
-          WHITESPACE@55..56 " "
+                   IDENT@43..46 "bar" 
+               COMMA@46..48 "," " "
+              SINGLE_PATTERN@48..52
+                NAME@48..52
+                   IDENT@48..52 "baz" " "
+             R_CURLY@52..54 "}" " "
+           EQ@54..56 "=" " "
           OBJECT_EXPR@56..58
-            L_CURLY@56..57 "{"
+             L_CURLY@56..57 "{" 
             LIST@57..57
-            R_CURLY@57..58 "}"
-  WHITESPACE@58..59 "\n"
+             R_CURLY@57..58 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -5,26 +5,26 @@ MODULE@0..26
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     VAR_DECL@0..11
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..10
         DECLARATOR@4..10
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..10
             None L_CURLY@8..9 "{" None
             LIST@9..9
             None R_CURLY@9..10 "}" None
       None SEMICOLON@10..11 ";" None
     VAR_DECL@11..26
-      Whitespace(1) IDENT@11..16 "let" Whitespace(1)
+      Whitespace(1) IDENT@12..15 "let" Whitespace(1)
       LIST@16..26
         DECLARATOR@16..26
           SINGLE_PATTERN@16..18
             NAME@16..18
-              None IDENT@16..18 "b" Whitespace(1)
-          None EQ@18..20 "=" Whitespace(1)
+              None IDENT@16..17 "b" Whitespace(1)
+          None EQ@18..19 "=" Whitespace(1)
           OBJECT_EXPR@20..26
             None L_CURLY@20..21 "{" None
             LIST@21..25

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -1,39 +1,35 @@
+<<<<<<< HEAD
 JS_MODULE@0..27
+=======
+MODULE@0..26
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     VAR_DECL@0..11
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..10
         DECLARATOR@4..10
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..10
-            L_CURLY@8..9 "{"
+             L_CURLY@8..9 "{" 
             LIST@9..9
-            R_CURLY@9..10 "}"
-      SEMICOLON@10..11 ";"
-    WHITESPACE@11..12 "\n"
-    VAR_DECL@12..26
-      IDENT@12..15 "let"
-      WHITESPACE@15..16 " "
+             R_CURLY@9..10 "}" 
+       SEMICOLON@10..11 ";" 
+    VAR_DECL@11..26
+      "\n" IDENT@11..16 "let" " "
       LIST@16..26
         DECLARATOR@16..26
-          SINGLE_PATTERN@16..17
-            NAME@16..17
-              IDENT@16..17 "b"
-          WHITESPACE@17..18 " "
-          EQ@18..19 "="
-          WHITESPACE@19..20 " "
+          SINGLE_PATTERN@16..18
+            NAME@16..18
+               IDENT@16..18 "b" " "
+           EQ@18..20 "=" " "
           OBJECT_EXPR@20..26
-            L_CURLY@20..21 "{"
+             L_CURLY@20..21 "{" 
             LIST@21..25
               IDENT_PROP@21..24
                 NAME@21..24
-                  IDENT@21..24 "foo"
-              COMMA@24..25 ","
-            R_CURLY@25..26 "}"
-  WHITESPACE@26..27 "\n"
+                   IDENT@21..24 "foo" 
+               COMMA@24..25 "," 
+             R_CURLY@25..26 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..27
-=======
-MODULE@0..26
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..26
   LIST@0..26
     VAR_DECL@0..11
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -5,31 +5,31 @@ MODULE@0..26
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..26
     VAR_DECL@0..11
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..10
         DECLARATOR@4..10
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..10
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..9
-             R_CURLY@9..10 "}" 
-       SEMICOLON@10..11 ";" 
+            None R_CURLY@9..10 "}" None
+      None SEMICOLON@10..11 ";" None
     VAR_DECL@11..26
-      "\n" IDENT@11..16 "let" " "
+      Whitespace(1) IDENT@11..16 "let" Whitespace(1)
       LIST@16..26
         DECLARATOR@16..26
           SINGLE_PATTERN@16..18
             NAME@16..18
-               IDENT@16..18 "b" " "
-           EQ@18..20 "=" " "
+              None IDENT@16..18 "b" Whitespace(1)
+          None EQ@18..20 "=" Whitespace(1)
           OBJECT_EXPR@20..26
-             L_CURLY@20..21 "{" 
+            None L_CURLY@20..21 "{" None
             LIST@21..25
               IDENT_PROP@21..24
                 NAME@21..24
-                   IDENT@21..24 "foo" 
-               COMMA@24..25 "," 
-             R_CURLY@25..26 "}" 
+                  None IDENT@21..24 "foo" None
+              None COMMA@24..25 "," None
+            None R_CURLY@25..26 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -5,27 +5,27 @@ MODULE@0..30
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..30
     VAR_DECL@0..30
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..30
         DECLARATOR@4..30
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..30
-             L_CURLY@8..10 "{" " "
+            None L_CURLY@8..10 "{" Whitespace(1)
             LIST@10..29
               INITIALIZED_PROP@10..17
                 NAME@10..14
-                   IDENT@10..14 "foo" " "
-                 EQ@14..16 "=" " "
+                  None IDENT@10..14 "foo" Whitespace(1)
+                None EQ@14..16 "=" Whitespace(1)
                 LITERAL@16..17
-                   NUMBER@16..17 "4" 
-               COMMA@17..19 "," " "
+                  None NUMBER@16..17 "4" None
+              None COMMA@17..19 "," Whitespace(1)
               INITIALIZED_PROP@19..29
                 NAME@19..23
-                   IDENT@19..23 "foo" " "
-                 EQ@23..25 "=" " "
+                  None IDENT@19..23 "foo" Whitespace(1)
+                None EQ@23..25 "=" Whitespace(1)
                 NAME_REF@25..29
-                   IDENT@25..29 "bar" " "
-             R_CURLY@29..30 "}" 
+                  None IDENT@25..29 "bar" Whitespace(1)
+            None R_CURLY@29..30 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..31
-=======
-MODULE@0..30
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..30
   LIST@0..30
     VAR_DECL@0..30
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -5,27 +5,27 @@ MODULE@0..30
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..30
     VAR_DECL@0..30
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..30
         DECLARATOR@4..30
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..30
-            None L_CURLY@8..10 "{" Whitespace(1)
+            None L_CURLY@8..9 "{" Whitespace(1)
             LIST@10..29
               INITIALIZED_PROP@10..17
                 NAME@10..14
-                  None IDENT@10..14 "foo" Whitespace(1)
-                None EQ@14..16 "=" Whitespace(1)
+                  None IDENT@10..13 "foo" Whitespace(1)
+                None EQ@14..15 "=" Whitespace(1)
                 LITERAL@16..17
                   None NUMBER@16..17 "4" None
-              None COMMA@17..19 "," Whitespace(1)
+              None COMMA@17..18 "," Whitespace(1)
               INITIALIZED_PROP@19..29
                 NAME@19..23
-                  None IDENT@19..23 "foo" Whitespace(1)
-                None EQ@23..25 "=" Whitespace(1)
+                  None IDENT@19..22 "foo" Whitespace(1)
+                None EQ@23..24 "=" Whitespace(1)
                 NAME_REF@25..29
-                  None IDENT@25..29 "bar" Whitespace(1)
+                  None IDENT@25..28 "bar" Whitespace(1)
             None R_CURLY@29..30 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -1,38 +1,31 @@
+<<<<<<< HEAD
 JS_MODULE@0..31
+=======
+MODULE@0..30
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..30
     VAR_DECL@0..30
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..30
         DECLARATOR@4..30
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..30
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..10 " "
-            LIST@10..28
+             L_CURLY@8..10 "{" " "
+            LIST@10..29
               INITIALIZED_PROP@10..17
-                NAME@10..13
-                  IDENT@10..13 "foo"
-                WHITESPACE@13..14 " "
-                EQ@14..15 "="
-                WHITESPACE@15..16 " "
+                NAME@10..14
+                   IDENT@10..14 "foo" " "
+                 EQ@14..16 "=" " "
                 LITERAL@16..17
-                  NUMBER@16..17 "4"
-              COMMA@17..18 ","
-              WHITESPACE@18..19 " "
-              INITIALIZED_PROP@19..28
-                NAME@19..22
-                  IDENT@19..22 "foo"
-                WHITESPACE@22..23 " "
-                EQ@23..24 "="
-                WHITESPACE@24..25 " "
-                NAME_REF@25..28
-                  IDENT@25..28 "bar"
-            WHITESPACE@28..29 " "
-            R_CURLY@29..30 "}"
-  WHITESPACE@30..31 "\n"
+                   NUMBER@16..17 "4" 
+               COMMA@17..19 "," " "
+              INITIALIZED_PROP@19..29
+                NAME@19..23
+                   IDENT@19..23 "foo" " "
+                 EQ@23..25 "=" " "
+                NAME_REF@25..29
+                   IDENT@25..29 "bar" " "
+             R_CURLY@29..30 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -5,23 +5,24 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..47
         DECLARATOR@4..47
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..47
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..45
               METHOD@9..26
-                "\n  " ASYNC_KW@9..18 "async" " "
+                Whitespace(3) ASYNC_KW@9..18 "async" Whitespace(1)
                 NAME@18..21
-                   IDENT@18..21 "foo" 
+                  None IDENT@18..21 "foo" None
                 PARAMETER_LIST@21..24
-                   L_PAREN@21..22 "(" 
+                  None L_PAREN@21..22 "(" None
                   LIST@22..22
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@22..23 ")"
                 WHITESPACE@23..24 " "
@@ -32,17 +33,23 @@ MODULE@0..47
                 BLOCK_STMT@24..26
                    L_CURLY@24..25 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                  None R_PAREN@22..24 ")" Whitespace(1)
+                BLOCK_STMT@24..26
+                  None L_CURLY@24..25 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@25..25
-                   R_CURLY@25..26 "}" 
-               COMMA@26..27 "," 
+                  None R_CURLY@25..26 "}" None
+              None COMMA@26..27 "," None
               METHOD@27..45
-                "\n  " ASYNC_KW@27..36 "async" " "
-                 STAR@36..37 "*" 
+                Whitespace(3) ASYNC_KW@27..36 "async" Whitespace(1)
+                None STAR@36..37 "*" None
                 NAME@37..40
-                   IDENT@37..40 "foo" 
+                  None IDENT@37..40 "foo" None
                 PARAMETER_LIST@40..43
-                   L_PAREN@40..41 "(" 
+                  None L_PAREN@40..41 "(" None
                   LIST@41..41
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@41..42 ")"
                 WHITESPACE@42..43 " "
@@ -53,6 +60,11 @@ MODULE@0..47
                 BLOCK_STMT@43..45
                    L_CURLY@43..44 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                  None R_PAREN@41..43 ")" Whitespace(1)
+                BLOCK_STMT@43..45
+                  None L_CURLY@43..44 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@44..44
-                   R_CURLY@44..45 "}" 
-            "\n" R_CURLY@45..47 "}" 
+                  None R_CURLY@44..45 "}" None
+            Whitespace(1) R_CURLY@45..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..48
-=======
-MODULE@0..47
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..47
   LIST@0..47
     VAR_DECL@0..47
       None IDENT@0..3 "let" Whitespace(1)
@@ -22,26 +18,9 @@ MODULE@0..47
                 PARAMETER_LIST@21..24
                   None L_PAREN@21..22 "(" None
                   LIST@22..22
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@22..23 ")"
-                WHITESPACE@23..24 " "
-                JS_BLOCK_STATEMENT@24..26
-                  L_CURLY@24..25 "{"
-=======
-                   R_PAREN@22..24 ")" " "
-                BLOCK_STMT@24..26
-                   L_CURLY@24..25 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                  None R_PAREN@22..24 ")" Whitespace(1)
-=======
                   None R_PAREN@22..23 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@24..26
+                JS_BLOCK_STATEMENT@24..26
                   None L_CURLY@24..25 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@25..25
                   None R_CURLY@25..26 "}" None
               None COMMA@26..27 "," None
@@ -53,26 +32,9 @@ MODULE@0..47
                 PARAMETER_LIST@40..43
                   None L_PAREN@40..41 "(" None
                   LIST@41..41
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@41..42 ")"
-                WHITESPACE@42..43 " "
-                JS_BLOCK_STATEMENT@43..45
-                  L_CURLY@43..44 "{"
-=======
-                   R_PAREN@41..43 ")" " "
-                BLOCK_STMT@43..45
-                   L_CURLY@43..44 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                  None R_PAREN@41..43 ")" Whitespace(1)
-=======
                   None R_PAREN@41..42 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@43..45
+                JS_BLOCK_STATEMENT@43..45
                   None L_CURLY@43..44 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@44..44
                   None R_CURLY@44..45 "}" None
             Whitespace(1) R_CURLY@46..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -5,23 +5,24 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..47
         DECLARATOR@4..47
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..47
             None L_CURLY@8..9 "{" None
             LIST@9..45
               METHOD@9..26
-                Whitespace(3) ASYNC_KW@9..18 "async" Whitespace(1)
+                Whitespace(3) ASYNC_KW@12..17 "async" Whitespace(1)
                 NAME@18..21
                   None IDENT@18..21 "foo" None
                 PARAMETER_LIST@21..24
                   None L_PAREN@21..22 "(" None
                   LIST@22..22
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@22..23 ")"
@@ -35,6 +36,9 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                   None R_PAREN@22..24 ")" Whitespace(1)
+=======
+                  None R_PAREN@22..23 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@24..26
                   None L_CURLY@24..25 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
@@ -42,13 +46,14 @@ MODULE@0..47
                   None R_CURLY@25..26 "}" None
               None COMMA@26..27 "," None
               METHOD@27..45
-                Whitespace(3) ASYNC_KW@27..36 "async" Whitespace(1)
+                Whitespace(3) ASYNC_KW@30..35 "async" Whitespace(1)
                 None STAR@36..37 "*" None
                 NAME@37..40
                   None IDENT@37..40 "foo" None
                 PARAMETER_LIST@40..43
                   None L_PAREN@40..41 "(" None
                   LIST@41..41
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@41..42 ")"
@@ -62,9 +67,12 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                   None R_PAREN@41..43 ")" Whitespace(1)
+=======
+                  None R_PAREN@41..42 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@43..45
                   None L_CURLY@43..44 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@44..44
                   None R_CURLY@44..45 "}" None
-            Whitespace(1) R_CURLY@45..47 "}" None
+            Whitespace(1) R_CURLY@46..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -1,51 +1,58 @@
+<<<<<<< HEAD
 JS_MODULE@0..48
+=======
+MODULE@0..47
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..47
         DECLARATOR@4..47
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..47
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..12 "\n  "
-            LIST@12..45
-              METHOD@12..26
-                ASYNC_KW@12..17 "async"
-                WHITESPACE@17..18 " "
+             L_CURLY@8..9 "{" 
+            LIST@9..45
+              METHOD@9..26
+                "\n  " ASYNC_KW@9..18 "async" " "
                 NAME@18..21
-                  IDENT@18..21 "foo"
-                PARAMETER_LIST@21..23
-                  L_PAREN@21..22 "("
+                   IDENT@18..21 "foo" 
+                PARAMETER_LIST@21..24
+                   L_PAREN@21..22 "(" 
                   LIST@22..22
+<<<<<<< HEAD
                   R_PAREN@22..23 ")"
                 WHITESPACE@23..24 " "
                 JS_BLOCK_STATEMENT@24..26
                   L_CURLY@24..25 "{"
+=======
+                   R_PAREN@22..24 ")" " "
+                BLOCK_STMT@24..26
+                   L_CURLY@24..25 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                   LIST@25..25
-                  R_CURLY@25..26 "}"
-              COMMA@26..27 ","
-              WHITESPACE@27..30 "\n  "
-              METHOD@30..45
-                ASYNC_KW@30..35 "async"
-                WHITESPACE@35..36 " "
-                STAR@36..37 "*"
+                   R_CURLY@25..26 "}" 
+               COMMA@26..27 "," 
+              METHOD@27..45
+                "\n  " ASYNC_KW@27..36 "async" " "
+                 STAR@36..37 "*" 
                 NAME@37..40
-                  IDENT@37..40 "foo"
-                PARAMETER_LIST@40..42
-                  L_PAREN@40..41 "("
+                   IDENT@37..40 "foo" 
+                PARAMETER_LIST@40..43
+                   L_PAREN@40..41 "(" 
                   LIST@41..41
+<<<<<<< HEAD
                   R_PAREN@41..42 ")"
                 WHITESPACE@42..43 " "
                 JS_BLOCK_STATEMENT@43..45
                   L_CURLY@43..44 "{"
+=======
+                   R_PAREN@41..43 ")" " "
+                BLOCK_STMT@43..45
+                   L_CURLY@43..44 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                   LIST@44..44
-                  R_CURLY@44..45 "}"
-            WHITESPACE@45..46 "\n"
-            R_CURLY@46..47 "}"
-  WHITESPACE@47..48 "\n"
+                   R_CURLY@44..45 "}" 
+            "\n" R_CURLY@45..47 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..22
-=======
-MODULE@0..21
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..21
   LIST@0..21
     VAR_DECL@0..21
       None IDENT@0..3 "let" Whitespace(1)
@@ -22,26 +18,9 @@ MODULE@0..21
                 PARAMETER_LIST@14..17
                   None L_PAREN@14..15 "(" None
                   LIST@15..15
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@15..16 ")"
-                WHITESPACE@16..17 " "
-                JS_BLOCK_STATEMENT@17..19
-                  L_CURLY@17..18 "{"
-=======
-                   R_PAREN@15..17 ")" " "
-                BLOCK_STMT@17..20
-                   L_CURLY@17..18 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                  None R_PAREN@15..17 ")" Whitespace(1)
-=======
                   None R_PAREN@15..16 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@17..20
+                JS_BLOCK_STATEMENT@17..20
                   None L_CURLY@17..18 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
                   None R_CURLY@18..19 "}" Whitespace(1)
             None R_CURLY@20..21 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -1,33 +1,37 @@
+<<<<<<< HEAD
 JS_MODULE@0..22
+=======
+MODULE@0..21
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     VAR_DECL@0..21
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..21
         DECLARATOR@4..21
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..21
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..10 " "
-            LIST@10..19
-              METHOD@10..19
-                STAR@10..11 "*"
+             L_CURLY@8..10 "{" " "
+            LIST@10..20
+              METHOD@10..20
+                 STAR@10..11 "*" 
                 NAME@11..14
-                  IDENT@11..14 "foo"
-                PARAMETER_LIST@14..16
-                  L_PAREN@14..15 "("
+                   IDENT@11..14 "foo" 
+                PARAMETER_LIST@14..17
+                   L_PAREN@14..15 "(" 
                   LIST@15..15
+<<<<<<< HEAD
                   R_PAREN@15..16 ")"
                 WHITESPACE@16..17 " "
                 JS_BLOCK_STATEMENT@17..19
                   L_CURLY@17..18 "{"
+=======
+                   R_PAREN@15..17 ")" " "
+                BLOCK_STMT@17..20
+                   L_CURLY@17..18 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                   LIST@18..18
-                  R_CURLY@18..19 "}"
-            WHITESPACE@19..20 " "
-            R_CURLY@20..21 "}"
-  WHITESPACE@21..22 "\n"
+                   R_CURLY@18..20 "}" " "
+             R_CURLY@20..21 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -5,15 +5,15 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     VAR_DECL@0..21
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..21
         DECLARATOR@4..21
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..21
-            None L_CURLY@8..10 "{" Whitespace(1)
+            None L_CURLY@8..9 "{" Whitespace(1)
             LIST@10..20
               METHOD@10..20
                 None STAR@10..11 "*" None
@@ -22,6 +22,7 @@ MODULE@0..21
                 PARAMETER_LIST@14..17
                   None L_PAREN@14..15 "(" None
                   LIST@15..15
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@15..16 ")"
@@ -35,9 +36,12 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                   None R_PAREN@15..17 ")" Whitespace(1)
+=======
+                  None R_PAREN@15..16 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@17..20
                   None L_CURLY@17..18 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
-                  None R_CURLY@18..20 "}" Whitespace(1)
+                  None R_CURLY@18..19 "}" Whitespace(1)
             None R_CURLY@20..21 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -5,23 +5,24 @@ MODULE@0..21
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..21
     VAR_DECL@0..21
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..21
         DECLARATOR@4..21
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..21
-             L_CURLY@8..10 "{" " "
+            None L_CURLY@8..10 "{" Whitespace(1)
             LIST@10..20
               METHOD@10..20
-                 STAR@10..11 "*" 
+                None STAR@10..11 "*" None
                 NAME@11..14
-                   IDENT@11..14 "foo" 
+                  None IDENT@11..14 "foo" None
                 PARAMETER_LIST@14..17
-                   L_PAREN@14..15 "(" 
+                  None L_PAREN@14..15 "(" None
                   LIST@15..15
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@15..16 ")"
                 WHITESPACE@16..17 " "
@@ -32,6 +33,11 @@ MODULE@0..21
                 BLOCK_STMT@17..20
                    L_CURLY@17..18 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                  None R_PAREN@15..17 ")" Whitespace(1)
+                BLOCK_STMT@17..20
+                  None L_CURLY@17..18 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
-                   R_CURLY@18..20 "}" " "
-             R_CURLY@20..21 "}" 
+                  None R_CURLY@18..20 "}" Whitespace(1)
+            None R_CURLY@20..21 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
@@ -5,23 +5,24 @@ MODULE@0..42
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..42
     VAR_DECL@0..42
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..42
         DECLARATOR@4..42
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..42
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..40
               GETTER@9..40
-                "\n " GET_KW@9..15 "get" " "
+                Whitespace(2) GET_KW@9..15 "get" Whitespace(1)
                 NAME@15..18
-                   IDENT@15..18 "foo" 
+                  None IDENT@15..18 "foo" None
                 PARAMETER_LIST@18..21
-                   L_PAREN@18..19 "(" 
+                  None L_PAREN@18..19 "(" None
                   LIST@19..19
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@19..20 ")"
                 WHITESPACE@20..21 " "
@@ -34,14 +35,21 @@ MODULE@0..42
                       WHITESPACE@32..33 " "
 =======
                    R_PAREN@19..21 ")" " "
+=======
+                  None R_PAREN@19..21 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                 BLOCK_STMT@21..40
-                   L_CURLY@21..22 "{" 
+                  None L_CURLY@21..22 "{" None
                   LIST@22..37
                     RETURN_STMT@22..37
+<<<<<<< HEAD
                       "\n   " RETURN_KW@22..33 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                      Whitespace(4) RETURN_KW@22..33 "return" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                       NAME_REF@33..36
-                         IDENT@33..36 "foo" 
-                       SEMICOLON@36..37 ";" 
-                  "\n " R_CURLY@37..40 "}" 
-            "\n" R_CURLY@40..42 "}" 
+                        None IDENT@33..36 "foo" None
+                      None SEMICOLON@36..37 ";" None
+                  Whitespace(2) R_CURLY@37..40 "}" None
+            Whitespace(1) R_CURLY@40..42 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
@@ -5,23 +5,24 @@ MODULE@0..42
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..42
     VAR_DECL@0..42
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..42
         DECLARATOR@4..42
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..42
             None L_CURLY@8..9 "{" None
             LIST@9..40
               GETTER@9..40
-                Whitespace(2) GET_KW@9..15 "get" Whitespace(1)
+                Whitespace(2) GET_KW@11..14 "get" Whitespace(1)
                 NAME@15..18
                   None IDENT@15..18 "foo" None
                 PARAMETER_LIST@18..21
                   None L_PAREN@18..19 "(" None
                   LIST@19..19
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@19..20 ")"
@@ -38,18 +39,25 @@ MODULE@0..42
 =======
                   None R_PAREN@19..21 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                  None R_PAREN@19..20 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@21..40
                   None L_CURLY@21..22 "{" None
                   LIST@22..37
                     RETURN_STMT@22..37
+<<<<<<< HEAD
 <<<<<<< HEAD
                       "\n   " RETURN_KW@22..33 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                       Whitespace(4) RETURN_KW@22..33 "return" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                      Whitespace(4) RETURN_KW@26..32 "return" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                       NAME_REF@33..36
                         None IDENT@33..36 "foo" None
                       None SEMICOLON@36..37 ";" None
-                  Whitespace(2) R_CURLY@37..40 "}" None
-            Whitespace(1) R_CURLY@40..42 "}" None
+                  Whitespace(2) R_CURLY@39..40 "}" None
+            Whitespace(1) R_CURLY@41..42 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..43
-=======
-MODULE@0..42
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..42
   LIST@0..42
     VAR_DECL@0..42
       None IDENT@0..3 "let" Whitespace(1)
@@ -22,40 +18,12 @@ MODULE@0..42
                 PARAMETER_LIST@18..21
                   None L_PAREN@18..19 "(" None
                   LIST@19..19
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@19..20 ")"
-                WHITESPACE@20..21 " "
-                JS_BLOCK_STATEMENT@21..40
-                  L_CURLY@21..22 "{"
-                  WHITESPACE@22..26 "\n   "
-                  LIST@26..37
-                    JS_RETURN_STATEMENT@26..37
-                      RETURN_KW@26..32 "return"
-                      WHITESPACE@32..33 " "
-=======
-                   R_PAREN@19..21 ")" " "
-=======
-                  None R_PAREN@19..21 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                   None R_PAREN@19..20 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@21..40
+                JS_BLOCK_STATEMENT@21..40
                   None L_CURLY@21..22 "{" None
                   LIST@22..37
-                    RETURN_STMT@22..37
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "\n   " RETURN_KW@22..33 "return" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                      Whitespace(4) RETURN_KW@22..33 "return" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+                    JS_RETURN_STATEMENT@22..37
                       Whitespace(4) RETURN_KW@26..32 "return" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                       NAME_REF@33..36
                         None IDENT@33..36 "foo" None
                       None SEMICOLON@36..37 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
@@ -1,28 +1,28 @@
+<<<<<<< HEAD
 JS_MODULE@0..43
+=======
+MODULE@0..42
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..42
     VAR_DECL@0..42
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..42
         DECLARATOR@4..42
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..42
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..11 "\n "
-            LIST@11..40
-              GETTER@11..40
-                GET_KW@11..14 "get"
-                WHITESPACE@14..15 " "
+             L_CURLY@8..9 "{" 
+            LIST@9..40
+              GETTER@9..40
+                "\n " GET_KW@9..15 "get" " "
                 NAME@15..18
-                  IDENT@15..18 "foo"
-                PARAMETER_LIST@18..20
-                  L_PAREN@18..19 "("
+                   IDENT@15..18 "foo" 
+                PARAMETER_LIST@18..21
+                   L_PAREN@18..19 "(" 
                   LIST@19..19
+<<<<<<< HEAD
                   R_PAREN@19..20 ")"
                 WHITESPACE@20..21 " "
                 JS_BLOCK_STATEMENT@21..40
@@ -32,11 +32,16 @@ JS_MODULE@0..43
                     JS_RETURN_STATEMENT@26..37
                       RETURN_KW@26..32 "return"
                       WHITESPACE@32..33 " "
+=======
+                   R_PAREN@19..21 ")" " "
+                BLOCK_STMT@21..40
+                   L_CURLY@21..22 "{" 
+                  LIST@22..37
+                    RETURN_STMT@22..37
+                      "\n   " RETURN_KW@22..33 "return" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                       NAME_REF@33..36
-                        IDENT@33..36 "foo"
-                      SEMICOLON@36..37 ";"
-                  WHITESPACE@37..39 "\n "
-                  R_CURLY@39..40 "}"
-            WHITESPACE@40..41 "\n"
-            R_CURLY@41..42 "}"
-  WHITESPACE@42..43 "\n"
+                         IDENT@33..36 "foo" 
+                       SEMICOLON@36..37 ";" 
+                  "\n " R_CURLY@37..40 "}" 
+            "\n" R_CURLY@40..42 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
@@ -5,22 +5,22 @@ MODULE@0..25
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..25
     VAR_DECL@0..25
-       CONST_KW@0..6 "const" " "
+      None CONST_KW@0..6 "const" Whitespace(1)
       LIST@6..24
         DECLARATOR@6..24
           SINGLE_PATTERN@6..10
             NAME@6..10
-               IDENT@6..10 "foo" " "
-           EQ@10..12 "=" " "
+              None IDENT@6..10 "foo" Whitespace(1)
+          None EQ@10..12 "=" Whitespace(1)
           OBJECT_EXPR@12..24
-             L_CURLY@12..14 "{" " "
+            None L_CURLY@12..14 "{" Whitespace(1)
             LIST@14..23
               IDENT_PROP@14..17
                 NAME@14..17
-                   IDENT@14..17 "set" 
-               COMMA@17..19 "," " "
+                  None IDENT@14..17 "set" None
+              None COMMA@17..19 "," Whitespace(1)
               IDENT_PROP@19..23
                 NAME@19..23
-                   IDENT@19..23 "get" " "
-             R_CURLY@23..24 "}" 
-       SEMICOLON@24..25 ";" 
+                  None IDENT@19..23 "get" Whitespace(1)
+            None R_CURLY@23..24 "}" None
+      None SEMICOLON@24..25 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
@@ -5,22 +5,22 @@ MODULE@0..25
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..25
     VAR_DECL@0..25
-      None CONST_KW@0..6 "const" Whitespace(1)
+      None CONST_KW@0..5 "const" Whitespace(1)
       LIST@6..24
         DECLARATOR@6..24
           SINGLE_PATTERN@6..10
             NAME@6..10
-              None IDENT@6..10 "foo" Whitespace(1)
-          None EQ@10..12 "=" Whitespace(1)
+              None IDENT@6..9 "foo" Whitespace(1)
+          None EQ@10..11 "=" Whitespace(1)
           OBJECT_EXPR@12..24
-            None L_CURLY@12..14 "{" Whitespace(1)
+            None L_CURLY@12..13 "{" Whitespace(1)
             LIST@14..23
               IDENT_PROP@14..17
                 NAME@14..17
                   None IDENT@14..17 "set" None
-              None COMMA@17..19 "," Whitespace(1)
+              None COMMA@17..18 "," Whitespace(1)
               IDENT_PROP@19..23
                 NAME@19..23
-                  None IDENT@19..23 "get" Whitespace(1)
+                  None IDENT@19..22 "get" Whitespace(1)
             None R_CURLY@23..24 "}" None
       None SEMICOLON@24..25 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..26
-=======
-MODULE@0..25
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..25
   LIST@0..25
     VAR_DECL@0..25
       None CONST_KW@0..5 "const" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_as_prop.rast
@@ -1,29 +1,26 @@
+<<<<<<< HEAD
 JS_MODULE@0..26
+=======
+MODULE@0..25
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..25
     VAR_DECL@0..25
-      CONST_KW@0..5 "const"
-      WHITESPACE@5..6 " "
+       CONST_KW@0..6 "const" " "
       LIST@6..24
         DECLARATOR@6..24
-          SINGLE_PATTERN@6..9
-            NAME@6..9
-              IDENT@6..9 "foo"
-          WHITESPACE@9..10 " "
-          EQ@10..11 "="
-          WHITESPACE@11..12 " "
+          SINGLE_PATTERN@6..10
+            NAME@6..10
+               IDENT@6..10 "foo" " "
+           EQ@10..12 "=" " "
           OBJECT_EXPR@12..24
-            L_CURLY@12..13 "{"
-            WHITESPACE@13..14 " "
-            LIST@14..22
+             L_CURLY@12..14 "{" " "
+            LIST@14..23
               IDENT_PROP@14..17
                 NAME@14..17
-                  IDENT@14..17 "set"
-              COMMA@17..18 ","
-              WHITESPACE@18..19 " "
-              IDENT_PROP@19..22
-                NAME@19..22
-                  IDENT@19..22 "get"
-            WHITESPACE@22..23 " "
-            R_CURLY@23..24 "}"
-      SEMICOLON@24..25 ";"
-  WHITESPACE@25..26 "\n"
+                   IDENT@14..17 "set" 
+               COMMA@17..19 "," " "
+              IDENT_PROP@19..23
+                NAME@19..23
+                   IDENT@19..23 "get" " "
+             R_CURLY@23..24 "}" 
+       SEMICOLON@24..25 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..48
-=======
-MODULE@0..47
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..47
   LIST@0..47
     VAR_DECL@0..47
       None IDENT@0..3 "let" Whitespace(1)
@@ -25,40 +21,12 @@ MODULE@0..47
                 PARAMETER_LIST@21..24
                   None L_PAREN@21..22 "(" None
                   LIST@22..22
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@22..23 ")"
-                WHITESPACE@23..24 " "
-                JS_BLOCK_STATEMENT@24..45
-                  L_CURLY@24..25 "{"
-                  WHITESPACE@25..30 "\n    "
-                  LIST@30..41
-                    JS_RETURN_STATEMENT@30..41
-                      RETURN_KW@30..36 "return"
-                      WHITESPACE@36..37 " "
-=======
-                   R_PAREN@22..24 ")" " "
-=======
-                  None R_PAREN@22..24 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                   None R_PAREN@22..23 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@24..45
+                JS_BLOCK_STATEMENT@24..45
                   None L_CURLY@24..25 "{" None
                   LIST@25..41
-                    RETURN_STMT@25..41
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "\n    " RETURN_KW@25..37 "return" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                      Whitespace(5) RETURN_KW@25..37 "return" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+                    JS_RETURN_STATEMENT@25..41
                       Whitespace(5) RETURN_KW@30..36 "return" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                       NAME_REF@37..40
                         None IDENT@37..40 "foo" None
                       None SEMICOLON@40..41 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -5,18 +5,18 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..47
         DECLARATOR@4..47
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..47
             None L_CURLY@8..9 "{" None
             LIST@9..45
               GETTER@9..45
-                Whitespace(3) GET_KW@9..16 "get" Whitespace(1)
+                Whitespace(3) GET_KW@12..15 "get" Whitespace(1)
                 COMPUTED_PROPERTY_NAME@16..21
                   None L_BRACK@16..17 "[" None
                   NAME_REF@17..20
@@ -25,6 +25,7 @@ MODULE@0..47
                 PARAMETER_LIST@21..24
                   None L_PAREN@21..22 "(" None
                   LIST@22..22
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@22..23 ")"
@@ -41,18 +42,25 @@ MODULE@0..47
 =======
                   None R_PAREN@22..24 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                  None R_PAREN@22..23 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@24..45
                   None L_CURLY@24..25 "{" None
                   LIST@25..41
                     RETURN_STMT@25..41
+<<<<<<< HEAD
 <<<<<<< HEAD
                       "\n    " RETURN_KW@25..37 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                       Whitespace(5) RETURN_KW@25..37 "return" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                      Whitespace(5) RETURN_KW@30..36 "return" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                       NAME_REF@37..40
                         None IDENT@37..40 "foo" None
                       None SEMICOLON@40..41 ";" None
-                  Whitespace(3) R_CURLY@41..45 "}" None
-            Whitespace(1) R_CURLY@45..47 "}" None
+                  Whitespace(3) R_CURLY@44..45 "}" None
+            Whitespace(1) R_CURLY@46..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -5,26 +5,27 @@ MODULE@0..47
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..47
         DECLARATOR@4..47
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..47
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..45
               GETTER@9..45
-                "\n  " GET_KW@9..16 "get" " "
+                Whitespace(3) GET_KW@9..16 "get" Whitespace(1)
                 COMPUTED_PROPERTY_NAME@16..21
-                   L_BRACK@16..17 "[" 
+                  None L_BRACK@16..17 "[" None
                   NAME_REF@17..20
-                     IDENT@17..20 "foo" 
-                   R_BRACK@20..21 "]" 
+                    None IDENT@17..20 "foo" None
+                  None R_BRACK@20..21 "]" None
                 PARAMETER_LIST@21..24
-                   L_PAREN@21..22 "(" 
+                  None L_PAREN@21..22 "(" None
                   LIST@22..22
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@22..23 ")"
                 WHITESPACE@23..24 " "
@@ -37,14 +38,21 @@ MODULE@0..47
                       WHITESPACE@36..37 " "
 =======
                    R_PAREN@22..24 ")" " "
+=======
+                  None R_PAREN@22..24 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                 BLOCK_STMT@24..45
-                   L_CURLY@24..25 "{" 
+                  None L_CURLY@24..25 "{" None
                   LIST@25..41
                     RETURN_STMT@25..41
+<<<<<<< HEAD
                       "\n    " RETURN_KW@25..37 "return" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                      Whitespace(5) RETURN_KW@25..37 "return" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                       NAME_REF@37..40
-                         IDENT@37..40 "foo" 
-                       SEMICOLON@40..41 ";" 
-                  "\n  " R_CURLY@41..45 "}" 
-            "\n" R_CURLY@45..47 "}" 
+                        None IDENT@37..40 "foo" None
+                      None SEMICOLON@40..41 ";" None
+                  Whitespace(3) R_CURLY@41..45 "}" None
+            Whitespace(1) R_CURLY@45..47 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -1,31 +1,31 @@
+<<<<<<< HEAD
 JS_MODULE@0..48
+=======
+MODULE@0..47
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..47
     VAR_DECL@0..47
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..47
         DECLARATOR@4..47
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..47
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..12 "\n  "
-            LIST@12..45
-              GETTER@12..45
-                GET_KW@12..15 "get"
-                WHITESPACE@15..16 " "
+             L_CURLY@8..9 "{" 
+            LIST@9..45
+              GETTER@9..45
+                "\n  " GET_KW@9..16 "get" " "
                 COMPUTED_PROPERTY_NAME@16..21
-                  L_BRACK@16..17 "["
+                   L_BRACK@16..17 "[" 
                   NAME_REF@17..20
-                    IDENT@17..20 "foo"
-                  R_BRACK@20..21 "]"
-                PARAMETER_LIST@21..23
-                  L_PAREN@21..22 "("
+                     IDENT@17..20 "foo" 
+                   R_BRACK@20..21 "]" 
+                PARAMETER_LIST@21..24
+                   L_PAREN@21..22 "(" 
                   LIST@22..22
+<<<<<<< HEAD
                   R_PAREN@22..23 ")"
                 WHITESPACE@23..24 " "
                 JS_BLOCK_STATEMENT@24..45
@@ -35,11 +35,16 @@ JS_MODULE@0..48
                     JS_RETURN_STATEMENT@30..41
                       RETURN_KW@30..36 "return"
                       WHITESPACE@36..37 " "
+=======
+                   R_PAREN@22..24 ")" " "
+                BLOCK_STMT@24..45
+                   L_CURLY@24..25 "{" 
+                  LIST@25..41
+                    RETURN_STMT@25..41
+                      "\n    " RETURN_KW@25..37 "return" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                       NAME_REF@37..40
-                        IDENT@37..40 "foo"
-                      SEMICOLON@40..41 ";"
-                  WHITESPACE@41..44 "\n  "
-                  R_CURLY@44..45 "}"
-            WHITESPACE@45..46 "\n"
-            R_CURLY@46..47 "}"
-  WHITESPACE@47..48 "\n"
+                         IDENT@37..40 "foo" 
+                       SEMICOLON@40..41 ";" 
+                  "\n  " R_CURLY@41..45 "}" 
+            "\n" R_CURLY@45..47 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..20
-=======
-MODULE@0..19
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..19
   LIST@0..19
     VAR_DECL@0..19
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -5,20 +5,20 @@ MODULE@0..19
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..19
     VAR_DECL@0..19
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..19
         DECLARATOR@4..19
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..19
-             L_CURLY@8..10 "{" " "
+            None L_CURLY@8..10 "{" Whitespace(1)
             LIST@10..18
               LITERAL_PROP@10..18
                 NAME@10..11
-                   IDENT@10..11 "a" 
-                 COLON@11..13 ":" " "
+                  None IDENT@10..11 "a" None
+                None COLON@11..13 ":" Whitespace(1)
                 LITERAL@13..18
-                   TRUE_KW@13..18 "true" " "
-             R_CURLY@18..19 "}" 
+                  None TRUE_KW@13..18 "true" Whitespace(1)
+            None R_CURLY@18..19 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -1,27 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..20
+=======
+MODULE@0..19
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..19
     VAR_DECL@0..19
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..19
         DECLARATOR@4..19
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..19
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..10 " "
-            LIST@10..17
-              LITERAL_PROP@10..17
+             L_CURLY@8..10 "{" " "
+            LIST@10..18
+              LITERAL_PROP@10..18
                 NAME@10..11
-                  IDENT@10..11 "a"
-                COLON@11..12 ":"
-                WHITESPACE@12..13 " "
-                LITERAL@13..17
-                  TRUE_KW@13..17 "true"
-            WHITESPACE@17..18 " "
-            R_CURLY@18..19 "}"
-  WHITESPACE@19..20 "\n"
+                   IDENT@10..11 "a" 
+                 COLON@11..13 ":" " "
+                LITERAL@13..18
+                   TRUE_KW@13..18 "true" " "
+             R_CURLY@18..19 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -5,20 +5,20 @@ MODULE@0..19
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..19
     VAR_DECL@0..19
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..19
         DECLARATOR@4..19
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..19
-            None L_CURLY@8..10 "{" Whitespace(1)
+            None L_CURLY@8..9 "{" Whitespace(1)
             LIST@10..18
               LITERAL_PROP@10..18
                 NAME@10..11
                   None IDENT@10..11 "a" None
-                None COLON@11..13 ":" Whitespace(1)
+                None COLON@11..12 ":" Whitespace(1)
                 LITERAL@13..18
-                  None TRUE_KW@13..18 "true" Whitespace(1)
+                  None TRUE_KW@13..17 "true" Whitespace(1)
             None R_CURLY@18..19 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -5,13 +5,13 @@ MODULE@0..13
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     VAR_DECL@0..13
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..13
             None L_CURLY@8..9 "{" None
             LIST@9..12

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -5,17 +5,17 @@ MODULE@0..13
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     VAR_DECL@0..13
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..13
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..12
               IDENT_PROP@9..12
                 NAME@9..12
-                   IDENT@9..12 "foo" 
-             R_CURLY@12..13 "}" 
+                  None IDENT@9..12 "foo" None
+            None R_CURLY@12..13 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -1,21 +1,21 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     VAR_DECL@0..13
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..13
         DECLARATOR@4..13
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..13
-            L_CURLY@8..9 "{"
+             L_CURLY@8..9 "{" 
             LIST@9..12
               IDENT_PROP@9..12
                 NAME@9..12
-                  IDENT@9..12 "foo"
-            R_CURLY@12..13 "}"
-  WHITESPACE@13..14 "\n"
+                   IDENT@9..12 "foo" 
+             R_CURLY@12..13 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     VAR_DECL@0..13
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -5,22 +5,23 @@ MODULE@0..22
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..22
     VAR_DECL@0..22
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..22
         DECLARATOR@4..22
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "b" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "b" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..22
             None L_CURLY@8..9 "{" None
             LIST@9..20
               METHOD@9..19
                 NAME@9..14
-                  Whitespace(2) IDENT@9..14 "foo" None
+                  Whitespace(2) IDENT@11..14 "foo" None
                 PARAMETER_LIST@14..17
                   None L_PAREN@14..15 "(" None
                   LIST@15..15
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@15..16 ")"
@@ -34,10 +35,13 @@ MODULE@0..22
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                   None R_PAREN@15..17 ")" Whitespace(1)
+=======
+                  None R_PAREN@15..16 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
                 BLOCK_STMT@17..19
                   None L_CURLY@17..18 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
                   None R_CURLY@18..19 "}" None
               None COMMA@19..20 "," None
-            Whitespace(1) R_CURLY@20..22 "}" None
+            Whitespace(1) R_CURLY@21..22 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -5,22 +5,23 @@ MODULE@0..22
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..22
     VAR_DECL@0..22
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..22
         DECLARATOR@4..22
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "b" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "b" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..22
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..20
               METHOD@9..19
                 NAME@9..14
-                  "\n " IDENT@9..14 "foo" 
+                  Whitespace(2) IDENT@9..14 "foo" None
                 PARAMETER_LIST@14..17
-                   L_PAREN@14..15 "(" 
+                  None L_PAREN@14..15 "(" None
                   LIST@15..15
+<<<<<<< HEAD
 <<<<<<< HEAD
                   R_PAREN@15..16 ")"
                 WHITESPACE@16..17 " "
@@ -31,7 +32,12 @@ MODULE@0..22
                 BLOCK_STMT@17..19
                    L_CURLY@17..18 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                  None R_PAREN@15..17 ")" Whitespace(1)
+                BLOCK_STMT@17..19
+                  None L_CURLY@17..18 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
-                   R_CURLY@18..19 "}" 
-               COMMA@19..20 "," 
-            "\n" R_CURLY@20..22 "}" 
+                  None R_CURLY@18..19 "}" None
+              None COMMA@19..20 "," None
+            Whitespace(1) R_CURLY@20..22 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -1,33 +1,37 @@
+<<<<<<< HEAD
 JS_MODULE@0..23
+=======
+MODULE@0..22
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..22
     VAR_DECL@0..22
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..22
         DECLARATOR@4..22
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "b"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "b" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..22
-            L_CURLY@8..9 "{"
-            WHITESPACE@9..11 "\n "
-            LIST@11..20
-              METHOD@11..19
-                NAME@11..14
-                  IDENT@11..14 "foo"
-                PARAMETER_LIST@14..16
-                  L_PAREN@14..15 "("
+             L_CURLY@8..9 "{" 
+            LIST@9..20
+              METHOD@9..19
+                NAME@9..14
+                  "\n " IDENT@9..14 "foo" 
+                PARAMETER_LIST@14..17
+                   L_PAREN@14..15 "(" 
                   LIST@15..15
+<<<<<<< HEAD
                   R_PAREN@15..16 ")"
                 WHITESPACE@16..17 " "
                 JS_BLOCK_STATEMENT@17..19
                   L_CURLY@17..18 "{"
+=======
+                   R_PAREN@15..17 ")" " "
+                BLOCK_STMT@17..19
+                   L_CURLY@17..18 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
                   LIST@18..18
-                  R_CURLY@18..19 "}"
-              COMMA@19..20 ","
-            WHITESPACE@20..21 "\n"
-            R_CURLY@21..22 "}"
-  WHITESPACE@22..23 "\n"
+                   R_CURLY@18..19 "}" 
+               COMMA@19..20 "," 
+            "\n" R_CURLY@20..22 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..23
-=======
-MODULE@0..22
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..22
   LIST@0..22
     VAR_DECL@0..22
       None IDENT@0..3 "let" Whitespace(1)
@@ -21,26 +17,9 @@ MODULE@0..22
                 PARAMETER_LIST@14..17
                   None L_PAREN@14..15 "(" None
                   LIST@15..15
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  R_PAREN@15..16 ")"
-                WHITESPACE@16..17 " "
-                JS_BLOCK_STATEMENT@17..19
-                  L_CURLY@17..18 "{"
-=======
-                   R_PAREN@15..17 ")" " "
-                BLOCK_STMT@17..19
-                   L_CURLY@17..18 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                  None R_PAREN@15..17 ")" Whitespace(1)
-=======
                   None R_PAREN@15..16 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-                BLOCK_STMT@17..19
+                JS_BLOCK_STATEMENT@17..19
                   None L_CURLY@17..18 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
                   LIST@18..18
                   None R_CURLY@18..19 "}" None
               None COMMA@19..20 "," None

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -1,22 +1,22 @@
+<<<<<<< HEAD
 JS_MODULE@0..17
+=======
+MODULE@0..16
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..16
     VAR_DECL@0..16
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..16
         DECLARATOR@4..16
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..16
-            L_CURLY@8..9 "{"
+             L_CURLY@8..9 "{" 
             LIST@9..15
               SPREAD_PROP@9..15
-                DOT2@9..12 "..."
+                 DOT2@9..12 "..." 
                 NAME_REF@12..15
-                  IDENT@12..15 "foo"
-            R_CURLY@15..16 "}"
-  WHITESPACE@16..17 "\n"
+                   IDENT@12..15 "foo" 
+             R_CURLY@15..16 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..17
-=======
-MODULE@0..16
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..16
   LIST@0..16
     VAR_DECL@0..16
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -5,13 +5,13 @@ MODULE@0..16
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..16
     VAR_DECL@0..16
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..16
             None L_CURLY@8..9 "{" None
             LIST@9..15

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -5,18 +5,18 @@ MODULE@0..16
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..16
     VAR_DECL@0..16
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..16
         DECLARATOR@4..16
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..16
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..15
               SPREAD_PROP@9..15
-                 DOT2@9..12 "..." 
+                None DOT2@9..12 "..." None
                 NAME_REF@12..15
-                   IDENT@12..15 "foo" 
-             R_CURLY@15..16 "}" 
+                  None IDENT@12..15 "foo" None
+            None R_CURLY@15..16 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -5,48 +5,48 @@ MODULE@0..52
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..52
     VAR_DECL@0..52
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..52
         DECLARATOR@4..52
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           OBJECT_EXPR@8..52
-             L_CURLY@8..9 "{" 
+            None L_CURLY@8..9 "{" None
             LIST@9..51
               LITERAL_PROP@9..19
                 LITERAL@9..14
-                   STRING@9..14 "\"foo\"" 
-                 COLON@14..16 ":" " "
+                  None STRING@9..14 "\"foo\"" None
+                None COLON@14..16 ":" Whitespace(1)
                 NAME_REF@16..19
-                   IDENT@16..19 "foo" 
-               COMMA@19..21 "," " "
+                  None IDENT@16..19 "foo" None
+              None COMMA@19..21 "," Whitespace(1)
               LITERAL_PROP@21..33
                 COMPUTED_PROPERTY_NAME@21..28
-                   L_BRACK@21..22 "[" 
+                  None L_BRACK@21..22 "[" None
                   BIN_EXPR@22..27
                     LITERAL@22..24
-                       NUMBER@22..24 "6" " "
-                     PLUS@24..26 "+" " "
+                      None NUMBER@22..24 "6" Whitespace(1)
+                    None PLUS@24..26 "+" Whitespace(1)
                     LITERAL@26..27
-                       NUMBER@26..27 "6" 
-                   R_BRACK@27..28 "]" 
-                 COLON@28..30 ":" " "
+                      None NUMBER@26..27 "6" None
+                  None R_BRACK@27..28 "]" None
+                None COLON@28..30 ":" Whitespace(1)
                 NAME_REF@30..33
-                   IDENT@30..33 "foo" 
-               COMMA@33..35 "," " "
+                  None IDENT@30..33 "foo" None
+              None COMMA@33..35 "," Whitespace(1)
               LITERAL_PROP@35..43
                 NAME@35..38
-                   IDENT@35..38 "bar" 
-                 COLON@38..40 ":" " "
+                  None IDENT@35..38 "bar" None
+                None COLON@38..40 ":" Whitespace(1)
                 NAME_REF@40..43
-                   IDENT@40..43 "foo" 
-               COMMA@43..45 "," " "
+                  None IDENT@40..43 "foo" None
+              None COMMA@43..45 "," Whitespace(1)
               LITERAL_PROP@45..51
                 LITERAL@45..46
-                   NUMBER@45..46 "7" 
-                 COLON@46..48 ":" " "
+                  None NUMBER@45..46 "7" None
+                None COLON@46..48 ":" Whitespace(1)
                 NAME_REF@48..51
-                   IDENT@48..51 "foo" 
-             R_CURLY@51..52 "}" 
+                  None IDENT@48..51 "foo" None
+            None R_CURLY@51..52 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -5,48 +5,48 @@ MODULE@0..52
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..52
     VAR_DECL@0..52
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..52
         DECLARATOR@4..52
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           OBJECT_EXPR@8..52
             None L_CURLY@8..9 "{" None
             LIST@9..51
               LITERAL_PROP@9..19
                 LITERAL@9..14
                   None STRING@9..14 "\"foo\"" None
-                None COLON@14..16 ":" Whitespace(1)
+                None COLON@14..15 ":" Whitespace(1)
                 NAME_REF@16..19
                   None IDENT@16..19 "foo" None
-              None COMMA@19..21 "," Whitespace(1)
+              None COMMA@19..20 "," Whitespace(1)
               LITERAL_PROP@21..33
                 COMPUTED_PROPERTY_NAME@21..28
                   None L_BRACK@21..22 "[" None
                   BIN_EXPR@22..27
                     LITERAL@22..24
-                      None NUMBER@22..24 "6" Whitespace(1)
-                    None PLUS@24..26 "+" Whitespace(1)
+                      None NUMBER@22..23 "6" Whitespace(1)
+                    None PLUS@24..25 "+" Whitespace(1)
                     LITERAL@26..27
                       None NUMBER@26..27 "6" None
                   None R_BRACK@27..28 "]" None
-                None COLON@28..30 ":" Whitespace(1)
+                None COLON@28..29 ":" Whitespace(1)
                 NAME_REF@30..33
                   None IDENT@30..33 "foo" None
-              None COMMA@33..35 "," Whitespace(1)
+              None COMMA@33..34 "," Whitespace(1)
               LITERAL_PROP@35..43
                 NAME@35..38
                   None IDENT@35..38 "bar" None
-                None COLON@38..40 ":" Whitespace(1)
+                None COLON@38..39 ":" Whitespace(1)
                 NAME_REF@40..43
                   None IDENT@40..43 "foo" None
-              None COMMA@43..45 "," Whitespace(1)
+              None COMMA@43..44 "," Whitespace(1)
               LITERAL_PROP@45..51
                 LITERAL@45..46
                   None NUMBER@45..46 "7" None
-                None COLON@46..48 ":" Whitespace(1)
+                None COLON@46..47 ":" Whitespace(1)
                 NAME_REF@48..51
                   None IDENT@48..51 "foo" None
             None R_CURLY@51..52 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..53
-=======
-MODULE@0..52
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..52
   LIST@0..52
     VAR_DECL@0..52
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -1,61 +1,52 @@
+<<<<<<< HEAD
 JS_MODULE@0..53
+=======
+MODULE@0..52
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..52
     VAR_DECL@0..52
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..52
         DECLARATOR@4..52
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           OBJECT_EXPR@8..52
-            L_CURLY@8..9 "{"
+             L_CURLY@8..9 "{" 
             LIST@9..51
               LITERAL_PROP@9..19
                 LITERAL@9..14
-                  STRING@9..14 "\"foo\""
-                COLON@14..15 ":"
-                WHITESPACE@15..16 " "
+                   STRING@9..14 "\"foo\"" 
+                 COLON@14..16 ":" " "
                 NAME_REF@16..19
-                  IDENT@16..19 "foo"
-              COMMA@19..20 ","
-              WHITESPACE@20..21 " "
+                   IDENT@16..19 "foo" 
+               COMMA@19..21 "," " "
               LITERAL_PROP@21..33
                 COMPUTED_PROPERTY_NAME@21..28
-                  L_BRACK@21..22 "["
+                   L_BRACK@21..22 "[" 
                   BIN_EXPR@22..27
-                    LITERAL@22..23
-                      NUMBER@22..23 "6"
-                    WHITESPACE@23..24 " "
-                    PLUS@24..25 "+"
-                    WHITESPACE@25..26 " "
+                    LITERAL@22..24
+                       NUMBER@22..24 "6" " "
+                     PLUS@24..26 "+" " "
                     LITERAL@26..27
-                      NUMBER@26..27 "6"
-                  R_BRACK@27..28 "]"
-                COLON@28..29 ":"
-                WHITESPACE@29..30 " "
+                       NUMBER@26..27 "6" 
+                   R_BRACK@27..28 "]" 
+                 COLON@28..30 ":" " "
                 NAME_REF@30..33
-                  IDENT@30..33 "foo"
-              COMMA@33..34 ","
-              WHITESPACE@34..35 " "
+                   IDENT@30..33 "foo" 
+               COMMA@33..35 "," " "
               LITERAL_PROP@35..43
                 NAME@35..38
-                  IDENT@35..38 "bar"
-                COLON@38..39 ":"
-                WHITESPACE@39..40 " "
+                   IDENT@35..38 "bar" 
+                 COLON@38..40 ":" " "
                 NAME_REF@40..43
-                  IDENT@40..43 "foo"
-              COMMA@43..44 ","
-              WHITESPACE@44..45 " "
+                   IDENT@40..43 "foo" 
+               COMMA@43..45 "," " "
               LITERAL_PROP@45..51
                 LITERAL@45..46
-                  NUMBER@45..46 "7"
-                COLON@46..47 ":"
-                WHITESPACE@47..48 " "
+                   NUMBER@45..46 "7" 
+                 COLON@46..48 ":" " "
                 NAME_REF@48..51
-                  IDENT@48..51 "foo"
-            R_CURLY@51..52 "}"
-  WHITESPACE@52..53 "\n"
+                   IDENT@48..51 "foo" 
+             R_CURLY@51..52 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -1,50 +1,13 @@
-<<<<<<< HEAD
-JS_MODULE@0..85
-=======
-MODULE@0..84
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..84
   LIST@0..84
     JS_EXPRESSION_STATEMENT@0..6
       GROUPING_EXPR@0..5
         None L_PAREN@0..1 "(" None
         NAME_REF@1..4
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@1..4 "foo"
-        R_PAREN@4..5 ")"
-      SEMICOLON@5..6 ";"
-    WHITESPACE@6..7 "\n"
-    JS_EXPRESSION_STATEMENT@7..19
-      ARROW_EXPR@7..18
-        PARAMETER_LIST@7..12
-          L_PAREN@7..8 "("
-          LIST@8..11
-            SINGLE_PATTERN@8..11
-              NAME@8..11
-                IDENT@8..11 "foo"
-          R_PAREN@11..12 ")"
-        WHITESPACE@12..13 " "
-        FAT_ARROW@13..15 "=>"
-        WHITESPACE@15..16 " "
-        JS_BLOCK_STATEMENT@16..18
-          L_CURLY@16..17 "{"
-          LIST@17..17
-          R_CURLY@17..18 "}"
-      SEMICOLON@18..19 ";"
-    WHITESPACE@19..20 "\n"
-    JS_EXPRESSION_STATEMENT@20..28
-      GROUPING_EXPR@20..27
-        L_PAREN@20..21 "("
-=======
-           IDENT@1..4 "foo" 
-         R_PAREN@4..5 ")" 
-       SEMICOLON@5..6 ";" 
-=======
           None IDENT@1..4 "foo" None
         None R_PAREN@4..5 ")" None
       None SEMICOLON@5..6 ";" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@6..19
+    JS_EXPRESSION_STATEMENT@6..19
       ARROW_EXPR@6..18
         PARAMETER_LIST@6..13
           Whitespace(1) L_PAREN@7..8 "(" None
@@ -54,60 +17,26 @@ MODULE@0..84
                 None IDENT@8..11 "foo" None
           None R_PAREN@11..12 ")" Whitespace(1)
         None FAT_ARROW@13..15 "=>" Whitespace(1)
-        BLOCK_STMT@16..18
+        JS_BLOCK_STATEMENT@16..18
           None L_CURLY@16..17 "{" None
           LIST@17..17
           None R_CURLY@17..18 "}" None
       None SEMICOLON@18..19 ";" None
-    EXPR_STMT@19..28
+    JS_EXPRESSION_STATEMENT@19..28
       GROUPING_EXPR@19..27
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "\n" L_PAREN@19..21 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-        Whitespace(1) L_PAREN@19..21 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) L_PAREN@20..21 "(" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@21..26
           LITERAL@21..23
             None NUMBER@21..22 "5" Whitespace(1)
           None PLUS@23..24 "+" Whitespace(1)
           LITERAL@25..26
-<<<<<<< HEAD
-<<<<<<< HEAD
-            NUMBER@25..26 "5"
-        R_PAREN@26..27 ")"
-      SEMICOLON@27..28 ";"
-    WHITESPACE@28..29 "\n"
-    JS_EXPRESSION_STATEMENT@29..64
-      ARROW_EXPR@29..63
-        PARAMETER_LIST@29..57
-          L_PAREN@29..30 "("
-=======
-             NUMBER@25..26 "5" 
-         R_PAREN@26..27 ")" 
-       SEMICOLON@27..28 ";" 
-    EXPR_STMT@28..64
-      ARROW_EXPR@28..63
-        PARAMETER_LIST@28..58
-          "\n" L_PAREN@28..30 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
             None NUMBER@25..26 "5" None
         None R_PAREN@26..27 ")" None
       None SEMICOLON@27..28 ";" None
-    EXPR_STMT@28..64
+    JS_EXPRESSION_STATEMENT@28..64
       ARROW_EXPR@28..63
         PARAMETER_LIST@28..58
-<<<<<<< HEAD
-          Whitespace(1) L_PAREN@28..30 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) L_PAREN@29..30 "(" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@30..56
             OBJECT_PATTERN@30..56
               None L_CURLY@30..31 "{" None
@@ -135,61 +64,20 @@ MODULE@0..84
                         None DOT2@48..51 "..." None
                         SINGLE_PATTERN@51..54
                           NAME@51..54
-<<<<<<< HEAD
-<<<<<<< HEAD
-                            IDENT@51..54 "baz"
-                    R_BRACK@54..55 "]"
-              R_CURLY@55..56 "}"
-          R_PAREN@56..57 ")"
-        WHITESPACE@57..58 " "
-        FAT_ARROW@58..60 "=>"
-        WHITESPACE@60..61 " "
-        JS_BLOCK_STATEMENT@61..63
-          L_CURLY@61..62 "{"
-          LIST@62..62
-          R_CURLY@62..63 "}"
-      SEMICOLON@63..64 ";"
-    WHITESPACE@64..65 "\n"
-    JS_EXPRESSION_STATEMENT@65..84
-      ARROW_EXPR@65..84
-        PARAMETER_LIST@65..78
-          L_PAREN@65..66 "("
-=======
-                             IDENT@51..54 "baz" 
-                     R_BRACK@54..55 "]" 
-               R_CURLY@55..56 "}" 
-           R_PAREN@56..58 ")" " "
-         FAT_ARROW@58..61 "=>" " "
-=======
                             None IDENT@51..54 "baz" None
                     None R_BRACK@54..55 "]" None
               None R_CURLY@55..56 "}" None
-<<<<<<< HEAD
-          None R_PAREN@56..58 ")" Whitespace(1)
-        None FAT_ARROW@58..61 "=>" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           None R_PAREN@56..57 ")" Whitespace(1)
         None FAT_ARROW@58..60 "=>" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-        BLOCK_STMT@61..63
+        JS_BLOCK_STATEMENT@61..63
           None L_CURLY@61..62 "{" None
           LIST@62..62
           None R_CURLY@62..63 "}" None
       None SEMICOLON@63..64 ";" None
-    EXPR_STMT@64..84
+    JS_EXPRESSION_STATEMENT@64..84
       ARROW_EXPR@64..84
         PARAMETER_LIST@64..79
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "\n" L_PAREN@64..66 "(" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          Whitespace(1) L_PAREN@64..66 "(" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           Whitespace(1) L_PAREN@65..66 "(" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@66..77
             SINGLE_PATTERN@66..69
               NAME@66..69
@@ -199,28 +87,10 @@ MODULE@0..84
               None DOT2@71..74 "..." None
               SINGLE_PATTERN@74..77
                 NAME@74..77
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  IDENT@74..77 "bar"
-          R_PAREN@77..78 ")"
-        WHITESPACE@78..79 " "
-        FAT_ARROW@79..81 "=>"
-        WHITESPACE@81..82 " "
-        JS_BLOCK_STATEMENT@82..84
-          L_CURLY@82..83 "{"
-=======
-                   IDENT@74..77 "bar" 
-           R_PAREN@77..79 ")" " "
-         FAT_ARROW@79..82 "=>" " "
-        BLOCK_STMT@82..84
-           L_CURLY@82..83 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
                   None IDENT@74..77 "bar" None
           None R_PAREN@77..78 ")" Whitespace(1)
         None FAT_ARROW@79..81 "=>" Whitespace(1)
-        BLOCK_STMT@82..84
+        JS_BLOCK_STATEMENT@82..84
           None L_CURLY@82..83 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@83..83
           None R_CURLY@83..84 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -47,13 +47,13 @@ MODULE@0..84
     EXPR_STMT@6..19
       ARROW_EXPR@6..18
         PARAMETER_LIST@6..13
-          Whitespace(1) L_PAREN@6..8 "(" None
+          Whitespace(1) L_PAREN@7..8 "(" None
           LIST@8..11
             SINGLE_PATTERN@8..11
               NAME@8..11
                 None IDENT@8..11 "foo" None
-          None R_PAREN@11..13 ")" Whitespace(1)
-        None FAT_ARROW@13..16 "=>" Whitespace(1)
+          None R_PAREN@11..12 ")" Whitespace(1)
+        None FAT_ARROW@13..15 "=>" Whitespace(1)
         BLOCK_STMT@16..18
           None L_CURLY@16..17 "{" None
           LIST@17..17
@@ -62,15 +62,19 @@ MODULE@0..84
     EXPR_STMT@19..28
       GROUPING_EXPR@19..27
 <<<<<<< HEAD
+<<<<<<< HEAD
         "\n" L_PAREN@19..21 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
         Whitespace(1) L_PAREN@19..21 "(" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) L_PAREN@20..21 "(" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BIN_EXPR@21..26
           LITERAL@21..23
-            None NUMBER@21..23 "5" Whitespace(1)
-          None PLUS@23..25 "+" Whitespace(1)
+            None NUMBER@21..22 "5" Whitespace(1)
+          None PLUS@23..24 "+" Whitespace(1)
           LITERAL@25..26
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -98,8 +102,12 @@ MODULE@0..84
     EXPR_STMT@28..64
       ARROW_EXPR@28..63
         PARAMETER_LIST@28..58
+<<<<<<< HEAD
           Whitespace(1) L_PAREN@28..30 "(" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) L_PAREN@29..30 "(" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@30..56
             OBJECT_PATTERN@30..56
               None L_CURLY@30..31 "{" None
@@ -107,22 +115,22 @@ MODULE@0..84
                 SINGLE_PATTERN@31..34
                   NAME@31..34
                     None IDENT@31..34 "foo" None
-                None COMMA@34..36 "," Whitespace(1)
+                None COMMA@34..35 "," Whitespace(1)
                 SINGLE_PATTERN@36..39
                   NAME@36..39
                     None IDENT@36..39 "bar" None
-                None COMMA@39..41 "," Whitespace(1)
+                None COMMA@39..40 "," Whitespace(1)
                 KEY_VALUE_PATTERN@41..55
                   NAME@41..42
                     None IDENT@41..42 "b" None
-                  None COLON@42..44 ":" Whitespace(1)
+                  None COLON@42..43 ":" Whitespace(1)
                   ARRAY_PATTERN@44..55
                     None L_BRACK@44..45 "[" None
                     LIST@45..54
                       SINGLE_PATTERN@45..46
                         NAME@45..46
                           None IDENT@45..46 "f" None
-                      None COMMA@46..48 "," Whitespace(1)
+                      None COMMA@46..47 "," Whitespace(1)
                       REST_PATTERN@48..54
                         None DOT2@48..51 "..." None
                         SINGLE_PATTERN@51..54
@@ -156,9 +164,14 @@ MODULE@0..84
                             None IDENT@51..54 "baz" None
                     None R_BRACK@54..55 "]" None
               None R_CURLY@55..56 "}" None
+<<<<<<< HEAD
           None R_PAREN@56..58 ")" Whitespace(1)
         None FAT_ARROW@58..61 "=>" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          None R_PAREN@56..57 ")" Whitespace(1)
+        None FAT_ARROW@58..60 "=>" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BLOCK_STMT@61..63
           None L_CURLY@61..62 "{" None
           LIST@62..62
@@ -168,16 +181,20 @@ MODULE@0..84
       ARROW_EXPR@64..84
         PARAMETER_LIST@64..79
 <<<<<<< HEAD
+<<<<<<< HEAD
           "\n" L_PAREN@64..66 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           Whitespace(1) L_PAREN@64..66 "(" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          Whitespace(1) L_PAREN@65..66 "(" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
           LIST@66..77
             SINGLE_PATTERN@66..69
               NAME@66..69
                 None IDENT@66..69 "foo" None
-            None COMMA@69..71 "," Whitespace(1)
+            None COMMA@69..70 "," Whitespace(1)
             REST_PATTERN@71..77
               None DOT2@71..74 "..." None
               SINGLE_PATTERN@74..77
@@ -200,8 +217,8 @@ MODULE@0..84
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                   None IDENT@74..77 "bar" None
-          None R_PAREN@77..79 ")" Whitespace(1)
-        None FAT_ARROW@79..82 "=>" Whitespace(1)
+          None R_PAREN@77..78 ")" Whitespace(1)
+        None FAT_ARROW@79..81 "=>" Whitespace(1)
         BLOCK_STMT@82..84
           None L_CURLY@82..83 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -6,8 +6,9 @@ MODULE@0..84
   LIST@0..84
     JS_EXPRESSION_STATEMENT@0..6
       GROUPING_EXPR@0..5
-         L_PAREN@0..1 "(" 
+        None L_PAREN@0..1 "(" None
         NAME_REF@1..4
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@1..4 "foo"
         R_PAREN@4..5 ")"
@@ -38,30 +39,40 @@ MODULE@0..84
            IDENT@1..4 "foo" 
          R_PAREN@4..5 ")" 
        SEMICOLON@5..6 ";" 
+=======
+          None IDENT@1..4 "foo" None
+        None R_PAREN@4..5 ")" None
+      None SEMICOLON@5..6 ";" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@6..19
       ARROW_EXPR@6..18
         PARAMETER_LIST@6..13
-          "\n" L_PAREN@6..8 "(" 
+          Whitespace(1) L_PAREN@6..8 "(" None
           LIST@8..11
             SINGLE_PATTERN@8..11
               NAME@8..11
-                 IDENT@8..11 "foo" 
-           R_PAREN@11..13 ")" " "
-         FAT_ARROW@13..16 "=>" " "
+                None IDENT@8..11 "foo" None
+          None R_PAREN@11..13 ")" Whitespace(1)
+        None FAT_ARROW@13..16 "=>" Whitespace(1)
         BLOCK_STMT@16..18
-           L_CURLY@16..17 "{" 
+          None L_CURLY@16..17 "{" None
           LIST@17..17
-           R_CURLY@17..18 "}" 
-       SEMICOLON@18..19 ";" 
+          None R_CURLY@17..18 "}" None
+      None SEMICOLON@18..19 ";" None
     EXPR_STMT@19..28
       GROUPING_EXPR@19..27
+<<<<<<< HEAD
         "\n" L_PAREN@19..21 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        Whitespace(1) L_PAREN@19..21 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BIN_EXPR@21..26
           LITERAL@21..23
-             NUMBER@21..23 "5" " "
-           PLUS@23..25 "+" " "
+            None NUMBER@21..23 "5" Whitespace(1)
+          None PLUS@23..25 "+" Whitespace(1)
           LITERAL@25..26
+<<<<<<< HEAD
 <<<<<<< HEAD
             NUMBER@25..26 "5"
         R_PAREN@26..27 ")"
@@ -80,33 +91,43 @@ MODULE@0..84
         PARAMETER_LIST@28..58
           "\n" L_PAREN@28..30 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+            None NUMBER@25..26 "5" None
+        None R_PAREN@26..27 ")" None
+      None SEMICOLON@27..28 ";" None
+    EXPR_STMT@28..64
+      ARROW_EXPR@28..63
+        PARAMETER_LIST@28..58
+          Whitespace(1) L_PAREN@28..30 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@30..56
             OBJECT_PATTERN@30..56
-               L_CURLY@30..31 "{" 
+              None L_CURLY@30..31 "{" None
               LIST@31..55
                 SINGLE_PATTERN@31..34
                   NAME@31..34
-                     IDENT@31..34 "foo" 
-                 COMMA@34..36 "," " "
+                    None IDENT@31..34 "foo" None
+                None COMMA@34..36 "," Whitespace(1)
                 SINGLE_PATTERN@36..39
                   NAME@36..39
-                     IDENT@36..39 "bar" 
-                 COMMA@39..41 "," " "
+                    None IDENT@36..39 "bar" None
+                None COMMA@39..41 "," Whitespace(1)
                 KEY_VALUE_PATTERN@41..55
                   NAME@41..42
-                     IDENT@41..42 "b" 
-                   COLON@42..44 ":" " "
+                    None IDENT@41..42 "b" None
+                  None COLON@42..44 ":" Whitespace(1)
                   ARRAY_PATTERN@44..55
-                     L_BRACK@44..45 "[" 
+                    None L_BRACK@44..45 "[" None
                     LIST@45..54
                       SINGLE_PATTERN@45..46
                         NAME@45..46
-                           IDENT@45..46 "f" 
-                       COMMA@46..48 "," " "
+                          None IDENT@45..46 "f" None
+                      None COMMA@46..48 "," Whitespace(1)
                       REST_PATTERN@48..54
-                         DOT2@48..51 "..." 
+                        None DOT2@48..51 "..." None
                         SINGLE_PATTERN@51..54
                           NAME@51..54
+<<<<<<< HEAD
 <<<<<<< HEAD
                             IDENT@51..54 "baz"
                     R_BRACK@54..55 "]"
@@ -131,25 +152,37 @@ MODULE@0..84
                R_CURLY@55..56 "}" 
            R_PAREN@56..58 ")" " "
          FAT_ARROW@58..61 "=>" " "
+=======
+                            None IDENT@51..54 "baz" None
+                    None R_BRACK@54..55 "]" None
+              None R_CURLY@55..56 "}" None
+          None R_PAREN@56..58 ")" Whitespace(1)
+        None FAT_ARROW@58..61 "=>" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BLOCK_STMT@61..63
-           L_CURLY@61..62 "{" 
+          None L_CURLY@61..62 "{" None
           LIST@62..62
-           R_CURLY@62..63 "}" 
-       SEMICOLON@63..64 ";" 
+          None R_CURLY@62..63 "}" None
+      None SEMICOLON@63..64 ";" None
     EXPR_STMT@64..84
       ARROW_EXPR@64..84
         PARAMETER_LIST@64..79
+<<<<<<< HEAD
           "\n" L_PAREN@64..66 "(" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          Whitespace(1) L_PAREN@64..66 "(" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@66..77
             SINGLE_PATTERN@66..69
               NAME@66..69
-                 IDENT@66..69 "foo" 
-             COMMA@69..71 "," " "
+                None IDENT@66..69 "foo" None
+            None COMMA@69..71 "," Whitespace(1)
             REST_PATTERN@71..77
-               DOT2@71..74 "..." 
+              None DOT2@71..74 "..." None
               SINGLE_PATTERN@74..77
                 NAME@74..77
+<<<<<<< HEAD
 <<<<<<< HEAD
                   IDENT@74..77 "bar"
           R_PAREN@77..78 ")"
@@ -165,5 +198,12 @@ MODULE@0..84
         BLOCK_STMT@82..84
            L_CURLY@82..83 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                  None IDENT@74..77 "bar" None
+          None R_PAREN@77..79 ")" Whitespace(1)
+        None FAT_ARROW@79..82 "=>" Whitespace(1)
+        BLOCK_STMT@82..84
+          None L_CURLY@82..83 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
           LIST@83..83
-           R_CURLY@83..84 "}" 
+          None R_CURLY@83..84 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -1,9 +1,14 @@
+<<<<<<< HEAD
 JS_MODULE@0..85
+=======
+MODULE@0..84
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..84
     JS_EXPRESSION_STATEMENT@0..6
       GROUPING_EXPR@0..5
-        L_PAREN@0..1 "("
+         L_PAREN@0..1 "(" 
         NAME_REF@1..4
+<<<<<<< HEAD
           IDENT@1..4 "foo"
         R_PAREN@4..5 ")"
       SEMICOLON@5..6 ";"
@@ -29,13 +34,35 @@ JS_MODULE@0..85
     JS_EXPRESSION_STATEMENT@20..28
       GROUPING_EXPR@20..27
         L_PAREN@20..21 "("
+=======
+           IDENT@1..4 "foo" 
+         R_PAREN@4..5 ")" 
+       SEMICOLON@5..6 ";" 
+    EXPR_STMT@6..19
+      ARROW_EXPR@6..18
+        PARAMETER_LIST@6..13
+          "\n" L_PAREN@6..8 "(" 
+          LIST@8..11
+            SINGLE_PATTERN@8..11
+              NAME@8..11
+                 IDENT@8..11 "foo" 
+           R_PAREN@11..13 ")" " "
+         FAT_ARROW@13..16 "=>" " "
+        BLOCK_STMT@16..18
+           L_CURLY@16..17 "{" 
+          LIST@17..17
+           R_CURLY@17..18 "}" 
+       SEMICOLON@18..19 ";" 
+    EXPR_STMT@19..28
+      GROUPING_EXPR@19..27
+        "\n" L_PAREN@19..21 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         BIN_EXPR@21..26
-          LITERAL@21..22
-            NUMBER@21..22 "5"
-          WHITESPACE@22..23 " "
-          PLUS@23..24 "+"
-          WHITESPACE@24..25 " "
+          LITERAL@21..23
+             NUMBER@21..23 "5" " "
+           PLUS@23..25 "+" " "
           LITERAL@25..26
+<<<<<<< HEAD
             NUMBER@25..26 "5"
         R_PAREN@26..27 ")"
       SEMICOLON@27..28 ";"
@@ -44,37 +71,43 @@ JS_MODULE@0..85
       ARROW_EXPR@29..63
         PARAMETER_LIST@29..57
           L_PAREN@29..30 "("
+=======
+             NUMBER@25..26 "5" 
+         R_PAREN@26..27 ")" 
+       SEMICOLON@27..28 ";" 
+    EXPR_STMT@28..64
+      ARROW_EXPR@28..63
+        PARAMETER_LIST@28..58
+          "\n" L_PAREN@28..30 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@30..56
             OBJECT_PATTERN@30..56
-              L_CURLY@30..31 "{"
+               L_CURLY@30..31 "{" 
               LIST@31..55
                 SINGLE_PATTERN@31..34
                   NAME@31..34
-                    IDENT@31..34 "foo"
-                COMMA@34..35 ","
-                WHITESPACE@35..36 " "
+                     IDENT@31..34 "foo" 
+                 COMMA@34..36 "," " "
                 SINGLE_PATTERN@36..39
                   NAME@36..39
-                    IDENT@36..39 "bar"
-                COMMA@39..40 ","
-                WHITESPACE@40..41 " "
+                     IDENT@36..39 "bar" 
+                 COMMA@39..41 "," " "
                 KEY_VALUE_PATTERN@41..55
                   NAME@41..42
-                    IDENT@41..42 "b"
-                  COLON@42..43 ":"
-                  WHITESPACE@43..44 " "
+                     IDENT@41..42 "b" 
+                   COLON@42..44 ":" " "
                   ARRAY_PATTERN@44..55
-                    L_BRACK@44..45 "["
+                     L_BRACK@44..45 "[" 
                     LIST@45..54
                       SINGLE_PATTERN@45..46
                         NAME@45..46
-                          IDENT@45..46 "f"
-                      COMMA@46..47 ","
-                      WHITESPACE@47..48 " "
+                           IDENT@45..46 "f" 
+                       COMMA@46..48 "," " "
                       REST_PATTERN@48..54
-                        DOT2@48..51 "..."
+                         DOT2@48..51 "..." 
                         SINGLE_PATTERN@51..54
                           NAME@51..54
+<<<<<<< HEAD
                             IDENT@51..54 "baz"
                     R_BRACK@54..55 "]"
               R_CURLY@55..56 "}"
@@ -92,16 +125,32 @@ JS_MODULE@0..85
       ARROW_EXPR@65..84
         PARAMETER_LIST@65..78
           L_PAREN@65..66 "("
+=======
+                             IDENT@51..54 "baz" 
+                     R_BRACK@54..55 "]" 
+               R_CURLY@55..56 "}" 
+           R_PAREN@56..58 ")" " "
+         FAT_ARROW@58..61 "=>" " "
+        BLOCK_STMT@61..63
+           L_CURLY@61..62 "{" 
+          LIST@62..62
+           R_CURLY@62..63 "}" 
+       SEMICOLON@63..64 ";" 
+    EXPR_STMT@64..84
+      ARROW_EXPR@64..84
+        PARAMETER_LIST@64..79
+          "\n" L_PAREN@64..66 "(" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@66..77
             SINGLE_PATTERN@66..69
               NAME@66..69
-                IDENT@66..69 "foo"
-            COMMA@69..70 ","
-            WHITESPACE@70..71 " "
+                 IDENT@66..69 "foo" 
+             COMMA@69..71 "," " "
             REST_PATTERN@71..77
-              DOT2@71..74 "..."
+               DOT2@71..74 "..." 
               SINGLE_PATTERN@74..77
                 NAME@74..77
+<<<<<<< HEAD
                   IDENT@74..77 "bar"
           R_PAREN@77..78 ")"
         WHITESPACE@78..79 " "
@@ -109,6 +158,12 @@ JS_MODULE@0..85
         WHITESPACE@81..82 " "
         JS_BLOCK_STATEMENT@82..84
           L_CURLY@82..83 "{"
+=======
+                   IDENT@74..77 "bar" 
+           R_PAREN@77..79 ")" " "
+         FAT_ARROW@79..82 "=>" " "
+        BLOCK_STMT@82..84
+           L_CURLY@82..83 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
           LIST@83..83
-          R_CURLY@83..84 "}"
-  WHITESPACE@84..85 "\n"
+           R_CURLY@83..84 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -1,8 +1,13 @@
+<<<<<<< HEAD
 JS_MODULE@0..12
+=======
+MODULE@0..11
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..5
       POST_UPDATE_EXPRESSION@0..5
         NAME_REF@0..3
+<<<<<<< HEAD
           IDENT@0..3 "foo"
         PLUS2@3..5 "++"
     WHITESPACE@5..6 "\n"
@@ -12,3 +17,12 @@ JS_MODULE@0..12
           IDENT@6..9 "foo"
         MINUS2@9..11 "--"
   WHITESPACE@11..12 "\n"
+=======
+           IDENT@0..3 "foo" 
+         PLUS2@3..5 "++" 
+    EXPR_STMT@5..11
+      UNARY_EXPR@5..11
+        NAME_REF@5..9
+          "\n" IDENT@5..9 "foo" 
+         MINUS2@9..11 "--" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -8,6 +8,7 @@ MODULE@0..11
       POST_UPDATE_EXPRESSION@0..5
         NAME_REF@0..3
 <<<<<<< HEAD
+<<<<<<< HEAD
           IDENT@0..3 "foo"
         PLUS2@3..5 "++"
     WHITESPACE@5..6 "\n"
@@ -26,3 +27,12 @@ MODULE@0..11
           "\n" IDENT@5..9 "foo" 
          MINUS2@9..11 "--" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None IDENT@0..3 "foo" None
+        None PLUS2@3..5 "++" None
+    EXPR_STMT@5..11
+      POST_UPDATE_EXPRESSION@5..11
+        NAME_REF@5..9
+          Whitespace(1) IDENT@5..9 "foo" None
+        None MINUS2@9..11 "--" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -21,7 +21,7 @@ MODULE@0..11
            IDENT@0..3 "foo" 
          PLUS2@3..5 "++" 
     EXPR_STMT@5..11
-      UNARY_EXPR@5..11
+      POST_UPDATE_EXPRESSION@5..11
         NAME_REF@5..9
           "\n" IDENT@5..9 "foo" 
          MINUS2@9..11 "--" 

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -1,38 +1,12 @@
-<<<<<<< HEAD
-JS_MODULE@0..12
-=======
-MODULE@0..11
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..11
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..5
       POST_UPDATE_EXPRESSION@0..5
         NAME_REF@0..3
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@0..3 "foo"
-        PLUS2@3..5 "++"
-    WHITESPACE@5..6 "\n"
-    JS_EXPRESSION_STATEMENT@6..11
-      POST_UPDATE_EXPRESSION@6..11
-        NAME_REF@6..9
-          IDENT@6..9 "foo"
-        MINUS2@9..11 "--"
-  WHITESPACE@11..12 "\n"
-=======
-           IDENT@0..3 "foo" 
-         PLUS2@3..5 "++" 
-    EXPR_STMT@5..11
-      POST_UPDATE_EXPRESSION@5..11
-        NAME_REF@5..9
-          "\n" IDENT@5..9 "foo" 
-         MINUS2@9..11 "--" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None IDENT@0..3 "foo" None
         None PLUS2@3..5 "++" None
-    EXPR_STMT@5..11
+    JS_EXPRESSION_STATEMENT@5..11
       POST_UPDATE_EXPRESSION@5..11
         NAME_REF@5..9
           Whitespace(1) IDENT@6..9 "foo" None
         None MINUS2@9..11 "--" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -33,6 +33,6 @@ MODULE@0..11
     EXPR_STMT@5..11
       POST_UPDATE_EXPRESSION@5..11
         NAME_REF@5..9
-          Whitespace(1) IDENT@5..9 "foo" None
+          Whitespace(1) IDENT@6..9 "foo" None
         None MINUS2@9..11 "--" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -25,7 +25,11 @@ MODULE@0..11
           None IDENT@2..5 "foo" None
     EXPR_STMT@5..11
       PRE_UPDATE_EXPRESSION@5..11
+<<<<<<< HEAD
         Whitespace(1) MINUS2@5..8 "--" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        Whitespace(1) MINUS2@6..8 "--" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@8..11
           None IDENT@8..11 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -6,8 +6,9 @@ MODULE@0..11
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..5
       PRE_UPDATE_EXPRESSION@0..5
-         PLUS2@0..2 "++" 
+        None PLUS2@0..2 "++" None
         NAME_REF@2..5
+<<<<<<< HEAD
 <<<<<<< HEAD
           IDENT@2..5 "foo"
     WHITESPACE@5..6 "\n"
@@ -20,5 +21,11 @@ MODULE@0..11
       PRE_UPDATE_EXPRESSION@5..11
         "\n" MINUS2@5..8 "--" 
 >>>>>>> 28a4e2282 (rebase)
+=======
+          None IDENT@2..5 "foo" None
+    EXPR_STMT@5..11
+      PRE_UPDATE_EXPRESSION@5..11
+        Whitespace(1) MINUS2@5..8 "--" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME_REF@8..11
-           IDENT@8..11 "foo" 
+          None IDENT@8..11 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -1,35 +1,12 @@
-<<<<<<< HEAD
-JS_MODULE@0..12
-=======
-MODULE@0..11
->>>>>>> 28a4e2282 (rebase)
+JS_MODULE@0..11
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..5
       PRE_UPDATE_EXPRESSION@0..5
         None PLUS2@0..2 "++" None
         NAME_REF@2..5
-<<<<<<< HEAD
-<<<<<<< HEAD
-          IDENT@2..5 "foo"
-    WHITESPACE@5..6 "\n"
-    JS_EXPRESSION_STATEMENT@6..11
-      PRE_UPDATE_EXPRESSION@6..11
-        MINUS2@6..8 "--"
-=======
-           IDENT@2..5 "foo" 
-    EXPR_STMT@5..11
-      PRE_UPDATE_EXPRESSION@5..11
-        "\n" MINUS2@5..8 "--" 
->>>>>>> 28a4e2282 (rebase)
-=======
           None IDENT@2..5 "foo" None
-    EXPR_STMT@5..11
+    JS_EXPRESSION_STATEMENT@5..11
       PRE_UPDATE_EXPRESSION@5..11
-<<<<<<< HEAD
-        Whitespace(1) MINUS2@5..8 "--" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         Whitespace(1) MINUS2@6..8 "--" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         NAME_REF@8..11
           None IDENT@8..11 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -1,14 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..12
+=======
+MODULE@0..11
+>>>>>>> 28a4e2282 (rebase)
   LIST@0..11
     JS_EXPRESSION_STATEMENT@0..5
       PRE_UPDATE_EXPRESSION@0..5
-        PLUS2@0..2 "++"
+         PLUS2@0..2 "++" 
         NAME_REF@2..5
+<<<<<<< HEAD
           IDENT@2..5 "foo"
     WHITESPACE@5..6 "\n"
     JS_EXPRESSION_STATEMENT@6..11
       PRE_UPDATE_EXPRESSION@6..11
         MINUS2@6..8 "--"
+=======
+           IDENT@2..5 "foo" 
+    EXPR_STMT@5..11
+      PRE_UPDATE_EXPRESSION@5..11
+        "\n" MINUS2@5..8 "--" 
+>>>>>>> 28a4e2282 (rebase)
         NAME_REF@8..11
-          IDENT@8..11 "foo"
-  WHITESPACE@11..12 "\n"
+           IDENT@8..11 "foo" 

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -1,74 +1,23 @@
-<<<<<<< HEAD
-JS_MODULE@0..43
-=======
-MODULE@0..42
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..42
   LIST@0..42
     JS_EXPRESSION_STATEMENT@0..42
       ARROW_EXPR@0..42
         PARAMETER_LIST@0..3
           None L_PAREN@0..1 "(" None
           LIST@1..1
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-          R_PAREN@1..2 ")"
-        WHITESPACE@2..3 " "
-        FAT_ARROW@3..5 "=>"
-        WHITESPACE@5..6 " "
-        JS_BLOCK_STATEMENT@6..42
-          L_CURLY@6..7 "{"
-          WHITESPACE@7..10 "\n  "
-          LIST@10..40
-            JS_RETURN_STATEMENT@10..17
-              RETURN_KW@10..16 "return"
-              SEMICOLON@16..17 ";"
-            WHITESPACE@17..20 "\n  "
-            JS_RETURN_STATEMENT@20..31
-              RETURN_KW@20..26 "return"
-              WHITESPACE@26..27 " "
-              NAME_REF@27..30
-                IDENT@27..30 "foo"
-              SEMICOLON@30..31 ";"
-            WHITESPACE@31..34 "\n  "
-            JS_RETURN_STATEMENT@34..40
-              RETURN_KW@34..40 "return"
-          WHITESPACE@40..41 "\n"
-          R_CURLY@41..42 "}"
-  WHITESPACE@42..43 "\n"
-=======
-           R_PAREN@1..3 ")" " "
-         FAT_ARROW@3..6 "=>" " "
-=======
-          None R_PAREN@1..3 ")" Whitespace(1)
-        None FAT_ARROW@3..6 "=>" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
           None R_PAREN@1..2 ")" Whitespace(1)
         None FAT_ARROW@3..5 "=>" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-        BLOCK_STMT@6..42
+        JS_BLOCK_STATEMENT@6..42
           None L_CURLY@6..7 "{" None
           LIST@7..40
-            RETURN_STMT@7..17
+            JS_RETURN_STATEMENT@7..17
               Whitespace(3) RETURN_KW@10..16 "return" None
               None SEMICOLON@16..17 ";" None
-            RETURN_STMT@17..31
+            JS_RETURN_STATEMENT@17..31
               Whitespace(3) RETURN_KW@20..26 "return" Whitespace(1)
               NAME_REF@27..30
                 None IDENT@27..30 "foo" None
               None SEMICOLON@30..31 ";" None
-            RETURN_STMT@31..40
-<<<<<<< HEAD
-<<<<<<< HEAD
-              "\n  " RETURN_KW@31..40 "return" 
-          "\n" R_CURLY@40..42 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              Whitespace(3) RETURN_KW@31..40 "return" None
-          Whitespace(1) R_CURLY@40..42 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+            JS_RETURN_STATEMENT@31..40
               Whitespace(3) RETURN_KW@34..40 "return" None
           Whitespace(1) R_CURLY@41..42 "}" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -7,8 +7,9 @@ MODULE@0..42
     JS_EXPRESSION_STATEMENT@0..42
       ARROW_EXPR@0..42
         PARAMETER_LIST@0..3
-           L_PAREN@0..1 "(" 
+          None L_PAREN@0..1 "(" None
           LIST@1..1
+<<<<<<< HEAD
 <<<<<<< HEAD
           R_PAREN@1..2 ")"
         WHITESPACE@2..3 " "
@@ -37,18 +38,27 @@ MODULE@0..42
 =======
            R_PAREN@1..3 ")" " "
          FAT_ARROW@3..6 "=>" " "
+=======
+          None R_PAREN@1..3 ")" Whitespace(1)
+        None FAT_ARROW@3..6 "=>" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         BLOCK_STMT@6..42
-           L_CURLY@6..7 "{" 
+          None L_CURLY@6..7 "{" None
           LIST@7..40
             RETURN_STMT@7..17
-              "\n  " RETURN_KW@7..16 "return" 
-               SEMICOLON@16..17 ";" 
+              Whitespace(3) RETURN_KW@7..16 "return" None
+              None SEMICOLON@16..17 ";" None
             RETURN_STMT@17..31
-              "\n  " RETURN_KW@17..27 "return" " "
+              Whitespace(3) RETURN_KW@17..27 "return" Whitespace(1)
               NAME_REF@27..30
-                 IDENT@27..30 "foo" 
-               SEMICOLON@30..31 ";" 
+                None IDENT@27..30 "foo" None
+              None SEMICOLON@30..31 ";" None
             RETURN_STMT@31..40
+<<<<<<< HEAD
               "\n  " RETURN_KW@31..40 "return" 
           "\n" R_CURLY@40..42 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              Whitespace(3) RETURN_KW@31..40 "return" None
+          Whitespace(1) R_CURLY@40..42 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -11,6 +11,7 @@ MODULE@0..42
           LIST@1..1
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
           R_PAREN@1..2 ")"
         WHITESPACE@2..3 " "
         FAT_ARROW@3..5 "=>"
@@ -42,18 +43,23 @@ MODULE@0..42
           None R_PAREN@1..3 ")" Whitespace(1)
         None FAT_ARROW@3..6 "=>" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+          None R_PAREN@1..2 ")" Whitespace(1)
+        None FAT_ARROW@3..5 "=>" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         BLOCK_STMT@6..42
           None L_CURLY@6..7 "{" None
           LIST@7..40
             RETURN_STMT@7..17
-              Whitespace(3) RETURN_KW@7..16 "return" None
+              Whitespace(3) RETURN_KW@10..16 "return" None
               None SEMICOLON@16..17 ";" None
             RETURN_STMT@17..31
-              Whitespace(3) RETURN_KW@17..27 "return" Whitespace(1)
+              Whitespace(3) RETURN_KW@20..26 "return" Whitespace(1)
               NAME_REF@27..30
                 None IDENT@27..30 "foo" None
               None SEMICOLON@30..31 ";" None
             RETURN_STMT@31..40
+<<<<<<< HEAD
 <<<<<<< HEAD
               "\n  " RETURN_KW@31..40 "return" 
           "\n" R_CURLY@40..42 "}" 
@@ -62,3 +68,7 @@ MODULE@0..42
               Whitespace(3) RETURN_KW@31..40 "return" None
           Whitespace(1) R_CURLY@40..42 "}" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              Whitespace(3) RETURN_KW@34..40 "return" None
+          Whitespace(1) R_CURLY@41..42 "}" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -1,10 +1,15 @@
+<<<<<<< HEAD
 JS_MODULE@0..43
+=======
+MODULE@0..42
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..42
     JS_EXPRESSION_STATEMENT@0..42
       ARROW_EXPR@0..42
-        PARAMETER_LIST@0..2
-          L_PAREN@0..1 "("
+        PARAMETER_LIST@0..3
+           L_PAREN@0..1 "(" 
           LIST@1..1
+<<<<<<< HEAD
           R_PAREN@1..2 ")"
         WHITESPACE@2..3 " "
         FAT_ARROW@3..5 "=>"
@@ -29,3 +34,21 @@ JS_MODULE@0..43
           WHITESPACE@40..41 "\n"
           R_CURLY@41..42 "}"
   WHITESPACE@42..43 "\n"
+=======
+           R_PAREN@1..3 ")" " "
+         FAT_ARROW@3..6 "=>" " "
+        BLOCK_STMT@6..42
+           L_CURLY@6..7 "{" 
+          LIST@7..40
+            RETURN_STMT@7..17
+              "\n  " RETURN_KW@7..16 "return" 
+               SEMICOLON@16..17 ";" 
+            RETURN_STMT@17..31
+              "\n  " RETURN_KW@17..27 "return" " "
+              NAME_REF@27..30
+                 IDENT@27..30 "foo" 
+               SEMICOLON@30..31 ";" 
+            RETURN_STMT@31..40
+              "\n  " RETURN_KW@31..40 "return" 
+          "\n" R_CURLY@40..42 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -5,56 +5,57 @@ MODULE@0..83
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..83
     VAR_DECL@0..14
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..8
             NAME@4..8
-               IDENT@4..8 "foo" " "
-           EQ@8..10 "=" " "
+              None IDENT@4..8 "foo" Whitespace(1)
+          None EQ@8..10 "=" Whitespace(1)
           NAME_REF@10..13
-             IDENT@10..13 "bar" 
-       SEMICOLON@13..14 ";" 
+            None IDENT@10..13 "bar" None
+      None SEMICOLON@13..14 ";" None
     VAR_DECL@14..27
-      "\n" IDENT@14..19 "let" " "
+      Whitespace(1) IDENT@14..19 "let" Whitespace(1)
       LIST@19..26
         DECLARATOR@19..26
           SINGLE_PATTERN@19..23
             NAME@19..23
-               IDENT@19..23 "foo" " "
-           EQ@23..25 "=" " "
+              None IDENT@19..23 "foo" Whitespace(1)
+          None EQ@23..25 "=" Whitespace(1)
           NAME_REF@25..26
-             IDENT@25..26 "b" 
-       SEMICOLON@26..27 ";" 
+            None IDENT@25..26 "b" None
+      None SEMICOLON@26..27 ";" None
     VAR_DECL@27..36
-      "\n" IDENT@27..32 "let" " "
+      Whitespace(1) IDENT@27..32 "let" Whitespace(1)
       LIST@32..35
         DECLARATOR@32..35
           SINGLE_PATTERN@32..35
             NAME@32..35
-               IDENT@32..35 "foo" 
-       SEMICOLON@35..36 ";" 
+              None IDENT@32..35 "foo" None
+      None SEMICOLON@35..36 ";" None
     VAR_DECL@36..44
-      "\n" IDENT@36..41 "let" " "
+      Whitespace(1) IDENT@36..41 "let" Whitespace(1)
       LIST@41..44
         DECLARATOR@41..44
           SINGLE_PATTERN@41..44
             NAME@41..44
-               IDENT@41..44 "foo" 
+              None IDENT@41..44 "foo" None
     VAR_DECL@44..52
-      "\n" IDENT@44..49 "let" " "
+      Whitespace(1) IDENT@44..49 "let" Whitespace(1)
       LIST@49..52
         DECLARATOR@49..52
           SINGLE_PATTERN@49..52
             NAME@49..52
-               IDENT@49..52 "foo" 
+              None IDENT@49..52 "foo" None
     FN_DECL@52..83
-      "\n" FUNCTION_KW@52..62 "function" " "
+      Whitespace(1) FUNCTION_KW@52..62 "function" Whitespace(1)
       NAME@62..65
-         IDENT@62..65 "foo" 
+        None IDENT@62..65 "foo" None
       PARAMETER_LIST@65..68
-         L_PAREN@65..66 "(" 
+        None L_PAREN@65..66 "(" None
         LIST@66..66
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@66..67 ")"
       WHITESPACE@67..68 " "
@@ -72,12 +73,20 @@ MODULE@0..83
   WHITESPACE@83..84 "\n"
 =======
          R_PAREN@66..68 ")" " "
+=======
+        None R_PAREN@66..68 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@68..83
-         L_CURLY@68..70 "{" " "
+        None L_CURLY@68..70 "{" Whitespace(1)
         LIST@70..82
           RETURN_STMT@70..82
-             RETURN_KW@70..77 "return" " "
+            None RETURN_KW@70..77 "return" Whitespace(1)
             LITERAL@77..82
+<<<<<<< HEAD
                TRUE_KW@77..82 "true" " "
          R_CURLY@82..83 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None TRUE_KW@77..82 "true" Whitespace(1)
+        None R_CURLY@82..83 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -1,71 +1,61 @@
+<<<<<<< HEAD
 JS_MODULE@0..84
+=======
+MODULE@0..83
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..83
     VAR_DECL@0..14
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..13
         DECLARATOR@4..13
-          SINGLE_PATTERN@4..7
-            NAME@4..7
-              IDENT@4..7 "foo"
-          WHITESPACE@7..8 " "
-          EQ@8..9 "="
-          WHITESPACE@9..10 " "
+          SINGLE_PATTERN@4..8
+            NAME@4..8
+               IDENT@4..8 "foo" " "
+           EQ@8..10 "=" " "
           NAME_REF@10..13
-            IDENT@10..13 "bar"
-      SEMICOLON@13..14 ";"
-    WHITESPACE@14..15 "\n"
-    VAR_DECL@15..27
-      IDENT@15..18 "let"
-      WHITESPACE@18..19 " "
+             IDENT@10..13 "bar" 
+       SEMICOLON@13..14 ";" 
+    VAR_DECL@14..27
+      "\n" IDENT@14..19 "let" " "
       LIST@19..26
         DECLARATOR@19..26
-          SINGLE_PATTERN@19..22
-            NAME@19..22
-              IDENT@19..22 "foo"
-          WHITESPACE@22..23 " "
-          EQ@23..24 "="
-          WHITESPACE@24..25 " "
+          SINGLE_PATTERN@19..23
+            NAME@19..23
+               IDENT@19..23 "foo" " "
+           EQ@23..25 "=" " "
           NAME_REF@25..26
-            IDENT@25..26 "b"
-      SEMICOLON@26..27 ";"
-    WHITESPACE@27..28 "\n"
-    VAR_DECL@28..36
-      IDENT@28..31 "let"
-      WHITESPACE@31..32 " "
+             IDENT@25..26 "b" 
+       SEMICOLON@26..27 ";" 
+    VAR_DECL@27..36
+      "\n" IDENT@27..32 "let" " "
       LIST@32..35
         DECLARATOR@32..35
           SINGLE_PATTERN@32..35
             NAME@32..35
-              IDENT@32..35 "foo"
-      SEMICOLON@35..36 ";"
-    WHITESPACE@36..37 "\n"
-    VAR_DECL@37..44
-      IDENT@37..40 "let"
-      WHITESPACE@40..41 " "
+               IDENT@32..35 "foo" 
+       SEMICOLON@35..36 ";" 
+    VAR_DECL@36..44
+      "\n" IDENT@36..41 "let" " "
       LIST@41..44
         DECLARATOR@41..44
           SINGLE_PATTERN@41..44
             NAME@41..44
-              IDENT@41..44 "foo"
-    WHITESPACE@44..45 "\n"
-    VAR_DECL@45..52
-      IDENT@45..48 "let"
-      WHITESPACE@48..49 " "
+               IDENT@41..44 "foo" 
+    VAR_DECL@44..52
+      "\n" IDENT@44..49 "let" " "
       LIST@49..52
         DECLARATOR@49..52
           SINGLE_PATTERN@49..52
             NAME@49..52
-              IDENT@49..52 "foo"
-    WHITESPACE@52..53 "\n"
-    FN_DECL@53..83
-      FUNCTION_KW@53..61 "function"
-      WHITESPACE@61..62 " "
+               IDENT@49..52 "foo" 
+    FN_DECL@52..83
+      "\n" FUNCTION_KW@52..62 "function" " "
       NAME@62..65
-        IDENT@62..65 "foo"
-      PARAMETER_LIST@65..67
-        L_PAREN@65..66 "("
+         IDENT@62..65 "foo" 
+      PARAMETER_LIST@65..68
+         L_PAREN@65..66 "(" 
         LIST@66..66
+<<<<<<< HEAD
         R_PAREN@66..67 ")"
       WHITESPACE@67..68 " "
       JS_BLOCK_STATEMENT@68..83
@@ -80,3 +70,14 @@ JS_MODULE@0..84
         WHITESPACE@81..82 " "
         R_CURLY@82..83 "}"
   WHITESPACE@83..84 "\n"
+=======
+         R_PAREN@66..68 ")" " "
+      BLOCK_STMT@68..83
+         L_CURLY@68..70 "{" " "
+        LIST@70..82
+          RETURN_STMT@70..82
+             RETURN_KW@70..77 "return" " "
+            LITERAL@77..82
+               TRUE_KW@77..82 "true" " "
+         R_CURLY@82..83 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..84
-=======
-MODULE@0..83
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..83
   LIST@0..83
     VAR_DECL@0..14
       None IDENT@0..3 "let" Whitespace(1)
@@ -55,46 +51,12 @@ MODULE@0..83
       PARAMETER_LIST@65..68
         None L_PAREN@65..66 "(" None
         LIST@66..66
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@66..67 ")"
-      WHITESPACE@67..68 " "
-      JS_BLOCK_STATEMENT@68..83
-        L_CURLY@68..69 "{"
-        WHITESPACE@69..70 " "
-        LIST@70..81
-          JS_RETURN_STATEMENT@70..81
-            RETURN_KW@70..76 "return"
-            WHITESPACE@76..77 " "
-            LITERAL@77..81
-              TRUE_KW@77..81 "true"
-        WHITESPACE@81..82 " "
-        R_CURLY@82..83 "}"
-  WHITESPACE@83..84 "\n"
-=======
-         R_PAREN@66..68 ")" " "
-=======
-        None R_PAREN@66..68 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@66..67 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@68..83
+      JS_BLOCK_STATEMENT@68..83
         None L_CURLY@68..69 "{" Whitespace(1)
         LIST@70..82
-          RETURN_STMT@70..82
+          JS_RETURN_STATEMENT@70..82
             None RETURN_KW@70..76 "return" Whitespace(1)
             LITERAL@77..82
-<<<<<<< HEAD
-<<<<<<< HEAD
-               TRUE_KW@77..82 "true" " "
-         R_CURLY@82..83 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None TRUE_KW@77..82 "true" Whitespace(1)
-=======
               None TRUE_KW@77..81 "true" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None R_CURLY@82..83 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -5,29 +5,29 @@ MODULE@0..83
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..83
     VAR_DECL@0..14
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..13
         DECLARATOR@4..13
           SINGLE_PATTERN@4..8
             NAME@4..8
-              None IDENT@4..8 "foo" Whitespace(1)
-          None EQ@8..10 "=" Whitespace(1)
+              None IDENT@4..7 "foo" Whitespace(1)
+          None EQ@8..9 "=" Whitespace(1)
           NAME_REF@10..13
             None IDENT@10..13 "bar" None
       None SEMICOLON@13..14 ";" None
     VAR_DECL@14..27
-      Whitespace(1) IDENT@14..19 "let" Whitespace(1)
+      Whitespace(1) IDENT@15..18 "let" Whitespace(1)
       LIST@19..26
         DECLARATOR@19..26
           SINGLE_PATTERN@19..23
             NAME@19..23
-              None IDENT@19..23 "foo" Whitespace(1)
-          None EQ@23..25 "=" Whitespace(1)
+              None IDENT@19..22 "foo" Whitespace(1)
+          None EQ@23..24 "=" Whitespace(1)
           NAME_REF@25..26
             None IDENT@25..26 "b" None
       None SEMICOLON@26..27 ";" None
     VAR_DECL@27..36
-      Whitespace(1) IDENT@27..32 "let" Whitespace(1)
+      Whitespace(1) IDENT@28..31 "let" Whitespace(1)
       LIST@32..35
         DECLARATOR@32..35
           SINGLE_PATTERN@32..35
@@ -35,26 +35,27 @@ MODULE@0..83
               None IDENT@32..35 "foo" None
       None SEMICOLON@35..36 ";" None
     VAR_DECL@36..44
-      Whitespace(1) IDENT@36..41 "let" Whitespace(1)
+      Whitespace(1) IDENT@37..40 "let" Whitespace(1)
       LIST@41..44
         DECLARATOR@41..44
           SINGLE_PATTERN@41..44
             NAME@41..44
               None IDENT@41..44 "foo" None
     VAR_DECL@44..52
-      Whitespace(1) IDENT@44..49 "let" Whitespace(1)
+      Whitespace(1) IDENT@45..48 "let" Whitespace(1)
       LIST@49..52
         DECLARATOR@49..52
           SINGLE_PATTERN@49..52
             NAME@49..52
               None IDENT@49..52 "foo" None
     FN_DECL@52..83
-      Whitespace(1) FUNCTION_KW@52..62 "function" Whitespace(1)
+      Whitespace(1) FUNCTION_KW@53..61 "function" Whitespace(1)
       NAME@62..65
         None IDENT@62..65 "foo" None
       PARAMETER_LIST@65..68
         None L_PAREN@65..66 "(" None
         LIST@66..66
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@66..67 ")"
@@ -76,17 +77,24 @@ MODULE@0..83
 =======
         None R_PAREN@66..68 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@66..67 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@68..83
-        None L_CURLY@68..70 "{" Whitespace(1)
+        None L_CURLY@68..69 "{" Whitespace(1)
         LIST@70..82
           RETURN_STMT@70..82
-            None RETURN_KW@70..77 "return" Whitespace(1)
+            None RETURN_KW@70..76 "return" Whitespace(1)
             LITERAL@77..82
+<<<<<<< HEAD
 <<<<<<< HEAD
                TRUE_KW@77..82 "true" " "
          R_CURLY@82..83 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None TRUE_KW@77..82 "true" Whitespace(1)
+=======
+              None TRUE_KW@77..81 "true" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
         None R_CURLY@82..83 "}" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -1,24 +1,23 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       SEQUENCE_EXPR@0..13
         LIST@0..13
           LITERAL@0..1
-            NUMBER@0..1 "1"
-          COMMA@1..2 ","
-          WHITESPACE@2..3 " "
+             NUMBER@0..1 "1" 
+           COMMA@1..3 "," " "
           LITERAL@3..4
-            NUMBER@3..4 "2"
-          COMMA@4..5 ","
-          WHITESPACE@5..6 " "
+             NUMBER@3..4 "2" 
+           COMMA@4..6 "," " "
           LITERAL@6..7
-            NUMBER@6..7 "3"
-          COMMA@7..8 ","
-          WHITESPACE@8..9 " "
+             NUMBER@6..7 "3" 
+           COMMA@7..9 "," " "
           LITERAL@9..10
-            NUMBER@9..10 "4"
-          COMMA@10..11 ","
-          WHITESPACE@11..12 " "
+             NUMBER@9..10 "4" 
+           COMMA@10..12 "," " "
           LITERAL@12..13
-            NUMBER@12..13 "5"
-  WHITESPACE@13..14 "\n"
+             NUMBER@12..13 "5" 

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -9,15 +9,15 @@ MODULE@0..13
         LIST@0..13
           LITERAL@0..1
             None NUMBER@0..1 "1" None
-          None COMMA@1..3 "," Whitespace(1)
+          None COMMA@1..2 "," Whitespace(1)
           LITERAL@3..4
             None NUMBER@3..4 "2" None
-          None COMMA@4..6 "," Whitespace(1)
+          None COMMA@4..5 "," Whitespace(1)
           LITERAL@6..7
             None NUMBER@6..7 "3" None
-          None COMMA@7..9 "," Whitespace(1)
+          None COMMA@7..8 "," Whitespace(1)
           LITERAL@9..10
             None NUMBER@9..10 "4" None
-          None COMMA@10..12 "," Whitespace(1)
+          None COMMA@10..11 "," Whitespace(1)
           LITERAL@12..13
             None NUMBER@12..13 "5" None

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -8,16 +8,16 @@ MODULE@0..13
       SEQUENCE_EXPR@0..13
         LIST@0..13
           LITERAL@0..1
-             NUMBER@0..1 "1" 
-           COMMA@1..3 "," " "
+            None NUMBER@0..1 "1" None
+          None COMMA@1..3 "," Whitespace(1)
           LITERAL@3..4
-             NUMBER@3..4 "2" 
-           COMMA@4..6 "," " "
+            None NUMBER@3..4 "2" None
+          None COMMA@4..6 "," Whitespace(1)
           LITERAL@6..7
-             NUMBER@6..7 "3" 
-           COMMA@7..9 "," " "
+            None NUMBER@6..7 "3" None
+          None COMMA@7..9 "," Whitespace(1)
           LITERAL@9..10
-             NUMBER@9..10 "4" 
-           COMMA@10..12 "," " "
+            None NUMBER@9..10 "4" None
+          None COMMA@10..12 "," Whitespace(1)
           LITERAL@12..13
-             NUMBER@12..13 "5" 
+            None NUMBER@12..13 "5" None

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..13
       SEQUENCE_EXPR@0..13

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -1,83 +1,98 @@
+<<<<<<< HEAD
 JS_MODULE@0..99
+=======
+MODULE@0..98
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..98
     CLASS_DECL@0..98
-      CLASS_KW@0..5 "class"
-      WHITESPACE@5..6 " "
-      NAME@6..9
-        IDENT@6..9 "foo"
-      WHITESPACE@9..10 " "
+       CLASS_KW@0..6 "class" " "
+      NAME@6..10
+         IDENT@6..10 "foo" " "
       CLASS_BODY@10..98
-        L_CURLY@10..11 "{"
-        WHITESPACE@11..13 "\n "
-        LIST@13..96
-          METHOD@13..31
-            STATIC_KW@13..19 "static"
-            WHITESPACE@19..20 " "
+         L_CURLY@10..11 "{" 
+        LIST@11..96
+          METHOD@11..31
+            "\n " STATIC_KW@11..20 "static" " "
             NAME@20..23
-              IDENT@20..23 "foo"
-            PARAMETER_LIST@23..28
-              L_PAREN@23..24 "("
+               IDENT@20..23 "foo" 
+            PARAMETER_LIST@23..29
+               L_PAREN@23..24 "(" 
               LIST@24..27
                 SINGLE_PATTERN@24..27
                   NAME@24..27
+<<<<<<< HEAD
                     IDENT@24..27 "bar"
               R_PAREN@27..28 ")"
             WHITESPACE@28..29 " "
             JS_BLOCK_STATEMENT@29..31
               L_CURLY@29..30 "{"
+=======
+                     IDENT@24..27 "bar" 
+               R_PAREN@27..29 ")" " "
+            BLOCK_STMT@29..31
+               L_CURLY@29..30 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@30..30
-              R_CURLY@30..31 "}"
-          WHITESPACE@31..33 "\n "
-          METHOD@33..49
-            STATIC_KW@33..39 "static"
-            WHITESPACE@39..40 " "
-            STAR@40..41 "*"
+               R_CURLY@30..31 "}" 
+          METHOD@31..49
+            "\n " STATIC_KW@31..40 "static" " "
+             STAR@40..41 "*" 
             NAME@41..44
-              IDENT@41..44 "foo"
-            PARAMETER_LIST@44..46
-              L_PAREN@44..45 "("
+               IDENT@41..44 "foo" 
+            PARAMETER_LIST@44..47
+               L_PAREN@44..45 "(" 
               LIST@45..45
+<<<<<<< HEAD
               R_PAREN@45..46 ")"
             WHITESPACE@46..47 " "
             JS_BLOCK_STATEMENT@47..49
               L_CURLY@47..48 "{"
+=======
+               R_PAREN@45..47 ")" " "
+            BLOCK_STMT@47..49
+               L_CURLY@47..48 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@48..48
-              R_CURLY@48..49 "}"
-          WHITESPACE@49..51 "\n "
-          METHOD@51..72
-            STATIC_KW@51..57 "static"
-            WHITESPACE@57..58 " "
-            ASYNC_KW@58..63 "async"
-            WHITESPACE@63..64 " "
+               R_CURLY@48..49 "}" 
+          METHOD@49..72
+            "\n " STATIC_KW@49..58 "static" " "
+             ASYNC_KW@58..64 "async" " "
             NAME@64..67
-              IDENT@64..67 "foo"
-            PARAMETER_LIST@67..69
-              L_PAREN@67..68 "("
+               IDENT@64..67 "foo" 
+            PARAMETER_LIST@67..70
+               L_PAREN@67..68 "(" 
               LIST@68..68
+<<<<<<< HEAD
               R_PAREN@68..69 ")"
             WHITESPACE@69..70 " "
             JS_BLOCK_STATEMENT@70..72
               L_CURLY@70..71 "{"
+=======
+               R_PAREN@68..70 ")" " "
+            BLOCK_STMT@70..72
+               L_CURLY@70..71 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@71..71
-              R_CURLY@71..72 "}"
-          WHITESPACE@72..74 "\n "
-          METHOD@74..96
-            STATIC_KW@74..80 "static"
-            WHITESPACE@80..81 " "
-            ASYNC_KW@81..86 "async"
-            WHITESPACE@86..87 " "
-            STAR@87..88 "*"
+               R_CURLY@71..72 "}" 
+          METHOD@72..96
+            "\n " STATIC_KW@72..81 "static" " "
+             ASYNC_KW@81..87 "async" " "
+             STAR@87..88 "*" 
             NAME@88..91
-              IDENT@88..91 "foo"
-            PARAMETER_LIST@91..93
-              L_PAREN@91..92 "("
+               IDENT@88..91 "foo" 
+            PARAMETER_LIST@91..94
+               L_PAREN@91..92 "(" 
               LIST@92..92
+<<<<<<< HEAD
               R_PAREN@92..93 ")"
             WHITESPACE@93..94 " "
             JS_BLOCK_STATEMENT@94..96
               L_CURLY@94..95 "{"
+=======
+               R_PAREN@92..94 ")" " "
+            BLOCK_STMT@94..96
+               L_CURLY@94..95 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               LIST@95..95
-              R_CURLY@95..96 "}"
-        WHITESPACE@96..97 "\n"
-        R_CURLY@97..98 "}"
-  WHITESPACE@98..99 "\n"
+               R_CURLY@95..96 "}" 
+        "\n" R_CURLY@96..98 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..99
-=======
-MODULE@0..98
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..98
   LIST@0..98
     CLASS_DECL@0..98
       None CLASS_KW@0..5 "class" Whitespace(1)
@@ -20,25 +16,10 @@ MODULE@0..98
               LIST@24..27
                 SINGLE_PATTERN@24..27
                   NAME@24..27
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    IDENT@24..27 "bar"
-              R_PAREN@27..28 ")"
-            WHITESPACE@28..29 " "
-            JS_BLOCK_STATEMENT@29..31
-              L_CURLY@29..30 "{"
-=======
-                     IDENT@24..27 "bar" 
-               R_PAREN@27..29 ")" " "
-            BLOCK_STMT@29..31
-               L_CURLY@29..30 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
                     None IDENT@24..27 "bar" None
               None R_PAREN@27..28 ")" Whitespace(1)
-            BLOCK_STMT@29..31
+            JS_BLOCK_STATEMENT@29..31
               None L_CURLY@29..30 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@30..30
               None R_CURLY@30..31 "}" None
           METHOD@31..49
@@ -49,26 +30,9 @@ MODULE@0..98
             PARAMETER_LIST@44..47
               None L_PAREN@44..45 "(" None
               LIST@45..45
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@45..46 ")"
-            WHITESPACE@46..47 " "
-            JS_BLOCK_STATEMENT@47..49
-              L_CURLY@47..48 "{"
-=======
-               R_PAREN@45..47 ")" " "
-            BLOCK_STMT@47..49
-               L_CURLY@47..48 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@45..47 ")" Whitespace(1)
-=======
               None R_PAREN@45..46 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@47..49
+            JS_BLOCK_STATEMENT@47..49
               None L_CURLY@47..48 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@48..48
               None R_CURLY@48..49 "}" None
           METHOD@49..72
@@ -79,26 +43,9 @@ MODULE@0..98
             PARAMETER_LIST@67..70
               None L_PAREN@67..68 "(" None
               LIST@68..68
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@68..69 ")"
-            WHITESPACE@69..70 " "
-            JS_BLOCK_STATEMENT@70..72
-              L_CURLY@70..71 "{"
-=======
-               R_PAREN@68..70 ")" " "
-            BLOCK_STMT@70..72
-               L_CURLY@70..71 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@68..70 ")" Whitespace(1)
-=======
               None R_PAREN@68..69 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@70..72
+            JS_BLOCK_STATEMENT@70..72
               None L_CURLY@70..71 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@71..71
               None R_CURLY@71..72 "}" None
           METHOD@72..96
@@ -110,26 +57,9 @@ MODULE@0..98
             PARAMETER_LIST@91..94
               None L_PAREN@91..92 "(" None
               LIST@92..92
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-              R_PAREN@92..93 ")"
-            WHITESPACE@93..94 " "
-            JS_BLOCK_STATEMENT@94..96
-              L_CURLY@94..95 "{"
-=======
-               R_PAREN@92..94 ")" " "
-            BLOCK_STMT@94..96
-               L_CURLY@94..95 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              None R_PAREN@92..94 ")" Whitespace(1)
-=======
               None R_PAREN@92..93 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-            BLOCK_STMT@94..96
+            JS_BLOCK_STATEMENT@94..96
               None L_CURLY@94..95 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@95..95
               None R_CURLY@95..96 "}" None
         Whitespace(1) R_CURLY@97..98 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -5,14 +5,14 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..98
     CLASS_DECL@0..98
-      None CLASS_KW@0..6 "class" Whitespace(1)
+      None CLASS_KW@0..5 "class" Whitespace(1)
       NAME@6..10
-        None IDENT@6..10 "foo" Whitespace(1)
+        None IDENT@6..9 "foo" Whitespace(1)
       CLASS_BODY@10..98
         None L_CURLY@10..11 "{" None
         LIST@11..96
           METHOD@11..31
-            Whitespace(2) STATIC_KW@11..20 "static" Whitespace(1)
+            Whitespace(2) STATIC_KW@13..19 "static" Whitespace(1)
             NAME@20..23
               None IDENT@20..23 "foo" None
             PARAMETER_LIST@23..29
@@ -35,20 +35,21 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                     None IDENT@24..27 "bar" None
-              None R_PAREN@27..29 ")" Whitespace(1)
+              None R_PAREN@27..28 ")" Whitespace(1)
             BLOCK_STMT@29..31
               None L_CURLY@29..30 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@30..30
               None R_CURLY@30..31 "}" None
           METHOD@31..49
-            Whitespace(2) STATIC_KW@31..40 "static" Whitespace(1)
+            Whitespace(2) STATIC_KW@33..39 "static" Whitespace(1)
             None STAR@40..41 "*" None
             NAME@41..44
               None IDENT@41..44 "foo" None
             PARAMETER_LIST@44..47
               None L_PAREN@44..45 "(" None
               LIST@45..45
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@45..46 ")"
@@ -62,19 +63,23 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@45..47 ")" Whitespace(1)
+=======
+              None R_PAREN@45..46 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@47..49
               None L_CURLY@47..48 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@48..48
               None R_CURLY@48..49 "}" None
           METHOD@49..72
-            Whitespace(2) STATIC_KW@49..58 "static" Whitespace(1)
-            None ASYNC_KW@58..64 "async" Whitespace(1)
+            Whitespace(2) STATIC_KW@51..57 "static" Whitespace(1)
+            None ASYNC_KW@58..63 "async" Whitespace(1)
             NAME@64..67
               None IDENT@64..67 "foo" None
             PARAMETER_LIST@67..70
               None L_PAREN@67..68 "(" None
               LIST@68..68
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@68..69 ")"
@@ -88,20 +93,24 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@68..70 ")" Whitespace(1)
+=======
+              None R_PAREN@68..69 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@70..72
               None L_CURLY@70..71 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@71..71
               None R_CURLY@71..72 "}" None
           METHOD@72..96
-            Whitespace(2) STATIC_KW@72..81 "static" Whitespace(1)
-            None ASYNC_KW@81..87 "async" Whitespace(1)
+            Whitespace(2) STATIC_KW@74..80 "static" Whitespace(1)
+            None ASYNC_KW@81..86 "async" Whitespace(1)
             None STAR@87..88 "*" None
             NAME@88..91
               None IDENT@88..91 "foo" None
             PARAMETER_LIST@91..94
               None L_PAREN@91..92 "(" None
               LIST@92..92
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@92..93 ")"
@@ -115,9 +124,12 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
               None R_PAREN@92..94 ")" Whitespace(1)
+=======
+              None R_PAREN@92..93 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
             BLOCK_STMT@94..96
               None L_CURLY@94..95 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@95..95
               None R_CURLY@95..96 "}" None
-        Whitespace(1) R_CURLY@96..98 "}" None
+        Whitespace(1) R_CURLY@97..98 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -5,21 +5,22 @@ MODULE@0..98
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..98
     CLASS_DECL@0..98
-       CLASS_KW@0..6 "class" " "
+      None CLASS_KW@0..6 "class" Whitespace(1)
       NAME@6..10
-         IDENT@6..10 "foo" " "
+        None IDENT@6..10 "foo" Whitespace(1)
       CLASS_BODY@10..98
-         L_CURLY@10..11 "{" 
+        None L_CURLY@10..11 "{" None
         LIST@11..96
           METHOD@11..31
-            "\n " STATIC_KW@11..20 "static" " "
+            Whitespace(2) STATIC_KW@11..20 "static" Whitespace(1)
             NAME@20..23
-               IDENT@20..23 "foo" 
+              None IDENT@20..23 "foo" None
             PARAMETER_LIST@23..29
-               L_PAREN@23..24 "(" 
+              None L_PAREN@23..24 "(" None
               LIST@24..27
                 SINGLE_PATTERN@24..27
                   NAME@24..27
+<<<<<<< HEAD
 <<<<<<< HEAD
                     IDENT@24..27 "bar"
               R_PAREN@27..28 ")"
@@ -32,16 +33,23 @@ MODULE@0..98
             BLOCK_STMT@29..31
                L_CURLY@29..30 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                    None IDENT@24..27 "bar" None
+              None R_PAREN@27..29 ")" Whitespace(1)
+            BLOCK_STMT@29..31
+              None L_CURLY@29..30 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@30..30
-               R_CURLY@30..31 "}" 
+              None R_CURLY@30..31 "}" None
           METHOD@31..49
-            "\n " STATIC_KW@31..40 "static" " "
-             STAR@40..41 "*" 
+            Whitespace(2) STATIC_KW@31..40 "static" Whitespace(1)
+            None STAR@40..41 "*" None
             NAME@41..44
-               IDENT@41..44 "foo" 
+              None IDENT@41..44 "foo" None
             PARAMETER_LIST@44..47
-               L_PAREN@44..45 "(" 
+              None L_PAREN@44..45 "(" None
               LIST@45..45
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@45..46 ")"
             WHITESPACE@46..47 " "
@@ -52,16 +60,22 @@ MODULE@0..98
             BLOCK_STMT@47..49
                L_CURLY@47..48 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@45..47 ")" Whitespace(1)
+            BLOCK_STMT@47..49
+              None L_CURLY@47..48 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@48..48
-               R_CURLY@48..49 "}" 
+              None R_CURLY@48..49 "}" None
           METHOD@49..72
-            "\n " STATIC_KW@49..58 "static" " "
-             ASYNC_KW@58..64 "async" " "
+            Whitespace(2) STATIC_KW@49..58 "static" Whitespace(1)
+            None ASYNC_KW@58..64 "async" Whitespace(1)
             NAME@64..67
-               IDENT@64..67 "foo" 
+              None IDENT@64..67 "foo" None
             PARAMETER_LIST@67..70
-               L_PAREN@67..68 "(" 
+              None L_PAREN@67..68 "(" None
               LIST@68..68
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@68..69 ")"
             WHITESPACE@69..70 " "
@@ -72,17 +86,23 @@ MODULE@0..98
             BLOCK_STMT@70..72
                L_CURLY@70..71 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@68..70 ")" Whitespace(1)
+            BLOCK_STMT@70..72
+              None L_CURLY@70..71 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@71..71
-               R_CURLY@71..72 "}" 
+              None R_CURLY@71..72 "}" None
           METHOD@72..96
-            "\n " STATIC_KW@72..81 "static" " "
-             ASYNC_KW@81..87 "async" " "
-             STAR@87..88 "*" 
+            Whitespace(2) STATIC_KW@72..81 "static" Whitespace(1)
+            None ASYNC_KW@81..87 "async" Whitespace(1)
+            None STAR@87..88 "*" None
             NAME@88..91
-               IDENT@88..91 "foo" 
+              None IDENT@88..91 "foo" None
             PARAMETER_LIST@91..94
-               L_PAREN@91..92 "(" 
+              None L_PAREN@91..92 "(" None
               LIST@92..92
+<<<<<<< HEAD
 <<<<<<< HEAD
               R_PAREN@92..93 ")"
             WHITESPACE@93..94 " "
@@ -93,6 +113,11 @@ MODULE@0..98
             BLOCK_STMT@94..96
                L_CURLY@94..95 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None R_PAREN@92..94 ")" Whitespace(1)
+            BLOCK_STMT@94..96
+              None L_CURLY@94..95 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               LIST@95..95
-               R_CURLY@95..96 "}" 
-        "\n" R_CURLY@96..98 "}" 
+              None R_CURLY@95..96 "}" None
+        Whitespace(1) R_CURLY@96..98 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -1,11 +1,16 @@
+<<<<<<< HEAD
 JS_MODULE@0..33
+=======
+MODULE@0..32
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..32
     JS_EXPRESSION_STATEMENT@0..8
       TEMPLATE@0..8
         NAME_REF@0..3
-          IDENT@0..3 "foo"
-        BACKTICK@3..4 "`"
+           IDENT@0..3 "foo" 
+         BACKTICK@3..4 "`" 
         LIST@4..7
+<<<<<<< HEAD
           TEMPLATE_CHUNK@4..7 "bar"
         BACKTICK@7..8 "`"
     WHITESPACE@8..9 "\n"
@@ -16,26 +21,36 @@ JS_MODULE@0..33
             CALL_EXPR@9..17
               NAME_REF@9..12
                 IDENT@9..12 "foo"
+=======
+           TEMPLATE_CHUNK@4..7 "bar" 
+         BACKTICK@7..8 "`" 
+    EXPR_STMT@8..32
+      BRACKET_EXPR@8..32
+        CALL_EXPR@8..27
+          CALL_EXPR@8..22
+            CALL_EXPR@8..17
+              NAME_REF@8..12
+                "\n" IDENT@8..12 "foo" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               ARG_LIST@12..17
-                L_PAREN@12..13 "("
+                 L_PAREN@12..13 "(" 
                 LIST@13..16
                   NAME_REF@13..16
-                    IDENT@13..16 "bar"
-                R_PAREN@16..17 ")"
+                     IDENT@13..16 "bar" 
+                 R_PAREN@16..17 ")" 
             ARG_LIST@17..22
-              L_PAREN@17..18 "("
+               L_PAREN@17..18 "(" 
               LIST@18..21
                 NAME_REF@18..21
-                  IDENT@18..21 "baz"
-              R_PAREN@21..22 ")"
+                   IDENT@18..21 "baz" 
+               R_PAREN@21..22 ")" 
           ARG_LIST@22..27
-            L_PAREN@22..23 "("
+             L_PAREN@22..23 "(" 
             LIST@23..26
               NAME_REF@23..26
-                IDENT@23..26 "baz"
-            R_PAREN@26..27 ")"
-        L_BRACK@27..28 "["
+                 IDENT@23..26 "baz" 
+             R_PAREN@26..27 ")" 
+         L_BRACK@27..28 "[" 
         NAME_REF@28..31
-          IDENT@28..31 "bar"
-        R_BRACK@31..32 "]"
-  WHITESPACE@32..33 "\n"
+           IDENT@28..31 "bar" 
+         R_BRACK@31..32 "]" 

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -36,11 +36,15 @@ MODULE@0..32
             CALL_EXPR@8..17
               NAME_REF@8..12
 <<<<<<< HEAD
+<<<<<<< HEAD
                 "\n" IDENT@8..12 "foo" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
                 Whitespace(1) IDENT@8..12 "foo" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+                Whitespace(1) IDENT@9..12 "foo" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               ARG_LIST@12..17
                 None L_PAREN@12..13 "(" None
                 LIST@13..16

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..33
-=======
-MODULE@0..32
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..32
   LIST@0..32
     JS_EXPRESSION_STATEMENT@0..8
       TEMPLATE@0..8
@@ -10,41 +6,15 @@ MODULE@0..32
           None IDENT@0..3 "foo" None
         None BACKTICK@3..4 "`" None
         LIST@4..7
-<<<<<<< HEAD
-<<<<<<< HEAD
-          TEMPLATE_CHUNK@4..7 "bar"
-        BACKTICK@7..8 "`"
-    WHITESPACE@8..9 "\n"
-    JS_EXPRESSION_STATEMENT@9..32
-      BRACKET_EXPR@9..32
-        CALL_EXPR@9..27
-          CALL_EXPR@9..22
-            CALL_EXPR@9..17
-              NAME_REF@9..12
-                IDENT@9..12 "foo"
-=======
-           TEMPLATE_CHUNK@4..7 "bar" 
-         BACKTICK@7..8 "`" 
-=======
           None TEMPLATE_CHUNK@4..7 "bar" None
         None BACKTICK@7..8 "`" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-    EXPR_STMT@8..32
+    JS_EXPRESSION_STATEMENT@8..32
       BRACKET_EXPR@8..32
         CALL_EXPR@8..27
           CALL_EXPR@8..22
             CALL_EXPR@8..17
               NAME_REF@8..12
-<<<<<<< HEAD
-<<<<<<< HEAD
-                "\n" IDENT@8..12 "foo" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-                Whitespace(1) IDENT@8..12 "foo" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
                 Whitespace(1) IDENT@9..12 "foo" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               ARG_LIST@12..17
                 None L_PAREN@12..13 "(" None
                 LIST@13..16

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -7,9 +7,10 @@ MODULE@0..32
     JS_EXPRESSION_STATEMENT@0..8
       TEMPLATE@0..8
         NAME_REF@0..3
-           IDENT@0..3 "foo" 
-         BACKTICK@3..4 "`" 
+          None IDENT@0..3 "foo" None
+        None BACKTICK@3..4 "`" None
         LIST@4..7
+<<<<<<< HEAD
 <<<<<<< HEAD
           TEMPLATE_CHUNK@4..7 "bar"
         BACKTICK@7..8 "`"
@@ -24,33 +25,41 @@ MODULE@0..32
 =======
            TEMPLATE_CHUNK@4..7 "bar" 
          BACKTICK@7..8 "`" 
+=======
+          None TEMPLATE_CHUNK@4..7 "bar" None
+        None BACKTICK@7..8 "`" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
     EXPR_STMT@8..32
       BRACKET_EXPR@8..32
         CALL_EXPR@8..27
           CALL_EXPR@8..22
             CALL_EXPR@8..17
               NAME_REF@8..12
+<<<<<<< HEAD
                 "\n" IDENT@8..12 "foo" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+                Whitespace(1) IDENT@8..12 "foo" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               ARG_LIST@12..17
-                 L_PAREN@12..13 "(" 
+                None L_PAREN@12..13 "(" None
                 LIST@13..16
                   NAME_REF@13..16
-                     IDENT@13..16 "bar" 
-                 R_PAREN@16..17 ")" 
+                    None IDENT@13..16 "bar" None
+                None R_PAREN@16..17 ")" None
             ARG_LIST@17..22
-               L_PAREN@17..18 "(" 
+              None L_PAREN@17..18 "(" None
               LIST@18..21
                 NAME_REF@18..21
-                   IDENT@18..21 "baz" 
-               R_PAREN@21..22 ")" 
+                  None IDENT@18..21 "baz" None
+              None R_PAREN@21..22 ")" None
           ARG_LIST@22..27
-             L_PAREN@22..23 "(" 
+            None L_PAREN@22..23 "(" None
             LIST@23..26
               NAME_REF@23..26
-                 IDENT@23..26 "baz" 
-             R_PAREN@26..27 ")" 
-         L_BRACK@27..28 "[" 
+                None IDENT@23..26 "baz" None
+            None R_PAREN@26..27 ")" None
+        None L_BRACK@27..28 "[" None
         NAME_REF@28..31
-           IDENT@28..31 "bar" 
-         R_BRACK@31..32 "]" 
+          None IDENT@28..31 "bar" None
+        None R_BRACK@31..32 "]" None

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -31,23 +31,27 @@ JS_MODULE@0..38
 MODULE@0..37
   LIST@0..37
     SWITCH_STMT@0..37
-       SWITCH_KW@0..7 "switch" " "
+      None SWITCH_KW@0..7 "switch" Whitespace(1)
       CONDITION@7..13
-         L_PAREN@7..8 "(" 
+        None L_PAREN@7..8 "(" None
         NAME_REF@8..11
-           IDENT@8..11 "foo" 
-         R_PAREN@11..13 ")" " "
-       L_CURLY@13..14 "{" 
+          None IDENT@8..11 "foo" None
+        None R_PAREN@11..13 ")" Whitespace(1)
+      None L_CURLY@13..14 "{" None
       LIST@14..35
         CASE_CLAUSE@14..25
-          "\n " CASE_KW@14..21 "case" " "
+          Whitespace(2) CASE_KW@14..21 "case" Whitespace(1)
           NAME_REF@21..24
-             IDENT@21..24 "bar" 
-           COLON@24..25 ":" 
+            None IDENT@21..24 "bar" None
+          None COLON@24..25 ":" None
           LIST@25..25
         DEFAULT_CLAUSE@25..35
-          "\n " DEFAULT_KW@25..34 "default" 
-           COLON@34..35 ":" 
+          Whitespace(2) DEFAULT_KW@25..34 "default" None
+          None COLON@34..35 ":" None
           LIST@35..35
+<<<<<<< HEAD
       "\n" R_CURLY@35..37 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      Whitespace(1) R_CURLY@35..37 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -1,61 +1,21 @@
-<<<<<<< HEAD
-JS_MODULE@0..38
+JS_MODULE@0..37
   LIST@0..37
     JS_SWITCH_STATEMENT@0..37
-      SWITCH_KW@0..6 "switch"
-      WHITESPACE@6..7 " "
-      L_PAREN@7..8 "("
-      NAME_REF@8..11
-        IDENT@8..11 "foo"
-      R_PAREN@11..12 ")"
-      WHITESPACE@12..13 " "
-      L_CURLY@13..14 "{"
-      WHITESPACE@14..16 "\n "
-      LIST@16..36
-        JS_CASE_CLAUSE@16..27
-          CASE_KW@16..20 "case"
-          WHITESPACE@20..21 " "
-          NAME_REF@21..24
-            IDENT@21..24 "bar"
-          COLON@24..25 ":"
-          WHITESPACE@25..27 "\n "
-          LIST@27..27
-        JS_DEFAULT_CLAUSE@27..36
-          DEFAULT_KW@27..34 "default"
-          COLON@34..35 ":"
-          WHITESPACE@35..36 "\n"
-          LIST@36..36
-      R_CURLY@36..37 "}"
-  WHITESPACE@37..38 "\n"
-=======
-MODULE@0..37
-  LIST@0..37
-    SWITCH_STMT@0..37
       None SWITCH_KW@0..6 "switch" Whitespace(1)
-      CONDITION@7..13
-        None L_PAREN@7..8 "(" None
-        NAME_REF@8..11
-          None IDENT@8..11 "foo" None
-        None R_PAREN@11..12 ")" Whitespace(1)
+      None L_PAREN@7..8 "(" None
+      NAME_REF@8..11
+        None IDENT@8..11 "foo" None
+      None R_PAREN@11..12 ")" Whitespace(1)
       None L_CURLY@13..14 "{" None
       LIST@14..35
-        CASE_CLAUSE@14..25
+        JS_CASE_CLAUSE@14..25
           Whitespace(2) CASE_KW@16..20 "case" Whitespace(1)
           NAME_REF@21..24
             None IDENT@21..24 "bar" None
           None COLON@24..25 ":" None
           LIST@25..25
-        DEFAULT_CLAUSE@25..35
+        JS_DEFAULT_CLAUSE@25..35
           Whitespace(2) DEFAULT_KW@27..34 "default" None
           None COLON@34..35 ":" None
           LIST@35..35
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "\n" R_CURLY@35..37 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-      Whitespace(1) R_CURLY@35..37 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
       Whitespace(1) R_CURLY@36..37 "}" None
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -31,27 +31,31 @@ JS_MODULE@0..38
 MODULE@0..37
   LIST@0..37
     SWITCH_STMT@0..37
-      None SWITCH_KW@0..7 "switch" Whitespace(1)
+      None SWITCH_KW@0..6 "switch" Whitespace(1)
       CONDITION@7..13
         None L_PAREN@7..8 "(" None
         NAME_REF@8..11
           None IDENT@8..11 "foo" None
-        None R_PAREN@11..13 ")" Whitespace(1)
+        None R_PAREN@11..12 ")" Whitespace(1)
       None L_CURLY@13..14 "{" None
       LIST@14..35
         CASE_CLAUSE@14..25
-          Whitespace(2) CASE_KW@14..21 "case" Whitespace(1)
+          Whitespace(2) CASE_KW@16..20 "case" Whitespace(1)
           NAME_REF@21..24
             None IDENT@21..24 "bar" None
           None COLON@24..25 ":" None
           LIST@25..25
         DEFAULT_CLAUSE@25..35
-          Whitespace(2) DEFAULT_KW@25..34 "default" None
+          Whitespace(2) DEFAULT_KW@27..34 "default" None
           None COLON@34..35 ":" None
           LIST@35..35
+<<<<<<< HEAD
 <<<<<<< HEAD
       "\n" R_CURLY@35..37 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
       Whitespace(1) R_CURLY@35..37 "}" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      Whitespace(1) R_CURLY@36..37 "}" None
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..38
   LIST@0..37
     JS_SWITCH_STATEMENT@0..37
@@ -26,3 +27,27 @@ JS_MODULE@0..38
           LIST@36..36
       R_CURLY@36..37 "}"
   WHITESPACE@37..38 "\n"
+=======
+MODULE@0..37
+  LIST@0..37
+    SWITCH_STMT@0..37
+       SWITCH_KW@0..7 "switch" " "
+      CONDITION@7..13
+         L_PAREN@7..8 "(" 
+        NAME_REF@8..11
+           IDENT@8..11 "foo" 
+         R_PAREN@11..13 ")" " "
+       L_CURLY@13..14 "{" 
+      LIST@14..35
+        CASE_CLAUSE@14..25
+          "\n " CASE_KW@14..21 "case" " "
+          NAME_REF@21..24
+             IDENT@21..24 "bar" 
+           COLON@24..25 ":" 
+          LIST@25..25
+        DEFAULT_CLAUSE@25..35
+          "\n " DEFAULT_KW@25..34 "default" 
+           COLON@34..35 ":" 
+          LIST@35..35
+      "\n" R_CURLY@35..37 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -5,66 +5,66 @@ MODULE@0..66
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     VAR_DECL@0..21
-       IDENT@0..4 "let" " "
+      None IDENT@0..4 "let" Whitespace(1)
       LIST@4..20
         DECLARATOR@4..20
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           TEMPLATE@8..20
-             BACKTICK@8..9 "`" 
+            None BACKTICK@8..9 "`" None
             LIST@9..19
-               TEMPLATE_CHUNK@9..13 "foo " 
+              None TEMPLATE_CHUNK@9..13 "foo " None
               TEMPLATE_ELEMENT@13..19
-                 DOLLARCURLY@13..15 "${" 
+                None DOLLARCURLY@13..15 "${" None
                 NAME_REF@15..18
-                   IDENT@15..18 "bar" 
-                 R_CURLY@18..19 "}" 
-             BACKTICK@19..20 "`" 
-       SEMICOLON@20..21 ";" 
+                  None IDENT@15..18 "bar" None
+                None R_CURLY@18..19 "}" None
+            None BACKTICK@19..20 "`" None
+      None SEMICOLON@20..21 ";" None
     VAR_DECL@21..33
-      "\n" IDENT@21..26 "let" " "
+      Whitespace(1) IDENT@21..26 "let" Whitespace(1)
       LIST@26..32
         DECLARATOR@26..32
           SINGLE_PATTERN@26..28
             NAME@26..28
-               IDENT@26..28 "a" " "
-           EQ@28..30 "=" " "
+              None IDENT@26..28 "a" Whitespace(1)
+          None EQ@28..30 "=" Whitespace(1)
           TEMPLATE@30..32
-             BACKTICK@30..31 "`" 
+            None BACKTICK@30..31 "`" None
             LIST@31..31
-             BACKTICK@31..32 "`" 
-       SEMICOLON@32..33 ";" 
+            None BACKTICK@31..32 "`" None
+      None SEMICOLON@32..33 ";" None
     VAR_DECL@33..51
-      "\n" IDENT@33..38 "let" " "
+      Whitespace(1) IDENT@33..38 "let" Whitespace(1)
       LIST@38..50
         DECLARATOR@38..50
           SINGLE_PATTERN@38..40
             NAME@38..40
-               IDENT@38..40 "a" " "
-           EQ@40..42 "=" " "
+              None IDENT@38..40 "a" Whitespace(1)
+          None EQ@40..42 "=" Whitespace(1)
           TEMPLATE@42..50
-             BACKTICK@42..43 "`" 
+            None BACKTICK@42..43 "`" None
             LIST@43..49
               TEMPLATE_ELEMENT@43..49
-                 DOLLARCURLY@43..45 "${" 
+                None DOLLARCURLY@43..45 "${" None
                 NAME_REF@45..48
-                   IDENT@45..48 "foo" 
-                 R_CURLY@48..49 "}" 
-             BACKTICK@49..50 "`" 
-       SEMICOLON@50..51 ";" 
+                  None IDENT@45..48 "foo" None
+                None R_CURLY@48..49 "}" None
+            None BACKTICK@49..50 "`" None
+      None SEMICOLON@50..51 ";" None
     VAR_DECL@51..66
-      "\n" IDENT@51..56 "let" " "
+      Whitespace(1) IDENT@51..56 "let" Whitespace(1)
       LIST@56..65
         DECLARATOR@56..65
           SINGLE_PATTERN@56..58
             NAME@56..58
-               IDENT@56..58 "a" " "
-           EQ@58..60 "=" " "
+              None IDENT@56..58 "a" Whitespace(1)
+          None EQ@58..60 "=" Whitespace(1)
           TEMPLATE@60..65
-             BACKTICK@60..61 "`" 
+            None BACKTICK@60..61 "`" None
             LIST@61..64
-               TEMPLATE_CHUNK@61..64 "foo" 
-             BACKTICK@64..65 "`" 
-       SEMICOLON@65..66 ";" 
+              None TEMPLATE_CHUNK@61..64 "foo" None
+            None BACKTICK@64..65 "`" None
+      None SEMICOLON@65..66 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -1,82 +1,70 @@
+<<<<<<< HEAD
 JS_MODULE@0..67
+=======
+MODULE@0..66
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     VAR_DECL@0..21
-      IDENT@0..3 "let"
-      WHITESPACE@3..4 " "
+       IDENT@0..4 "let" " "
       LIST@4..20
         DECLARATOR@4..20
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           TEMPLATE@8..20
-            BACKTICK@8..9 "`"
+             BACKTICK@8..9 "`" 
             LIST@9..19
-              TEMPLATE_CHUNK@9..13 "foo "
+               TEMPLATE_CHUNK@9..13 "foo " 
               TEMPLATE_ELEMENT@13..19
-                DOLLARCURLY@13..15 "${"
+                 DOLLARCURLY@13..15 "${" 
                 NAME_REF@15..18
-                  IDENT@15..18 "bar"
-                R_CURLY@18..19 "}"
-            BACKTICK@19..20 "`"
-      SEMICOLON@20..21 ";"
-    WHITESPACE@21..22 "\n"
-    VAR_DECL@22..33
-      IDENT@22..25 "let"
-      WHITESPACE@25..26 " "
+                   IDENT@15..18 "bar" 
+                 R_CURLY@18..19 "}" 
+             BACKTICK@19..20 "`" 
+       SEMICOLON@20..21 ";" 
+    VAR_DECL@21..33
+      "\n" IDENT@21..26 "let" " "
       LIST@26..32
         DECLARATOR@26..32
-          SINGLE_PATTERN@26..27
-            NAME@26..27
-              IDENT@26..27 "a"
-          WHITESPACE@27..28 " "
-          EQ@28..29 "="
-          WHITESPACE@29..30 " "
+          SINGLE_PATTERN@26..28
+            NAME@26..28
+               IDENT@26..28 "a" " "
+           EQ@28..30 "=" " "
           TEMPLATE@30..32
-            BACKTICK@30..31 "`"
+             BACKTICK@30..31 "`" 
             LIST@31..31
-            BACKTICK@31..32 "`"
-      SEMICOLON@32..33 ";"
-    WHITESPACE@33..34 "\n"
-    VAR_DECL@34..51
-      IDENT@34..37 "let"
-      WHITESPACE@37..38 " "
+             BACKTICK@31..32 "`" 
+       SEMICOLON@32..33 ";" 
+    VAR_DECL@33..51
+      "\n" IDENT@33..38 "let" " "
       LIST@38..50
         DECLARATOR@38..50
-          SINGLE_PATTERN@38..39
-            NAME@38..39
-              IDENT@38..39 "a"
-          WHITESPACE@39..40 " "
-          EQ@40..41 "="
-          WHITESPACE@41..42 " "
+          SINGLE_PATTERN@38..40
+            NAME@38..40
+               IDENT@38..40 "a" " "
+           EQ@40..42 "=" " "
           TEMPLATE@42..50
-            BACKTICK@42..43 "`"
+             BACKTICK@42..43 "`" 
             LIST@43..49
               TEMPLATE_ELEMENT@43..49
-                DOLLARCURLY@43..45 "${"
+                 DOLLARCURLY@43..45 "${" 
                 NAME_REF@45..48
-                  IDENT@45..48 "foo"
-                R_CURLY@48..49 "}"
-            BACKTICK@49..50 "`"
-      SEMICOLON@50..51 ";"
-    WHITESPACE@51..52 "\n"
-    VAR_DECL@52..66
-      IDENT@52..55 "let"
-      WHITESPACE@55..56 " "
+                   IDENT@45..48 "foo" 
+                 R_CURLY@48..49 "}" 
+             BACKTICK@49..50 "`" 
+       SEMICOLON@50..51 ";" 
+    VAR_DECL@51..66
+      "\n" IDENT@51..56 "let" " "
       LIST@56..65
         DECLARATOR@56..65
-          SINGLE_PATTERN@56..57
-            NAME@56..57
-              IDENT@56..57 "a"
-          WHITESPACE@57..58 " "
-          EQ@58..59 "="
-          WHITESPACE@59..60 " "
+          SINGLE_PATTERN@56..58
+            NAME@56..58
+               IDENT@56..58 "a" " "
+           EQ@58..60 "=" " "
           TEMPLATE@60..65
-            BACKTICK@60..61 "`"
+             BACKTICK@60..61 "`" 
             LIST@61..64
-              TEMPLATE_CHUNK@61..64 "foo"
-            BACKTICK@64..65 "`"
-      SEMICOLON@65..66 ";"
-  WHITESPACE@66..67 "\n"
+               TEMPLATE_CHUNK@61..64 "foo" 
+             BACKTICK@64..65 "`" 
+       SEMICOLON@65..66 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..67
-=======
-MODULE@0..66
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..66
   LIST@0..66
     VAR_DECL@0..21
       None IDENT@0..3 "let" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -5,13 +5,13 @@ MODULE@0..66
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..66
     VAR_DECL@0..21
-      None IDENT@0..4 "let" Whitespace(1)
+      None IDENT@0..3 "let" Whitespace(1)
       LIST@4..20
         DECLARATOR@4..20
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           TEMPLATE@8..20
             None BACKTICK@8..9 "`" None
             LIST@9..19
@@ -24,26 +24,26 @@ MODULE@0..66
             None BACKTICK@19..20 "`" None
       None SEMICOLON@20..21 ";" None
     VAR_DECL@21..33
-      Whitespace(1) IDENT@21..26 "let" Whitespace(1)
+      Whitespace(1) IDENT@22..25 "let" Whitespace(1)
       LIST@26..32
         DECLARATOR@26..32
           SINGLE_PATTERN@26..28
             NAME@26..28
-              None IDENT@26..28 "a" Whitespace(1)
-          None EQ@28..30 "=" Whitespace(1)
+              None IDENT@26..27 "a" Whitespace(1)
+          None EQ@28..29 "=" Whitespace(1)
           TEMPLATE@30..32
             None BACKTICK@30..31 "`" None
             LIST@31..31
             None BACKTICK@31..32 "`" None
       None SEMICOLON@32..33 ";" None
     VAR_DECL@33..51
-      Whitespace(1) IDENT@33..38 "let" Whitespace(1)
+      Whitespace(1) IDENT@34..37 "let" Whitespace(1)
       LIST@38..50
         DECLARATOR@38..50
           SINGLE_PATTERN@38..40
             NAME@38..40
-              None IDENT@38..40 "a" Whitespace(1)
-          None EQ@40..42 "=" Whitespace(1)
+              None IDENT@38..39 "a" Whitespace(1)
+          None EQ@40..41 "=" Whitespace(1)
           TEMPLATE@42..50
             None BACKTICK@42..43 "`" None
             LIST@43..49
@@ -55,13 +55,13 @@ MODULE@0..66
             None BACKTICK@49..50 "`" None
       None SEMICOLON@50..51 ";" None
     VAR_DECL@51..66
-      Whitespace(1) IDENT@51..56 "let" Whitespace(1)
+      Whitespace(1) IDENT@52..55 "let" Whitespace(1)
       LIST@56..65
         DECLARATOR@56..65
           SINGLE_PATTERN@56..58
             NAME@56..58
-              None IDENT@56..58 "a" Whitespace(1)
-          None EQ@58..60 "=" Whitespace(1)
+              None IDENT@56..57 "a" Whitespace(1)
+          None EQ@58..59 "=" Whitespace(1)
           TEMPLATE@60..65
             None BACKTICK@60..61 "`" None
             LIST@61..64

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -1,35 +1,12 @@
-<<<<<<< HEAD
-JS_MODULE@0..14
-=======
-MODULE@0..13
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..13
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..4
       THIS_EXPR@0..4
-<<<<<<< HEAD
-<<<<<<< HEAD
-        THIS_KW@0..4 "this"
-    WHITESPACE@4..5 "\n"
-    JS_EXPRESSION_STATEMENT@5..13
-      DOT_EXPR@5..13
-        THIS_EXPR@5..9
-          THIS_KW@5..9 "this"
-        DOT@9..10 "."
-=======
-         THIS_KW@0..4 "this" 
-    EXPR_STMT@4..13
-      DOT_EXPR@4..13
-        THIS_EXPR@4..9
-          "\n" THIS_KW@4..9 "this" 
-         DOT@9..10 "." 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
         None THIS_KW@0..4 "this" None
-    EXPR_STMT@4..13
+    JS_EXPRESSION_STATEMENT@4..13
       DOT_EXPR@4..13
         THIS_EXPR@4..9
           Whitespace(1) THIS_KW@5..9 "this" None
         None DOT@9..10 "." None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@10..13
           None IDENT@10..13 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -1,7 +1,12 @@
+<<<<<<< HEAD
 JS_MODULE@0..14
+=======
+MODULE@0..13
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..13
     JS_EXPRESSION_STATEMENT@0..4
       THIS_EXPR@0..4
+<<<<<<< HEAD
         THIS_KW@0..4 "this"
     WHITESPACE@4..5 "\n"
     JS_EXPRESSION_STATEMENT@5..13
@@ -9,6 +14,13 @@ JS_MODULE@0..14
         THIS_EXPR@5..9
           THIS_KW@5..9 "this"
         DOT@9..10 "."
+=======
+         THIS_KW@0..4 "this" 
+    EXPR_STMT@4..13
+      DOT_EXPR@4..13
+        THIS_EXPR@4..9
+          "\n" THIS_KW@4..9 "this" 
+         DOT@9..10 "." 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         NAME@10..13
-          IDENT@10..13 "foo"
-  WHITESPACE@13..14 "\n"
+           IDENT@10..13 "foo" 

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -7,6 +7,7 @@ MODULE@0..13
     JS_EXPRESSION_STATEMENT@0..4
       THIS_EXPR@0..4
 <<<<<<< HEAD
+<<<<<<< HEAD
         THIS_KW@0..4 "this"
     WHITESPACE@4..5 "\n"
     JS_EXPRESSION_STATEMENT@5..13
@@ -22,5 +23,13 @@ MODULE@0..13
           "\n" THIS_KW@4..9 "this" 
          DOT@9..10 "." 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+        None THIS_KW@0..4 "this" None
+    EXPR_STMT@4..13
+      DOT_EXPR@4..13
+        THIS_EXPR@4..9
+          Whitespace(1) THIS_KW@4..9 "this" None
+        None DOT@9..10 "." None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@10..13
-           IDENT@10..13 "foo" 
+          None IDENT@10..13 "foo" None

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -28,7 +28,7 @@ MODULE@0..13
     EXPR_STMT@4..13
       DOT_EXPR@4..13
         THIS_EXPR@4..9
-          Whitespace(1) THIS_KW@4..9 "this" None
+          Whitespace(1) THIS_KW@5..9 "this" None
         None DOT@9..10 "." None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         NAME@10..13

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -1,17 +1,24 @@
+<<<<<<< HEAD
 JS_MODULE@0..36
   LIST@0..35
     JS_THROW_STATEMENT@0..23
       THROW_KW@0..5 "throw"
       WHITESPACE@5..6 " "
+=======
+MODULE@0..35
+  LIST@0..35
+    THROW_STMT@0..23
+       THROW_KW@0..6 "throw" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       NEW_EXPR@6..22
-        NEW_KW@6..9 "new"
-        WHITESPACE@9..10 " "
+         NEW_KW@6..10 "new" " "
         NAME_REF@10..15
-          IDENT@10..15 "Error"
+           IDENT@10..15 "Error" 
         ARG_LIST@15..22
-          L_PAREN@15..16 "("
+           L_PAREN@15..16 "(" 
           LIST@16..21
             LITERAL@16..21
+<<<<<<< HEAD
               STRING@16..21 "\"foo\""
           R_PAREN@21..22 ")"
       SEMICOLON@22..23 ";"
@@ -19,6 +26,12 @@ JS_MODULE@0..36
     JS_THROW_STATEMENT@24..35
       THROW_KW@24..29 "throw"
       WHITESPACE@29..30 " "
+=======
+               STRING@16..21 "\"foo\"" 
+           R_PAREN@21..22 ")" 
+       SEMICOLON@22..23 ";" 
+    THROW_STMT@23..35
+      "\n" THROW_KW@23..30 "throw" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
       LITERAL@30..35
-        STRING@30..35 "\"foo\""
-  WHITESPACE@35..36 "\n"
+         STRING@30..35 "\"foo\"" 

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -1,23 +1,7 @@
-<<<<<<< HEAD
-JS_MODULE@0..36
+JS_MODULE@0..35
   LIST@0..35
     JS_THROW_STATEMENT@0..23
-      THROW_KW@0..5 "throw"
-      WHITESPACE@5..6 " "
-=======
-MODULE@0..35
-  LIST@0..35
-    THROW_STMT@0..23
-<<<<<<< HEAD
-<<<<<<< HEAD
-       THROW_KW@0..6 "throw" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-      None THROW_KW@0..6 "throw" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
       None THROW_KW@0..5 "throw" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NEW_EXPR@6..22
         None NEW_KW@6..9 "new" Whitespace(1)
         NAME_REF@10..15
@@ -26,32 +10,10 @@ MODULE@0..35
           None L_PAREN@15..16 "(" None
           LIST@16..21
             LITERAL@16..21
-<<<<<<< HEAD
-<<<<<<< HEAD
-              STRING@16..21 "\"foo\""
-          R_PAREN@21..22 ")"
-      SEMICOLON@22..23 ";"
-    WHITESPACE@23..24 "\n"
-    JS_THROW_STATEMENT@24..35
-      THROW_KW@24..29 "throw"
-      WHITESPACE@29..30 " "
-=======
-               STRING@16..21 "\"foo\"" 
-           R_PAREN@21..22 ")" 
-       SEMICOLON@22..23 ";" 
-    THROW_STMT@23..35
-      "\n" THROW_KW@23..30 "throw" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
               None STRING@16..21 "\"foo\"" None
           None R_PAREN@21..22 ")" None
       None SEMICOLON@22..23 ";" None
-    THROW_STMT@23..35
-<<<<<<< HEAD
-      Whitespace(1) THROW_KW@23..30 "throw" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
+    JS_THROW_STATEMENT@23..35
       Whitespace(1) THROW_KW@24..29 "throw" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       LITERAL@30..35
         None STRING@30..35 "\"foo\"" None

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -9,13 +9,17 @@ MODULE@0..35
   LIST@0..35
     THROW_STMT@0..23
 <<<<<<< HEAD
+<<<<<<< HEAD
        THROW_KW@0..6 "throw" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
       None THROW_KW@0..6 "throw" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      None THROW_KW@0..5 "throw" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       NEW_EXPR@6..22
-        None NEW_KW@6..10 "new" Whitespace(1)
+        None NEW_KW@6..9 "new" Whitespace(1)
         NAME_REF@10..15
           None IDENT@10..15 "Error" None
         ARG_LIST@15..22
@@ -43,7 +47,11 @@ MODULE@0..35
           None R_PAREN@21..22 ")" None
       None SEMICOLON@22..23 ";" None
     THROW_STMT@23..35
+<<<<<<< HEAD
       Whitespace(1) THROW_KW@23..30 "throw" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+      Whitespace(1) THROW_KW@24..29 "throw" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       LITERAL@30..35
         None STRING@30..35 "\"foo\"" None

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -8,16 +8,21 @@ JS_MODULE@0..36
 MODULE@0..35
   LIST@0..35
     THROW_STMT@0..23
+<<<<<<< HEAD
        THROW_KW@0..6 "throw" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+      None THROW_KW@0..6 "throw" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       NEW_EXPR@6..22
-         NEW_KW@6..10 "new" " "
+        None NEW_KW@6..10 "new" Whitespace(1)
         NAME_REF@10..15
-           IDENT@10..15 "Error" 
+          None IDENT@10..15 "Error" None
         ARG_LIST@15..22
-           L_PAREN@15..16 "(" 
+          None L_PAREN@15..16 "(" None
           LIST@16..21
             LITERAL@16..21
+<<<<<<< HEAD
 <<<<<<< HEAD
               STRING@16..21 "\"foo\""
           R_PAREN@21..22 ")"
@@ -33,5 +38,12 @@ MODULE@0..35
     THROW_STMT@23..35
       "\n" THROW_KW@23..30 "throw" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              None STRING@16..21 "\"foo\"" None
+          None R_PAREN@21..22 ")" None
+      None SEMICOLON@22..23 ";" None
+    THROW_STMT@23..35
+      Whitespace(1) THROW_KW@23..30 "throw" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       LITERAL@30..35
-         STRING@30..35 "\"foo\"" 
+        None STRING@30..35 "\"foo\"" None

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -115,38 +115,42 @@ JS_MODULE@0..112
 MODULE@0..46
   LIST@0..46
     TRY_STMT@0..19
-       TRY_KW@0..4 "try" " "
+      None TRY_KW@0..4 "try" Whitespace(1)
       BLOCK_STMT@4..7
-         L_CURLY@4..5 "{" 
+        None L_CURLY@4..5 "{" None
         LIST@5..5
-         R_CURLY@5..7 "}" " "
+        None R_CURLY@5..7 "}" Whitespace(1)
       CATCH_CLAUSE@7..19
-         CATCH_KW@7..13 "catch" " "
-         L_PAREN@13..14 "(" 
+        None CATCH_KW@7..13 "catch" Whitespace(1)
+        None L_PAREN@13..14 "(" None
         SINGLE_PATTERN@14..15
           NAME@14..15
-             IDENT@14..15 "e" 
-         R_PAREN@15..17 ")" " "
+            None IDENT@14..15 "e" None
+        None R_PAREN@15..17 ")" Whitespace(1)
         BLOCK_STMT@17..19
-           L_CURLY@17..18 "{" 
+          None L_CURLY@17..18 "{" None
           LIST@18..18
-           R_CURLY@18..19 "}" 
+          None R_CURLY@18..19 "}" None
     TRY_STMT@19..46
-      "\n" TRY_KW@19..24 "try" " "
+      Whitespace(1) TRY_KW@19..24 "try" Whitespace(1)
       BLOCK_STMT@24..27
-         L_CURLY@24..25 "{" 
+        None L_CURLY@24..25 "{" None
         LIST@25..25
-         R_CURLY@25..27 "}" " "
+        None R_CURLY@25..27 "}" Whitespace(1)
       CATCH_CLAUSE@27..36
-         CATCH_KW@27..33 "catch" " "
+        None CATCH_KW@27..33 "catch" Whitespace(1)
         BLOCK_STMT@33..36
-           L_CURLY@33..34 "{" 
+          None L_CURLY@33..34 "{" None
           LIST@34..34
-           R_CURLY@34..36 "}" " "
+          None R_CURLY@34..36 "}" Whitespace(1)
       FINALIZER@36..46
-         FINALLY_KW@36..44 "finally" " "
+        None FINALLY_KW@36..44 "finally" Whitespace(1)
         BLOCK_STMT@44..46
-           L_CURLY@44..45 "{" 
+          None L_CURLY@44..45 "{" None
           LIST@45..45
+<<<<<<< HEAD
            R_CURLY@45..46 "}" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None R_CURLY@45..46 "}" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -115,36 +115,36 @@ JS_MODULE@0..112
 MODULE@0..46
   LIST@0..46
     TRY_STMT@0..19
-      None TRY_KW@0..4 "try" Whitespace(1)
+      None TRY_KW@0..3 "try" Whitespace(1)
       BLOCK_STMT@4..7
         None L_CURLY@4..5 "{" None
         LIST@5..5
-        None R_CURLY@5..7 "}" Whitespace(1)
+        None R_CURLY@5..6 "}" Whitespace(1)
       CATCH_CLAUSE@7..19
-        None CATCH_KW@7..13 "catch" Whitespace(1)
+        None CATCH_KW@7..12 "catch" Whitespace(1)
         None L_PAREN@13..14 "(" None
         SINGLE_PATTERN@14..15
           NAME@14..15
             None IDENT@14..15 "e" None
-        None R_PAREN@15..17 ")" Whitespace(1)
+        None R_PAREN@15..16 ")" Whitespace(1)
         BLOCK_STMT@17..19
           None L_CURLY@17..18 "{" None
           LIST@18..18
           None R_CURLY@18..19 "}" None
     TRY_STMT@19..46
-      Whitespace(1) TRY_KW@19..24 "try" Whitespace(1)
+      Whitespace(1) TRY_KW@20..23 "try" Whitespace(1)
       BLOCK_STMT@24..27
         None L_CURLY@24..25 "{" None
         LIST@25..25
-        None R_CURLY@25..27 "}" Whitespace(1)
+        None R_CURLY@25..26 "}" Whitespace(1)
       CATCH_CLAUSE@27..36
-        None CATCH_KW@27..33 "catch" Whitespace(1)
+        None CATCH_KW@27..32 "catch" Whitespace(1)
         BLOCK_STMT@33..36
           None L_CURLY@33..34 "{" None
           LIST@34..34
-          None R_CURLY@34..36 "}" Whitespace(1)
+          None R_CURLY@34..35 "}" Whitespace(1)
       FINALIZER@36..46
-        None FINALLY_KW@36..44 "finally" Whitespace(1)
+        None FINALLY_KW@36..43 "finally" Whitespace(1)
         BLOCK_STMT@44..46
           None L_CURLY@44..45 "{" None
           LIST@45..45

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -1,156 +1,86 @@
-<<<<<<< HEAD
-JS_MODULE@0..112
+JS_MODULE@0..111
   LIST@0..111
     JS_TRY_STATEMENT@0..15
-      TRY_KW@0..3 "try"
-      WHITESPACE@3..4 " "
-      JS_BLOCK_STATEMENT@4..6
-        L_CURLY@4..5 "{"
-        LIST@5..5
-        R_CURLY@5..6 "}"
-      WHITESPACE@6..7 " "
-      JS_CATCH_CLAUSE@7..15
-        CATCH_KW@7..12 "catch"
-        WHITESPACE@12..13 " "
-        JS_BLOCK_STATEMENT@13..15
-          L_CURLY@13..14 "{"
-          LIST@14..14
-          R_CURLY@14..15 "}"
-    WHITESPACE@15..16 "\n"
-    JS_TRY_STATEMENT@16..35
-      TRY_KW@16..19 "try"
-      WHITESPACE@19..20 " "
-      JS_BLOCK_STATEMENT@20..22
-        L_CURLY@20..21 "{"
-        LIST@21..21
-        R_CURLY@21..22 "}"
-      WHITESPACE@22..23 " "
-      JS_CATCH_CLAUSE@23..35
-        CATCH_KW@23..28 "catch"
-        WHITESPACE@28..29 " "
-        JS_CATCH_DECLARATION@29..32
-          L_PAREN@29..30 "("
-          SINGLE_PATTERN@30..31
-            NAME@30..31
-              IDENT@30..31 "e"
-          R_PAREN@31..32 ")"
-        WHITESPACE@32..33 " "
-        JS_BLOCK_STATEMENT@33..35
-          L_CURLY@33..34 "{"
-          LIST@34..34
-          R_CURLY@34..35 "}"
-    WHITESPACE@35..36 "\n"
-    JS_TRY_FINALLY_STATEMENT@36..62
-      TRY_KW@36..39 "try"
-      WHITESPACE@39..40 " "
-      JS_BLOCK_STATEMENT@40..42
-        L_CURLY@40..41 "{"
-        LIST@41..41
-        R_CURLY@41..42 "}"
-      WHITESPACE@42..43 " "
-      JS_CATCH_CLAUSE@43..51
-        CATCH_KW@43..48 "catch"
-        WHITESPACE@48..49 " "
-        JS_BLOCK_STATEMENT@49..51
-          L_CURLY@49..50 "{"
-          LIST@50..50
-          R_CURLY@50..51 "}"
-      WHITESPACE@51..52 " "
-      JS_FINALLY_CLAUSE@52..62
-        FINALLY_KW@52..59 "finally"
-        WHITESPACE@59..60 " "
-        JS_BLOCK_STATEMENT@60..62
-          L_CURLY@60..61 "{"
-          LIST@61..61
-          R_CURLY@61..62 "}"
-    WHITESPACE@62..63 "\n"
-    JS_TRY_FINALLY_STATEMENT@63..93
-      TRY_KW@63..66 "try"
-      WHITESPACE@66..67 " "
-      JS_BLOCK_STATEMENT@67..69
-        L_CURLY@67..68 "{"
-        LIST@68..68
-        R_CURLY@68..69 "}"
-      WHITESPACE@69..70 " "
-      JS_CATCH_CLAUSE@70..82
-        CATCH_KW@70..75 "catch"
-        WHITESPACE@75..76 " "
-        JS_CATCH_DECLARATION@76..79
-          L_PAREN@76..77 "("
-          SINGLE_PATTERN@77..78
-            NAME@77..78
-              IDENT@77..78 "e"
-          R_PAREN@78..79 ")"
-        WHITESPACE@79..80 " "
-        JS_BLOCK_STATEMENT@80..82
-          L_CURLY@80..81 "{"
-          LIST@81..81
-          R_CURLY@81..82 "}"
-      WHITESPACE@82..83 " "
-      JS_FINALLY_CLAUSE@83..93
-        FINALLY_KW@83..90 "finally"
-        WHITESPACE@90..91 " "
-        JS_BLOCK_STATEMENT@91..93
-          L_CURLY@91..92 "{"
-          LIST@92..92
-          R_CURLY@92..93 "}"
-    WHITESPACE@93..94 "\n"
-    JS_TRY_FINALLY_STATEMENT@94..111
-      TRY_KW@94..97 "try"
-      WHITESPACE@97..98 " "
-      JS_BLOCK_STATEMENT@98..100
-        L_CURLY@98..99 "{"
-        LIST@99..99
-        R_CURLY@99..100 "}"
-      WHITESPACE@100..101 " "
-      JS_FINALLY_CLAUSE@101..111
-        FINALLY_KW@101..108 "finally"
-        WHITESPACE@108..109 " "
-        JS_BLOCK_STATEMENT@109..111
-          L_CURLY@109..110 "{"
-          LIST@110..110
-          R_CURLY@110..111 "}"
-  WHITESPACE@111..112 "\n"
-=======
-MODULE@0..46
-  LIST@0..46
-    TRY_STMT@0..19
       None TRY_KW@0..3 "try" Whitespace(1)
-      BLOCK_STMT@4..7
+      JS_BLOCK_STATEMENT@4..7
         None L_CURLY@4..5 "{" None
         LIST@5..5
         None R_CURLY@5..6 "}" Whitespace(1)
-      CATCH_CLAUSE@7..19
+      JS_CATCH_CLAUSE@7..15
         None CATCH_KW@7..12 "catch" Whitespace(1)
-        None L_PAREN@13..14 "(" None
-        SINGLE_PATTERN@14..15
-          NAME@14..15
-            None IDENT@14..15 "e" None
-        None R_PAREN@15..16 ")" Whitespace(1)
-        BLOCK_STMT@17..19
-          None L_CURLY@17..18 "{" None
-          LIST@18..18
-          None R_CURLY@18..19 "}" None
-    TRY_STMT@19..46
-      Whitespace(1) TRY_KW@20..23 "try" Whitespace(1)
-      BLOCK_STMT@24..27
-        None L_CURLY@24..25 "{" None
-        LIST@25..25
-        None R_CURLY@25..26 "}" Whitespace(1)
-      CATCH_CLAUSE@27..36
-        None CATCH_KW@27..32 "catch" Whitespace(1)
-        BLOCK_STMT@33..36
+        JS_BLOCK_STATEMENT@13..15
+          None L_CURLY@13..14 "{" None
+          LIST@14..14
+          None R_CURLY@14..15 "}" None
+    JS_TRY_STATEMENT@15..35
+      Whitespace(1) TRY_KW@16..19 "try" Whitespace(1)
+      JS_BLOCK_STATEMENT@20..23
+        None L_CURLY@20..21 "{" None
+        LIST@21..21
+        None R_CURLY@21..22 "}" Whitespace(1)
+      JS_CATCH_CLAUSE@23..35
+        None CATCH_KW@23..28 "catch" Whitespace(1)
+        JS_CATCH_DECLARATION@29..33
+          None L_PAREN@29..30 "(" None
+          SINGLE_PATTERN@30..31
+            NAME@30..31
+              None IDENT@30..31 "e" None
+          None R_PAREN@31..32 ")" Whitespace(1)
+        JS_BLOCK_STATEMENT@33..35
           None L_CURLY@33..34 "{" None
           LIST@34..34
-          None R_CURLY@34..35 "}" Whitespace(1)
-      FINALIZER@36..46
-        None FINALLY_KW@36..43 "finally" Whitespace(1)
-        BLOCK_STMT@44..46
-          None L_CURLY@44..45 "{" None
-          LIST@45..45
-<<<<<<< HEAD
-           R_CURLY@45..46 "}" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-          None R_CURLY@45..46 "}" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+          None R_CURLY@34..35 "}" None
+    JS_TRY_FINALLY_STATEMENT@35..62
+      Whitespace(1) TRY_KW@36..39 "try" Whitespace(1)
+      JS_BLOCK_STATEMENT@40..43
+        None L_CURLY@40..41 "{" None
+        LIST@41..41
+        None R_CURLY@41..42 "}" Whitespace(1)
+      JS_CATCH_CLAUSE@43..52
+        None CATCH_KW@43..48 "catch" Whitespace(1)
+        JS_BLOCK_STATEMENT@49..52
+          None L_CURLY@49..50 "{" None
+          LIST@50..50
+          None R_CURLY@50..51 "}" Whitespace(1)
+      JS_FINALLY_CLAUSE@52..62
+        None FINALLY_KW@52..59 "finally" Whitespace(1)
+        JS_BLOCK_STATEMENT@60..62
+          None L_CURLY@60..61 "{" None
+          LIST@61..61
+          None R_CURLY@61..62 "}" None
+    JS_TRY_FINALLY_STATEMENT@62..93
+      Whitespace(1) TRY_KW@63..66 "try" Whitespace(1)
+      JS_BLOCK_STATEMENT@67..70
+        None L_CURLY@67..68 "{" None
+        LIST@68..68
+        None R_CURLY@68..69 "}" Whitespace(1)
+      JS_CATCH_CLAUSE@70..83
+        None CATCH_KW@70..75 "catch" Whitespace(1)
+        JS_CATCH_DECLARATION@76..80
+          None L_PAREN@76..77 "(" None
+          SINGLE_PATTERN@77..78
+            NAME@77..78
+              None IDENT@77..78 "e" None
+          None R_PAREN@78..79 ")" Whitespace(1)
+        JS_BLOCK_STATEMENT@80..83
+          None L_CURLY@80..81 "{" None
+          LIST@81..81
+          None R_CURLY@81..82 "}" Whitespace(1)
+      JS_FINALLY_CLAUSE@83..93
+        None FINALLY_KW@83..90 "finally" Whitespace(1)
+        JS_BLOCK_STATEMENT@91..93
+          None L_CURLY@91..92 "{" None
+          LIST@92..92
+          None R_CURLY@92..93 "}" None
+    JS_TRY_FINALLY_STATEMENT@93..111
+      Whitespace(1) TRY_KW@94..97 "try" Whitespace(1)
+      JS_BLOCK_STATEMENT@98..101
+        None L_CURLY@98..99 "{" None
+        LIST@99..99
+        None R_CURLY@99..100 "}" Whitespace(1)
+      JS_FINALLY_CLAUSE@101..111
+        None FINALLY_KW@101..108 "finally" Whitespace(1)
+        JS_BLOCK_STATEMENT@109..111
+          None L_CURLY@109..110 "{" None
+          LIST@110..110
+          None R_CURLY@110..111 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 JS_MODULE@0..112
   LIST@0..111
     JS_TRY_STATEMENT@0..15
@@ -110,3 +111,42 @@ JS_MODULE@0..112
           LIST@110..110
           R_CURLY@110..111 "}"
   WHITESPACE@111..112 "\n"
+=======
+MODULE@0..46
+  LIST@0..46
+    TRY_STMT@0..19
+       TRY_KW@0..4 "try" " "
+      BLOCK_STMT@4..7
+         L_CURLY@4..5 "{" 
+        LIST@5..5
+         R_CURLY@5..7 "}" " "
+      CATCH_CLAUSE@7..19
+         CATCH_KW@7..13 "catch" " "
+         L_PAREN@13..14 "(" 
+        SINGLE_PATTERN@14..15
+          NAME@14..15
+             IDENT@14..15 "e" 
+         R_PAREN@15..17 ")" " "
+        BLOCK_STMT@17..19
+           L_CURLY@17..18 "{" 
+          LIST@18..18
+           R_CURLY@18..19 "}" 
+    TRY_STMT@19..46
+      "\n" TRY_KW@19..24 "try" " "
+      BLOCK_STMT@24..27
+         L_CURLY@24..25 "{" 
+        LIST@25..25
+         R_CURLY@25..27 "}" " "
+      CATCH_CLAUSE@27..36
+         CATCH_KW@27..33 "catch" " "
+        BLOCK_STMT@33..36
+           L_CURLY@33..34 "{" 
+          LIST@34..34
+           R_CURLY@34..36 "}" " "
+      FINALIZER@36..46
+         FINALLY_KW@36..44 "finally" " "
+        BLOCK_STMT@44..46
+           L_CURLY@44..45 "{" 
+          LIST@45..45
+           R_CURLY@45..46 "}" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..92
-=======
-MODULE@0..91
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..91
   LIST@0..91
     VAR_DECL@0..10
       None VAR_KW@0..3 "var" Whitespace(1)

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -5,70 +5,70 @@ MODULE@0..91
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..91
     VAR_DECL@0..10
-      None VAR_KW@0..4 "var" Whitespace(1)
+      None VAR_KW@0..3 "var" Whitespace(1)
       LIST@4..9
         DECLARATOR@4..9
           SINGLE_PATTERN@4..6
             NAME@4..6
-              None IDENT@4..6 "a" Whitespace(1)
-          None EQ@6..8 "=" Whitespace(1)
+              None IDENT@4..5 "a" Whitespace(1)
+          None EQ@6..7 "=" Whitespace(1)
           LITERAL@8..9
             None NUMBER@8..9 "5" None
       None SEMICOLON@9..10 ";" None
     VAR_DECL@10..32
-      Whitespace(1) IDENT@10..15 "let" Whitespace(1)
+      Whitespace(1) IDENT@11..14 "let" Whitespace(1)
       LIST@15..31
         DECLARATOR@15..31
           OBJECT_PATTERN@15..28
-            None L_CURLY@15..17 "{" Whitespace(1)
+            None L_CURLY@15..16 "{" Whitespace(1)
             LIST@17..26
               SINGLE_PATTERN@17..20
                 NAME@17..20
                   None IDENT@17..20 "foo" None
-              None COMMA@20..22 "," Whitespace(1)
+              None COMMA@20..21 "," Whitespace(1)
               SINGLE_PATTERN@22..26
                 NAME@22..26
-                  None IDENT@22..26 "bar" Whitespace(1)
-            None R_CURLY@26..28 "}" Whitespace(1)
-          None EQ@28..30 "=" Whitespace(1)
+                  None IDENT@22..25 "bar" Whitespace(1)
+            None R_CURLY@26..27 "}" Whitespace(1)
+          None EQ@28..29 "=" Whitespace(1)
           LITERAL@30..31
             None NUMBER@30..31 "5" None
       None SEMICOLON@31..32 ";" None
     VAR_DECL@32..46
-      Whitespace(1) IDENT@32..37 "let" Whitespace(1)
+      Whitespace(1) IDENT@33..36 "let" Whitespace(1)
       LIST@37..45
         DECLARATOR@37..40
           SINGLE_PATTERN@37..40
             NAME@37..40
               None IDENT@37..40 "bar" None
-        None COMMA@40..42 "," Whitespace(1)
+        None COMMA@40..41 "," Whitespace(1)
         DECLARATOR@42..45
           SINGLE_PATTERN@42..45
             NAME@42..45
               None IDENT@42..45 "foo" None
       None SEMICOLON@45..46 ";" None
     VAR_DECL@46..59
-      Whitespace(1) CONST_KW@46..53 "const" Whitespace(1)
+      Whitespace(1) CONST_KW@47..52 "const" Whitespace(1)
       LIST@53..58
         DECLARATOR@53..58
           SINGLE_PATTERN@53..55
             NAME@53..55
-              None IDENT@53..55 "a" Whitespace(1)
-          None EQ@55..57 "=" Whitespace(1)
+              None IDENT@53..54 "a" Whitespace(1)
+          None EQ@55..56 "=" Whitespace(1)
           LITERAL@57..58
             None NUMBER@57..58 "5" None
       None SEMICOLON@58..59 ";" None
     VAR_DECL@59..91
-      Whitespace(1) CONST_KW@59..66 "const" Whitespace(1)
+      Whitespace(1) CONST_KW@60..65 "const" Whitespace(1)
       LIST@66..90
         DECLARATOR@66..90
           OBJECT_PATTERN@66..86
-            None L_CURLY@66..68 "{" Whitespace(1)
+            None L_CURLY@66..67 "{" Whitespace(1)
             LIST@68..84
               KEY_VALUE_PATTERN@68..78
                 NAME@68..71
                   None IDENT@68..71 "foo" None
-                None COLON@71..73 ":" Whitespace(1)
+                None COLON@71..72 ":" Whitespace(1)
                 ARRAY_PATTERN@73..78
                   None L_BRACK@73..74 "[" None
                   LIST@74..77
@@ -76,12 +76,12 @@ MODULE@0..91
                       NAME@74..77
                         None IDENT@74..77 "bar" None
                   None R_BRACK@77..78 "]" None
-              None COMMA@78..80 "," Whitespace(1)
+              None COMMA@78..79 "," Whitespace(1)
               SINGLE_PATTERN@80..84
                 NAME@80..84
-                  None IDENT@80..84 "baz" Whitespace(1)
-            None R_CURLY@84..86 "}" Whitespace(1)
-          None EQ@86..88 "=" Whitespace(1)
+                  None IDENT@80..83 "baz" Whitespace(1)
+            None R_CURLY@84..85 "}" Whitespace(1)
+          None EQ@86..87 "=" Whitespace(1)
           OBJECT_EXPR@88..90
             None L_CURLY@88..89 "{" None
             LIST@89..89

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -5,85 +5,85 @@ MODULE@0..91
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..91
     VAR_DECL@0..10
-       VAR_KW@0..4 "var" " "
+      None VAR_KW@0..4 "var" Whitespace(1)
       LIST@4..9
         DECLARATOR@4..9
           SINGLE_PATTERN@4..6
             NAME@4..6
-               IDENT@4..6 "a" " "
-           EQ@6..8 "=" " "
+              None IDENT@4..6 "a" Whitespace(1)
+          None EQ@6..8 "=" Whitespace(1)
           LITERAL@8..9
-             NUMBER@8..9 "5" 
-       SEMICOLON@9..10 ";" 
+            None NUMBER@8..9 "5" None
+      None SEMICOLON@9..10 ";" None
     VAR_DECL@10..32
-      "\n" IDENT@10..15 "let" " "
+      Whitespace(1) IDENT@10..15 "let" Whitespace(1)
       LIST@15..31
         DECLARATOR@15..31
           OBJECT_PATTERN@15..28
-             L_CURLY@15..17 "{" " "
+            None L_CURLY@15..17 "{" Whitespace(1)
             LIST@17..26
               SINGLE_PATTERN@17..20
                 NAME@17..20
-                   IDENT@17..20 "foo" 
-               COMMA@20..22 "," " "
+                  None IDENT@17..20 "foo" None
+              None COMMA@20..22 "," Whitespace(1)
               SINGLE_PATTERN@22..26
                 NAME@22..26
-                   IDENT@22..26 "bar" " "
-             R_CURLY@26..28 "}" " "
-           EQ@28..30 "=" " "
+                  None IDENT@22..26 "bar" Whitespace(1)
+            None R_CURLY@26..28 "}" Whitespace(1)
+          None EQ@28..30 "=" Whitespace(1)
           LITERAL@30..31
-             NUMBER@30..31 "5" 
-       SEMICOLON@31..32 ";" 
+            None NUMBER@30..31 "5" None
+      None SEMICOLON@31..32 ";" None
     VAR_DECL@32..46
-      "\n" IDENT@32..37 "let" " "
+      Whitespace(1) IDENT@32..37 "let" Whitespace(1)
       LIST@37..45
         DECLARATOR@37..40
           SINGLE_PATTERN@37..40
             NAME@37..40
-               IDENT@37..40 "bar" 
-         COMMA@40..42 "," " "
+              None IDENT@37..40 "bar" None
+        None COMMA@40..42 "," Whitespace(1)
         DECLARATOR@42..45
           SINGLE_PATTERN@42..45
             NAME@42..45
-               IDENT@42..45 "foo" 
-       SEMICOLON@45..46 ";" 
+              None IDENT@42..45 "foo" None
+      None SEMICOLON@45..46 ";" None
     VAR_DECL@46..59
-      "\n" CONST_KW@46..53 "const" " "
+      Whitespace(1) CONST_KW@46..53 "const" Whitespace(1)
       LIST@53..58
         DECLARATOR@53..58
           SINGLE_PATTERN@53..55
             NAME@53..55
-               IDENT@53..55 "a" " "
-           EQ@55..57 "=" " "
+              None IDENT@53..55 "a" Whitespace(1)
+          None EQ@55..57 "=" Whitespace(1)
           LITERAL@57..58
-             NUMBER@57..58 "5" 
-       SEMICOLON@58..59 ";" 
+            None NUMBER@57..58 "5" None
+      None SEMICOLON@58..59 ";" None
     VAR_DECL@59..91
-      "\n" CONST_KW@59..66 "const" " "
+      Whitespace(1) CONST_KW@59..66 "const" Whitespace(1)
       LIST@66..90
         DECLARATOR@66..90
           OBJECT_PATTERN@66..86
-             L_CURLY@66..68 "{" " "
+            None L_CURLY@66..68 "{" Whitespace(1)
             LIST@68..84
               KEY_VALUE_PATTERN@68..78
                 NAME@68..71
-                   IDENT@68..71 "foo" 
-                 COLON@71..73 ":" " "
+                  None IDENT@68..71 "foo" None
+                None COLON@71..73 ":" Whitespace(1)
                 ARRAY_PATTERN@73..78
-                   L_BRACK@73..74 "[" 
+                  None L_BRACK@73..74 "[" None
                   LIST@74..77
                     SINGLE_PATTERN@74..77
                       NAME@74..77
-                         IDENT@74..77 "bar" 
-                   R_BRACK@77..78 "]" 
-               COMMA@78..80 "," " "
+                        None IDENT@74..77 "bar" None
+                  None R_BRACK@77..78 "]" None
+              None COMMA@78..80 "," Whitespace(1)
               SINGLE_PATTERN@80..84
                 NAME@80..84
-                   IDENT@80..84 "baz" " "
-             R_CURLY@84..86 "}" " "
-           EQ@86..88 "=" " "
+                  None IDENT@80..84 "baz" Whitespace(1)
+            None R_CURLY@84..86 "}" Whitespace(1)
+          None EQ@86..88 "=" Whitespace(1)
           OBJECT_EXPR@88..90
-             L_CURLY@88..89 "{" 
+            None L_CURLY@88..89 "{" None
             LIST@89..89
-             R_CURLY@89..90 "}" 
-       SEMICOLON@90..91 ";" 
+            None R_CURLY@89..90 "}" None
+      None SEMICOLON@90..91 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -1,111 +1,89 @@
+<<<<<<< HEAD
 JS_MODULE@0..92
+=======
+MODULE@0..91
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..91
     VAR_DECL@0..10
-      VAR_KW@0..3 "var"
-      WHITESPACE@3..4 " "
+       VAR_KW@0..4 "var" " "
       LIST@4..9
         DECLARATOR@4..9
-          SINGLE_PATTERN@4..5
-            NAME@4..5
-              IDENT@4..5 "a"
-          WHITESPACE@5..6 " "
-          EQ@6..7 "="
-          WHITESPACE@7..8 " "
+          SINGLE_PATTERN@4..6
+            NAME@4..6
+               IDENT@4..6 "a" " "
+           EQ@6..8 "=" " "
           LITERAL@8..9
-            NUMBER@8..9 "5"
-      SEMICOLON@9..10 ";"
-    WHITESPACE@10..11 "\n"
-    VAR_DECL@11..32
-      IDENT@11..14 "let"
-      WHITESPACE@14..15 " "
+             NUMBER@8..9 "5" 
+       SEMICOLON@9..10 ";" 
+    VAR_DECL@10..32
+      "\n" IDENT@10..15 "let" " "
       LIST@15..31
         DECLARATOR@15..31
-          OBJECT_PATTERN@15..27
-            L_CURLY@15..16 "{"
-            WHITESPACE@16..17 " "
-            LIST@17..25
+          OBJECT_PATTERN@15..28
+             L_CURLY@15..17 "{" " "
+            LIST@17..26
               SINGLE_PATTERN@17..20
                 NAME@17..20
-                  IDENT@17..20 "foo"
-              COMMA@20..21 ","
-              WHITESPACE@21..22 " "
-              SINGLE_PATTERN@22..25
-                NAME@22..25
-                  IDENT@22..25 "bar"
-            WHITESPACE@25..26 " "
-            R_CURLY@26..27 "}"
-          WHITESPACE@27..28 " "
-          EQ@28..29 "="
-          WHITESPACE@29..30 " "
+                   IDENT@17..20 "foo" 
+               COMMA@20..22 "," " "
+              SINGLE_PATTERN@22..26
+                NAME@22..26
+                   IDENT@22..26 "bar" " "
+             R_CURLY@26..28 "}" " "
+           EQ@28..30 "=" " "
           LITERAL@30..31
-            NUMBER@30..31 "5"
-      SEMICOLON@31..32 ";"
-    WHITESPACE@32..33 "\n"
-    VAR_DECL@33..46
-      IDENT@33..36 "let"
-      WHITESPACE@36..37 " "
+             NUMBER@30..31 "5" 
+       SEMICOLON@31..32 ";" 
+    VAR_DECL@32..46
+      "\n" IDENT@32..37 "let" " "
       LIST@37..45
         DECLARATOR@37..40
           SINGLE_PATTERN@37..40
             NAME@37..40
-              IDENT@37..40 "bar"
-        COMMA@40..41 ","
-        WHITESPACE@41..42 " "
+               IDENT@37..40 "bar" 
+         COMMA@40..42 "," " "
         DECLARATOR@42..45
           SINGLE_PATTERN@42..45
             NAME@42..45
-              IDENT@42..45 "foo"
-      SEMICOLON@45..46 ";"
-    WHITESPACE@46..47 "\n"
-    VAR_DECL@47..59
-      CONST_KW@47..52 "const"
-      WHITESPACE@52..53 " "
+               IDENT@42..45 "foo" 
+       SEMICOLON@45..46 ";" 
+    VAR_DECL@46..59
+      "\n" CONST_KW@46..53 "const" " "
       LIST@53..58
         DECLARATOR@53..58
-          SINGLE_PATTERN@53..54
-            NAME@53..54
-              IDENT@53..54 "a"
-          WHITESPACE@54..55 " "
-          EQ@55..56 "="
-          WHITESPACE@56..57 " "
+          SINGLE_PATTERN@53..55
+            NAME@53..55
+               IDENT@53..55 "a" " "
+           EQ@55..57 "=" " "
           LITERAL@57..58
-            NUMBER@57..58 "5"
-      SEMICOLON@58..59 ";"
-    WHITESPACE@59..60 "\n"
-    VAR_DECL@60..91
-      CONST_KW@60..65 "const"
-      WHITESPACE@65..66 " "
+             NUMBER@57..58 "5" 
+       SEMICOLON@58..59 ";" 
+    VAR_DECL@59..91
+      "\n" CONST_KW@59..66 "const" " "
       LIST@66..90
         DECLARATOR@66..90
-          OBJECT_PATTERN@66..85
-            L_CURLY@66..67 "{"
-            WHITESPACE@67..68 " "
-            LIST@68..83
+          OBJECT_PATTERN@66..86
+             L_CURLY@66..68 "{" " "
+            LIST@68..84
               KEY_VALUE_PATTERN@68..78
                 NAME@68..71
-                  IDENT@68..71 "foo"
-                COLON@71..72 ":"
-                WHITESPACE@72..73 " "
+                   IDENT@68..71 "foo" 
+                 COLON@71..73 ":" " "
                 ARRAY_PATTERN@73..78
-                  L_BRACK@73..74 "["
+                   L_BRACK@73..74 "[" 
                   LIST@74..77
                     SINGLE_PATTERN@74..77
                       NAME@74..77
-                        IDENT@74..77 "bar"
-                  R_BRACK@77..78 "]"
-              COMMA@78..79 ","
-              WHITESPACE@79..80 " "
-              SINGLE_PATTERN@80..83
-                NAME@80..83
-                  IDENT@80..83 "baz"
-            WHITESPACE@83..84 " "
-            R_CURLY@84..85 "}"
-          WHITESPACE@85..86 " "
-          EQ@86..87 "="
-          WHITESPACE@87..88 " "
+                         IDENT@74..77 "bar" 
+                   R_BRACK@77..78 "]" 
+               COMMA@78..80 "," " "
+              SINGLE_PATTERN@80..84
+                NAME@80..84
+                   IDENT@80..84 "baz" " "
+             R_CURLY@84..86 "}" " "
+           EQ@86..88 "=" " "
           OBJECT_EXPR@88..90
-            L_CURLY@88..89 "{"
+             L_CURLY@88..89 "{" 
             LIST@89..89
-            R_CURLY@89..90 "}"
-      SEMICOLON@90..91 ";"
-  WHITESPACE@91..92 "\n"
+             R_CURLY@89..90 "}" 
+       SEMICOLON@90..91 ";" 

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -1,30 +1,44 @@
+<<<<<<< HEAD
 JS_MODULE@0..29
+=======
+MODULE@0..28
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..28
     WHILE_STMT@0..15
-      WHILE_KW@0..5 "while"
-      WHITESPACE@5..6 " "
-      CONDITION@6..12
-        L_PAREN@6..7 "("
+       WHILE_KW@0..6 "while" " "
+      CONDITION@6..13
+         L_PAREN@6..7 "(" 
         LITERAL@7..11
+<<<<<<< HEAD
           TRUE_KW@7..11 "true"
         R_PAREN@11..12 ")"
       WHITESPACE@12..13 " "
       JS_BLOCK_STATEMENT@13..15
         L_CURLY@13..14 "{"
+=======
+           TRUE_KW@7..11 "true" 
+         R_PAREN@11..13 ")" " "
+      BLOCK_STMT@13..15
+         L_CURLY@13..14 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@14..14
-        R_CURLY@14..15 "}"
-    WHITESPACE@15..16 "\n"
-    WHILE_STMT@16..28
-      WHILE_KW@16..21 "while"
-      WHITESPACE@21..22 " "
-      CONDITION@22..25
-        L_PAREN@22..23 "("
+         R_CURLY@14..15 "}" 
+    WHILE_STMT@15..28
+      "\n" WHILE_KW@15..22 "while" " "
+      CONDITION@22..26
+         L_PAREN@22..23 "(" 
         LITERAL@23..24
+<<<<<<< HEAD
           NUMBER@23..24 "5"
         R_PAREN@24..25 ")"
       WHITESPACE@25..26 " "
       JS_BLOCK_STATEMENT@26..28
         L_CURLY@26..27 "{"
+=======
+           NUMBER@23..24 "5" 
+         R_PAREN@24..26 ")" " "
+      BLOCK_STMT@26..28
+         L_CURLY@26..27 "{" 
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
         LIST@27..27
-        R_CURLY@27..28 "}"
-  WHITESPACE@28..29 "\n"
+         R_CURLY@27..28 "}" 

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -5,10 +5,11 @@ MODULE@0..28
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..28
     WHILE_STMT@0..15
-       WHILE_KW@0..6 "while" " "
+      None WHILE_KW@0..6 "while" Whitespace(1)
       CONDITION@6..13
-         L_PAREN@6..7 "(" 
+        None L_PAREN@6..7 "(" None
         LITERAL@7..11
+<<<<<<< HEAD
 <<<<<<< HEAD
           TRUE_KW@7..11 "true"
         R_PAREN@11..12 ")"
@@ -21,13 +22,20 @@ MODULE@0..28
       BLOCK_STMT@13..15
          L_CURLY@13..14 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None TRUE_KW@7..11 "true" None
+        None R_PAREN@11..13 ")" Whitespace(1)
+      BLOCK_STMT@13..15
+        None L_CURLY@13..14 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@14..14
-         R_CURLY@14..15 "}" 
+        None R_CURLY@14..15 "}" None
     WHILE_STMT@15..28
-      "\n" WHILE_KW@15..22 "while" " "
+      Whitespace(1) WHILE_KW@15..22 "while" Whitespace(1)
       CONDITION@22..26
-         L_PAREN@22..23 "(" 
+        None L_PAREN@22..23 "(" None
         LITERAL@23..24
+<<<<<<< HEAD
 <<<<<<< HEAD
           NUMBER@23..24 "5"
         R_PAREN@24..25 ")"
@@ -40,5 +48,11 @@ MODULE@0..28
       BLOCK_STMT@26..28
          L_CURLY@26..27 "{" 
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+          None NUMBER@23..24 "5" None
+        None R_PAREN@24..26 ")" Whitespace(1)
+      BLOCK_STMT@26..28
+        None L_CURLY@26..27 "{" None
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@27..27
-         R_CURLY@27..28 "}" 
+        None R_CURLY@27..28 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -5,7 +5,7 @@ MODULE@0..28
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..28
     WHILE_STMT@0..15
-      None WHILE_KW@0..6 "while" Whitespace(1)
+      None WHILE_KW@0..5 "while" Whitespace(1)
       CONDITION@6..13
         None L_PAREN@6..7 "(" None
         LITERAL@7..11
@@ -24,14 +24,14 @@ MODULE@0..28
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           None TRUE_KW@7..11 "true" None
-        None R_PAREN@11..13 ")" Whitespace(1)
+        None R_PAREN@11..12 ")" Whitespace(1)
       BLOCK_STMT@13..15
         None L_CURLY@13..14 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@14..14
         None R_CURLY@14..15 "}" None
     WHILE_STMT@15..28
-      Whitespace(1) WHILE_KW@15..22 "while" Whitespace(1)
+      Whitespace(1) WHILE_KW@16..21 "while" Whitespace(1)
       CONDITION@22..26
         None L_PAREN@22..23 "(" None
         LITERAL@23..24
@@ -50,7 +50,7 @@ MODULE@0..28
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
 =======
           None NUMBER@23..24 "5" None
-        None R_PAREN@24..26 ")" Whitespace(1)
+        None R_PAREN@24..25 ")" Whitespace(1)
       BLOCK_STMT@26..28
         None L_CURLY@26..27 "{" None
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -1,33 +1,14 @@
-<<<<<<< HEAD
-JS_MODULE@0..29
-=======
-MODULE@0..28
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..28
   LIST@0..28
     WHILE_STMT@0..15
       None WHILE_KW@0..5 "while" Whitespace(1)
       CONDITION@6..13
         None L_PAREN@6..7 "(" None
         LITERAL@7..11
-<<<<<<< HEAD
-<<<<<<< HEAD
-          TRUE_KW@7..11 "true"
-        R_PAREN@11..12 ")"
-      WHITESPACE@12..13 " "
-      JS_BLOCK_STATEMENT@13..15
-        L_CURLY@13..14 "{"
-=======
-           TRUE_KW@7..11 "true" 
-         R_PAREN@11..13 ")" " "
-      BLOCK_STMT@13..15
-         L_CURLY@13..14 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None TRUE_KW@7..11 "true" None
         None R_PAREN@11..12 ")" Whitespace(1)
-      BLOCK_STMT@13..15
+      JS_BLOCK_STATEMENT@13..15
         None L_CURLY@13..14 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@14..14
         None R_CURLY@14..15 "}" None
     WHILE_STMT@15..28
@@ -35,24 +16,9 @@ MODULE@0..28
       CONDITION@22..26
         None L_PAREN@22..23 "(" None
         LITERAL@23..24
-<<<<<<< HEAD
-<<<<<<< HEAD
-          NUMBER@23..24 "5"
-        R_PAREN@24..25 ")"
-      WHITESPACE@25..26 " "
-      JS_BLOCK_STATEMENT@26..28
-        L_CURLY@26..27 "{"
-=======
-           NUMBER@23..24 "5" 
-         R_PAREN@24..26 ")" " "
-      BLOCK_STMT@26..28
-         L_CURLY@26..27 "{" 
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
           None NUMBER@23..24 "5" None
         None R_PAREN@24..25 ")" Whitespace(1)
-      BLOCK_STMT@26..28
+      JS_BLOCK_STATEMENT@26..28
         None L_CURLY@26..27 "{" None
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
         LIST@27..27
         None R_CURLY@27..28 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -1,58 +1,46 @@
-JS_SCRIPT@0..65
-  COMMENT@0..9 "// SCRIPT"
-  WHITESPACE@9..11 "\n\n"
-  LIST@11..64
-    FN_DECL@11..64
-      FUNCTION_KW@11..19 "function"
-      WHITESPACE@19..20 " "
+JS_SCRIPT@0..64
+  LIST@0..64
+    FN_DECL@0..64
+      Many([Comment(9), Whitespace(2)]) FUNCTION_KW@11..19 "function" Whitespace(1)
       NAME@20..21
-        IDENT@20..21 "f"
-      PARAMETER_LIST@21..27
-        L_PAREN@21..22 "("
+        None IDENT@20..21 "f" None
+      PARAMETER_LIST@21..28
+        None L_PAREN@21..22 "(" None
         LIST@22..26
           SINGLE_PATTERN@22..23
             NAME@22..23
-              IDENT@22..23 "x"
-          COMMA@23..24 ","
-          WHITESPACE@24..25 " "
+              None IDENT@22..23 "x" None
+          None COMMA@23..24 "," Whitespace(1)
           SINGLE_PATTERN@25..26
             NAME@25..26
-              IDENT@25..26 "o"
-        R_PAREN@26..27 ")"
-      WHITESPACE@27..28 " "
+              None IDENT@25..26 "o" None
+        None R_PAREN@26..27 ")" Whitespace(1)
       JS_BLOCK_STATEMENT@28..64
-        L_CURLY@28..29 "{"
-        WHITESPACE@29..31 "\n\t"
-        LIST@31..62
-          JS_WITH_STATEMENT@31..62
-            WITH_KW@31..35 "with"
-            WHITESPACE@35..36 " "
-            L_PAREN@36..37 "("
+        None L_CURLY@28..29 "{" None
+        LIST@29..62
+          JS_WITH_STATEMENT@29..62
+            Whitespace(2) WITH_KW@31..35 "with" Whitespace(1)
+            None L_PAREN@36..37 "(" None
             NAME_REF@37..38
-              IDENT@37..38 "o"
-            R_PAREN@38..39 ")"
-            WHITESPACE@39..40 " "
+              None IDENT@37..38 "o" None
+            None R_PAREN@38..39 ")" Whitespace(1)
             JS_BLOCK_STATEMENT@40..62
-              L_CURLY@40..41 "{"
-              WHITESPACE@41..44 "\n\t\t"
-              LIST@44..59
-                JS_EXPRESSION_STATEMENT@44..59
-                  CALL_EXPR@44..58
-                    DOT_EXPR@44..55
-                      NAME_REF@44..51
-                        IDENT@44..51 "console"
-                      DOT@51..52 "."
+              None L_CURLY@40..41 "{" None
+              LIST@41..59
+                JS_EXPRESSION_STATEMENT@41..59
+                  CALL_EXPR@41..58
+                    DOT_EXPR@41..55
+                      NAME_REF@41..51
+                        Whitespace(3) IDENT@44..51 "console" None
+                      None DOT@51..52 "." None
                       NAME@52..55
-                        IDENT@52..55 "log"
+                        None IDENT@52..55 "log" None
                     ARG_LIST@55..58
-                      L_PAREN@55..56 "("
+                      None L_PAREN@55..56 "(" None
                       LIST@56..57
                         NAME_REF@56..57
-                          IDENT@56..57 "x"
-                      R_PAREN@57..58 ")"
-                  SEMICOLON@58..59 ";"
-              WHITESPACE@59..61 "\n\t"
-              R_CURLY@61..62 "}"
-        WHITESPACE@62..63 "\n"
-        R_CURLY@63..64 "}"
-  WHITESPACE@64..65 "\n"
+                          None IDENT@56..57 "x" None
+                      None R_PAREN@57..58 ")" None
+                  None SEMICOLON@58..59 ";" None
+              Whitespace(2) R_CURLY@61..62 "}" None
+        Whitespace(1) R_CURLY@63..64 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -5,13 +5,14 @@ MODULE@0..44
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..44
     FN_DECL@0..44
-       FUNCTION_KW@0..9 "function" " "
-       STAR@9..10 "*" 
+      None FUNCTION_KW@0..9 "function" Whitespace(1)
+      None STAR@9..10 "*" None
       NAME@10..13
-         IDENT@10..13 "foo" 
+        None IDENT@10..13 "foo" None
       PARAMETER_LIST@13..16
-         L_PAREN@13..14 "(" 
+        None L_PAREN@13..14 "(" None
         LIST@14..14
+<<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@14..15 ")"
       WHITESPACE@15..16 " "
@@ -34,21 +35,29 @@ MODULE@0..44
               WHITESPACE@37..38 " "
 =======
          R_PAREN@14..16 ")" " "
+=======
+        None R_PAREN@14..16 ")" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
       BLOCK_STMT@16..44
-         L_CURLY@16..17 "{" 
+        None L_CURLY@16..17 "{" None
         LIST@17..42
           EXPR_STMT@17..29
             YIELD_EXPR@17..28
-              "\n " YIELD_KW@17..25 "yield" " "
+              Whitespace(2) YIELD_KW@17..25 "yield" Whitespace(1)
               NAME_REF@25..28
-                 IDENT@25..28 "foo" 
-             SEMICOLON@28..29 ";" 
+                None IDENT@25..28 "foo" None
+            None SEMICOLON@28..29 ";" None
           EXPR_STMT@29..42
             YIELD_EXPR@29..41
+<<<<<<< HEAD
               "\n " YIELD_KW@29..36 "yield" 
                STAR@36..38 "*" " "
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+=======
+              Whitespace(2) YIELD_KW@29..36 "yield" None
+              None STAR@36..38 "*" Whitespace(1)
+>>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
               NAME_REF@38..41
-                 IDENT@38..41 "foo" 
-             SEMICOLON@41..42 ";" 
-        "\n" R_CURLY@42..44 "}" 
+                None IDENT@38..41 "foo" None
+            None SEMICOLON@41..42 ";" None
+        Whitespace(1) R_CURLY@42..44 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-JS_MODULE@0..45
-=======
-MODULE@0..44
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
+JS_MODULE@0..44
   LIST@0..44
     FN_DECL@0..44
       None FUNCTION_KW@0..8 "function" Whitespace(1)
@@ -12,60 +8,20 @@ MODULE@0..44
       PARAMETER_LIST@13..16
         None L_PAREN@13..14 "(" None
         LIST@14..14
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        R_PAREN@14..15 ")"
-      WHITESPACE@15..16 " "
-      JS_BLOCK_STATEMENT@16..44
-        L_CURLY@16..17 "{"
-        WHITESPACE@17..19 "\n "
-        LIST@19..42
-          JS_EXPRESSION_STATEMENT@19..29
-            YIELD_EXPR@19..28
-              YIELD_KW@19..24 "yield"
-              WHITESPACE@24..25 " "
-              NAME_REF@25..28
-                IDENT@25..28 "foo"
-            SEMICOLON@28..29 ";"
-          WHITESPACE@29..31 "\n "
-          JS_EXPRESSION_STATEMENT@31..42
-            YIELD_EXPR@31..41
-              YIELD_KW@31..36 "yield"
-              STAR@36..37 "*"
-              WHITESPACE@37..38 " "
-=======
-         R_PAREN@14..16 ")" " "
-=======
-        None R_PAREN@14..16 ")" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
         None R_PAREN@14..15 ")" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
-      BLOCK_STMT@16..44
+      JS_BLOCK_STATEMENT@16..44
         None L_CURLY@16..17 "{" None
         LIST@17..42
-          EXPR_STMT@17..29
+          JS_EXPRESSION_STATEMENT@17..29
             YIELD_EXPR@17..28
               Whitespace(2) YIELD_KW@19..24 "yield" Whitespace(1)
               NAME_REF@25..28
                 None IDENT@25..28 "foo" None
             None SEMICOLON@28..29 ";" None
-          EXPR_STMT@29..42
+          JS_EXPRESSION_STATEMENT@29..42
             YIELD_EXPR@29..41
-<<<<<<< HEAD
-<<<<<<< HEAD
-              "\n " YIELD_KW@29..36 "yield" 
-               STAR@36..38 "*" " "
->>>>>>> 56d750195 (trim format_raw when formatter finds an error)
-=======
-              Whitespace(2) YIELD_KW@29..36 "yield" None
-              None STAR@36..38 "*" Whitespace(1)
->>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
-=======
               Whitespace(2) YIELD_KW@31..36 "yield" None
               None STAR@36..37 "*" Whitespace(1)
->>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               NAME_REF@38..41
                 None IDENT@38..41 "foo" None
             None SEMICOLON@41..42 ";" None

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -5,13 +5,14 @@ MODULE@0..44
 >>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..44
     FN_DECL@0..44
-      None FUNCTION_KW@0..9 "function" Whitespace(1)
+      None FUNCTION_KW@0..8 "function" Whitespace(1)
       None STAR@9..10 "*" None
       NAME@10..13
         None IDENT@10..13 "foo" None
       PARAMETER_LIST@13..16
         None L_PAREN@13..14 "(" None
         LIST@14..14
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
         R_PAREN@14..15 ")"
@@ -38,17 +39,21 @@ MODULE@0..44
 =======
         None R_PAREN@14..16 ")" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+        None R_PAREN@14..15 ")" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
       BLOCK_STMT@16..44
         None L_CURLY@16..17 "{" None
         LIST@17..42
           EXPR_STMT@17..29
             YIELD_EXPR@17..28
-              Whitespace(2) YIELD_KW@17..25 "yield" Whitespace(1)
+              Whitespace(2) YIELD_KW@19..24 "yield" Whitespace(1)
               NAME_REF@25..28
                 None IDENT@25..28 "foo" None
             None SEMICOLON@28..29 ";" None
           EXPR_STMT@29..42
             YIELD_EXPR@29..41
+<<<<<<< HEAD
 <<<<<<< HEAD
               "\n " YIELD_KW@29..36 "yield" 
                STAR@36..38 "*" " "
@@ -57,7 +62,11 @@ MODULE@0..44
               Whitespace(2) YIELD_KW@29..36 "yield" None
               None STAR@36..38 "*" Whitespace(1)
 >>>>>>> 03257ad46 (greentoken slice contains everything from first leading to last trailing trivia)
+=======
+              Whitespace(2) YIELD_KW@31..36 "yield" None
+              None STAR@36..37 "*" Whitespace(1)
+>>>>>>> c96756449 (fixing text and text_with_trivia and ranges)
               NAME_REF@38..41
                 None IDENT@38..41 "foo" None
             None SEMICOLON@41..42 ";" None
-        Whitespace(1) R_CURLY@42..44 "}" None
+        Whitespace(1) R_CURLY@43..44 "}" None

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -1,14 +1,18 @@
+<<<<<<< HEAD
 JS_MODULE@0..45
+=======
+MODULE@0..44
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
   LIST@0..44
     FN_DECL@0..44
-      FUNCTION_KW@0..8 "function"
-      WHITESPACE@8..9 " "
-      STAR@9..10 "*"
+       FUNCTION_KW@0..9 "function" " "
+       STAR@9..10 "*" 
       NAME@10..13
-        IDENT@10..13 "foo"
-      PARAMETER_LIST@13..15
-        L_PAREN@13..14 "("
+         IDENT@10..13 "foo" 
+      PARAMETER_LIST@13..16
+         L_PAREN@13..14 "(" 
         LIST@14..14
+<<<<<<< HEAD
         R_PAREN@14..15 ")"
       WHITESPACE@15..16 " "
       JS_BLOCK_STATEMENT@16..44
@@ -28,9 +32,23 @@ JS_MODULE@0..45
               YIELD_KW@31..36 "yield"
               STAR@36..37 "*"
               WHITESPACE@37..38 " "
+=======
+         R_PAREN@14..16 ")" " "
+      BLOCK_STMT@16..44
+         L_CURLY@16..17 "{" 
+        LIST@17..42
+          EXPR_STMT@17..29
+            YIELD_EXPR@17..28
+              "\n " YIELD_KW@17..25 "yield" " "
+              NAME_REF@25..28
+                 IDENT@25..28 "foo" 
+             SEMICOLON@28..29 ";" 
+          EXPR_STMT@29..42
+            YIELD_EXPR@29..41
+              "\n " YIELD_KW@29..36 "yield" 
+               STAR@36..38 "*" " "
+>>>>>>> 56d750195 (trim format_raw when formatter finds an error)
               NAME_REF@38..41
-                IDENT@38..41 "foo"
-            SEMICOLON@41..42 ";"
-        WHITESPACE@42..43 "\n"
-        R_CURLY@43..44 "}"
-  WHITESPACE@44..45 "\n"
+                 IDENT@38..41 "foo" 
+             SEMICOLON@41..42 ";" 
+        "\n" R_CURLY@42..44 "}" 


### PR DESCRIPTION
part of: #1720

# Tasks

- [x] ```GreenToken``` will have an enum with the trivial case and a fallback using Vec.
- [ ] ```SyntaxTrivia``` will wrap ```GreenTokenTrivia```
- [x] Change ```PartialEq``` and ```Hash``` implementations for the *Token structs to consider the trivia.
- [x] Change ```Display``` and ```Debug``` implementations to print trivia.
- [x] Improve ```Display``` and ```Debug```
- [x] Change the ```NodeCache``` to respect trivia (not fixed by changing ```Hash``` implementation)
- [ ] Change ```LossyTreeSink```
- [x] Change ```LosslessTreeSink```
- [x] Fix GreenToken slice to contains leading, token and trailing trivia. In one slice. Otherwise the ```Syntax``` layer end up with all offsets wrong.
- [x] Fix doctests
- [x] Improve ```test_trivia_attached_to_tokens```

## Debug

```
  VAR_DECL@0..11
    " " IDENT@0..5 "let" " "         <- Range is bigger than "let" because we need the trivia now
    DECLARATOR@5..10
      SINGLE_PATTERN@5..7
        NAME@5..7
           IDENT@5..7 "a" " "
       EQ@7..9 "=" " "
      LITERAL@9..10
         NUMBER@9..10 "1"
     SEMICOLON@10..11 ";"
```

# Decisions

- Now the token "slice" contains all its trivia.
- To trim this trivia we have to ask leading().text_len() and trailing().text_len() and computer where the token text is.
- Formatter is not working because we must manually insert trailing space between tokens. Maybe we need a couple of helper methods for this.

# How to test

```rust
> cargo test -p rslint_parser
> cargo xtask coverage
...
│ Tests ran │ Passed │ Failed │ Panics │ Coverage │
├───────────┼────────┼────────┼────────┼──────────┤
│   17604   │ 16767  │  836   │   1    │  95.25   │
...
``` 

Coverage is the same as before.