### PR TITLE
fixing parser marker bombs for some js libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_rgb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a730095eb14ee842a0f1e68504b85c8d4a19b1ef2ac2a9b4debf0ed982f9b08a"
+dependencies = [
+ "rgb",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +99,12 @@ name = "bumpalo"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+
+[[package]]
+name = "bytemuck"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "case"
@@ -958,6 +973,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rgb"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27fa03bb1e3e2941f52d4a555a395a72bf79b0a85fbbaab79447050c97d978c"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "timing"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef973380ab2960e2b4e49d552291930c217b947ee831f73000ebc5439074bf0"
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1636,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "xtask"
 version = "0.0.0"
 dependencies = [
+ "ansi_rgb",
  "anyhow",
  "ascii_table",
  "colored",
@@ -1624,6 +1655,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "syn",
+ "timing",
  "ungrammar",
  "unindent",
  "ureq",

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -1013,12 +1013,10 @@ pub fn ts_non_array_type(p: &mut Parser) -> Option<CompletedMarker> {
 				let _m = p.start();
 				p.bump_any();
 				_m.complete(p, JS_NUMBER_LITERAL_EXPRESSION);
-			} else {
-				if p.expect_no_recover(JS_NUMBER_LITERAL).is_none() {
-					m.abandon(p);
-					p.rewind(t);
-					return None;
-				};
+			} else if p.expect_no_recover(JS_NUMBER_LITERAL).is_none() {
+				m.abandon(p);
+				p.rewind(t);
+				return None;
 			}
 			Some(m.complete(p, TS_LITERAL))
 		}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,3 +30,5 @@ num_cpus = "1.13"
 ungrammar = "1.14.9"
 ureq = { version = "2.3.1" } 
 url = "2.2.2"
+timing = "0.2.3"
+ansi_rgb = "0.2.0"

--- a/xtask/src/libs/libs.txt
+++ b/xtask/src/libs/libs.txt
@@ -1,2 +1,10 @@
 https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
 https://cdn.jsdelivr.net/npm/vue@3.2.22/dist/vue.global.prod.js
+https://cdn.jsdelivr.net/npm/react@17.0.2/cjs/react.production.min.js
+https://cdn.jsdelivr.net/npm/react-dom@17.0.2/cjs/react-dom.production.min.js
+https://cdn.jsdelivr.net/npm/svelte@3.44.2/compiler.js
+https://cdn.jsdelivr.net/npm/dojo@1.16.4/dojo.js
+https://cdn.jsdelivr.net/npm/d3@7.1.1/dist/d3.min.js
+https://cdn.jsdelivr.net/npm/pixi.js@6.2.0/dist/browser/pixi.min.js
+https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
+https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -1,3 +1,4 @@
+use ansi_rgb::{red, Foreground};
 use std::{path::PathBuf, str::FromStr};
 
 fn err_to_string<E: std::fmt::Debug>(e: E) -> String {
@@ -18,7 +19,7 @@ pub fn get_code(lib: &str) -> Result<String, String> {
 
 	match std::fs::read_to_string(&file) {
 		Ok(code) => {
-			println!("[{}] - using [{}]", filename, file.display());
+			println!("[{}] - using [{}]", filename.fg(red()), file.display());
 			Ok(code)
 		}
 		Err(_) => {
@@ -44,13 +45,49 @@ pub fn get_code(lib: &str) -> Result<String, String> {
 	}
 }
 
-pub fn run() {
+pub fn run(filter: String) {
+	let regex = regex::Regex::new(filter.as_str()).unwrap();
 	let libs = include_str!("libs.txt").lines();
 	for lib in libs {
+		if !regex.is_match(lib) {
+			continue;
+		}
+
 		let code = get_code(lib);
 		match code {
 			Ok(code) => {
-				let _ = std::panic::catch_unwind(|| rslint_parser::parse_module(code.as_str(), 0));
+				let t = timing::start();
+				let _ = std::panic::catch_unwind(|| {
+					let text = code;
+
+					let tokenizer_timing = timing::start();
+					let (tokens, mut errors) = rslint_parser::tokenize(text.as_str(), 0);
+					let tok_source = rslint_parser::TokenSource::new(text.as_str(), &tokens);
+					println!("\ttokenizer took {:?}", tokenizer_timing.stop());
+
+					let parser_timing = timing::start();
+					let (events, errors, tokens) = {
+						let mut parser = rslint_parser::Parser::new(
+							tok_source,
+							0,
+							rslint_parser::Syntax::default().module(),
+						);
+						rslint_parser::syntax::program::parse(&mut parser);
+						let (events, p_errs) = parser.finish();
+						errors.extend(p_errs);
+						(events, errors, tokens)
+					};
+					println!("\tparser took {:?}", parser_timing.stop());
+
+					let treesink_timing = timing::start();
+					let mut tree_sink =
+						rslint_parser::LosslessTreeSink::new(text.as_str(), &tokens);
+					rslint_parser::process(&mut tree_sink, events, errors);
+					let (_green, _parse_errors) = tree_sink.finish();
+					println!("\ttree sink took {:?}", treesink_timing.stop());
+				});
+				let dur = t.stop();
+				println!("total: {:?}", dur);
 			}
 			Err(e) => println!("{:?}", e),
 		}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,7 +51,11 @@ fn main() -> Result<()> {
 			Ok(())
 		}
 		"coverage-libs" => {
-			xtask::libs::run();
+			let filter: String = args
+				.opt_value_from_str("--filter")
+				.unwrap()
+				.unwrap_or_else(|| ".*".to_string());
+			xtask::libs::run(filter);
 			Ok(())
 		}
 		_ => {


### PR DESCRIPTION
Some files were panicking because ```Marker```s were being dropped without being abandoned/completed. We may have more bombs lurking. I fixed only those necessary to make all the libs below to be parsed.

We may also discuss what we want to do with this new ```xtask```.

# How to run 

I prefer to run as ```--release``` so files are parsed faster.

```
>cargo run -p xtask --release -- coverage-libs                                 
Finished release [optimized] target(s) in 45.25s
     Running `target\release\xtask.exe coverage-libs`
[jquery.min.js] - using [target\jquery.min.js]
        tokenizer took 3.5149ms
        parser took 135.0601ms
        tree sink took 8.1032ms
total: 149.6376ms
[vue.global.prod.js] - using [target\vue.global.prod.js]
        tokenizer took 7.5291ms
        parser took 381.4876ms
        tree sink took 16.3364ms
total: 411.0224ms
[react.production.min.js] - using [target\react.production.min.js]
        tokenizer took 414.8µs
        parser took 2.6274ms
        tree sink took 1.1218ms
total: 6.1889ms
[react-dom.production.min.js] - using [target\react-dom.production.min.js]
        tokenizer took 5.5346ms
        parser took 206.8835ms
        tree sink took 14.5155ms
total: 231.3164ms
[compiler.js] - using [target\compiler.js]
        tokenizer took 22.179ms
        parser took 1.3198807s
        tree sink took 68.1227ms
total: 1.4204385s
[dojo.js] - using [target\dojo.js]
        tokenizer took 1.3409ms
        parser took 20.047ms
        tree sink took 4.556ms
total: 28.7149ms
[d3.min.js] - using [target\d3.min.js]
        tokenizer took 13.4533ms
        parser took 4.0752422s
        tree sink took 31.1268ms
total: 4.1274071s
[pixi.min.js] - using [target\pixi.min.js]
        tokenizer took 9.2972ms
        parser took 2.6517687s
        tree sink took 38.0329ms
total: 2.7059498s
[three.min.js] - using [target\three.min.js]
        tokenizer took 17.0617ms
        parser took 3.5618422s
        tree sink took 41.6696ms
total: 3.6288377s
[tex-chtml-full.js] - using [target\tex-chtml-full.js]
        tokenizer took 31.1219ms
        parser took 4.2314657s
        tree sink took 71.4601ms
total: 4.3472474s
end
```

Can also be filtered

```
>cargo run -p xtask --release -- coverage-libs --filter=jquery    
    Finished release [optimized] target(s) in 1.18s
     Running `target\release\xtask.exe coverage-libs --filter=jquery`
[jquery.min.js] - using [target\jquery.min.js]
        tokenizer took 4.3508ms
        parser took 132.7335ms
        tree sink took 8.3056ms
total: 149.945ms
end
```