### PR TITLE
trivia attached to GreenTokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "expect-test"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +381,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -757,10 +778,21 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
- "rand",
- "rand_core",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -768,6 +800,17 @@ name = "quickcheck_macros"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -789,11 +832,20 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -803,7 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -812,7 +864,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -821,7 +882,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -912,8 +973,11 @@ dependencies = [
  "hashbrown",
  "m_lexer",
  "memoffset",
+ "quickcheck 1.0.3",
+ "quickcheck_macros 1.0.0",
  "rustc-hash",
  "serde",
+ "serde_json",
  "text-size",
 ]
 
@@ -936,8 +1000,8 @@ version = "0.2.0"
 dependencies = [
  "ansi_term",
  "atty",
- "quickcheck",
- "quickcheck_macros",
+ "quickcheck 0.9.2",
+ "quickcheck_macros 0.9.1",
  "rslint_errors",
  "rslint_syntax",
 ]
@@ -1085,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1327,6 +1391,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2018"
 
 [dependencies]
 rustc-hash = "1.0.1"
-hashbrown = { version = "0.11.2", features = ["inline-more"], default-features = false }
+hashbrown = { version = "0.11.2", features = [
+    "inline-more",
+], default-features = false }
 text-size = "1.1.0"
 memoffset = "0.6"
 countme = "2.0.0"
@@ -18,6 +20,9 @@ serde = { version = "1.0.89", optional = true, default-features = false }
 
 [dev-dependencies]
 m_lexer = "0.0.4"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
+serde_json = "1.0.69"
 
 [features]
