### PR TITLE
Use fixed offsets for Script, Module, ...

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -398,6 +398,13 @@ impl<L: Language> SyntaxElement<L> {
 			NodeOrToken::Token(it) => it.detach(),
 		}
 	}
+
+	pub fn into_list(self) -> Option<SyntaxList<L>> {
+		match self {
+			NodeOrToken::Node(it) => it.into_list(),
+			_ => None,
+		}
+	}
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rslint_parser/src/ast/expr_ext.rs
+++ b/crates/rslint_parser/src/ast/expr_ext.rs
@@ -4,30 +4,36 @@ use crate::{ast::*, numbers::*, util::*, SyntaxText, TextRange, TextSize, TokenS
 use SyntaxKind::*;
 
 impl BracketExpr {
+	#[allow(deprecated)]
 	pub fn object(&self) -> Option<JsAnyExpression> {
 		support::child(self.syntax())
 	}
 
+	#[allow(deprecated)]
 	pub fn prop(&self) -> Option<JsAnyExpression> {
 		support::children(self.syntax()).nth(1)
 	}
 }
 
 impl CondExpr {
+	#[allow(deprecated)]
 	pub fn test(&self) -> Option<JsAnyExpression> {
 		support::child(self.syntax())
 	}
 
+	#[allow(deprecated)]
 	pub fn cons(&self) -> Option<JsAnyExpression> {
 		support::children(self.syntax()).nth(1)
 	}
 
+	#[allow(deprecated)]
 	pub fn alt(&self) -> Option<JsAnyExpression> {
 		support::children(self.syntax()).nth(2)
 	}
 }
 
 impl LiteralProp {
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<PropName> {
 		support::as_mandatory_node::<PropName>(self.syntax())
 	}
@@ -143,10 +149,12 @@ impl BinExpr {
 		self.op_details().map(|t| t.0)
 	}
 
+	#[allow(deprecated)]
 	pub fn lhs(&self) -> Option<JsAnyExpression> {
 		support::child(self.syntax())
 	}
 
+	#[allow(deprecated)]
 	pub fn rhs(&self) -> Option<JsAnyExpression> {
 		support::children(self.syntax()).nth(1)
 	}

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -54,6 +54,7 @@ pub struct Ident {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Ident {
+	#[allow(deprecated)]
 	pub fn ident_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![ident])
 	}
@@ -63,34 +64,37 @@ pub struct JsScript {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsScript {
+	#[allow(deprecated)]
 	pub fn interpreter_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![js_shebang])
 	}
-	pub fn statements(&self) -> AstNodeList<JsAnyStatement> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	#[allow(deprecated)]
+	pub fn statements(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct JsModule {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsModule {
+	#[allow(deprecated)]
 	pub fn interpreter_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![js_shebang])
 	}
-	pub fn statements(&self) -> AstNodeList<JsAnyStatement> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	#[allow(deprecated)]
+	pub fn statements(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BlockStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl BlockStmt {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn stmts(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn stmts(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -100,6 +104,7 @@ pub struct EmptyStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl EmptyStmt {
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -109,6 +114,7 @@ pub struct ExprStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprStmt {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -116,10 +122,13 @@ pub struct IfStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl IfStmt {
+	#[allow(deprecated)]
 	pub fn if_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![if])
 	}
+	#[allow(deprecated)]
 	pub fn condition(&self) -> SyntaxResult<Condition> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![else])
 	}
@@ -129,14 +138,19 @@ pub struct DoWhileStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl DoWhileStmt {
+	#[allow(deprecated)]
 	pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![do])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![while])
 	}
+	#[allow(deprecated)]
 	pub fn condition(&self) -> SyntaxResult<Condition> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -146,10 +160,13 @@ pub struct WhileStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl WhileStmt {
+	#[allow(deprecated)]
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![while])
 	}
+	#[allow(deprecated)]
 	pub fn condition(&self) -> SyntaxResult<Condition> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -157,18 +174,25 @@ pub struct ForStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmt {
+	#[allow(deprecated)]
 	pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![for])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn init(&self) -> Option<ForStmtInit> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn test(&self) -> Option<ForStmtTest> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn update(&self) -> Option<ForStmtUpdate> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -176,22 +200,29 @@ pub struct ForInStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForInStmt {
+	#[allow(deprecated)]
 	pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![for])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn in_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![in])
 	}
+	#[allow(deprecated)]
 	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -199,22 +230,29 @@ pub struct ForOfStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForOfStmt {
+	#[allow(deprecated)]
 	pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![for])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![of])
 	}
