### PR TITLE
xtask to download and parse js libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,10 +107,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
@@ -360,7 +378,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
 dependencies = [
- "spin",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -597,7 +615,7 @@ version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e02724627e9ef8ba91f461ebc01d48aebbd13a4b7c9dc547a0a2890f53e2171"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "bitflags",
  "serde",
  "serde_json",
@@ -940,6 +958,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rome_cli"
 version = "0.0.0"
 dependencies = [
@@ -1063,6 +1096,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1151,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1187,6 +1242,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -1358,6 +1419,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c448dcb78ec38c7d59ec61f87f70a98ea19171e06c139357e012ee226fec90"
+dependencies = [
+ "base64 0.13.0",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1553,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1626,8 @@ dependencies = [
  "syn",
  "ungrammar",
  "unindent",
+ "ureq",
+ "url",
  "walkdir",
  "yastl",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -28,3 +28,5 @@ schemars = "0.8"
 yastl = "0.1"
 num_cpus = "1.13"
 ungrammar = "1.14.9"
+ureq = { version = "2.3.1" } 
+url = "2.2.2"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -5,6 +5,7 @@ pub mod compare;
 pub mod coverage;
 pub mod docgen;
 pub mod glue;
+pub mod libs;
 
 use std::{
 	env,

--- a/xtask/src/libs/libs.txt
+++ b/xtask/src/libs/libs.txt
@@ -1,0 +1,2 @@
+https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
+https://cdn.jsdelivr.net/npm/vue@3.2.22/dist/vue.global.prod.js

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -1,0 +1,39 @@
+use std::{path::PathBuf, str::FromStr};
+
+pub fn run() {
+	let out = PathBuf::from_str("target").unwrap();
+	let libs = include_str!("libs.txt").lines();
+	for lib in libs {
+		let url = url::Url::from_str(lib).unwrap();
+		let filename = url.path_segments().unwrap().last().unwrap();
+
+		let mut file = out.clone();
+		file.push(filename);
+
+		let code = match std::fs::read_to_string(&file) {
+			Ok(code) => {
+				println!("{} - using {}", filename, file.display());
+				code
+			}
+			Err(_) => {
+				println!("{} - Downloading {} to {}", filename, lib, file.display());
+				match ureq::get(lib).call() {
+					Ok(response) => {
+						let mut reader = response.into_reader();
+
+						let _ = std::fs::remove_file(&file);
+						let mut writer = std::fs::File::create(&file).unwrap();
+						let _ = std::io::copy(&mut reader, &mut writer);
+
+						std::fs::read_to_string(&file).unwrap()
+					}
+					Err(_) => todo!(),
+				}
+			}
+		};
+
+		let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
+	}
+
+	println!("end");
+}

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -1,38 +1,55 @@
 use std::{path::PathBuf, str::FromStr};
 
+fn err_to_string<E: std::fmt::Debug>(e: E) -> String {
+    format!("{:?}", e)
+}
+
+pub fn get_code(lib: &str) -> Result<String, String> {
+    let url = url::Url::from_str(lib).map_err(err_to_string)?;
+    let segments = url.path_segments() 
+        .ok_or_else(|| "lib url has no segments".to_string())?;
+    let filename = segments.last()
+        .ok_or_else(|| "lib url has no segments".to_string())?;
+
+    let out = PathBuf::from_str("target").map_err(err_to_string)?;
+    let mut file = out.clone();
+    file.push(filename);
+
+    match std::fs::read_to_string(&file) {
+        Ok(code) => {
+            println!("[{}] - using [{}]", filename, file.display());
+            Ok(code)
+        }
+        Err(_) => {
+            println!("[{}] - Downloading [{}] to [{}]", filename, lib, file.display());
+            match ureq::get(lib).call() {
+                Ok(response) => {
+                    let mut reader = response.into_reader();
+
+                    let _ = std::fs::remove_file(&file);
+                    let mut writer = std::fs::File::create(&file).map_err(err_to_string)?;
+                    let _ = std::io::copy(&mut reader, &mut writer);
+
+                    std::fs::read_to_string(&file)
+                        .map_err(err_to_string)
+                }
+                Err(e) => Err(format!("{:?}", e))
+            }
+        }
+    }
+}
+
 pub fn run() {
-	let out = PathBuf::from_str("target").unwrap();
+	
 	let libs = include_str!("libs.txt").lines();
 	for lib in libs {
-		let url = url::Url::from_str(lib).unwrap();
-		let filename = url.path_segments().unwrap().last().unwrap();
-
-		let mut file = out.clone();
-		file.push(filename);
-
-		let code = match std::fs::read_to_string(&file) {
-			Ok(code) => {
-				println!("{} - using {}", filename, file.display());
-				code
-			}
-			Err(_) => {
-				println!("{} - Downloading {} to {}", filename, lib, file.display());
-				match ureq::get(lib).call() {
-					Ok(response) => {
-						let mut reader = response.into_reader();
-
-						let _ = std::fs::remove_file(&file);
-						let mut writer = std::fs::File::create(&file).unwrap();
-						let _ = std::io::copy(&mut reader, &mut writer);
-
-						std::fs::read_to_string(&file).unwrap()
-					}
-					Err(_) => todo!(),
-				}
-			}
-		};
-
-		let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
+		let code = get_code(lib);
+        match code {
+            Ok(code ) => {
+                let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
+            },
+            Err(e) => println!("{:?}", e),
+        }
 	}
 
 	println!("end");

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -1,55 +1,59 @@
 use std::{path::PathBuf, str::FromStr};
 
 fn err_to_string<E: std::fmt::Debug>(e: E) -> String {
-    format!("{:?}", e)
+	format!("{:?}", e)
 }
 
 pub fn get_code(lib: &str) -> Result<String, String> {
-    let url = url::Url::from_str(lib).map_err(err_to_string)?;
-    let segments = url.path_segments() 
-        .ok_or_else(|| "lib url has no segments".to_string())?;
-    let filename = segments.last()
-        .ok_or_else(|| "lib url has no segments".to_string())?;
+	let url = url::Url::from_str(lib).map_err(err_to_string)?;
+	let segments = url
+		.path_segments()
+		.ok_or_else(|| "lib url has no segments".to_string())?;
+	let filename = segments
+		.last()
+		.ok_or_else(|| "lib url has no segments".to_string())?;
 
-    let out = PathBuf::from_str("target").map_err(err_to_string)?;
-    let mut file = out.clone();
-    file.push(filename);
+	let mut file = PathBuf::from_str("target").map_err(err_to_string)?;
+	file.push(filename);
 
-    match std::fs::read_to_string(&file) {
-        Ok(code) => {
-            println!("[{}] - using [{}]", filename, file.display());
-            Ok(code)
-        }
-        Err(_) => {
-            println!("[{}] - Downloading [{}] to [{}]", filename, lib, file.display());
-            match ureq::get(lib).call() {
-                Ok(response) => {
-                    let mut reader = response.into_reader();
+	match std::fs::read_to_string(&file) {
+		Ok(code) => {
+			println!("[{}] - using [{}]", filename, file.display());
+			Ok(code)
+		}
+		Err(_) => {
+			println!(
+				"[{}] - Downloading [{}] to [{}]",
+				filename,
+				lib,
+				file.display()
+			);
+			match ureq::get(lib).call() {
+				Ok(response) => {
+					let mut reader = response.into_reader();
 
-                    let _ = std::fs::remove_file(&file);
-                    let mut writer = std::fs::File::create(&file).map_err(err_to_string)?;
-                    let _ = std::io::copy(&mut reader, &mut writer);
+					let _ = std::fs::remove_file(&file);
+					let mut writer = std::fs::File::create(&file).map_err(err_to_string)?;
+					let _ = std::io::copy(&mut reader, &mut writer);
 
-                    std::fs::read_to_string(&file)
-                        .map_err(err_to_string)
-                }
-                Err(e) => Err(format!("{:?}", e))
-            }
-        }
-    }
+					std::fs::read_to_string(&file).map_err(err_to_string)
+				}
+				Err(e) => Err(format!("{:?}", e)),
+			}
+		}
+	}
 }
 
 pub fn run() {
-	
 	let libs = include_str!("libs.txt").lines();
 	for lib in libs {
 		let code = get_code(lib);
-        match code {
-            Ok(code ) => {
-                let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
-            },
-            Err(e) => println!("{:?}", e),
-        }
+		match code {
+			Ok(code) => {
+				let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
+			}
+			Err(e) => println!("{:?}", e),
+		}
 	}
 
 	println!("end");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -50,6 +50,10 @@ fn main() -> Result<()> {
 			coverage::run(query, yastl::Pool::with_config(num_cpus::get(), pool), json);
 			Ok(())
 		}
+		"coverage-libs" => {
+			xtask::libs::run();
+			Ok(())
+		}
 		_ => {
 			eprintln!(
 				"\
@@ -63,7 +67,8 @@ SUBCOMMANDS:
     syntax
     docgen
     coverage [--json]
-		compare [--markdown]
+    coverage-libs
+    compare [--markdown]
 OPTIONS
     --markdown   Emits supported output into markdown format. Supported by compare subcommand
     --json       Emits supported output into json format. Supported by coverage subcommand


### PR DESCRIPTION
The current version is as simple as possible. Download and parse every file at ```xtask\src\libs\libs.txt```. If the file is already downloaded, just use the cache, which is at ```target``` folder.

Currently we can't parse ```jquery``` and ```vue```. The only two examples I pre-selected.

# How to run

```
cargo xtask  coverage-libs
   Compiling xtask v0.0.0 (C:\github\rome\tools\xtask)
    Finished dev [unoptimized + debuginfo] target(s) in 3.17s
     Running `target\debug\xtask.exe coverage-libs`
jquery.min.js - using target\jquery.min.js
thread 'main' panicked at 'Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent.', C:\Users\xunil\.cargo\registry\src\github.com-1ecc6299db9ec823\drop_bomb-0.1.5\src\lib.rs:113:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
vue.global.prod.js - using target\vue.global.prod.js
thread 'main' panicked at 'Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent.', C:\Users\xunil\.cargo\registry\src\github.com-1ecc6299db9ec823\drop_bomb-0.1.5\src\lib.rs:113:13
end
```