### PR TITLE
feat: pass error kind via parameter

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+       os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -33,31 +33,28 @@ jobs:
         uses: Swatinem/rust-cache@v1
       - name: Run Test262 suite
         continue-on-error: true
-        run: cargo xtask coverage --json
-      - name: Rename the emitted file
-        run: |
-          mv base_results.json new_results.json
+        run:  cargo xtask coverage --json > new_results.json
       - name: Save test results
         uses: actions/upload-artifact@v2
         with:
           name: new_results
           path: new_results.json
 
-  compare:
+# This job compares the coverage results from this PR and the coverage results from master
+  coverage-comparison:
     needs: coverage
     name: Compare coverage
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+       os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           submodules: recursive
-          # To restore once the main branch has the new command
-          # ref: main
+          ref: main
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -67,10 +64,55 @@ jobs:
         uses: Swatinem/rust-cache@v1
       - name: Run Test262 suite on main branch
         continue-on-error: true
-        run: cargo xtask coverage --json
+        run:  cargo xtask coverage --json > base_results.json
       - name: Download PRs test results
         uses: actions/download-artifact@v2
         with:
           name: new_results
       - name: Compare results on ${{ matrix.os }}
-        run: cargo xtask compare ./base_results.json ./new_results.json  --markdown
+        if: github.event_name == 'pull_request'
+        id: comparison
+        shell: bash
+        run: |
+          comment="$(cargo xtask compare ./base_results.json ./new_results.json  --markdown)"
+          comment="${comment//'%'/'%25'}"
+          comment="${comment//$'\n'/'%0A'}"
+          comment="${comment//$'\r'/'%0D'}"
+          echo "::set-output name=comment::$comment"
+
+      - name: Get the PR number
+        if: github.event_name == 'pull_request'
+        id: pr-number
+        uses: kkak10/pr-number-action@v1.3
+
+      - name: Find Previous Comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v1.3.0
+        id: previous-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body-includes: Test262 conformance changes
+
+      - name: Update comment
+        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.previous-comment.outputs.comment-id }}
+          body: |
+            ### Test262 comparison coverage results on ${{ matrix.os }}
+
+            ${{ steps.comparison.outputs.comment }}
+          edit-mode: replace
+
+      - name: Write a new comment
+        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body: |
+            ### Test262 comparison coverage results on ${{ matrix.os }}
+
+            ${{ steps.comparison.outputs.comment }}
+

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -185,6 +185,8 @@ impl<'t> Parser<'t> {
 		error: impl Into<ParserError>,
 		recovery: TokenSet,
 		include_braces: bool,
+		// The kind of unknown token the parser wanted to try to guess at that position
+		unknown_syntax_kind: SyntaxKind,
 	) -> Option<()> {
 		if self.state.no_recovery {
 			return None;
@@ -206,12 +208,17 @@ impl<'t> Parser<'t> {
 		let m = self.start();
 		self.error(error);
 		self.bump_any();
-		m.complete(self, SyntaxKind::ERROR);
+		m.complete(self, unknown_syntax_kind);
 		Some(())
 	}
 
 	/// Recover from an error but don't add an error to the events
-	pub fn err_recover_no_err(&mut self, recovery: TokenSet, include_braces: bool) {
+	pub fn err_recover_no_err(
+		&mut self,
+		recovery: TokenSet,
+		include_braces: bool,
+		unknown_syntax_kind: SyntaxKind,
+	) {
 		match self.cur() {
 			T!['{'] | T!['}'] if include_braces => {
 				return;
@@ -225,7 +232,7 @@ impl<'t> Parser<'t> {
 
 		let m = self.start();
 		self.bump_any();
-		m.complete(self, SyntaxKind::ERROR);
+		m.complete(self, unknown_syntax_kind);
 	}
 
 	/// Starts a new node in the syntax tree. All nodes and tokens

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -423,19 +423,24 @@ impl<'t> Parser<'t> {
 	}
 
 	/// Bump and add an error event
-	pub fn err_and_bump(&mut self, err: impl Into<ParserError>) {
+	pub fn err_and_bump(&mut self, err: impl Into<ParserError>, unknown_syntax_kind: SyntaxKind) {
 		let m = self.start();
 		self.bump_any();
-		m.complete(self, SyntaxKind::ERROR);
+		m.complete(self, unknown_syntax_kind);
 		self.error(err);
 	}
 
-	pub fn err_if_not_ts(&mut self, mut marker: impl BorrowMut<CompletedMarker>, err: &str) {
+	pub fn err_if_not_ts(
+		&mut self,
+		mut marker: impl BorrowMut<CompletedMarker>,
+		err: &str,
+		unknown_syntax_kind: SyntaxKind,
+	) {
 		if self.typescript() {
 			return;
 		}
 		let borrow = marker.borrow_mut();
-		borrow.change_kind(self, SyntaxKind::ERROR);
+		borrow.change_kind(self, unknown_syntax_kind);
 		let err = self.err_builder(err).primary(borrow.range(self), "");
 
 		self.error(err);
@@ -489,7 +494,11 @@ impl<'t> Parser<'t> {
 		start..end
 	}
 
-	pub fn expr_with_semi_recovery(&mut self, assign: bool) -> Option<CompletedMarker> {
+	pub fn expr_with_semi_recovery(
+		&mut self,
+		assign: bool,
+		unknown_syntax_kind: SyntaxKind,
+	) -> Option<CompletedMarker> {
 		let func = if assign {
 			syntax::expr::assign_expr
 		} else {
@@ -504,7 +513,7 @@ impl<'t> Parser<'t> {
 
 			self.error(err);
 			self.bump_any();
-			m.complete(self, SyntaxKind::ERROR);
+			m.complete(self, unknown_syntax_kind);
 			return None;
 		}
 
@@ -715,7 +724,7 @@ impl CompletedMarker {
 	}
 
 	pub fn err_if_not_ts(&mut self, p: &mut Parser, err: &str) {
-		p.err_if_not_ts(self, err);
+		p.err_if_not_ts(self, err, SyntaxKind::ERROR);
 	}
 }
 

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -180,13 +180,20 @@ impl<'t> Parser<'t> {
 	}
 
 	/// Recover from an error with a recovery set or by using a `{` or `}`.
+	///
+	/// # Arguments
+	///
+	/// * `error` -  the [Diagnostic] to emit
+	/// * `recovery` - it recovers the parser position is inside a set [tokens](TokenSet)
+	/// * `include_braces` - it recovers the parser if the current token is a curly brace
+	/// * `unknown_node` - The kind of the unknown node the parser inserts if it isn't able to recover because
+	/// the current token is neither in the recovery set nor any of `{` or `}`.
 	pub fn err_recover(
 		&mut self,
 		error: impl Into<ParserError>,
 		recovery: TokenSet,
 		include_braces: bool,
-		// The kind of unknown token the parser wanted to try to guess at that position
-		unknown_syntax_kind: SyntaxKind,
+		unknown_node: SyntaxKind,
 	) -> Option<()> {
 		if self.state.no_recovery {
 			return None;
@@ -208,16 +215,23 @@ impl<'t> Parser<'t> {
 		let m = self.start();
 		self.error(error);
 		self.bump_any();
-		m.complete(self, unknown_syntax_kind);
+		m.complete(self, unknown_node);
 		Some(())
 	}
 
 	/// Recover from an error but don't add an error to the events
+	///
+	/// # Arguments
+	///
+	/// * `recovery` - it recovers the parser position is inside a set [tokens](TokenSet)
+	/// * `include_braces` - it recovers the parser if the current token is a curly brace
+	/// * `unknown_node` - The kind of the unknown node the parser inserts if it isn't able to recover because
+	/// the current token is neither in the recovery set nor any of `{` or `}`.
 	pub fn err_recover_no_err(
 		&mut self,
 		recovery: TokenSet,
 		include_braces: bool,
-		unknown_syntax_kind: SyntaxKind,
+		unknown_node: SyntaxKind,
 	) {
 		match self.cur() {
 			T!['{'] | T!['}'] if include_braces => {
@@ -232,7 +246,7 @@ impl<'t> Parser<'t> {
 
 		let m = self.start();
 		self.bump_any();
-		m.complete(self, unknown_syntax_kind);
+		m.complete(self, unknown_node);
 	}
 
 	/// Starts a new node in the syntax tree. All nodes and tokens

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -295,6 +295,7 @@ fn parameters_common(p: &mut Parser, constructor_params: bool) -> CompletedMarke
 						T![')'],
 					],
 					true,
+					ERROR,
 				);
 				None
 			}
@@ -963,6 +964,7 @@ fn class_member_no_semi(p: &mut Parser) -> Option<CompletedMarker> {
 		err,
 		token_set![T![;], T![ident], T![async], T![yield], T!['}'], T![#]],
 		false,
+		ERROR,
 	);
 	None
 }
@@ -1061,6 +1063,7 @@ pub fn method(
 				err,
 				recovery_set.into().unwrap_or(BASE_METHOD_RECOVERY_SET),
 				false,
+				ERROR,
 			);
 			return None;
 		}

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -1012,7 +1012,7 @@ pub fn primary_expr(p: &mut Parser) -> Option<CompletedMarker> {
 						))
 						.primary(p.cur_tok().range, "");
 
-					p.err_and_bump(err);
+					p.err_and_bump(err, ERROR);
 					m.complete(p, ERROR)
 				} else {
 					let err = p

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -715,7 +715,7 @@ pub fn paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> CompletedMarke
 						let err = temp.err_builder(&format!("expect a closing parenthesis after a spread element, but instead found `{}`", temp.cur_src()))
                     .primary(temp.cur_tok().range, "");
 
-						temp.err_recover(err, EXPR_RECOVERY_SET, false);
+						temp.err_recover(err, EXPR_RECOVERY_SET, false, ERROR);
 					}
 				}
 				break;
@@ -1047,7 +1047,7 @@ pub fn primary_expr(p: &mut Parser) -> Option<CompletedMarker> {
 			let err = p
 				.err_builder("Expected an expression, but found none")
 				.primary(p.cur_tok().range, "Expected an expression here");
-			p.err_recover(err, p.state.expr_recovery_set, true);
+			p.err_recover(err, p.state.expr_recovery_set, true, ERROR);
 			return None;
 		}
 	};
@@ -1067,7 +1067,7 @@ pub fn identifier_reference(p: &mut Parser) -> Option<CompletedMarker> {
 				.err_builder("Expected an identifier, but found none")
 				.primary(p.cur_tok().range, "");
 
-			p.err_recover(err, p.state.expr_recovery_set, true);
+			p.err_recover(err, p.state.expr_recovery_set, true, ERROR);
 			None
 		}
 	}
@@ -1263,7 +1263,7 @@ pub fn object_property(p: &mut Parser) -> Option<CompletedMarker> {
 				// let a = { /: 6, /: /foo/ }
 				// let a = {{}}
 				if prop.is_none() {
-					p.err_recover_no_err(token_set![T![:], T![,]], false);
+					p.err_recover_no_err(token_set![T![:], T![,]], false, ERROR);
 				}
 				// test_err object_expr_non_ident_literal_prop
 				// let b = {5}

--- a/crates/rslint_parser/src/syntax/pat.rs
+++ b/crates/rslint_parser/src/syntax/pat.rs
@@ -70,7 +70,7 @@ pub fn pattern(p: &mut Parser, parameters: bool, assignment: bool) -> Option<Com
 			if p.state.allow_object_expr {
 				ts = ts.union(token_set![T!['{']]);
 			}
-			p.err_recover(err, ts, false);
+			p.err_recover(err, ts, false, ERROR);
 			return None;
 		}
 	})
@@ -171,6 +171,7 @@ pub fn array_binding_pattern(
 			p.err_recover_no_err(
 				token_set![T![await], T![ident], T![yield], T![:], T![=], T![']']],
 				false,
+				ERROR,
 			);
 		}
 		if !p.at(T![']']) {
@@ -239,6 +240,7 @@ fn object_binding_prop(p: &mut Parser, parameters: bool) -> Option<CompletedMark
 		p.err_recover_no_err(
 			token_set![T![await], T![ident], T![yield], T![:], T![=], T!['}']],
 			false,
+			ERROR,
 		);
 		return None;
 	};

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -117,7 +117,12 @@ pub fn stmt(p: &mut Parser, recovery_set: impl Into<Option<TokenSet>>) -> Option
 				return None;
 			}
 
-			p.err_recover(err, recovery_set.into().unwrap_or(STMT_RECOVERY_SET), false);
+			p.err_recover(
+				err,
+				recovery_set.into().unwrap_or(STMT_RECOVERY_SET),
+				false,
+				ERROR,
+			);
 			return None;
 		}
 	};
@@ -969,7 +974,7 @@ fn switch_clause(p: &mut Parser) -> Option<Range<usize>> {
 					"Expected the start to a case or default clause here",
 				);
 
-			p.err_recover(err, STMT_RECOVERY_SET, true);
+			p.err_recover(err, STMT_RECOVERY_SET, true, ERROR);
 		}
 	}
 	None

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -589,6 +589,7 @@ pub fn ts_enum(p: &mut Parser) -> CompletedMarker {
 				err,
 				token_set![T!['}'], T![ident], T![yield], T![await], T![=], T![,]],
 				false,
+				ERROR,
 			);
 			true
 		} else {
@@ -1026,6 +1027,7 @@ pub fn ts_non_array_type(p: &mut Parser) -> Option<CompletedMarker> {
 					T![|]
 				]),
 				false,