+	#[allow(deprecated)]
 	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -222,10 +260,13 @@ pub struct ContinueStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ContinueStmt {
+	#[allow(deprecated)]
 	pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![continue])
 	}
+	#[allow(deprecated)]
 	pub fn name_ref(&self) -> SyntaxResult<NameRef> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -235,12 +276,15 @@ pub struct BreakStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl BreakStmt {
+	#[allow(deprecated)]
 	pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![break])
 	}
+	#[allow(deprecated)]
 	pub fn ident_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![ident])
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [;])
 	}
@@ -250,12 +294,15 @@ pub struct ReturnStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ReturnStmt {
+	#[allow(deprecated)]
 	pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![return])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -265,10 +312,13 @@ pub struct WithStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl WithStmt {
+	#[allow(deprecated)]
 	pub fn with_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![with])
 	}
+	#[allow(deprecated)]
 	pub fn condition(&self) -> SyntaxResult<Condition> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -276,10 +326,13 @@ pub struct LabelledStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl LabelledStmt {
+	#[allow(deprecated)]
 	pub fn label(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn stmt(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -287,14 +340,19 @@ pub struct SwitchStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SwitchStmt {
+	#[allow(deprecated)]
 	pub fn switch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![switch])
 	}
+	#[allow(deprecated)]
 	pub fn test(&self) -> SyntaxResult<Condition> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn cases(&self) -> AstNodeList<SwitchCase> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn cases(&self) -> AstNodeList<SwitchCase> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -304,12 +362,15 @@ pub struct ThrowStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ThrowStmt {
+	#[allow(deprecated)]
 	pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![throw])
 	}
+	#[allow(deprecated)]
 	pub fn exception(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [;])
 	}
@@ -319,11 +380,15 @@ pub struct TryStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TryStmt {
+	#[allow(deprecated)]
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![try])
 	}
+	#[allow(deprecated)]
 	pub fn test(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn handler(&self) -> Option<CatchClause> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn finalizer(&self) -> Option<Finalizer> { support::as_optional_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -331,9 +396,11 @@ pub struct DebuggerStmt {
 	pub(crate) syntax: SyntaxNode,
 }
 impl DebuggerStmt {
+	#[allow(deprecated)]
 	pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![debugger])
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -343,22 +410,29 @@ pub struct ImportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ImportDecl {
+	#[allow(deprecated)]
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![import])
 	}
-	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![from])
 	}
+	#[allow(deprecated)]
 	pub fn asserted_object(&self) -> SyntaxResult<ObjectExpr> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn assert_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![assert])
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -368,21 +442,27 @@ pub struct ExportNamed {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExportNamed {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn from_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![from])
 	}
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn specifiers(&self) -> AstSeparatedList<Specifier> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -392,15 +472,19 @@ pub struct ExportDefaultDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExportDefaultDecl {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn default_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![default])
 	}
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn decl(&self) -> SyntaxResult<DefaultDecl> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -408,15 +492,19 @@ pub struct ExportDefaultExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExportDefaultExpr {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn default_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![default])
 	}
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -424,19 +512,25 @@ pub struct ExportWildcard {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExportWildcard {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn as_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![as])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> Option<Ident> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![from])
 	}
@@ -446,12 +540,15 @@ pub struct ExportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExportDecl {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn decl(&self) -> SyntaxResult<Decl> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -459,17 +556,23 @@ pub struct TsImportEqualsDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsImportEqualsDecl {
+	#[allow(deprecated)]
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![import])
 	}
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn module(&self) -> SyntaxResult<TsModuleRef> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -479,13 +582,17 @@ pub struct TsExportAssignment {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExportAssignment {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -495,16 +602,21 @@ pub struct TsNamespaceExportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNamespaceExportDecl {
+	#[allow(deprecated)]
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![export])
 	}
+	#[allow(deprecated)]
 	pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![as])
 	}
