### PR TITLE
Implement Drop for Marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
 
 [[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1016,7 @@ dependencies = [
 name = "rslint_parser"
 version = "0.3.0"
 dependencies = [
+ "drop_bomb",
  "expect-test",
  "lexical",
  "num-bigint",

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -14,6 +14,7 @@ rslint_lexer = { path = "../rslint_lexer", version = "0.2", features = ["highlig
 rome_rowan = { path = "../rome_rowan", version = "0.0.0" }
 num-bigint = "0.3.0"
 lexical = { version = "5.2.0", features = ["radix"] }
+drop_bomb = "0.1.5"
 
 [dev-dependencies]
 expect-test = "1.0"

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -602,6 +602,16 @@ impl Marker {
 	}
 }
 
+impl Drop for Marker {
+	fn drop(&mut self) {
+		debug_assert!(
+			panicking() || self.finished,
+			"Dropped marker '{:?}' without calling abandon, complete or ignore. Make sure you call 'complete' or 'abandon' on any marker you started with parser.start().",
+			self
+		);
+	}
+}
+
 /// A structure signifying a completed node
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CompletedMarker {

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -739,3 +739,47 @@ pub struct Checkpoint {
 	pub event_pos: usize,
 	pub errors_pos: usize,
 }
+
+#[cfg(test)]
+mod tests {
+	use crate::{Parser, Syntax, TokenSource};
+	use rslint_lexer::Token;
+	use rslint_syntax::SyntaxKind;
+
+	#[test]
+	#[should_panic(
+		expected = "Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent."
+	)]
+	fn uncompleted_markers_panic() {
+		let tokens = vec![Token::new(SyntaxKind::JS_STRING_LITERAL_TOKEN, 12)];
+		let token_source = TokenSource::new("'use strict'", tokens.as_slice());
+
+		let mut parser = Parser::new(token_source, 0, Syntax::default());
+
+		let m = parser.start();
+		// drop the marker without calling complete or abandon
+	}
+
+	#[test]
+	fn completed_marker_doesnt_panic() {
+		let tokens = vec![Token::new(SyntaxKind::JS_STRING_LITERAL_TOKEN, 12)];
+		let token_source = TokenSource::new("'use strict'", tokens.as_slice());
+
+		let mut p = Parser::new(token_source, 0, Syntax::default());
+
+		let m = p.start();
+		p.expect(SyntaxKind::JS_STRING_LITERAL_TOKEN);
+		m.complete(&mut p, SyntaxKind::JS_STRING_LITERAL);
+	}
+
+	#[test]
+	fn abandoned_marker_doesnt_panic() {
+		let tokens = vec![Token::new(SyntaxKind::JS_STRING_LITERAL_TOKEN, 12)];
+		let token_source = TokenSource::new("'use strict'", tokens.as_slice());
+
+		let mut p = Parser::new(token_source, 0, Syntax::default());
+
+		let m = p.start();
+		m.abandon(&mut p);
+	}
+}

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -394,6 +394,7 @@ impl<'t> Parser<'t> {
 	}
 
 	/// Get a checkpoint representing the progress of the parser at this point in time
+	#[must_use]
 	pub fn checkpoint(&self) -> Checkpoint {
 		Checkpoint {
 			token_pos: self.token_pos(),
@@ -756,7 +757,7 @@ mod tests {
 
 		let mut parser = Parser::new(token_source, 0, Syntax::default());
 
-		let m = parser.start();
+		let _ = parser.start();
 		// drop the marker without calling complete or abandon
 	}
 

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -167,8 +167,7 @@ impl<'t> Parser<'t> {
 
 	/// Check if a token lookahead is something, `n` must be smaller or equal to `4`
 	pub fn nth_at(&self, n: usize, kind: SyntaxKind) -> bool {
-		self.overflow_check();
-		self.tokens.lookahead_nth(n).kind == kind
+		self.nth_tok(n).kind == kind
 	}
 
 	/// Consume the next token if `kind` matches.
@@ -599,16 +598,6 @@ impl Marker {
 				}
 				_ => unreachable!(),
 			}
-		}
-	}
-}
-
-impl Drop for Marker {
-	fn drop(&mut self) {
-		if !panicking() && !self.finished {
-			panic!(
-			"Dropped marker '{:?}' without calling abandon, complete or ignore. Make sure you call 'complete' or 'abandon' on any marker you started with parser.start().",
-			self);
 		}
 	}
 }

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -41,7 +41,13 @@ pub(super) fn formal_param_pat(p: &mut Parser) -> Option<CompletedMarker> {
 		}
 	}
 
-	let pat = pattern(p, true, false)?;
+	let pat = if let Some(pattern) = pattern(p, true, false) {
+		pattern
+	} else {
+		m.abandon(p);
+		return None;
+	};
+
 	let pat_range = pat.range(p);
 	let mut kind = pat.kind();
 	pat.undo_completion(p).abandon(p);

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -424,8 +424,14 @@ pub fn member_or_new_expr(p: &mut Parser, new_expr: bool) -> Option<CompletedMar
 			return Some(subscripts(p, complete, true));
 		}
 
-		let complete = member_or_new_expr(p, new_expr)?;
+		let complete = if let Some(expr) = member_or_new_expr(p, new_expr) {
+			expr
+		} else {
+			m.abandon(p);
+			return None;
+		};
 		if complete.kind() == JS_ARROW_FUNCTION_EXPRESSION {
+			m.abandon(p);
 			return Some(complete);
 		}
 

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -279,10 +279,11 @@ fn method_object_member(p: &mut Parser) -> Option<CompletedMarker> {
 		}
 	};
 
