### PR TITLE
ci: split workflows for PRs and `main` branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,10 @@
-name: CI
+
+# This workflow run when something is pushed on main and it does:
+  # - normal checks like in the normal PRs
+  # - runs the coverage and prints in the command line
+name: CI on main
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
 
@@ -73,4 +74,26 @@ jobs:
         with:
           command: test
           args: --workspace --verbose
+  coverage:
+    name: Test262 coverage
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+       os: [windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.56.1
+          profile: minimal
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Run Test262 suite
+        continue-on-error: true
+        run:  cargo xtask coverage
 

--- a/.github/workflows/pul_request.yml
+++ b/.github/workflows/pul_request.yml
@@ -1,0 +1,75 @@
+
+# Jobs run on pull request
+name: Pull request
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  RUST_LOG: info
+  RUST_BACKTRACE: 1
+
+jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.56.1
+          profile: minimal
+          components: rustfmt
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --verbose -- --check
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.56.1
+          profile: minimal
+          components: clippy
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-targets --verbose -- --deny warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.56.1
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+      - name: Compile for tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-run --workspace --verbose
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        env:
+          RUST_TEST_THREADS: 1
+        with:
+          command: test
+          args: --workspace --verbose
+

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -1,8 +1,6 @@
-name: CI
+# Test coverage job. It is run on pull request because it prints the results via comment
+name: Test262 coverage and comparison
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR puts some order to our workflows:

- `pull_request.yml` is the workflow where we run on pull requests. This is where we might have some bot that does some fancy stuff, like the coverage;
- `main.yml` is the workflow that we trigger when something is pushed on `main` branch. It does usual checks like in the PR. It also run the coverage and prints it in the command line (different behaviour from the PR workflow). This will also set the foundation for other jobs that we want to run only in certain occasions, specifically those jobs that take long time;
- `test262.yml` stays the same that runs on pull requests only. I plan to merge it into `pull_request.yml` but only when I figure out a wait to save artifacts between workflows

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