+	#[allow(deprecated)]
 	pub fn namespace_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![namespace])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> Option<Ident> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -514,12 +626,15 @@ pub struct Condition {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Condition {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn condition(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -529,7 +644,9 @@ pub struct ForStmtInit {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtInit {
+	#[allow(deprecated)]
 	pub fn inner(&self) -> SyntaxResult<ForHead> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [;])
 	}
@@ -539,7 +656,9 @@ pub struct ForStmtTest {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtTest {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [;])
 	}
@@ -549,6 +668,7 @@ pub struct ForStmtUpdate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtUpdate {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -556,15 +676,17 @@ pub struct VarDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl VarDecl {
+	#[allow(deprecated)]
 	pub fn var_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![var])
 	}
+	#[allow(deprecated)]
 	pub fn const_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![const])
 	}
-	pub fn declared(&self) -> AstSeparatedList<Declarator> {
-		support::separated_list(&self.syntax, 0usize)
-	}
+	#[allow(deprecated)]
+	pub fn declared(&self) -> AstSeparatedList<Declarator> { support::separated_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -574,6 +696,7 @@ pub struct NameRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl NameRef {
+	#[allow(deprecated)]
 	pub fn ident_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![ident])
 	}
@@ -583,6 +706,7 @@ pub struct Name {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Name {
+	#[allow(deprecated)]
 	pub fn ident_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![ident])
 	}
@@ -592,43 +716,55 @@ pub struct CaseClause {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CaseClause {
+	#[allow(deprecated)]
 	pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![case])
 	}
+	#[allow(deprecated)]
 	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
-	pub fn cons(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn cons(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DefaultClause {
 	pub(crate) syntax: SyntaxNode,
 }
 impl DefaultClause {
+	#[allow(deprecated)]
 	pub fn default_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![default])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
-	pub fn cons(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn cons(&self) -> AstNodeList<JsAnyStatement> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CatchClause {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CatchClause {
+	#[allow(deprecated)]
 	pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![catch])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn error(&self) -> SyntaxResult<Pattern> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -636,9 +772,11 @@ pub struct Finalizer {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Finalizer {
+	#[allow(deprecated)]
 	pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![finally])
 	}
+	#[allow(deprecated)]
 	pub fn cons(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -646,17 +784,23 @@ pub struct ArrowExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ArrowExpr {
+	#[allow(deprecated)]
 	pub fn async_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![async])
 	}
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> Option<TsTypeParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn params(&self) -> Option<ArrowExprParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=>])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -664,21 +808,27 @@ pub struct Literal {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Literal {
+	#[allow(deprecated)]
 	pub fn true_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![true])
 	}
+	#[allow(deprecated)]
 	pub fn false_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![false])
 	}
+	#[allow(deprecated)]
 	pub fn number_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![number])
 	}
+	#[allow(deprecated)]
 	pub fn regex_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![regex])
 	}
+	#[allow(deprecated)]
 	pub fn float_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![float])
 	}
+	#[allow(deprecated)]
 	pub fn big_int_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![big_int])
 	}
@@ -688,6 +838,7 @@ pub struct Template {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Template {
+	#[allow(deprecated)]
 	pub fn backtick_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['`'])
 	}
@@ -697,6 +848,7 @@ pub struct ThisExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ThisExpr {
+	#[allow(deprecated)]
 	pub fn this_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![this])
 	}
