### PR TITLE
Add support for empty slots to nodes

### DIFF
--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -5,7 +5,7 @@ mod token;
 
 pub(crate) use self::{
 	element::{GreenElement, GreenElementRef},
-	node::{GreenChild, GreenNode, GreenNodeData},
+	node::{Child, Children, GreenNode, GreenNodeData, Slot},
 	token::{GreenToken, GreenTokenData},
 };
 

--- a/crates/rome_rowan/src/green/element.rs
+++ b/crates/rome_rowan/src/green/element.rs
@@ -1,9 +1,8 @@
-use std::borrow::Cow;
-
 use crate::{
 	green::{GreenNode, GreenToken, SyntaxKind},
 	GreenNodeData, NodeOrToken, TextSize,
 };
+use std::borrow::Cow;
 
 use super::GreenTokenData;
 


### PR DESCRIPTION
## Summary

Our goal is to use fixed offsets to get a specific child instead of iterating and trying to match the child by its type. 

This PR extends the rowan `*Node` types to support empty slots, a slot for a child that wasn't present in the tree either because it's an optional child or because of a syntax error. 

The proposed implementation renames the `GreenChild` enum to `Slot` and adds an `Empty` variant. This isn't the most space-efficient representation if nodes have many optional children / sparse nodes (requires 16 bytes for every empty slot). But I believe it's sufficient for now and we can research more efficient sparse array data structures in the future if this turns out to be a problem measuring with real-world programs. 

Part of #1724 

## Test Plan

Added new tests for siblings and children. Ran the coverage and there's no change in the test results.
