### PR TITLE
feat(codegen): Respect label for tokens & support optional token unions

### DIFF
--- a/xtask/src/codegen/ast.rs
+++ b/xtask/src/codegen/ast.rs
@@ -144,7 +144,7 @@ fn handle_rule(
 
 			if name != "int_number" && name != "string" {
 				let field = Field::Token {
-					name,
+					name: label.cloned().unwrap_or(name),
 					token_kinds: vec![],
 					optional,
 				};
@@ -244,6 +244,11 @@ fn handle_tokens_in_unions(
 	label: &str,
 	optional: bool,
 ) -> bool {
+	let (rule, optional) = match rule {
+		Rule::Opt(rule) => (&**rule, true),
+		_ => (rule, optional),
+	};
+
 	let rule = match rule {
 		Rule::Alt(rule) => rule,
 		_ => return false,


### PR DESCRIPTION
## Summary

Changes the syntax codegen to respect the label for single tokens, for example, `optional: '?.'` and to create a single field for an optional token union, for example, `operator: ('a' | 'b')?`

Part of #1725 

## Test Plan

Ran the codegen on the grammar proposed in #1719 and the codegen correctly generated the union types & and no longer failed on the `?.` token. 