-	let mut guard = p.with_state(state);
-	object_member_name(&mut *guard);
-	method_object_member_body(&mut *guard).ok()?;
-	drop(guard);
+	{
+		let mut guard = p.with_state(state);
+		object_member_name(&mut *guard);
+		method_object_member_body(&mut *guard).ok();
+	}
 
 	Some(m.complete(p, JS_METHOD_OBJECT_MEMBER))
 }

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -145,7 +145,7 @@ fn object_member(p: &mut Parser) -> Option<CompletedMarker> {
 					assign_expr(p);
 					Some(m.complete(p, JS_PROPERTY_OBJECT_MEMBER))
 				} else {
-					None
+					Some(m.complete(p, JS_UNKNOWN_MEMBER))
 				}
 			}
 		}
@@ -248,6 +248,7 @@ pub(super) fn literal_member_name(p: &mut Parser) -> Option<CompletedMarker> {
 					"Expected an identifier, a keyword, or a string or number literal here",
 				);
 			p.error(err);
+			m.abandon(p);
 			return None;
 		}
 	}

--- a/crates/rslint_parser/src/syntax/pat.rs
+++ b/crates/rslint_parser/src/syntax/pat.rs
@@ -237,6 +237,7 @@ fn object_binding_prop(p: &mut Parser, parameters: bool) -> Option<CompletedMark
 	let name = if let Some(n) = name {
 		n
 	} else {
+		m.abandon(p);
 		p.err_recover_no_err(
 			token_set![T![await], T![ident], T![yield], T![:], T![=], T!['}']],
 			false,
@@ -245,6 +246,7 @@ fn object_binding_prop(p: &mut Parser, parameters: bool) -> Option<CompletedMark
 	};
 
 	if name.kind() != NAME {
+		m.abandon(p);
 		let err = p
 			.err_builder("Expected an identifier for a pattern, but found none")
 			.primary(name.range(p), "");
@@ -258,6 +260,7 @@ fn object_binding_prop(p: &mut Parser, parameters: bool) -> Option<CompletedMark
 		assign_expr(p);
 		Some(m.complete(p, ASSIGN_PATTERN))
 	} else {
+		m.abandon(p);
 		Some(sp_marker)
 	}
 }