@@ -706,10 +858,13 @@ pub struct ArrayExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ArrayExpr {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<ExprOrSpread> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn elements(&self) -> AstNodeList<ExprOrSpread> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -719,12 +874,13 @@ pub struct ObjectExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ObjectExpr {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn props(&self) -> AstSeparatedList<ObjectProp> {
-		support::separated_list(&self.syntax, 0usize)
-	}
+	#[allow(deprecated)]
+	pub fn props(&self) -> AstSeparatedList<ObjectProp> { support::separated_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -734,12 +890,15 @@ pub struct GroupingExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl GroupingExpr {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn inner(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -749,12 +908,15 @@ pub struct BracketExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl BracketExpr {
+	#[allow(deprecated)]
 	pub fn super_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![super])
 	}
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -764,15 +926,19 @@ pub struct DotExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl DotExpr {
+	#[allow(deprecated)]
 	pub fn super_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![super])
 	}
+	#[allow(deprecated)]
 	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn prop(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -780,13 +946,17 @@ pub struct NewExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl NewExpr {
+	#[allow(deprecated)]
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![new])
 	}
+	#[allow(deprecated)]
 	pub fn type_args(&self) -> Option<TsTypeArgs> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -794,10 +964,13 @@ pub struct CallExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CallExpr {
+	#[allow(deprecated)]
 	pub fn type_args(&self) -> Option<TsTypeArgs> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -805,6 +978,7 @@ pub struct UnaryExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl UnaryExpr {
+	#[allow(deprecated)]
 	pub fn operator(&self) -> Option<SyntaxToken> {
 		support::find_token(
 			&self.syntax,
@@ -820,6 +994,7 @@ impl UnaryExpr {
 			],
 		)
 	}
+	#[allow(deprecated)]
 	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -829,9 +1004,11 @@ pub struct PreUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl PreUpdateExpression {
+	#[allow(deprecated)]
 	pub fn operator(&self) -> Option<SyntaxToken> {
 		support::find_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
+	#[allow(deprecated)]
 	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -841,9 +1018,11 @@ pub struct PostUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl PostUpdateExpression {
+	#[allow(deprecated)]
 	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn operator(&self) -> Option<SyntaxToken> {
 		support::find_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
@@ -853,6 +1032,7 @@ pub struct BinExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl BinExpr {
+	#[allow(deprecated)]
 	pub fn operator(&self) -> Option<SyntaxToken> {
 		support::find_token(
 			&self.syntax,
@@ -891,9 +1071,11 @@ pub struct CondExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CondExpr {
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
@@ -903,6 +1085,7 @@ pub struct AssignExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignExpr {
+	#[allow(deprecated)]
 	pub fn operator(&self) -> Option<SyntaxToken> {
 		support::find_token(
 			&self.syntax,
@@ -931,9 +1114,11 @@ pub struct SequenceExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SequenceExpr {
+	#[allow(deprecated)]
 	pub fn exprs(&self) -> AstSeparatedList<JsAnyExpression> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn bin_expr(&self) -> SyntaxResult<BinExpr> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -941,22 +1126,31 @@ pub struct FnExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl FnExpr {
+	#[allow(deprecated)]
 	pub fn async_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![async])
 	}
+	#[allow(deprecated)]
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![function])
 	}
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> Option<TsTypeParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ArgList> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -964,18 +1158,25 @@ pub struct ClassExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ClassExpr {
+	#[allow(deprecated)]
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![class])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> Option<TsTypeParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parent(&self) -> Option<JsAnyExpression> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn implements_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![implements])
 	}
+	#[allow(deprecated)]
 	pub fn implements(&self) -> Option<TsExprWithTypeArgs> {
 		support::as_optional_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<ClassBody> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -983,12 +1184,15 @@ pub struct NewTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl NewTarget {
+	#[allow(deprecated)]
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![new])
 	}
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn target_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![target])
 	}
@@ -998,9 +1202,11 @@ pub struct ImportMeta {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ImportMeta {
+	#[allow(deprecated)]
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![import])
 	}
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [.])
 	}
@@ -1010,9 +1216,11 @@ pub struct SuperCall {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SuperCall {
+	#[allow(deprecated)]
 	pub fn super_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![super])
 	}
+	#[allow(deprecated)]
 	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1020,15 +1228,19 @@ pub struct ImportCall {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ImportCall {
+	#[allow(deprecated)]
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![import])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1038,12 +1250,15 @@ pub struct YieldExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl YieldExpr {
+	#[allow(deprecated)]
 	pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![yield])
 	}
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1053,9 +1268,11 @@ pub struct AwaitExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AwaitExpr {
+	#[allow(deprecated)]
 	pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![await])
 	}
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1063,10 +1280,13 @@ pub struct PrivatePropAccess {
 	pub(crate) syntax: SyntaxNode,
 }
 impl PrivatePropAccess {
+	#[allow(deprecated)]
 	pub fn lhs(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn rhs(&self) -> SyntaxResult<PrivateName> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1074,7 +1294,9 @@ pub struct TsNonNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![!])
 	}
@@ -1084,12 +1306,17 @@ pub struct TsAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAssertion {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [<])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [>])
 	}
@@ -1099,14 +1326,19 @@ pub struct TsConstAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstAssertion {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [<])
 	}
+	#[allow(deprecated)]
 	pub fn const_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![const])
 	}
+	#[allow(deprecated)]
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [>])
 	}
@@ -1116,10 +1348,13 @@ pub struct TsTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeArgs {
+	#[allow(deprecated)]
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [<])
 	}
+	#[allow(deprecated)]
 	pub fn args(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [>])
 	}
