### PR TITLE
Lexer trivia newline

### DIFF
--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -125,7 +125,7 @@ impl<'src> Lexer<'src> {
 	}
 
 	fn consume_newlines(&mut self) {
-		while let Some(_) = self.current().copied() {
+		while self.current().is_some() {
 			let chr = self.get_unicode_char();
 			if is_linebreak(chr) {
 				self.state.had_linebreak = true;

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -1361,7 +1361,6 @@ impl<'src> Lexer<'src> {
 					|| (UNICODE_WHITESPACE_STARTS.contains(&byte) && UNICODE_SPACES.contains(&chr))
 				{
 					self.consume_whitespace();
-					println!("{}", self.cur - start);
 					tok!(WHITESPACE, self.cur - start)
 				} else {
 					self.cur += chr.len_utf8() - 1;

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -162,8 +162,7 @@ fn all_whitespace() {
 	assert_lex! {
 		"
 		",
-		WHITESPACE:1
-		WHITESPACE:2
+		WHITESPACE:3
 	}
 }
 
@@ -840,8 +839,7 @@ fn single_line_comments() {
 		"//abc
 	",
 		COMMENT:5,
-		WHITESPACE:1
-		WHITESPACE:1
+		WHITESPACE:2
 	}
 
 	assert_lex! {
@@ -1055,36 +1053,34 @@ fn object_expr_getter() {
 fn newline_space_must_be_two_tokens() {
 	assert_lex! {
 		"\n ",
-		WHITESPACE:1
-		WHITESPACE:1
+		WHITESPACE:2
 	}
 	assert_lex! {
 		" \n",
-		WHITESPACE:2
+		WHITESPACE:1
+		WHITESPACE:1
 	}
 	assert_lex! {
 		" \n ",
-		WHITESPACE:2
 		WHITESPACE:1
+		WHITESPACE:2
 	}
 
 	assert_lex! {
 		" a\n b \n ",
 		WHITESPACE:1
 		IDENT:1
-		WHITESPACE:1
-		WHITESPACE:1
-		IDENT:1
 		WHITESPACE:2
+		IDENT:1
 		WHITESPACE:1
+		WHITESPACE:2
 	}
 	assert_lex! {
 		"a //COMMENT \n /*COMMENT*/ b /*COM\nMENT*/",
 		IDENT:1
 		WHITESPACE:1
 		COMMENT:10
-		WHITESPACE:1
-		WHITESPACE:1
+		WHITESPACE:2
 		COMMENT:11
 		WHITESPACE:1
 		IDENT:1
@@ -1096,8 +1092,7 @@ fn newline_space_must_be_two_tokens() {
 		IDENT:1
 		WHITESPACE:1
 		COMMENT:10
-		WHITESPACE:1
-		WHITESPACE:1
+		WHITESPACE:2
 		COMMENT:11
 		WHITESPACE:1
 		IDENT:1
@@ -1105,40 +1100,38 @@ fn newline_space_must_be_two_tokens() {
 		COMMENT:12
 	}
 
-	// Now with CR
+	//Now with CR
 	assert_lex! {
 		"\r\n ",
-		WHITESPACE:2
-		WHITESPACE:1
+		WHITESPACE:3
 	}
 
 	assert_lex! {
 		" \r\n",
-		WHITESPACE:3
+		WHITESPACE:1
+		WHITESPACE:2
 	}
 	assert_lex! {
 		" \r\n ",
-		WHITESPACE:3
 		WHITESPACE:1
+		WHITESPACE:3
 	}
 
 	assert_lex! {
 		" a\r\n b \r\n ",
 		WHITESPACE:1
 		IDENT:1
-		WHITESPACE:2
-		WHITESPACE:1
-		IDENT:1
 		WHITESPACE:3
+		IDENT:1
 		WHITESPACE:1
+		WHITESPACE:3
 	}
 	assert_lex! {
 		"a //COMMENT \r\n /*COMMENT*/ b /*COM\r\nMENT*/",
 		IDENT:1
 		WHITESPACE:1
 		COMMENT:10
-		WHITESPACE:2
-		WHITESPACE:1
+		WHITESPACE:3
 		COMMENT:11
 		WHITESPACE:1
 		IDENT:1
@@ -1150,8 +1143,7 @@ fn newline_space_must_be_two_tokens() {
 		IDENT:1
 		WHITESPACE:1
 		COMMENT:10
-		WHITESPACE:2
-		WHITESPACE:1
+		WHITESPACE:3
 		COMMENT:11
 		WHITESPACE:1
 		IDENT:1

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -145,8 +145,6 @@ mod tests {
 	#[test]
 	fn var_decl_let_token() {
 		let parsed = parse_text("/* */let a = 5;", 0).syntax();
-		println!("{:#?}", parsed);
-
 		assert!(parsed
 			.child_with_ast::<ast::VarDecl>()
 			.unwrap()

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -145,6 +145,7 @@ mod tests {
 	#[test]
 	fn var_decl_let_token() {
 		let parsed = parse_text("/* */let a = 5;", 0).syntax();
+		println!("{:#?}", parsed);
 
 		assert!(parsed
 			.child_with_ast::<ast::VarDecl>()

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -40,8 +40,7 @@ MODULE@0..83
     WHITESPACE@46..47 " "
     BLOCK_STMT@47..68
       L_CURLY@47..48 "{"
-      WHITESPACE@48..49 "\n"
-      WHITESPACE@49..52 "   "
+      WHITESPACE@48..52 "\n   "
       VAR_DECL@52..66
         IDENT@52..55 "let"
         WHITESPACE@55..56 " "

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -1,8 +1,7 @@
 MODULE@0..34
   BLOCK_STMT@0..33
     L_CURLY@0..1 "{"
-    WHITESPACE@1..2 "\n"
-    WHITESPACE@2..3 " "
+    WHITESPACE@1..3 "\n "
     ERROR@3..31
       EXPORT_KW@3..9 "export"
       WHITESPACE@9..10 " "

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -1,8 +1,7 @@
 MODULE@0..28
   BLOCK_STMT@0..27
     L_CURLY@0..1 "{"
-    WHITESPACE@1..2 "\n"
-    WHITESPACE@2..3 " "
+    WHITESPACE@1..3 "\n "
     ERROR@3..25
       IMPORT_KW@3..9 "import"
       WHITESPACE@9..10 " "

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -4,8 +4,7 @@ MODULE@0..48
     WHITESPACE@5..6 " "
     CLASS_BODY@6..46
       L_CURLY@6..7 "{"
-      WHITESPACE@7..8 "\n"
-      WHITESPACE@8..10 "  "
+      WHITESPACE@7..10 "\n  "
       CLASS_PROP@10..44
         COMPUTED_PROPERTY_NAME@10..17
           L_BRACK@10..11 "["
@@ -30,8 +29,7 @@ MODULE@0..48
           WHITESPACE@25..26 " "
           BLOCK_STMT@26..43
             L_CURLY@26..27 "{"
-            WHITESPACE@27..28 "\n"
-            WHITESPACE@28..32 "    "
+            WHITESPACE@27..32 "\n    "
             VAR_DECL@32..39
               IDENT@32..35 "let"
               WHITESPACE@35..36 " "
@@ -42,8 +40,7 @@ MODULE@0..48
                 EQ@37..38 "="
                 ERROR@38..39
                   SEMICOLON@38..39 ";"
-            WHITESPACE@39..40 "\n"
-            WHITESPACE@40..42 "  "
+            WHITESPACE@39..42 "\n  "
             R_CURLY@42..43 "}"
         SEMICOLON@43..44 ";"
       WHITESPACE@44..45 "\n"

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -7,8 +7,7 @@ MODULE@0..22
     WHITESPACE@9..10 " "
     CLASS_BODY@10..19
       L_CURLY@10..11 "{"
-      WHITESPACE@11..12 "\n"
-      WHITESPACE@12..13 " "
+      WHITESPACE@11..13 "\n "
       CLASS_PROP@13..16
         NAME@13..16
           IDENT@13..16 "get"

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -7,8 +7,7 @@ MODULE@0..47
     WHITESPACE@9..10 " "
     CLASS_BODY@10..46
       L_CURLY@10..11 "{"
-      WHITESPACE@11..12 "\n"
-      WHITESPACE@12..13 " "
+      WHITESPACE@11..13 "\n "
       METHOD@13..27
         ASYNC_KW@13..18 "async"
         WHITESPACE@18..19 " "
@@ -21,8 +20,7 @@ MODULE@0..47
         BLOCK_STMT@25..27
           L_CURLY@25..26 "{"
           R_CURLY@26..27 "}"
-      WHITESPACE@27..28 "\n"
-      WHITESPACE@28..29 " "
+      WHITESPACE@27..29 "\n "
       METHOD@29..44
         ASYNC_KW@29..34 "async"
         WHITESPACE@34..35 " "

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -35,8 +35,7 @@ MODULE@0..72
         WHITESPACE@35..36 " "
         CLASS_BODY@36..57
           L_CURLY@36..37 "{"
-          WHITESPACE@37..38 "\n"
-          WHITESPACE@38..39 " "
+          WHITESPACE@37..39 "\n "
           CONSTRUCTOR@39..55
             NAME@39..50
               IDENT@39..50 "constructor"

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -19,21 +19,18 @@ MODULE@0..64
     WHITESPACE@20..21 " "
     BLOCK_STMT@21..63
       L_CURLY@21..22 "{"
-      WHITESPACE@22..23 "\n"
-      WHITESPACE@23..25 "  "
+      WHITESPACE@22..25 "\n  "
       CONTINUE_STMT@25..34
         CONTINUE_KW@25..33 "continue"
         SEMICOLON@33..34 ";"
-      WHITESPACE@34..35 "\n"
-      WHITESPACE@35..37 "  "
+      WHITESPACE@34..37 "\n  "
       CONTINUE_STMT@37..50
         CONTINUE_KW@37..45 "continue"
         WHITESPACE@45..46 " "
         NAME_REF@46..49
           IDENT@46..49 "foo"
         SEMICOLON@49..50 ";"
-      WHITESPACE@50..51 "\n"
-      WHITESPACE@51..53 "  "
+      WHITESPACE@50..53 "\n  "
       CONTINUE_STMT@53..61
         CONTINUE_KW@53..61 "continue"
       WHITESPACE@61..62 "\n"

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -85,8 +85,7 @@ MODULE@0..142
     WHITESPACE@124..125 " "
     BLOCK_STMT@125..141
       L_CURLY@125..126 "{"
-      WHITESPACE@126..127 "\n"
-      WHITESPACE@127..129 "  "
+      WHITESPACE@126..129 "\n  "
       EXPR_STMT@129..139
         YIELD_EXPR@129..138
           YIELD_KW@129..134 "yield"

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -7,8 +7,7 @@ MODULE@0..28
     WHITESPACE@9..10 " "
     CLASS_BODY@10..27
       L_CURLY@10..11 "{"
-      WHITESPACE@11..12 "\n"
-      WHITESPACE@12..13 " "
+      WHITESPACE@11..13 "\n "
       GETTER@13..25
         GET_KW@13..16 "get"
         WHITESPACE@16..17 " "

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -7,8 +7,7 @@ MODULE@0..28
     WHITESPACE@9..10 " "
     CLASS_BODY@10..27
       L_CURLY@10..11 "{"
-      WHITESPACE@11..12 "\n"
-      WHITESPACE@12..13 " "
+      WHITESPACE@11..13 "\n "
       SETTER@13..25
         SET_KW@13..16 "set"
         WHITESPACE@16..17 " "

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -11,8 +11,7 @@ MODULE@0..48
       WHITESPACE@7..8 " "
       OBJECT_EXPR@8..47
         L_CURLY@8..9 "{"
-        WHITESPACE@9..10 "\n"
-        WHITESPACE@10..12 "  "
+        WHITESPACE@9..12 "\n  "
         METHOD@12..26
           ASYNC_KW@12..17 "async"
           WHITESPACE@17..18 " "
@@ -26,8 +25,7 @@ MODULE@0..48
             L_CURLY@24..25 "{"
             R_CURLY@25..26 "}"
         COMMA@26..27 ","
-        WHITESPACE@27..28 "\n"
-        WHITESPACE@28..30 "  "
+        WHITESPACE@27..30 "\n  "
         METHOD@30..45
           ASYNC_KW@30..35 "async"
           WHITESPACE@35..36 " "

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter.rast
@@ -11,8 +11,7 @@ MODULE@0..43
       WHITESPACE@7..8 " "
       OBJECT_EXPR@8..42
         L_CURLY@8..9 "{"
-        WHITESPACE@9..10 "\n"
-        WHITESPACE@10..11 " "
+        WHITESPACE@9..11 "\n "
         GETTER@11..40
           GET_KW@11..14 "get"
           WHITESPACE@14..15 " "
@@ -24,16 +23,14 @@ MODULE@0..43
           WHITESPACE@20..21 " "
           BLOCK_STMT@21..40
             L_CURLY@21..22 "{"
-            WHITESPACE@22..23 "\n"
-            WHITESPACE@23..26 "   "
+            WHITESPACE@22..26 "\n   "
             RETURN_STMT@26..37
               RETURN_KW@26..32 "return"
               WHITESPACE@32..33 " "
               NAME_REF@33..36
                 IDENT@33..36 "foo"
               SEMICOLON@36..37 ";"
-            WHITESPACE@37..38 "\n"
-            WHITESPACE@38..39 " "
+            WHITESPACE@37..39 "\n "
             R_CURLY@39..40 "}"
         WHITESPACE@40..41 "\n"
         R_CURLY@41..42 "}"

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter_setter_computed.rast
@@ -11,8 +11,7 @@ MODULE@0..48
       WHITESPACE@7..8 " "
       OBJECT_EXPR@8..47
         L_CURLY@8..9 "{"
-        WHITESPACE@9..10 "\n"
-        WHITESPACE@10..12 "  "
+        WHITESPACE@9..12 "\n  "
         GETTER@12..45
           GET_KW@12..15 "get"
           WHITESPACE@15..16 " "
@@ -27,16 +26,14 @@ MODULE@0..48
           WHITESPACE@23..24 " "
           BLOCK_STMT@24..45
             L_CURLY@24..25 "{"
-            WHITESPACE@25..26 "\n"
-            WHITESPACE@26..30 "    "
+            WHITESPACE@25..30 "\n    "
             RETURN_STMT@30..41
               RETURN_KW@30..36 "return"
               WHITESPACE@36..37 " "
               NAME_REF@37..40
                 IDENT@37..40 "foo"
               SEMICOLON@40..41 ";"
-            WHITESPACE@41..42 "\n"
-            WHITESPACE@42..44 "  "
+            WHITESPACE@41..44 "\n  "
             R_CURLY@44..45 "}"
         WHITESPACE@45..46 "\n"
         R_CURLY@46..47 "}"

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -11,8 +11,7 @@ MODULE@0..23
       WHITESPACE@7..8 " "
       OBJECT_EXPR@8..22
         L_CURLY@8..9 "{"
-        WHITESPACE@9..10 "\n"
-        WHITESPACE@10..11 " "
+        WHITESPACE@9..11 "\n "
         METHOD@11..19
           NAME@11..14
             IDENT@11..14 "foo"

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -9,21 +9,18 @@ MODULE@0..43
       WHITESPACE@5..6 " "
       BLOCK_STMT@6..42
         L_CURLY@6..7 "{"
-        WHITESPACE@7..8 "\n"
-        WHITESPACE@8..10 "  "
+        WHITESPACE@7..10 "\n  "
         RETURN_STMT@10..17
           RETURN_KW@10..16 "return"
           SEMICOLON@16..17 ";"
-        WHITESPACE@17..18 "\n"
-        WHITESPACE@18..20 "  "
+        WHITESPACE@17..20 "\n  "
         RETURN_STMT@20..31
           RETURN_KW@20..26 "return"
           WHITESPACE@26..27 " "
           NAME_REF@27..30
             IDENT@27..30 "foo"
           SEMICOLON@30..31 ";"
-        WHITESPACE@31..32 "\n"
-        WHITESPACE@32..34 "  "
+        WHITESPACE@31..34 "\n  "
         RETURN_STMT@34..40
           RETURN_KW@34..40 "return"
         WHITESPACE@40..41 "\n"

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -7,8 +7,7 @@ MODULE@0..99
     WHITESPACE@9..10 " "
     CLASS_BODY@10..98
       L_CURLY@10..11 "{"
-      WHITESPACE@11..12 "\n"
-      WHITESPACE@12..13 " "
+      WHITESPACE@11..13 "\n "
       METHOD@13..31
         STATIC_KW@13..19 "static"
         WHITESPACE@19..20 " "
@@ -24,8 +23,7 @@ MODULE@0..99
         BLOCK_STMT@29..31
           L_CURLY@29..30 "{"
           R_CURLY@30..31 "}"
-      WHITESPACE@31..32 "\n"
-      WHITESPACE@32..33 " "
+      WHITESPACE@31..33 "\n "
       METHOD@33..49
         STATIC_KW@33..39 "static"
         WHITESPACE@39..40 " "
@@ -39,8 +37,7 @@ MODULE@0..99
         BLOCK_STMT@47..49
           L_CURLY@47..48 "{"
           R_CURLY@48..49 "}"
-      WHITESPACE@49..50 "\n"
-      WHITESPACE@50..51 " "
+      WHITESPACE@49..51 "\n "
       METHOD@51..72
         STATIC_KW@51..57 "static"
         WHITESPACE@57..58 " "
@@ -55,8 +52,7 @@ MODULE@0..99
         BLOCK_STMT@70..72
           L_CURLY@70..71 "{"
           R_CURLY@71..72 "}"
-      WHITESPACE@72..73 "\n"
-      WHITESPACE@73..74 " "
+      WHITESPACE@72..74 "\n "
       METHOD@74..96
         STATIC_KW@74..80 "static"
         WHITESPACE@80..81 " "

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -9,16 +9,14 @@ MODULE@0..38
       R_PAREN@11..12 ")"
     WHITESPACE@12..13 " "
     L_CURLY@13..14 "{"
-    WHITESPACE@14..15 "\n"
-    WHITESPACE@15..16 " "
+    WHITESPACE@14..16 "\n "
     CASE_CLAUSE@16..25
       CASE_KW@16..20 "case"
       WHITESPACE@20..21 " "
       NAME_REF@21..24
         IDENT@21..24 "bar"
       COLON@24..25 ":"
-    WHITESPACE@25..26 "\n"
-    WHITESPACE@26..27 " "
+    WHITESPACE@25..27 "\n "
     DEFAULT_CLAUSE@27..35
       DEFAULT_KW@27..34 "default"
       COLON@34..35 ":"

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -11,8 +11,7 @@ MODULE@0..45
     WHITESPACE@15..16 " "
     BLOCK_STMT@16..44
       L_CURLY@16..17 "{"
-      WHITESPACE@17..18 "\n"
-      WHITESPACE@18..19 " "
+      WHITESPACE@17..19 "\n "
       EXPR_STMT@19..29
         YIELD_EXPR@19..28
           YIELD_KW@19..24 "yield"
@@ -20,8 +19,7 @@ MODULE@0..45
           NAME_REF@25..28
             IDENT@25..28 "foo"
         SEMICOLON@28..29 ";"
-      WHITESPACE@29..30 "\n"
-      WHITESPACE@30..31 " "
+      WHITESPACE@29..31 "\n "
       EXPR_STMT@31..42
         YIELD_EXPR@31..41
           YIELD_KW@31..36 "yield"


### PR DESCRIPTION
Fixing lexer breaking newline. Now newline is always in the leading trivia.

# How to test

```rust
> cargo test -p rslint_lexer
> cargo test -p rslint_parser
> cargo xtask coverage
```

Coverage has not improved.