+				ERROR,
 			);
 			None
 		}
@@ -1123,6 +1125,7 @@ fn type_param(p: &mut Parser) -> Option<CompletedMarker> {
 			err,
 			token_set![T![ident], T![yield], T![await], T![>], T![=]],
 			false,
+			ERROR,
 		);
 		None
 	}
@@ -1358,6 +1361,6 @@ pub fn ts_type_name(
 		))
 		.primary(p.cur_tok().range, "");
 
-	p.err_recover(err, set, false)?;
+	p.err_recover(err, set, false, ERROR)?;
 	None
 }

--- a/xtask/src/compare/mod.rs
+++ b/xtask/src/compare/mod.rs
@@ -3,7 +3,11 @@ use std::path::PathBuf;
 
 mod results;
 
-pub fn run(base_result_path: Option<&str>, new_result_path: Option<&str>, markdown: bool) {
+pub fn coverage_compare(
+	base_result_path: Option<&str>,
+	new_result_path: Option<&str>,
+	markdown: bool,
+) {
 	// resolve the path passed as argument, or retrieve the default one
 	let base_result_dir = if let Some(base_result_path) = base_result_path {
 		PathBuf::from(base_result_path)

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -11,7 +11,7 @@ use yastl::Pool;
 pub const TEST_JSON_PATH: &str = "xtask/src/base_results.json";
 
 pub fn run(query: Option<&str>, pool: Pool, json: bool) {
-	let files = get_test_files(query, &pool);
+	let files = get_test_files(query, &pool, json);
 	let num_ran = files.len();
 
 	let detailed = num_ran < 10;
@@ -71,49 +71,48 @@ pub fn run(query: Option<&str>, pool: Pool, json: bool) {
 	let _ = std::panic::take_hook();
 
 	pb.finish_and_clear();
-	println!(
-		"\n{} {} tests in {:.2}s\n",
-		"Ran".bold().bright_green(),
-		num_ran,
-		start_tests.elapsed().as_secs_f32()
-	);
-
-	let panicked = test_results.summary.panics;
-	let errored = test_results.summary.failed;
-	let passed = test_results.summary.passed;
-	let coverage = format!("{:.2}", test_results.summary.coverage);
-
-	let mut table = AsciiTable::default();
-
-	let mut counter = 0usize;
-	let mut create_column = |name: colored::ColoredString| {
-		let column = Column {
-			header: name.to_string(),
-			align: ascii_table::Align::Center,
-			..Column::default()
-		};
-		table.columns.insert(counter, column);
-		counter += 1;
-	};
-
-	create_column("Tests ran".into());
-	create_column("Passed".green());
-	create_column("Failed".red());
-	create_column("Panics".red());
-	create_column("Coverage".cyan());
-	let numbers: Vec<&dyn std::fmt::Display> =
-		vec![&num_ran, &passed, &errored, &panicked, &coverage];
-
-	table.print(vec![numbers]);
 
 	if json {
 		test_results.dump_to_json();
-	}
-
-	if passed > 0 {
-		std::process::exit(1);
 	} else {
-		std::process::exit(0);
+		println!(
+			"\n{} {} tests in {:.2}s\n",
+			"Ran".bold().bright_green(),
+			num_ran,
+			start_tests.elapsed().as_secs_f32()
+		);
+
+		let panicked = test_results.summary.panics;
+		let errored = test_results.summary.failed;
+		let passed = test_results.summary.passed;
+		let coverage = format!("{:.2}", test_results.summary.coverage);
+
+		let mut table = AsciiTable::default();
+
+		let mut counter = 0usize;
+		let mut create_column = |name: colored::ColoredString| {
+			let column = Column {
+				header: name.to_string(),
+				align: ascii_table::Align::Center,
+				..Column::default()
+			};
+			table.columns.insert(counter, column);
+			counter += 1;
+		};
+		create_column("Tests ran".into());
+		create_column("Passed".green());
+		create_column("Failed".red());
+		create_column("Panics".red());
+		create_column("Coverage".cyan());
+		let numbers: Vec<&dyn std::fmt::Display> =
+			vec![&num_ran, &passed, &errored, &panicked, &coverage];
+
+		table.print(vec![numbers]);
+		if passed > 0 {
+			std::process::exit(1);
+		} else {
+			std::process::exit(0);
+		}
 	}
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
 			let base_result_path = free.get(0).map(String::as_str);
 			let new_result_path = free.get(1).map(String::as_str);
 
-			compare::run(base_result_path, new_result_path, markdown);
+			compare::coverage_compare(base_result_path, new_result_path, markdown);
 			Ok(())
 		}
 		// "docgen" => {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

First PR that implements #1759 


This change is very simple, every time we need to mark error inside the tree, we explicitly pass the `SyntaxKind::ERROR` as parameter instead of having it hardcoded. 

This change will make things much easier and smoother when applying specific errors during the parsing phase.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