@@ -1129,12 +1364,15 @@ pub struct ArgList {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ArgList {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn args(&self) -> AstSeparatedList<JsAnyExpression> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1144,10 +1382,13 @@ pub struct TsTypeParams {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParams {
+	#[allow(deprecated)]
 	pub fn l_angle_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [<])
 	}
+	#[allow(deprecated)]
 	pub fn params(&self) -> SyntaxResult<TsTypeParam> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_angle_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [>])
 	}
@@ -1157,12 +1398,13 @@ pub struct ParameterList {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ParameterList {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
-	pub fn parameters(&self) -> AstSeparatedList<Pattern> {
-		support::separated_list(&self.syntax, 0usize)
-	}
+	#[allow(deprecated)]
+	pub fn parameters(&self) -> AstSeparatedList<Pattern> { support::separated_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1172,7 +1414,9 @@ pub struct TsExprWithTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
+	#[allow(deprecated)]
 	pub fn item(&self) -> SyntaxResult<TsEntityName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1182,10 +1426,13 @@ pub struct ClassBody {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ClassBody {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn elements(&self) -> AstNodeList<ClassElement> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn elements(&self) -> AstNodeList<ClassElement> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -1195,24 +1442,33 @@ pub struct Method {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Method {
+	#[allow(deprecated)]
 	pub fn static_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![static])
 	}
+	#[allow(deprecated)]
 	pub fn async_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![async])
 	}
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> Option<TsTypeParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1220,6 +1476,7 @@ pub struct PrivateProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl PrivateProp {
+	#[allow(deprecated)]
 	pub fn class_prop(&self) -> SyntaxResult<ClassProp> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1227,33 +1484,45 @@ pub struct ClassProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ClassProp {
+	#[allow(deprecated)]
 	pub fn declare_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![declare])
 	}
+	#[allow(deprecated)]
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![abstract])
 	}
+	#[allow(deprecated)]
 	pub fn static_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![static])
 	}
