### PR TITLE
typed api access to each piece of the trivia

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -277,15 +277,13 @@ impl<L: Language> Iterator for SyntaxTriviaPiecesIterator<L> {
 	type Item = SyntaxTriviaPiece<L>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		match self.iter.next() {
-			Some((offset, trivia)) => Some(SyntaxTriviaPiece {
-				raw: self.iter.raw.clone(),
-				offset,
-				trivia,
-				_p: PhantomData,
-			}),
-			None => None,
-		}
+		let (offset, trivia) = self.iter.next()?;
+		Some(SyntaxTriviaPiece {
+			raw: self.iter.raw.clone(),
+			offset,
+			trivia,
+			_p: PhantomData,
+		})
 	}
 }
 

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -563,17 +563,13 @@ impl Iterator for SyntaxTriviaPiecesIterator {
 	type Item = (TextSize, Trivia);
 
 	fn next(&mut self) -> Option<Self::Item> {
-		match self.raw.get_piece(self.next_index) {
-			Some(trivia) => {
-				let piece = (self.next_offset, trivia);
+		let trivia = self.raw.get_piece(self.next_index)?;
+		let piece = (self.next_offset, trivia);
 
-				self.next_index += 1;
-				self.next_offset += trivia.text_len();
+		self.next_index += 1;
+		self.next_offset += trivia.text_len();
 
-				Some(piece)
-			}
-			None => None,
-		}
+		Some(piece)
 	}
 }
 

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -2,7 +2,7 @@ use hashbrown::hash_map::RawEntryMut;
 use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 
