### PR TITLE
fix: remove macos from test262 coverage workflow

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       os: [windows-latest, macos-latest, ubuntu-latest]
+       os: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       os: [windows-latest, macos-latest, ubuntu-latest]
+       os: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Removes macos-latest from OS's for test262 coverage workflow. Now it targets only ubuntu-latest and windows-latest.

Closes #1792.