--- a/crates/rslint_parser/src/syntax/pat.rs
+++ b/crates/rslint_parser/src/syntax/pat.rs
@@ -15,7 +15,13 @@ pub fn pattern(p: &mut Parser, parameters: bool, assignment: bool) -> Option<Com
 		T!['{'] if p.state.allow_object_expr => object_binding_pattern(p, parameters),
 		_ if assignment => {
 			let m = p.start();
-			let mut complete = lhs_expr(p)?;
+			let mut complete = if let Some(expr) = lhs_expr(p) {
+				expr
+			} else {
+				m.abandon(p);
+				return None;
+			};
+
 			if complete.kind() == JS_REFERENCE_IDENTIFIER_EXPRESSION {
 				complete.change_kind(p, NAME);
 			}

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -730,9 +730,14 @@ pub(crate) fn variable_declarator(
 ) -> Option<CompletedMarker> {
 	let m = p.start();
 	p.state.should_record_names = is_const.is_some() || is_let;
-	let pat_m = p.start();
-	let pat = pattern(p, false, false)?;
-	pat.undo_completion(p).abandon(p);
+	let pat = if let Some(pattern) = pattern(p, false, false) {
+		pattern
+	} else {
+		m.abandon(p);
+		return None;
+	};
+
+	let pat_m = pat.undo_completion(p);
 	p.state.should_record_names = false;
 	let kind = pat.kind();
 

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -985,6 +985,7 @@ fn switch_clause(p: &mut Parser) -> Option<Range<usize>> {
 			m.complete(p, JS_CASE_CLAUSE);
 		}
 		_ => {
+			m.abandon(p);
 			let err = p
 				.err_builder(
 					"Expected a `case` or `default` clause in a switch statement, but found none",

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -530,10 +530,8 @@ pub(crate) fn try_parse_index_signature(
 		return Err(m);
 	}
 
-	if p.eat(T![:]) {
-		if ts_type(p).is_none() && p.state.no_recovery {
-			return Err(m);
-		}
+	if p.eat(T![:]) && ts_type(p).is_none() && p.state.no_recovery {
+		return Err(m);
 	}
 
 	type_member_semi(p);

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -1084,7 +1084,12 @@ pub fn ts_type_args(p: &mut Parser) -> Option<CompletedMarker> {
 			m.abandon(p);
 			return None;
 		}
-		no_recover!(p, ts_type(p));
+
+		if ts_type(p).is_none() && p.state.no_recovery {
+			args_list.abandon(p);
+			m.abandon(p);
+			return None;
+		}
 	}
 	args_list.complete(p, LIST);
 
@@ -1322,6 +1327,7 @@ pub(crate) fn maybe_eat_incorrect_modifier(p: &mut Parser) -> Option<CompletedMa
 	} else if ts_modifier(p, &["readonly"]).is_some() {
 		Some(maybe_err.complete(p, ERROR))
 	} else {
+		maybe_err.abandon(p);
 		None
 	}
 }

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -19,6 +19,14 @@ fn parser_smoke_test() {
 }
 
 #[test]
+fn parse_file_test() {
+	let file_name = r"C:\Users\Micha\git\rome\xtask\src\coverage\test262\test\language\expressions\less-than\S11.8.1_A2.2_T1.js";
+	let src = std::fs::read_to_string(Path::new(file_name)).unwrap();
+
+	assert!(parse_module(&src, 0).ok().is_ok());
+}
+
+#[test]
 fn parser_missing_smoke_test() {
 	let src = r#"
 		console.log("Hello world";

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -19,14 +19,6 @@ fn parser_smoke_test() {
 }
 
 #[test]
-fn parse_file_test() {
-	let file_name = r"C:\Users\Micha\git\rome\xtask\src\coverage\test262\test\language\expressions\less-than\S11.8.1_A2.2_T1.js";
-	let src = std::fs::read_to_string(Path::new(file_name)).unwrap();
-
-	assert!(parse_module(&src, 0).ok().is_ok());
-}
-
-#[test]
 fn parser_missing_smoke_test() {
 	let src = r#"
 		console.log("Hello world";

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -8,8 +8,9 @@ JS_ROOT@0..12
         IDENT@6..7 "S"
       L_CURLY@7..8 "{"
       LIST@8..9
-        ERROR@8..9
-          L_CURLY@8..9 "{"
+        JS_UNKNOWN_MEMBER@8..9
+          ERROR@8..9
+            L_CURLY@8..9 "{"
       R_CURLY@9..10 "}"
     ERROR@10..11
       R_CURLY@10..11 "}"

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -41,12 +41,12 @@ JS_ROOT@0..137
           JS_LITERAL_MEMBER_NAME@53..58
             IDENT@53..58 "class"
         WHITESPACE@58..59 " "
-        JS_UNKNOWN_MEMBER@59..62
+        JS_UNKNOWN_MEMBER@59..64
           JS_LITERAL_MEMBER_NAME@59..62
             IDENT@59..62 "foo"
-        WHITESPACE@62..63 " "
-        ERROR@63..64
-          L_CURLY@63..64 "{"
+          WHITESPACE@62..63 " "
+          ERROR@63..64
+            L_CURLY@63..64 "{"
         WHITESPACE@64..65 " "
         JS_SETTER_CLASS_MEMBER@65..71
           SET_KW@65..68 "set"

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -44,8 +44,9 @@ JS_ROOT@0..40
               JS_OBJECT_EXPRESSION@35..38
                 L_CURLY@35..36 "{"
                 LIST@36..37
-                  ERROR@36..37
-                    L_CURLY@36..37 "{"
+                  JS_UNKNOWN_MEMBER@36..37
+                    ERROR@36..37
+                      L_CURLY@36..37 "{"
                 R_CURLY@37..38 "}"
     ERROR@38..39
       R_CURLY@38..39 "}"


### PR DESCRIPTION
## Summary

This PR adds a drop bomb to the Parser's `Marker` implementation to ensure we always call either `abandon` or `complete` on every marker. 

I was stunned to see that the parser is able to produce a valid tree even with nodes in the tree that were never completed, and, therefore, don't have a `SyntaxKind` set. 

The reason why this works is that the parser sets the kind to `TOMBSTONE` when starting a new node and these get skipped when building the final tree. The problem is, skipped means the children of the `TOMBSTONE`d node get attached to the parent. 

This "bubbling up" of children is problematic, because let's say we have a node that calls into `expr`. The expectation would be that `expr` either produces a `UnknownExpression` or doesn't add any nodes to the parse tree. However, this isn't the case. `expr` may start parsing and then decide that it doesn't know how to continue and it then bails out with the result that all parsed tokens and nodes get attached to the parent. 

Bailing out is fine, but we should be very considerate about what we want to do in those cases, either completing the node with an `UNKNOWN` kind or propagating the error to the parent (by, for example, returning a `Result` type). 

## Test Plan

Verified coverage. 
