### PR TITLE
Parser: Create empty slots for expected tokens

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -119,6 +119,14 @@ impl<L: Language> SyntaxNode<L> {
 		SyntaxNode::from(cursor::SyntaxNode::new_root(green))
 	}
 
+	/// Returns the element stored in the slot with the given index. Returns [None] if the slot is empty.
+	///
+	/// ## Panics
+	/// If the slot index is out of bounds
+	pub fn element_in_slot(&self, slot: u32) -> Option<SyntaxElement<L>> {
+		self.raw.element_in_slot(slot).map(SyntaxElement::from)
+	}
+
 	pub fn kind(&self) -> L::Kind {
 		L::kind_from_raw(self.raw.kind())
 	}

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -609,6 +609,23 @@ impl SyntaxNode {
 		self.data().offset()
 	}
 
+	pub(crate) fn element_in_slot(&self, slot_index: u32) -> Option<SyntaxElement> {
+		let slot = self
+			.green_ref()
+			.slots()
+			.nth(slot_index as usize)
+			.expect("Slot index out of bounds");
+
+		slot.as_ref().map(|element| {
+			SyntaxElement::new(
+				element,
+				self.clone(),
+				slot_index,
+				self.offset() + slot.rel_offset(),
+			)
+		})
+	}
+
 	#[inline]
 	pub fn text_range(&self) -> TextRange {
 		self.data().text_range()

--- a/crates/rslint_parser/src/event.rs
+++ b/crates/rslint_parser/src/event.rs
@@ -39,6 +39,10 @@ pub enum Event {
 		range: Range<usize>,
 	},
 
+	/// Missing child element, either because the child is optional and wasn't present in the source
+	/// or a required child is missing because of a syntax error
+	Missing,
+
 	MultipleTokens {
 		amount: u8,
 		kind: SyntaxKind,
@@ -104,6 +108,7 @@ pub fn process(sink: &mut impl TreeSink, mut events: Vec<Event>, errors: Vec<Par
 				}
 			}
 			Event::Finish { .. } => sink.finish_node(),
+			Event::Missing => sink.missing(),
 			Event::Token { kind, .. } => {
 				sink.token(kind);
 			}

--- a/crates/rslint_parser/src/lib.rs
+++ b/crates/rslint_parser/src/lib.rs
@@ -130,6 +130,9 @@ pub trait TreeSink {
 	/// branch as current.
 	fn finish_node(&mut self);
 
+	/// Expected a token or child node that wasn't present and adds it to the current branch.
+	fn missing(&mut self);
+
 	/// Emit errors
 	fn errors(&mut self, errors: Vec<ParserError>);
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -63,6 +63,16 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
 		self.do_token(kind, len);
 	}
 
+	fn missing(&mut self) {
+		match mem::replace(&mut self.state, State::Normal) {
+			State::PendingStart => unreachable!(),
+			State::PendingFinish => self.inner.finish_node(),
+			State::Normal => (),
+		}
+
+		self.inner.missing();
+	}
+
 	// TODO: Attach comment whitespace to nodes
 	fn start_node(&mut self, kind: SyntaxKind) {
 		match mem::replace(&mut self.state, State::Normal) {

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -56,6 +56,16 @@ impl<'a> TreeSink for LossyTreeSink<'a> {
 		self.do_token(kind, len, false);
 	}
 
+	fn missing(&mut self) {
+		match mem::replace(&mut self.state, State::Normal) {
+			State::PendingStart => unreachable!(),
+			State::PendingFinish => self.inner.finish_node(),
+			State::Normal => (),
+		}
+
+		self.inner.missing();
+	}
+
 	fn start_node(&mut self, kind: SyntaxKind) {
 		match mem::replace(&mut self.state, State::Normal) {
 			State::PendingStart => {

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -285,6 +285,12 @@ impl<'t> Parser<'t> {
 		self.push_event(Event::Token { kind, range });
 	}
 
+	/// Inserts a marker for a missing child element because the child is optional and wasn't present in the source
+	/// or it's a mandatory child that wasn't present in the source because of a syntax error.
+	pub fn missing(&mut self) {
+		self.push_event(Event::Missing);
+	}
+
 	fn push_event(&mut self, event: Event) {
 		self.events.push(event)
 	}
@@ -307,7 +313,7 @@ impl<'t> Parser<'t> {
 			.expect("Parser source and tokens mismatch")
 	}
 
-	/// Try to eat a specific token kind, if the kind is not there then add an error to the events stack.
+	/// Try to eat a specific token kind, if the kind is not there then add a missing marker and add an error to the events stack.
 	pub fn expect(&mut self, kind: SyntaxKind) -> bool {
 		if self.eat(kind) {
 			true
@@ -331,6 +337,7 @@ impl<'t> Parser<'t> {
 				.primary(self.cur_tok().range, "unexpected")
 			};
 
+			self.missing();
 			self.error(err);
 			false
 		}


### PR DESCRIPTION
## Summary

Changes the parser to generate a `missing` event if it expected a specific token that isn't present in the source code. Tracking the missing children of a node is required to implement fixed offsets for children. 

It's probably best to only review the second commit as the first commit is part of #1761 

Part of #1724 

## Test Plan

Verified that coverage isn't changing.