### PR TITLE
ci: add matrix.os to body inlcudes

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -91,7 +91,7 @@ jobs:
         id: previous-comment
         with:
           issue-number: ${{ steps.pr-number.outputs.pr }}
-          body-includes: Test262 comparison coverage
+          body-includes: Test262 comparison coverage results on ${{ matrix.os }}
 
       - name: Update comment
         if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Noticed another bug introduced by https://github.com/rome/tools/pull/1795, we need to add the `${{ matrix.os }}` inside `body-includes`so the CI can update the correct message, related to the correct OS.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
