### PR TITLE
feat: add replace_nodes method for SyntaxNode

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -114,6 +114,20 @@ impl<L: Language> SyntaxNode<L> {
 		SyntaxNode::from(cursor::SyntaxNode::new_root(green))
 	}
 
+	pub fn replace_nodes(&self, replacements: &[(SyntaxNode<L>, SyntaxNode<L>)]) -> SyntaxNode<L> {
+		let replacer = cursor::SyntaxNodeReplacer::from_pairs(replacements);
+		SyntaxNode::new_root(self.raw.replace_nodes(&replacer))
+	}
+
+	pub fn replace_nodes_with(
+		&self,
+		nodes: &[SyntaxNode<L>],
+		compute: impl Fn(&SyntaxNode<L>) -> SyntaxNode<L>,
+	) -> SyntaxNode<L> {
+		let replacer = cursor::SyntaxNodeReplacer::from_fn(nodes, compute);
+		SyntaxNode::new_root(self.raw.replace_nodes(&replacer))
+	}
+
 	pub fn kind(&self) -> L::Kind {
 		L::kind_from_raw(self.raw.kind())
 	}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This draft PR is a piece of the CST transform work related to #1739 

It adds a method for replacing multiple syntax nodes from a single immutable syntax tree, building a new syntax tree all at once. This allows for identifying and collecting references to multiple nodes of interest then replacing them all simultaneously.

Attempting to immutably replace multiple target nodes one-by-one can be a challenge because each replacement creates a new tree which the remaining targets nodes are no longer a part of. Roslyn has a [TrackNodes](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.syntaxnodeextensions.tracknodes?view=roslyn-dotnet-4.0.1) method which is another solution to this problem that we may also want to consider.

This approach attempts to make multiple replacements efficiently, maintaining structural sharing where possible and avoiding traversal into subtrees that don’t contain nodes targeted for replacement.

It first sorts the replacements to make use of binary search and to restrict the slice of replacements checked by subtrees during recursion. This optimization hasn’t been validated yet with benchmarks. If we do decide to use the `replace_nodes` approach as part of our CST transform infrastructure, we should test performance and evaluate assumptions (e.g. sorting a vector of replacements may not pay off in every situation).

TODO: 
 - Add tests and recheck logic in `SyntaxNodeReplacer::matches`
 - Put more thought into naming things and clean up the code/data structures/API