+	#[allow(deprecated)]
 	pub fn accessibility(&self) -> Option<TsAccessibility> {
 		support::as_optional_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn hash_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [#])
 	}
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn excl_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![!])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> Option<JsAnyExpression> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -1263,14 +1532,19 @@ pub struct Constructor {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Constructor {
+	#[allow(deprecated)]
 	pub fn accessibility(&self) -> Option<TsAccessibility> {
 		support::as_optional_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> Option<TsTypeParams> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1278,17 +1552,23 @@ pub struct TsIndexSignature {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIndexSignature {
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![readonly])
 	}
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn pat(&self) -> SyntaxResult<SinglePattern> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -1298,13 +1578,17 @@ pub struct Getter {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Getter {
+	#[allow(deprecated)]
 	pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![get])
 	}
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1312,13 +1596,17 @@ pub struct Setter {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Setter {
+	#[allow(deprecated)]
 	pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![set])
 	}
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1326,9 +1614,11 @@ pub struct TsAccessibility {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAccessibility {
+	#[allow(deprecated)]
 	pub fn private_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![private])
 	}
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![readonly])
 	}
@@ -1338,12 +1628,15 @@ pub struct ConstructorParameters {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ConstructorParameters {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> AstSeparatedList<ConstructorParamOrPat> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1353,9 +1646,11 @@ pub struct TsConstructorParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructorParam {
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![readonly])
 	}
+	#[allow(deprecated)]
 	pub fn pat(&self) -> SyntaxResult<Pattern> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1363,9 +1658,11 @@ pub struct SpreadElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SpreadElement {
+	#[allow(deprecated)]
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [...])
 	}
+	#[allow(deprecated)]
 	pub fn element(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1375,6 +1672,7 @@ pub struct Null {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Null {
+	#[allow(deprecated)]
 	pub fn null_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![null])
 	}
@@ -1384,6 +1682,7 @@ pub struct Undefined {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Undefined {
+	#[allow(deprecated)]
 	pub fn undefined_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![undefined])
 	}
@@ -1393,16 +1692,21 @@ pub struct SinglePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SinglePattern {
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn excl_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![!])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1410,9 +1714,11 @@ pub struct RestPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl RestPattern {
+	#[allow(deprecated)]
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [...])
 	}
+	#[allow(deprecated)]
 	pub fn pat(&self) -> SyntaxResult<Pattern> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1420,14 +1726,19 @@ pub struct AssignPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignPattern {
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<Pattern> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1437,12 +1748,15 @@ pub struct ObjectPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ObjectPattern {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn elements(&self) -> AstSeparatedList<ObjectPatternProp> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -1452,19 +1766,25 @@ pub struct ArrayPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ArrayPattern {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
+	#[allow(deprecated)]
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![!])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1472,6 +1792,7 @@ pub struct ExprPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprPattern {
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1479,7 +1800,9 @@ pub struct KeyValuePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl KeyValuePattern {
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<PropName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
@@ -1489,6 +1812,7 @@ pub struct LiteralProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl LiteralProp {
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
@@ -1498,9 +1822,11 @@ pub struct SpreadProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SpreadProp {
+	#[allow(deprecated)]
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [...])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1510,10 +1836,13 @@ pub struct InitializedProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl InitializedProp {
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1523,6 +1852,7 @@ pub struct IdentProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl IdentProp {
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1530,10 +1860,13 @@ pub struct ComputedPropertyName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ComputedPropertyName {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -1543,9 +1876,11 @@ pub struct PrivateName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl PrivateName {
+	#[allow(deprecated)]
 	pub fn hash_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [#])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1553,26 +1888,35 @@ pub struct FnDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl FnDecl {
+	#[allow(deprecated)]
 	pub fn async_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![async])
 	}
+	#[allow(deprecated)]
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![function])
 	}
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_parameters(&self) -> Option<TsTypeParams> {
 		support::as_optional_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<BlockStmt> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1580,14 +1924,19 @@ pub struct ClassDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ClassDecl {
+	#[allow(deprecated)]
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![class])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Name> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![extends])
 	}
+	#[allow(deprecated)]
 	pub fn parent(&self) -> SyntaxResult<NameRef> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<ClassBody> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1595,17 +1944,23 @@ pub struct TsEnum {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
+	#[allow(deprecated)]
 	pub fn const_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![const])
 	}
+	#[allow(deprecated)]
 	pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![enum])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -1615,15 +1970,19 @@ pub struct TsTypeAliasDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeAliasDecl {
+	#[allow(deprecated)]
 	pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![type])
 	}
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1631,13 +1990,17 @@ pub struct TsNamespaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNamespaceDecl {
+	#[allow(deprecated)]
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![declare])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1645,19 +2008,25 @@ pub struct TsModuleDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsModuleDecl {
+	#[allow(deprecated)]
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![declare])
 	}
+	#[allow(deprecated)]
 	pub fn global_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![global])
 	}
+	#[allow(deprecated)]
 	pub fn module_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![module])
 	}
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1665,25 +2034,33 @@ pub struct TsInterfaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInterfaceDecl {
+	#[allow(deprecated)]
 	pub fn declare_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![declare])
 	}
+	#[allow(deprecated)]
 	pub fn interface_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![interface])
 	}
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn extends_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![extends])
 	}
+	#[allow(deprecated)]
 	pub fn extends(&self) -> Option<TsExprWithTypeArgs> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn members(&self) -> SyntaxResult<TsTypeElement> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -1693,13 +2070,17 @@ pub struct Declarator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Declarator {
+	#[allow(deprecated)]
 	pub fn pattern(&self) -> SyntaxResult<Pattern> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![!])
 	}
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1709,12 +2090,15 @@ pub struct WildcardImport {
 	pub(crate) syntax: SyntaxNode,
 }
 impl WildcardImport {
+	#[allow(deprecated)]
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [*])
 	}