-serde1 = [ "serde", "text-size/serde" ]
+serde1 = ["serde", "text-size/serde"]

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -33,7 +33,7 @@ impl Language for RawLanguage {
 	}
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Trivia {
 	Whitespace(usize),
 	Comments(usize),
@@ -173,15 +173,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// assert_eq!("\n\t let \t\ta; \t\t", node.text());
@@ -191,7 +191,7 @@ impl<L: Language> SyntaxNode<L> {
 	}
 
 	/// Returns the text of all descendants tokens combined,
-	/// excluding the fist token leading trivia, and the last token trailing trivia.
+	/// excluding the first token leading trivia, and the last token trailing trivia.
 	/// All other trivia is included.
 	///
 	/// ```
@@ -201,15 +201,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// assert_eq!("let \t\ta;", node.text_trimmed());
@@ -227,15 +227,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// let range = node.text_range();
@@ -257,15 +257,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// let range = node.text_trimmed_range();
@@ -285,15 +285,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// let trivia = node.first_leading_trivia();
@@ -320,15 +320,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	///     builder.token(SyntaxKind(1), "a");
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "; \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// });
 	/// let trivia = node.last_trailing_trivia();
@@ -528,8 +528,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("\n\t let \t\t", token.text());
@@ -547,8 +547,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("let", token.text_trimmed());
@@ -603,8 +603,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("\n\t ", token.leading_trivia().text());
@@ -626,8 +626,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         SyntaxKind(1),
 	///         "\n\t let \t\t",
-	///         &[Trivia::Whitespace(3)],
-	///         &[Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
+	///         vec![Trivia::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!(" \t\t", token.trailing_trivia().text());
@@ -1130,8 +1130,8 @@ mod tests {
 		builder.token_with_trivia(
 			crate::SyntaxKind(0),
 			"\n\t let \t\t",
-			&[Trivia::Whitespace(3)],
-			&[Trivia::Whitespace(3)],
+			vec![Trivia::Whitespace(3)],
+			vec![Trivia::Whitespace(3)],
 		);
 		builder.finish_node();
 
@@ -1159,23 +1159,23 @@ mod tests {
 		builder.token_with_trivia(
 			crate::SyntaxKind(0),
 			"\n\t let \t\t",
-			&[Trivia::Whitespace(3)],
-			&[Trivia::Whitespace(3)],
+			vec![Trivia::Whitespace(3)],
+			vec![Trivia::Whitespace(3)],
 		);
 		builder.token_with_trivia(
 			crate::SyntaxKind(0),
 			"a ",
-			&[Trivia::Whitespace(0)],
-			&[Trivia::Whitespace(1)],
+			vec![Trivia::Whitespace(0)],
+			vec![Trivia::Whitespace(1)],
 		);
 		builder.token_with_trivia(
 			crate::SyntaxKind(1),
 			"\n=\n",
-			&[Trivia::Whitespace(1)],
-			&[Trivia::Whitespace(1)],
+			vec![Trivia::Whitespace(1)],
+			vec![Trivia::Whitespace(1)],
 		);
 		builder.token(crate::SyntaxKind(0), "1");
-		builder.token_with_trivia(crate::SyntaxKind(0), ";\t\t", &[], &[Trivia::Whitespace(2)]);
+		builder.token_with_trivia(crate::SyntaxKind(0), ";\t\t", vec![], vec![Trivia::Whitespace(2)]);
 		builder.finish_node();
 
 		let node = builder.finish();

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -49,12 +49,6 @@ impl Trivia {
 	}
 }
 
-pub enum SyntaxTriviaPiece {
-	Whitespace {},
-	NewLine {},
-	Comments {},
-}
-
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SyntaxTrivia<L: Language> {
 	raw: cursor::SyntaxTrivia,

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -1175,7 +1175,12 @@ mod tests {
 			vec![Trivia::Whitespace(1)],
 		);
 		builder.token(crate::SyntaxKind(0), "1");
-		builder.token_with_trivia(crate::SyntaxKind(0), ";\t\t", vec![], vec![Trivia::Whitespace(2)]);
+		builder.token_with_trivia(
+			crate::SyntaxKind(0),
+			";\t\t",
+			vec![],
+			vec![Trivia::Whitespace(2)],
+		);
 		builder.finish_node();
 
 		let node = builder.finish();

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -247,7 +247,7 @@ impl<L: Language> SyntaxNode<L> {
 	}
 
 	/// Returns the range corresponding for the text of all descendants tokens combined,
-	/// excluding the fist token leading  trivia, and the last token trailing trivia.
+	/// excluding the first token leading  trivia, and the last token trailing trivia.
 	/// All other trivia is included.
 	///
 	/// ```

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -564,9 +564,9 @@ impl SyntaxTrivia {
 	pub(crate) fn text(&self) -> &str {
 		let green_token = self.token.green();
 		if self.is_leading {
-			green_token.text_leading()
+			green_token.text_leading_trivia()
 		} else {
-			green_token.text_trailing()
+			green_token.text_trailing_trivia()
 		}
 	}
 

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -554,7 +554,7 @@ impl SyntaxTrivia {
 	pub(crate) fn text_range(&self) -> TextRange {
 		let green_token = self.token.green();
 		if self.is_leading {
-			TextRange::at(self.offset, green_token.leading().text_len())
+			TextRange::at(self.offset, green_token.leading_trivia().text_len())
 		} else {
 			let (_, trailing_len, total_len) = green_token.leading_trailing_total_len();
 			TextRange::at(self.offset + total_len - trailing_len, trailing_len)
@@ -573,9 +573,9 @@ impl SyntaxTrivia {
 	pub(crate) fn text_len(&self) -> TextSize {
 		let green_token = self.token.green();
 		if self.is_leading {
-			green_token.leading().text_len()
+			green_token.leading_trivia().text_len()
 		} else {
-			green_token.trailing().text_len()
+			green_token.trailing_trivia().text_len()
 		}
 	}
 }
@@ -998,8 +998,8 @@ impl SyntaxToken {
 	#[inline]
 	pub fn text_trimmed_range(&self) -> TextRange {
 		let green_token = self.green();
-		let leading_len = green_token.leading().text_len();
-		let trailing_len = green_token.trailing().text_len();
+		let leading_len = green_token.leading_trivia().text_len();
+		let trailing_len = green_token.trailing_trivia().text_len();
 
 		let range = self.text_range();
 		TextRange::new(range.start() + leading_len, range.end() - trailing_len)

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -148,7 +148,7 @@ unsafe impl sll::Elem for NodeData {
 
 pub(crate) type SyntaxElement = NodeOrToken<SyntaxNode, SyntaxToken>;
 
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone, Hash)]
 pub(crate) struct SyntaxTrivia {
 	offset: TextSize,
 	token: SyntaxToken,
@@ -1196,23 +1196,6 @@ impl SyntaxElement {
 }
 
 // region: impls
-
-impl PartialEq for SyntaxTrivia {
-	#[inline]
-	fn eq(&self, other: &Self) -> bool {
-		self.token == other.token && self.is_leading == other.is_leading
-	}
-}
-
-impl Eq for SyntaxTrivia {}
-
-impl Hash for SyntaxTrivia {
-	#[inline]
-	fn hash<H: Hasher>(&self, state: &mut H) {
-		self.token.hash(state);
-		self.is_leading.hash(state);
-	}
-}
 
 impl fmt::Debug for SyntaxTrivia {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -154,15 +154,15 @@ impl NodeCache {
 	}
 
 	pub(crate) fn token(&mut self, kind: SyntaxKind, text: &str) -> (u64, GreenToken) {
-		self.token_with_trivia(kind, text, &[], &[])
+		self.token_with_trivia(kind, text, Vec::new(), Vec::new())
 	}
 
 	pub(crate) fn token_with_trivia(
 		&mut self,
 		kind: SyntaxKind,
 		text: &str,
-		leading: &[Trivia],
-		trailing: &[Trivia],
+		leading: Vec<Trivia>,
+		trailing: Vec<Trivia>,
 	) -> (u64, GreenToken) {
 		let hash = token_hash_of(kind, text);
 

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -2,6 +2,7 @@ use hashbrown::hash_map::RawEntryMut;
 use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 
+use crate::api::Trivia;
 use crate::green::Slot;
 use crate::{
 	green::GreenElementRef, GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken,
@@ -9,6 +10,7 @@ use crate::{
 };
 
 use super::element::GreenElement;
+use super::token::GreenTokenTrivia;
 
 type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
@@ -40,11 +42,15 @@ pub struct NodeCache {
 	tokens: HashMap<NoHash<GreenToken>, ()>,
 }
 
-fn token_hash(token: &GreenTokenData) -> u64 {
+fn token_hash_of(kind: SyntaxKind, text: &str) -> u64 {
 	let mut h = FxHasher::default();
-	token.kind().hash(&mut h);
-	token.text().hash(&mut h);
+	kind.hash(&mut h);
+	text.hash(&mut h);
 	h.finish()
+}
+
+fn token_hash(token: &GreenTokenData) -> u64 {
+	token_hash_of(token.kind(), token.text())
 }
 
 fn node_hash(node: &GreenNodeData) -> u64 {
@@ -148,12 +154,20 @@ impl NodeCache {
 	}
 
 	pub(crate) fn token(&mut self, kind: SyntaxKind, text: &str) -> (u64, GreenToken) {
-		let hash = {
-			let mut h = FxHasher::default();
-			kind.hash(&mut h);
-			text.hash(&mut h);
-			h.finish()
-		};
+		self.token_with_trivia(kind, text, &[], &[])
+	}
+
+	pub(crate) fn token_with_trivia(
+		&mut self,
+		kind: SyntaxKind,
+		text: &str,
+		leading: &[Trivia],
+		trailing: &[Trivia],
+	) -> (u64, GreenToken) {
+		let hash = token_hash_of(kind, text);
+
+		let leading = GreenTokenTrivia::from(leading);
+		let trailing = GreenTokenTrivia::from(trailing);
 
 		let entry = self.tokens.raw_entry_mut().from_hash(hash, |token| {
 			token.0.kind() == kind && token.0.text() == text
@@ -162,7 +176,7 @@ impl NodeCache {
 		let token = match entry {
 			RawEntryMut::Occupied(entry) => entry.key().0.clone(),
 			RawEntryMut::Vacant(entry) => {
-				let token = GreenToken::new(kind, text);
+				let token = GreenToken::with_trivia(kind, text, leading, trailing);
 				entry.insert_with_hasher(hash, NoHash(token.clone()), (), |t| token_hash(&t.0));
 				token
 			}
@@ -170,4 +184,35 @@ impl NodeCache {
 
 		(hash, token)
 	}
+}
+
+#[test]
+fn green_token_hash() {
+	let kind = SyntaxKind(0);
+	let text = " let ";
+	let t1 = GreenToken::with_trivia(
+		kind,
+		text,
+		GreenTokenTrivia::Whitespace(1),
+		GreenTokenTrivia::Whitespace(1),
+	);
+	let t2 = GreenToken::with_trivia(
+		kind,
+		text,
+		GreenTokenTrivia::Whitespace(1),
+		GreenTokenTrivia::Whitespace(1),
+	);
+
+	assert_eq!(token_hash(&t1), token_hash(&t2));
+
+	let t3 = GreenToken::new(kind, "let");
+	assert_ne!(token_hash(&t1), token_hash(&t3));
+
+	let t4 = GreenToken::with_trivia(
+		kind,
+		"\tlet ",
+		GreenTokenTrivia::Whitespace(1),
+		GreenTokenTrivia::Whitespace(1),
+	);
+	assert_ne!(token_hash(&t1), token_hash(&t4));
 }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -177,7 +177,7 @@ impl GreenTokenData {
 	}
 
 	#[inline]
-	pub fn text_leading(&self) -> &str {
+	pub fn text_leading_trivia(&self) -> &str {
 		let leading_len = self.leading().text_len();
 
 		let end: usize = leading_len.into();
@@ -186,7 +186,7 @@ impl GreenTokenData {
 	}
 
 	#[inline]
-	pub fn text_trailing(&self) -> &str {
+	pub fn text_trailing_trivia(&self) -> &str {
 		let (_, trailing_len, total_len) = self.leading_trailing_total_len();
 
 		let start: usize = (total_len - trailing_len).into();
@@ -291,8 +291,8 @@ mod tests {
 		assert_eq!("let", t.text_trimmed());
 		assert_eq!(TextSize::from(3), t.text_trimmed_len());
 
-		assert_eq!("\n\t ", t.text_leading());
-		assert_eq!(" \t\t", t.text_trailing());
+		assert_eq!("\n\t ", t.text_leading_trivia());
+		assert_eq!(" \t\t", t.text_trailing_trivia());
 
 		assert_eq!("\n\t let \t\t", format!("{}", t));
 	}

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -158,7 +158,7 @@ impl GreenTokenData {
 		unsafe { std::str::from_utf8_unchecked(self.data.slice()) }
 	}
 
-	fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
+	pub(crate) fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
 		let leading_len = self.data.header.leading.text_len();
 		let trailing_len = self.data.header.trailing.text_len();
 		let total_len = self.data.slice().len() as u32;

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -119,8 +119,8 @@ impl fmt::Debug for GreenTokenData {
 		f.debug_struct("GreenToken")
 			.field("kind", &self.kind())
 			.field("text", &self.text())
-			.field("leading", &self.leading())
-			.field("trailing", &self.trailing())
+			.field("leading", &self.leading_trivia())
+			.field("trailing", &self.trailing_trivia())
 			.finish()
 	}
 }
@@ -178,7 +178,7 @@ impl GreenTokenData {
 
 	#[inline]
 	pub fn text_leading_trivia(&self) -> &str {
-		let leading_len = self.leading().text_len();
+		let leading_len = self.leading_trivia().text_len();
 
 		let end: usize = leading_len.into();
 		let text = unsafe { std::str::from_utf8_unchecked(self.data.slice()) };
@@ -201,18 +201,12 @@ impl GreenTokenData {
 	}
 
 	#[inline]
-	#[allow(dead_code)]
-	pub fn text_trimmed_len(&self) -> TextSize {
-		TextSize::of(self.text_trimmed())
-	}
-
-	#[inline]
-	pub fn leading(&self) -> &GreenTokenTrivia {
+	pub fn leading_trivia(&self) -> &GreenTokenTrivia {
 		&self.data.header.leading
 	}
 
 	#[inline]
-	pub fn trailing(&self) -> &GreenTokenTrivia {
+	pub fn trailing_trivia(&self) -> &GreenTokenTrivia {
 		&self.data.header.trailing
 	}
 }
@@ -289,7 +283,6 @@ mod tests {
 		assert_eq!(TextSize::from(9), t.text_len());
 
 		assert_eq!("let", t.text_trimmed());
-		assert_eq!(TextSize::from(3), t.text_trimmed_len());
 
 		assert_eq!("\n\t ", t.text_leading_trivia());
 		assert_eq!(" \t\t", t.text_trailing_trivia());

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -41,28 +41,16 @@ impl GreenTokenTrivia {
 	}
 }
 
-impl From<&[Trivia]> for GreenTokenTrivia {
-	fn from(trivias: &[Trivia]) -> Self {
-		let mut trivia = GreenTokenTrivia::None;
-		for current_trivia in trivias.iter().map(Clone::clone) {
-			trivia = match (trivia, current_trivia) {
-				(GreenTokenTrivia::None, Trivia::Whitespace(len)) => {
-					GreenTokenTrivia::Whitespace(len)
-				}
-				(GreenTokenTrivia::None, Trivia::Comments(len)) => GreenTokenTrivia::Comments(len),
-				(GreenTokenTrivia::Whitespace(len), second) => {
-					GreenTokenTrivia::Many(Box::new(vec![Trivia::Whitespace(len), second]))
-				}
-				(GreenTokenTrivia::Comments(len), second) => {
-					GreenTokenTrivia::Many(Box::new(vec![Trivia::Comments(len), second]))
-				}
-				(GreenTokenTrivia::Many(mut v), second) => {
-					v.push(second);
-					GreenTokenTrivia::Many(v)
-				}
-			}
+impl From<Vec<Trivia>> for GreenTokenTrivia {
+	fn from(trivias: Vec<Trivia>) -> Self {
+		match trivias.as_slice() {
+			[] => GreenTokenTrivia::None,
+			[Trivia::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
+			[Trivia::Comments(len)] => GreenTokenTrivia::Comments(*len),
+			_ => {
+				GreenTokenTrivia::Many(Box::new(trivias))
+			},
 		}
-		trivia
 	}
 }
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -199,7 +199,7 @@ impl GreenTokenData {
 
 impl GreenToken {
 	#[inline]
-	#[allow(dead_code)]
+	#[cfg(test)]
 	pub fn new(kind: SyntaxKind, text: &str) -> GreenToken {
 		Self::with_trivia(kind, text, GreenTokenTrivia::None, GreenTokenTrivia::None)
 	}

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -47,9 +47,7 @@ impl From<Vec<Trivia>> for GreenTokenTrivia {
 			[] => GreenTokenTrivia::None,
 			[Trivia::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
 			[Trivia::Comments(len)] => GreenTokenTrivia::Comments(*len),
-			_ => {
-				GreenTokenTrivia::Many(Box::new(trivias))
-			},
+			_ => GreenTokenTrivia::Many(Box::new(trivias)),
 		}
 	}
 }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -8,14 +8,69 @@ use std::{
 use countme::Count;
 
 use crate::{
+	api::Trivia,
 	arc::{Arc, HeaderSlice, ThinArc},
 	green::SyntaxKind,
 	TextSize,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(clippy::box_vec)]
+pub enum GreenTokenTrivia {
+	None,
+	Whitespace(usize),
+	Comments(usize),
+	Many(Box<Vec<Trivia>>),
+}
+
+impl GreenTokenTrivia {
+	pub fn text_len(&self) -> TextSize {
+		match self {
+			GreenTokenTrivia::None => 0.into(),
+			GreenTokenTrivia::Whitespace(len) => (*len as u32).into(),
+			GreenTokenTrivia::Comments(len) => (*len as u32).into(),
+			GreenTokenTrivia::Many(v) => {
+				let r = v.iter().fold(Some(TextSize::of("")), |len, trivia| {
+					len.and_then(|x| x.checked_add(trivia.text_len()))
+				});
+
+				// Realistically we will never have files bigger than usize::MAX, nor u32::MAX
+				r.unwrap_or_else(|| u32::MAX.into())
+			}
+		}
+	}
+}
+
+impl From<&[Trivia]> for GreenTokenTrivia {
+	fn from(trivias: &[Trivia]) -> Self {
+		let mut trivia = GreenTokenTrivia::None;
+		for current_trivia in trivias.iter().map(Clone::clone) {
+			trivia = match (trivia, current_trivia) {
+				(GreenTokenTrivia::None, Trivia::Whitespace(len)) => {
+					GreenTokenTrivia::Whitespace(len)
+				}
+				(GreenTokenTrivia::None, Trivia::Comments(len)) => GreenTokenTrivia::Comments(len),
+				(GreenTokenTrivia::Whitespace(len), second) => {
+					GreenTokenTrivia::Many(Box::new(vec![Trivia::Whitespace(len), second]))
+				}
+				(GreenTokenTrivia::Comments(len), second) => {
+					GreenTokenTrivia::Many(Box::new(vec![Trivia::Comments(len), second]))
+				}
+				(GreenTokenTrivia::Many(mut v), second) => {
+					v.push(second);
+					GreenTokenTrivia::Many(v)
+				}
+			}
+		}
+		trivia
+	}
+}
+
 #[derive(PartialEq, Eq, Hash)]
 struct GreenTokenHead {
 	kind: SyntaxKind,
+	leading: GreenTokenTrivia,
+	trailing: GreenTokenTrivia,
 	_c: Count<GreenToken>,
 }
 
@@ -64,6 +119,8 @@ impl fmt::Debug for GreenTokenData {
 		f.debug_struct("GreenToken")
 			.field("kind", &self.kind())
 			.field("text", &self.text())
+			.field("leading", &self.leading())
+			.field("trailing", &self.trailing())
 			.finish()
 	}
 }
@@ -95,10 +152,46 @@ impl GreenTokenData {
 		self.data.header.kind
 	}
 
-	/// Text of this Token.
+	/// Whole text of this Token, including all trivia.
 	#[inline]
 	pub fn text(&self) -> &str {
 		unsafe { std::str::from_utf8_unchecked(self.data.slice()) }
+	}
+
+	fn leading_trailing_total_len(&self) -> (TextSize, TextSize, TextSize) {
+		let leading_len = self.data.header.leading.text_len();
+		let trailing_len = self.data.header.trailing.text_len();
+		let total_len = self.data.slice().len() as u32;
+		(leading_len, trailing_len, total_len.into())
+	}
+
+	/// Text of this Token, excluding all trivia.
+	#[inline]
+	pub fn text_trimmed(&self) -> &str {
+		let (leading_len, trailing_len, total_len) = self.leading_trailing_total_len();
+
+		let start: usize = leading_len.into();
+		let end: usize = (total_len - trailing_len).into();
+		let text = unsafe { std::str::from_utf8_unchecked(self.data.slice()) };
+		&text[start..end]
+	}
+
+	#[inline]
+	pub fn text_leading(&self) -> &str {
+		let leading_len = self.leading().text_len();
+
+		let end: usize = leading_len.into();
+		let text = unsafe { std::str::from_utf8_unchecked(self.data.slice()) };
+		&text[0..end]
+	}
+
+	#[inline]
+	pub fn text_trailing(&self) -> &str {
+		let (_, trailing_len, total_len) = self.leading_trailing_total_len();
+
+		let start: usize = (total_len - trailing_len).into();
+		let text = unsafe { std::str::from_utf8_unchecked(self.data.slice()) };
+		&text[start..]
 	}
 
 	/// Returns the length of the text covered by this token.
@@ -106,19 +199,48 @@ impl GreenTokenData {
 	pub fn text_len(&self) -> TextSize {
 		TextSize::of(self.text())
 	}
+
+	#[inline]
+	#[allow(dead_code)]
+	pub fn text_trimmed_len(&self) -> TextSize {
+		TextSize::of(self.text_trimmed())
+	}
+
+	#[inline]
+	pub fn leading(&self) -> &GreenTokenTrivia {
+		&self.data.header.leading
+	}
+
+	#[inline]
+	pub fn trailing(&self) -> &GreenTokenTrivia {
+		&self.data.header.trailing
+	}
 }
 
 impl GreenToken {
-	/// Creates new Token.
 	#[inline]
+	#[allow(dead_code)]
 	pub fn new(kind: SyntaxKind, text: &str) -> GreenToken {
+		Self::with_trivia(kind, text, GreenTokenTrivia::None, GreenTokenTrivia::None)
+	}
+
+	#[inline]
+	pub fn with_trivia(
+		kind: SyntaxKind,
+		text: &str,
+		leading: GreenTokenTrivia,
+		trailing: GreenTokenTrivia,
+	) -> GreenToken {
 		let head = GreenTokenHead {
 			kind,
+			leading,
+			trailing,
 			_c: Count::new(),
 		};
 		let ptr = ThinArc::from_header_and_iter(head, text.bytes());
 		GreenToken { ptr }
 	}
+
 	#[inline]
 	pub(crate) fn into_raw(this: GreenToken) -> ptr::NonNull<GreenTokenData> {
 		let green = ManuallyDrop::new(this);
@@ -144,5 +266,72 @@ impl ops::Deref for GreenToken {
 			let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
 			mem::transmute::<&ReprThin, &GreenTokenData>(repr)
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::api::Trivia;
+
+	use super::*;
+	use quickcheck_macros::*;
+
+	#[test]
+	fn green_token_text_and_len() {
+		let t = GreenToken::with_trivia(
+			SyntaxKind(0),
+			"\n\t let \t\t",
+			GreenTokenTrivia::Whitespace(3),
+			GreenTokenTrivia::Whitespace(3),
+		);
+
+		assert_eq!("\n\t let \t\t", t.text());
+		assert_eq!(TextSize::from(9), t.text_len());
+
+		assert_eq!("let", t.text_trimmed());
+		assert_eq!(TextSize::from(3), t.text_trimmed_len());
+
+		assert_eq!("\n\t ", t.text_leading());
+		assert_eq!(" \t\t", t.text_trailing());
+
+		assert_eq!("\n\t let \t\t", format!("{}", t));
+	}
+
+	#[test]
+	fn none_text_len() {
+		assert_eq!(TextSize::from(0), GreenTokenTrivia::None.text_len());
+	}
+
+	#[quickcheck]
+	fn whitespace_and_comments_text_len(len: usize) {
+		assert_eq!(
+			TextSize::from(len as u32),
+			GreenTokenTrivia::Whitespace(len).text_len()
+		);
+		assert_eq!(
+			TextSize::from(len as u32),
+			GreenTokenTrivia::Comments(len).text_len()
+		);
+	}
+
+	#[test]
+	fn many_text_len_dont_panic() {
+		let trivia = GreenTokenTrivia::Many(Box::new(vec![
+			Trivia::Whitespace(usize::MAX),
+			Trivia::Comments(1),
+		]));
+		assert_eq!(TextSize::from(u32::MAX), trivia.text_len());
+	}
+
+	#[quickcheck]
+	fn many_text_len(lengths: Vec<u32>) {
+		let trivia: Vec<_> = lengths
+			.iter()
+			.map(|x| Trivia::Whitespace(*x as usize))
+			.collect();
+		let trivia = GreenTokenTrivia::Many(Box::new(trivia));
+
+		let total_len = lengths.iter().fold(0u32, |acc, x| acc.saturating_add(*x));
+		assert_eq!(TextSize::from(total_len), trivia.text_len());
 	}
 }

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -31,7 +31,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 pub use crate::{
 	api::{
 		Language, SyntaxElement, SyntaxElementChildren, SyntaxList, SyntaxNode, SyntaxNodeChildren,
-		SyntaxToken,
+		SyntaxToken, Trivia,
 	},
 	green::SyntaxKind,
 	syntax_text::SyntaxText,

--- a/crates/rome_rowan/src/serde_impls.rs
+++ b/crates/rome_rowan/src/serde_impls.rs
@@ -2,7 +2,7 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{
-	api::{Language, SyntaxNode, SyntaxToken},
+	api::{Language, RawLanguage, SyntaxNode, SyntaxToken},
 	NodeOrToken,
 };
 
@@ -45,6 +45,10 @@ impl<L: Language> Serialize for SyntaxToken<L> {
 		state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
 		state.serialize_entry("text_range", &self.text_range())?;
 		state.serialize_entry("text", &self.text())?;
+
+		// To implement this, SyntaxTrivia will need to expose the kind and the length of each trivia
+		// state.serialize_entry("leading", &self.leading())?;
+		// state.serialize_entry("trailing", &self.trailing())?;
 		state.end()
 	}
 }
@@ -65,4 +69,15 @@ impl<L: Language> Serialize for Children<&'_ SyntaxNode<L>> {
 			})?;
 		state.end()
 	}
+}
+
+#[test]
+pub fn serialization() {
+	let mut builder: crate::TreeBuilder<crate::api::RawLanguage> = crate::TreeBuilder::new();
+	builder.start_node(crate::SyntaxKind(0));
+	builder.token(crate::SyntaxKind(0), "\n\tlet ");
+	builder.finish_node();
+	let root = builder.finish();
+
+	assert!(serde_json::to_string(&root).is_ok());
 }

--- a/crates/rome_rowan/src/syntax_text.rs
+++ b/crates/rome_rowan/src/syntax_text.rs
@@ -17,6 +17,10 @@ impl SyntaxText {
 		SyntaxText { node, range }
 	}
 
+	pub(crate) fn with_range(node: SyntaxNode, range: TextRange) -> SyntaxText {
+		SyntaxText { node, range }
+	}
+
 	pub fn len(&self) -> TextSize {
 		self.range.len()
 	}

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -72,8 +72,8 @@ impl<L: Language> TreeBuilder<'_, L> {
 		&mut self,
 		kind: L::Kind,
 		text: &str,
-		leading: &[Trivia],
-		trailing: &[Trivia],
+		leading: Vec<Trivia>,
+		trailing: Vec<Trivia>,
 	) {
 		let (hash, token) =
 			self.cache

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -1,4 +1,5 @@
 use crate::{
+	api::Trivia,
 	cow_mut::CowMut,
 	green::{GreenElement, NodeCache},
 	GreenNode, Language, NodeOrToken, SyntaxNode,
@@ -46,6 +47,21 @@ impl<L: Language> TreeBuilder<'_, L> {
 	#[inline]
 	pub fn token(&mut self, kind: L::Kind, text: &str) {
 		let (hash, token) = self.cache.token(L::kind_to_raw(kind), text);
+		self.children.push((hash, Some(token.into())));
+	}
+
+	/// Adds new token to the current branch.
+	#[inline]
+	pub fn token_with_trivia(
+		&mut self,
+		kind: L::Kind,
+		text: &str,
+		leading: &[Trivia],
+		trailing: &[Trivia],
+	) {
+		let (hash, token) =
+			self.cache
+				.token_with_trivia(L::kind_to_raw(kind), text, leading, trailing);
 		self.children.push((hash, Some(token.into())));
 	}
 

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -43,6 +43,22 @@ impl<L: Language> TreeBuilder<'_, L> {
 		}
 	}
 
+	/// Method to quickly wrap a tree with a node.
+	///
+	/// TreeBuilder::<RawLanguage>::wrap_with_node(SyntaxKind(0), |builder| {
+	///     builder.token(SyntaxKind(1), "let");
+	/// });
+	pub fn wrap_with_node<F>(kind: L::Kind, build: F) -> SyntaxNode<L>
+	where
+		F: Fn(&mut Self),
+	{
+		let mut builder = TreeBuilder::<L>::new();
+		builder.start_node(kind);
+		build(&mut builder);
+		builder.finish_node();
+		builder.finish()
+	}
+
 	/// Adds new token to the current branch.
 	#[inline]
 	pub fn token(&mut self, kind: L::Kind, text: &str) {


### PR DESCRIPTION
part of: #1720
Improved changes of #1738

# Tasks

- [x] ```GreenToken``` own a list of its trivia lengths
- [x] ```SyntaxTrivia``` wraps ```GreenTokenTrivia```
- [x] ```PartialEq``` and ```Hash```
- [x] ```Display``` and ```Debug```
- [x] ```NodeCache``` must take into consideration the token trivia (not fixed by changing ```Hash``` implementation)

# Decisions

- Now the GreenToken "slice" contains all its trivia.
- To trim this trivia we have to ask leading().text_len() and trailing().text_len() and compute where the token text actually is.
- Given that ```GreenToken``` already has its trivia, we ignore the trivia when hashing and caching. Advantage: faster; Disadvantage: dangerous. At least in theory, two equal strings can come from two different parsers and end up with two different trivia.

- GreenToken now is 32 bytes bigger (16 bytes for each trivia). Hard to improve here because ```Box<>``` wants to be aligned.

```rust
pub enum GreenTokenTrivia {
	None,
	One(Trivia),
	Many(Box<Vec<Trivia>>),
}

print-type-size type: `GreenTokenTrivia`: 16 bytes, alignment: 8 bytes
print-type-size     discriminant: 8 bytes
print-type-size     variant `Whitespace`: 8 bytes
print-type-size         field `.0`: 8 bytes
print-type-size     variant `Comment`: 8 bytes
print-type-size         field `.0`: 8 bytes
print-type-size     variant `Many`: 8 bytes
print-type-size         field `.0`: 8 bytes
print-type-size     variant `None`: 0 bytes
```

- Box<Vec<Trivia>> is frown upon. See https://github.com/rust-lang/rust-clippy/blob/b7f3f7f6082679da2da9a0b3faf1b5adef3afd3b/clippy_lints/src/types/box_collection.rs. But I still think it may be a good idea here. We will need to measure.

# How to test

```rust
> cargo test -p rome_rowan
> cargo xtask coverage
...
│ Tests ran │ Passed │ Failed │ Panics │ Coverage │
├───────────┼────────┼────────┼────────┼──────────┤
│   17604   │ 16767  │  836   │   1    │  95.25   │
...
``` 

Coverage is the same as before.