-use crate::api::Trivia;
+use crate::api::TriviaPiece;
 use crate::green::Slot;
 use crate::{
 	green::GreenElementRef, GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken,
@@ -161,8 +161,8 @@ impl NodeCache {
 		&mut self,
 		kind: SyntaxKind,
 		text: &str,
-		leading: Vec<Trivia>,
-		trailing: Vec<Trivia>,
+		leading: Vec<TriviaPiece>,
+		trailing: Vec<TriviaPiece>,
 	) -> (u64, GreenToken) {
 		let hash = token_hash_of(kind, text);
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -8,7 +8,7 @@ use std::{
 use countme::Count;
 
 use crate::{
-	api::Trivia,
+	api::TriviaPiece,
 	arc::{Arc, HeaderSlice, ThinArc},
 	green::SyntaxKind,
 	TextSize,
@@ -20,7 +20,7 @@ pub enum GreenTokenTrivia {
 	None,
 	Whitespace(usize),
 	Comments(usize),
-	Many(Box<Vec<Trivia>>),
+	Many(Box<Vec<TriviaPiece>>),
 }
 
 impl GreenTokenTrivia {
@@ -40,22 +40,22 @@ impl GreenTokenTrivia {
 		}
 	}
 
-	pub(crate) fn get_piece(&self, index: usize) -> Option<Trivia> {
+	pub(crate) fn get_piece(&self, index: usize) -> Option<TriviaPiece> {
 		match self {
-			GreenTokenTrivia::Whitespace(l) if index == 0 => Some(Trivia::Whitespace(*l)),
-			GreenTokenTrivia::Comments(l) if index == 0 => Some(Trivia::Comments(*l)),
+			GreenTokenTrivia::Whitespace(l) if index == 0 => Some(TriviaPiece::Whitespace(*l)),
+			GreenTokenTrivia::Comments(l) if index == 0 => Some(TriviaPiece::Comments(*l)),
 			GreenTokenTrivia::Many(v) => v.get(index).copied(),
 			_ => None,
 		}
 	}
 }
 
-impl From<Vec<Trivia>> for GreenTokenTrivia {
-	fn from(trivias: Vec<Trivia>) -> Self {
+impl From<Vec<TriviaPiece>> for GreenTokenTrivia {
+	fn from(trivias: Vec<TriviaPiece>) -> Self {
 		match trivias.as_slice() {
 			[] => GreenTokenTrivia::None,
-			[Trivia::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
-			[Trivia::Comments(len)] => GreenTokenTrivia::Comments(*len),
+			[TriviaPiece::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
+			[TriviaPiece::Comments(len)] => GreenTokenTrivia::Comments(*len),
 			_ => GreenTokenTrivia::Many(Box::new(trivias)),
 		}
 	}
@@ -260,7 +260,7 @@ impl ops::Deref for GreenToken {
 
 #[cfg(test)]
 mod tests {
-	use crate::api::Trivia;
+	use crate::api::TriviaPiece;
 
 	use super::*;
 	use quickcheck_macros::*;
@@ -305,8 +305,8 @@ mod tests {
 	#[test]
 	fn many_text_len_dont_panic() {
 		let trivia = GreenTokenTrivia::Many(Box::new(vec![
-			Trivia::Whitespace(usize::MAX),
-			Trivia::Comments(1),
+			TriviaPiece::Whitespace(usize::MAX),
+			TriviaPiece::Comments(1),
 		]));
 		assert_eq!(TextSize::from(u32::MAX), trivia.text_len());
 	}
@@ -315,7 +315,7 @@ mod tests {
 	fn many_text_len(lengths: Vec<u32>) {
 		let trivia: Vec<_> = lengths
 			.iter()
-			.map(|x| Trivia::Whitespace(*x as usize))
+			.map(|x| TriviaPiece::Whitespace(*x as usize))
 			.collect();
 		let trivia = GreenTokenTrivia::Many(Box::new(trivia));
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -39,6 +39,15 @@ impl GreenTokenTrivia {
 			}
 		}
 	}
+
+	pub(crate) fn get_piece(&self, index: usize) -> Option<Trivia> {
+		match self {
+			GreenTokenTrivia::Whitespace(l) if index == 0 => Some(Trivia::Whitespace(*l)),
+			GreenTokenTrivia::Comments(l) if index == 0 => Some(Trivia::Comments(*l)),
+			GreenTokenTrivia::Many(v) => v.get(index).map(Clone::clone),
+			_ => None,
+		}
+	}
 }
 
 impl From<Vec<Trivia>> for GreenTokenTrivia {

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -44,7 +44,7 @@ impl GreenTokenTrivia {
 		match self {
 			GreenTokenTrivia::Whitespace(l) if index == 0 => Some(Trivia::Whitespace(*l)),
 			GreenTokenTrivia::Comments(l) if index == 0 => Some(Trivia::Comments(*l)),
-			GreenTokenTrivia::Many(v) => v.get(index).map(Clone::clone),
+			GreenTokenTrivia::Many(v) => v.get(index).copied(),
 			_ => None,
 		}
 	}

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -31,7 +31,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 pub use crate::{
 	api::{
 		Language, SyntaxElement, SyntaxElementChildren, SyntaxList, SyntaxNode, SyntaxNodeChildren,
-		SyntaxToken, Trivia,
+		SyntaxToken, TriviaPiece,
 	},
 	green::SyntaxKind,
 	syntax_text::SyntaxText,

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-	api::Trivia,
+	api::TriviaPiece,
 	cow_mut::CowMut,
 	green::{GreenElement, NodeCache},
 	GreenNode, Language, NodeOrToken, SyntaxNode,
@@ -72,8 +72,8 @@ impl<L: Language> TreeBuilder<'_, L> {
 		&mut self,
 		kind: L::Kind,
 		text: &str,
-		leading: Vec<Trivia>,
-		trailing: Vec<Trivia>,
+		leading: Vec<TriviaPiece>,
+		trailing: Vec<TriviaPiece>,
 	) {
 		let (hash, token) =
 			self.cache


### PR DESCRIPTION
part of: #1720
Improved changes of #1738

# Tasks

- [x] Typed ```Syntax*``` api for each trivia piece. Currently each ```strcut``` is empty, but we will add methods in the future, as needed. 

# How to test

```rust
> cargo test -p rome_rowan
> cargo xtask coverage
```

# Complete example of the api

```rust

#[test]
pub fn syntax_trivia_pieces() {
	use crate::*;
	let node = TreeBuilder::<RawLanguage>::wrap_with_node(SyntaxKind(0),|builder| {
		builder.token_with_trivia(
			SyntaxKind(1),
			"\n\t /**/let \t\t",
			vec![Trivia::Whitespace(3), Trivia::Comments(4)],
			vec![Trivia::Whitespace(3)],
		);
	});
	let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
	assert_eq!(2, pieces.len());

	assert_eq!("\n\t ", pieces[0].text());
	assert_eq!(TextSize::from(3), pieces[0].text_len());
	assert_eq!(TextRange::new(0.into(), 3.into()), pieces[0].text_range());
	assert!(pieces[0].as_whitespace().is_some());

	assert_eq!("/**/", pieces[1].text());
	assert_eq!(TextSize::from(4), pieces[1].text_len());
	assert_eq!(TextRange::new(3.into(), 7.into()), pieces[1].text_range());
	assert!(pieces[1].as_comments().is_some());
}
```