+	#[allow(deprecated)]
 	pub fn as_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![as])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> Option<Ident> { support::as_optional_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1722,12 +2106,15 @@ pub struct NamedImports {
 	pub(crate) syntax: SyntaxNode,
 }
 impl NamedImports {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn specifiers(&self) -> AstSeparatedList<Specifier> {
-		support::separated_list(&self.syntax, 0usize)
+		support::separated_list(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -1742,6 +2129,7 @@ pub struct Specifier {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Specifier {
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1749,12 +2137,15 @@ pub struct TsExternalModuleRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExternalModuleRef {
+	#[allow(deprecated)]
 	pub fn require_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![require])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1764,6 +2155,7 @@ pub struct TsAny {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAny {
+	#[allow(deprecated)]
 	pub fn any_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![any])
 	}
@@ -1773,6 +2165,7 @@ pub struct TsUnknown {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnknown {
+	#[allow(deprecated)]
 	pub fn unknown_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![unknown])
 	}
@@ -1782,6 +2175,7 @@ pub struct TsNumber {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNumber {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1789,6 +2183,7 @@ pub struct TsObject {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObject {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1796,6 +2191,7 @@ pub struct TsBoolean {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBoolean {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1803,6 +2199,7 @@ pub struct TsBigint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBigint {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1810,6 +2207,7 @@ pub struct TsString {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsString {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1817,6 +2215,7 @@ pub struct TsSymbol {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbol {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1824,6 +2223,7 @@ pub struct TsVoid {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsVoid {
+	#[allow(deprecated)]
 	pub fn void_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![void])
 	}
@@ -1833,6 +2233,7 @@ pub struct TsUndefined {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUndefined {
+	#[allow(deprecated)]
 	pub fn undefined_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![undefined])
 	}
@@ -1842,6 +2243,7 @@ pub struct TsNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNull {
+	#[allow(deprecated)]
 	pub fn null_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![null])
 	}
@@ -1851,6 +2253,7 @@ pub struct TsNever {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNever {
+	#[allow(deprecated)]
 	pub fn never_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![never])
 	}
@@ -1860,6 +2263,7 @@ pub struct TsThis {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsThis {
+	#[allow(deprecated)]
 	pub fn this_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![this])
 	}
@@ -1869,6 +2273,7 @@ pub struct TsLiteral {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsLiteral {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1876,7 +2281,9 @@ pub struct TsPredicate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPredicate {
+	#[allow(deprecated)]
 	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn rhs(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1884,12 +2291,15 @@ pub struct TsTuple {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTuple {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn elements(&self) -> SyntaxResult<TsTupleElement> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -1899,10 +2309,13 @@ pub struct TsParen {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsParen {
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1912,7 +2325,9 @@ pub struct TsTypeRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeRef {
+	#[allow(deprecated)]
 	pub fn name(&self) -> SyntaxResult<TsEntityName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1920,6 +2335,7 @@ pub struct TsTemplate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplate {
+	#[allow(deprecated)]
 	pub fn elements(&self) -> SyntaxResult<TsTemplateElement> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -1929,31 +2345,41 @@ pub struct TsMappedType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedType {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> {
 		support::as_optional_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn minus_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [-])
 	}
+	#[allow(deprecated)]
 	pub fn plus_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [+])
 	}
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
+	#[allow(deprecated)]
 	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [;])
 	}
@@ -1963,19 +2389,25 @@ pub struct TsImport {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsImport {
+	#[allow(deprecated)]
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![import])
 	}
+	#[allow(deprecated)]
 	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['('])
 	}
+	#[allow(deprecated)]
 	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![')'])
 	}
@@ -1985,10 +2417,13 @@ pub struct TsArray {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsArray {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -1998,10 +2433,13 @@ pub struct TsIndexedArray {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIndexedArray {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![']'])
 	}
@@ -2011,6 +2449,7 @@ pub struct TsTypeOperator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperator {
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2018,24 +2457,29 @@ pub struct TsIntersection {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersection {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TsUnion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnion {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TsFnType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsFnType {
+	#[allow(deprecated)]
 	pub fn params(&self) -> SyntaxResult<ParameterList> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=>])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2043,13 +2487,17 @@ pub struct TsConstructorType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructorType {
+	#[allow(deprecated)]
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![new])
 	}
+	#[allow(deprecated)]
 	pub fn params(&self) -> SyntaxResult<ParameterList> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> Option<TsType> { support::as_optional_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2057,13 +2505,17 @@ pub struct TsConditionalType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn extends(&self) -> SyntaxResult<TsExtends> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2071,10 +2523,13 @@ pub struct TsObjectType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObjectType {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax, 0usize) }
+	#[allow(deprecated)]
+	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -2084,9 +2539,11 @@ pub struct TsInfer {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInfer {
+	#[allow(deprecated)]
 	pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![infer])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2094,16 +2551,21 @@ pub struct TsTupleElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleElement {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [...])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2111,10 +2573,13 @@ pub struct TsEnumMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
 		support::as_mandatory_node(&self.syntax)
 	}
@@ -2124,7 +2589,9 @@ pub struct TsTemplateElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -2134,12 +2601,15 @@ pub struct TsMappedTypeReadonly {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonly {
+	#[allow(deprecated)]
 	pub fn minus_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [-])
 	}
+	#[allow(deprecated)]
 	pub fn plus_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [+])
 	}
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![readonly])
 	}
@@ -2149,14 +2619,19 @@ pub struct TsMappedTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeParam {
+	#[allow(deprecated)]
 	pub fn l_brack_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T!['['])
 	}
+	#[allow(deprecated)]
 	pub fn name(&self) -> Option<TsTypeName> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_brack_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![']'])
 	}
+	#[allow(deprecated)]
 	pub fn ident(&self) -> Option<Ident> { support::as_optional_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2164,6 +2639,7 @@ pub struct TsTypeName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeName {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2171,9 +2647,11 @@ pub struct TsExtends {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExtends {
+	#[allow(deprecated)]
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![extends])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2181,10 +2659,13 @@ pub struct TsModuleBlock {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsModuleBlock {
+	#[allow(deprecated)]
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['{'])
 	}
+	#[allow(deprecated)]
 	pub fn items(&self) -> SyntaxResult<JsAnyStatement> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T!['}'])
 	}
@@ -2194,10 +2675,13 @@ pub struct TsTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParam {
+	#[allow(deprecated)]
 	pub fn ident(&self) -> SyntaxResult<Ident> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn constraint(&self) -> SyntaxResult<TsConstraint> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn default(&self) -> SyntaxResult<TsDefault> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2205,9 +2689,11 @@ pub struct TsConstraint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstraint {
+	#[allow(deprecated)]
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![extends])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2215,9 +2701,11 @@ pub struct TsDefault {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsDefault {
+	#[allow(deprecated)]
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [=])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2225,15 +2713,19 @@ pub struct TsCallSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureDecl {
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2241,18 +2733,23 @@ pub struct TsConstructSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructSignatureDecl {
+	#[allow(deprecated)]
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T![new])
 	}
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2260,16 +2757,21 @@ pub struct TsPropertySignature {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPropertySignature {
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![readonly])
 	}
+	#[allow(deprecated)]
 	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn ty(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2277,22 +2779,29 @@ pub struct TsMethodSignature {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMethodSignature {
+	#[allow(deprecated)]
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T![readonly])
 	}
+	#[allow(deprecated)]
 	pub fn key(&self) -> SyntaxResult<JsAnyExpression> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn parameters(&self) -> SyntaxResult<ParameterList> {
 		support::as_mandatory_node(&self.syntax)
 	}
+	#[allow(deprecated)]
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::as_optional_token(&self.syntax, T ! [?])
 	}
+	#[allow(deprecated)]
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [:])
 	}
+	#[allow(deprecated)]
 	pub fn return_type(&self) -> SyntaxResult<TsType> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2300,10 +2809,13 @@ pub struct TsQualifiedPath {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedPath {
+	#[allow(deprecated)]
 	pub fn lhs(&self) -> SyntaxResult<TsEntityName> { support::as_mandatory_node(&self.syntax) }
+	#[allow(deprecated)]
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::as_mandatory_token(&self.syntax, T ! [.])
 	}
+	#[allow(deprecated)]
 	pub fn rhs(&self) -> SyntaxResult<TsTypeName> { support::as_mandatory_node(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -157,6 +157,7 @@ mod tests {
 }
 
 impl TsEnumMember {
+	#[allow(deprecated)]
 	pub fn string_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, STRING)
 	}

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -179,6 +179,16 @@ impl<'t> Parser<'t> {
 		true
 	}
 
+	/// Eats an optional token if it matches kind or emits a missing event.
+	pub fn eat_optional(&mut self, kind: SyntaxKind) -> bool {
+		if self.eat(kind) {
+			true
+		} else {
+			self.missing();
+			false
+		}
+	}
+
 	/// Recover from an error with a recovery set or by using a `{` or `}`.
 	pub fn err_recover(
 		&mut self,

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -21,7 +21,7 @@ macro_rules! at_ident_name {
 
 pub fn parse(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
-	p.eat(T![js_shebang]);
+	p.eat_optional(T![js_shebang]);
 	block_items(p, true, true, false, None);
 	m.complete(
 		p,


### PR DESCRIPTION
## Summary

Changes the parser to generate the missing events and changes the codegen to use fixed offsets for the following nodes:

* Script
* Module

Part of #1724 

Depends on #1738 and #1760 

## Test Plan


