### PR TITLE
Assert AST Test in parser integration test

### DIFF
--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -2,7 +2,7 @@ use crate::{
 	format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
 	FormatElement, FormatResult, Formatter, ToFormatElement,
 };
-use rslint_parser::ast::JsParameterList;
+use rslint_parser::ast::{JsAnyParameter, JsParameterList};
 
 impl ToFormatElement for JsParameterList {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -16,5 +16,14 @@ impl ToFormatElement for JsParameterList {
 			),),
 			formatter.format_token(&self.r_paren_token()?)?
 		]))
+	}
+}
+
+impl ToFormatElement for JsAnyParameter {
+	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+		match self {
+			JsAnyParameter::Pattern(pattern) => pattern.to_format_element(formatter),
+			JsAnyParameter::JsRestParameter(_) => todo!("rest parameter"),
+		}
 	}
 }

--- a/crates/rslint_parser/src/ast.rs
+++ b/crates/rslint_parser/src/ast.rs
@@ -384,7 +384,7 @@ mod support {
 		AstNode, AstNodeList, AstSeparatedList, SyntaxElementChildren, SyntaxKind, SyntaxNode,
 		SyntaxToken,
 	};
-	use crate::ast::{AstChildren, JsAnyParameter};
+	use crate::ast::AstChildren;
 	use crate::SyntaxList;
 	use crate::{SyntaxError, SyntaxResult};
 	use std::fmt::{Debug, Formatter};

--- a/crates/rslint_parser/src/ast.rs
+++ b/crates/rslint_parser/src/ast.rs
@@ -193,10 +193,21 @@ impl<N: AstNode> IntoIterator for AstNodeList<N> {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AstSeparatedElement<N> {
 	node: N,
 	trailing_separator: Option<SyntaxToken>,
+}
+
+impl<N: Debug> Debug for AstSeparatedElement<N> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		N::fmt(&self.node, f)?;
+		f.write_str("\n")?;
+		match &self.trailing_separator {
+			Some(separator) => separator.fmt(f),
+			None => Ok(()),
+		}
+	}
 }
 
 /// List of nodes where every two nodes are separated by a token.

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -12,42 +12,42 @@ pub struct JsUnknownStatement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownPattern {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownMember {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownBinding {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownAssignmentTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownAssignmentTarget {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
@@ -2695,7 +2695,7 @@ impl AstNode for JsUnknownStatement {
 impl std::fmt::Debug for JsUnknownStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownStatement")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }
@@ -2713,7 +2713,7 @@ impl AstNode for JsUnknownExpression {
 impl std::fmt::Debug for JsUnknownExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownExpression")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }
@@ -2731,7 +2731,7 @@ impl AstNode for JsUnknownPattern {
 impl std::fmt::Debug for JsUnknownPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownPattern")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }
@@ -2749,7 +2749,7 @@ impl AstNode for JsUnknownMember {
 impl std::fmt::Debug for JsUnknownMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownMember")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }
@@ -2767,7 +2767,7 @@ impl AstNode for JsUnknownBinding {
 impl std::fmt::Debug for JsUnknownBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownBinding")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }
@@ -2785,7 +2785,7 @@ impl AstNode for JsUnknownAssignmentTarget {
 impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnknownAssignmentTarget")
-			.field("syntax_element", &self.syntax_element())
+			.field("items", &self.items())
 			.finish()
 	}
 }

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -12,54 +12,42 @@ pub struct JsUnknownStatement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownPattern {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownMember {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownBinding {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownAssignmentTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownAssignmentTarget {
-	pub fn syntax_element(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
@@ -93,9 +81,7 @@ impl JsDirective {
 	pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBlockStatement {
@@ -129,9 +115,7 @@ impl JsExpressionStatement {
 	pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsIfStatement {
@@ -144,18 +128,14 @@ impl JsIfStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 	pub fn consequent(&self) -> SyntaxResult<JsAnyStatement> {
 		support::required_node(&self.syntax)
 	}
-	pub fn else_clause(&self) -> Option<JsElseClause> {
-		support::node(&self.syntax)
-	}
+	pub fn else_clause(&self) -> Option<JsElseClause> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDoWhileStatement {
@@ -165,24 +145,18 @@ impl JsDoWhileStatement {
 	pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![do])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![while])
 	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWhileStatement {
@@ -195,15 +169,11 @@ impl JsWhileStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmt {
@@ -216,21 +186,13 @@ impl ForStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn init(&self) -> Option<ForStmtInit> {
-		support::node(&self.syntax)
-	}
-	pub fn test(&self) -> Option<ForStmtTest> {
-		support::node(&self.syntax)
-	}
-	pub fn update(&self) -> Option<ForStmtUpdate> {
-		support::node(&self.syntax)
-	}
+	pub fn init(&self) -> Option<ForStmtInit> { support::node(&self.syntax) }
+	pub fn test(&self) -> Option<ForStmtTest> { support::node(&self.syntax) }
+	pub fn update(&self) -> Option<ForStmtUpdate> { support::node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForInStmt {
@@ -243,21 +205,15 @@ impl ForInStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
 	pub fn in_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![in])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForOfStmt {
@@ -270,21 +226,15 @@ impl ForOfStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
 	pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![of])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsContinueStatement {
@@ -294,12 +244,8 @@ impl JsContinueStatement {
 	pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![continue])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![ident])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBreakStatement {
@@ -309,12 +255,8 @@ impl JsBreakStatement {
 	pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![break])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![ident])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReturnStatement {
@@ -324,12 +266,8 @@ impl JsReturnStatement {
 	pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![return])
 	}
-	pub fn argument(&self) -> Option<JsAnyExpression> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWithStatement {
@@ -342,15 +280,11 @@ impl JsWithStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLabeledStatement {
@@ -363,9 +297,7 @@ impl JsLabeledStatement {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSwitchStatement {
@@ -402,12 +334,8 @@ impl JsThrowStatement {
 	pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![throw])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsTryStatement {
@@ -417,9 +345,7 @@ impl JsTryStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 	pub fn catch_clause(&self) -> SyntaxResult<JsCatchClause> {
 		support::required_node(&self.syntax)
 	}
@@ -432,12 +358,8 @@ impl JsTryFinallyStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
-	pub fn catch_clause(&self) -> Option<JsCatchClause> {
-		support::node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn catch_clause(&self) -> Option<JsCatchClause> { support::node(&self.syntax) }
 	pub fn finally_clause(&self) -> SyntaxResult<JsFinallyClause> {
 		support::required_node(&self.syntax)
 	}
@@ -450,39 +372,25 @@ impl JsDebuggerStatement {
 	pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![debugger])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionDeclaration {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsClassDeclaration {
@@ -492,15 +400,9 @@ impl JsClassDeclaration {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
-		support::required_node(&self.syntax)
-	}
-	pub fn implements_clause(&self) -> Option<TsImplementsClause> {
-		support::node(&self.syntax)
-	}
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
+	pub fn implements_clause(&self) -> Option<TsImplementsClause> { support::node(&self.syntax) }
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -519,30 +421,22 @@ impl JsVariableDeclarationStatement {
 	pub fn declaration(&self) -> SyntaxResult<JsVariableDeclaration> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnum {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
-	pub fn const_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![const])
-	}
+	pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
 	pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![enum])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsEnumMember> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -555,15 +449,11 @@ impl TsTypeAliasDecl {
 	pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![type])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceDecl {
@@ -573,15 +463,9 @@ impl TsNamespaceDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleDecl {
@@ -591,48 +475,30 @@ impl TsModuleDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn global_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![global])
-	}
+	pub fn global_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![global]) }
 	pub fn module_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![module])
 	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsInterfaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInterfaceDecl {
-	pub fn declare_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![declare])
-	}
+	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
 	pub fn interface_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![interface])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
-	pub fn extends_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![extends])
-	}
-	pub fn extends(&self) -> Option<TsExprWithTypeArgs> {
-		support::node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn extends_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![extends]) }
+	pub fn extends(&self) -> Option<TsExprWithTypeArgs> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> SyntaxResult<TsTypeElement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn members(&self) -> SyntaxResult<TsTypeElement> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -645,12 +511,8 @@ impl ImportDecl {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn imports(&self) -> AstNodeList<ImportClause> {
-		support::node_list(&self.syntax, 0usize)
-	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax, 0usize) }
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -660,12 +522,8 @@ impl ImportDecl {
 	pub fn asserted_object(&self) -> SyntaxResult<JsObjectExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn assert_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![assert])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn assert_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![assert]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportNamed {
@@ -675,12 +533,8 @@ impl ExportNamed {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn from_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![from])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn from_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![from]) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -699,15 +553,9 @@ impl ExportDefaultDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn default_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![default])
-	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn decl(&self) -> SyntaxResult<DefaultDecl> {
-		support::required_node(&self.syntax)
-	}
+	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn decl(&self) -> SyntaxResult<DefaultDecl> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDefaultExpr {
@@ -717,15 +565,9 @@ impl ExportDefaultExpr {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn default_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![default])
-	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportWildcard {
@@ -735,18 +577,12 @@ impl ExportWildcard {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![as])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
+	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -762,9 +598,7 @@ impl ExportDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn decl(&self) -> SyntaxResult<JsAnyExportDeclaration> {
 		support::required_node(&self.syntax)
 	}
@@ -780,18 +614,12 @@ impl TsImportEqualsDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn module(&self) -> SyntaxResult<TsModuleRef> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn module(&self) -> SyntaxResult<TsModuleRef> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExportAssignment {
@@ -804,12 +632,8 @@ impl TsExportAssignment {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceExportDecl {
@@ -825,12 +649,8 @@ impl TsNamespaceExportDecl {
 	pub fn namespace_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![namespace])
 	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsElseClause {
@@ -840,18 +660,14 @@ impl JsElseClause {
 	pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![else])
 	}
-	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtInit {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtInit {
-	pub fn inner(&self) -> SyntaxResult<ForHead> {
-		support::required_node(&self.syntax)
-	}
+	pub fn inner(&self) -> SyntaxResult<ForHead> { support::required_node(&self.syntax) }
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -861,9 +677,7 @@ pub struct ForStmtTest {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtTest {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -873,9 +687,7 @@ pub struct ForStmtUpdate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtUpdate {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclaration {
@@ -897,9 +709,7 @@ impl JsCaseClause {
 	pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![case])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -930,12 +740,8 @@ impl JsCatchClause {
 	pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![catch])
 	}
-	pub fn declaration(&self) -> Option<JsCatchDeclaration> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn declaration(&self) -> Option<JsCatchDeclaration> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFinallyClause {
@@ -945,9 +751,7 @@ impl JsFinallyClause {
 	pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![finally])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCatchDeclaration {
@@ -957,9 +761,7 @@ impl JsCatchDeclaration {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -984,21 +786,15 @@ pub struct JsArrowFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsArrowFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> Option<JsAnyArrowFunctionParameters> {
 		support::node(&self.syntax)
 	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAwaitExpression {
@@ -1008,18 +804,14 @@ impl JsAwaitExpression {
 	pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![await])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBinaryExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsBinaryExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(
 			&self.syntax,
@@ -1058,12 +850,8 @@ impl JsClassExpression {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> {
-		support::node(&self.syntax)
-	}
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -1079,9 +867,7 @@ pub struct JsConditionalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConditionalExpression {
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
@@ -1094,9 +880,7 @@ pub struct JsComputedMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn optional_chain_token_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?.])
 	}
@@ -1112,30 +896,18 @@ pub struct JsFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> {
-		support::node(&self.syntax)
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportCallExpression {
@@ -1148,9 +920,7 @@ impl JsImportCallExpression {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -1160,9 +930,7 @@ pub struct JsLogicalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsLogicalExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [??], T ! [||], T ! [&&]])
 	}
@@ -1211,9 +979,7 @@ pub struct JsSequenceExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSequenceExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn comma_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [,])
 	}
@@ -1223,9 +989,7 @@ pub struct JsStaticMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [.], T ! [?.]])
 	}
@@ -1270,9 +1034,7 @@ impl JsUnaryExpression {
 			],
 		)
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPreUpdateExpression {
@@ -1282,18 +1044,14 @@ impl JsPreUpdateExpression {
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPostUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPostUpdateExpression {
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
@@ -1306,12 +1064,8 @@ impl JsYieldExpression {
 	pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![yield])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn argument(&self) -> Option<JsAnyExpression> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Template {
@@ -1330,30 +1084,18 @@ impl NewExpr {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_args(&self) -> Option<TsTypeArgs> {
-		support::node(&self.syntax)
-	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn arguments(&self) -> SyntaxResult<ArgList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CallExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CallExpr {
-	pub fn type_args(&self) -> Option<TsTypeArgs> {
-		support::node(&self.syntax)
-	}
-	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn arguments(&self) -> SyntaxResult<ArgList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
+	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignExpr {
@@ -1415,9 +1157,7 @@ pub struct TsNonNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
@@ -1427,18 +1167,12 @@ pub struct TsAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1448,12 +1182,8 @@ pub struct TsConstAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
@@ -1472,9 +1202,7 @@ impl TsTypeArgs {
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn args(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn args(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1508,15 +1236,9 @@ pub struct TsTypeParams {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParams {
-	pub fn l_angle_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [<])
-	}
-	pub fn params(&self) -> SyntaxResult<TsTypeParam> {
-		support::required_node(&self.syntax)
-	}
-	pub fn r_angle_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [>])
-	}
+	pub fn l_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [<]) }
+	pub fn params(&self) -> SyntaxResult<TsTypeParam> { support::required_node(&self.syntax) }
+	pub fn r_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [>]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsParameterList {
@@ -1541,9 +1263,7 @@ impl TsTypeAnnotation {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionBody {
@@ -1571,9 +1291,7 @@ impl SpreadElement {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn element(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn element(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrayHole {
@@ -1624,27 +1342,17 @@ pub struct JsMethodObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodObjectMember {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_params(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn type_params(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterObjectMember {
@@ -1663,12 +1371,8 @@ impl JsGetterObjectMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterObjectMember {
@@ -1684,30 +1388,22 @@ impl JsSetterObjectMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct InitializedProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl InitializedProp {
-	pub fn key(&self) -> SyntaxResult<Name> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsShorthandPropertyObjectMember {
@@ -1726,9 +1422,7 @@ impl JsSpread {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsStringLiteralExpression {
@@ -1786,12 +1480,8 @@ pub struct TsExprWithTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
-	pub fn item(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
+	pub fn item(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPrivateClassMemberName {
@@ -1810,105 +1500,67 @@ pub struct JsConstructorClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
-	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> { support::required_node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsConstructorParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPropertyClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyClassMember {
-	pub fn declare_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![declare])
-	}
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![!])
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn value(&self) -> Option<JsEqualValueClause> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn value(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsMethodClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![get])
 	}
@@ -1921,27 +1573,19 @@ impl JsGetterClassMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![set])
 	}
@@ -1951,15 +1595,11 @@ impl JsSetterClassMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEmptyClassMember {
@@ -1981,15 +1621,11 @@ impl TsIndexSignature {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn pat(&self) -> SyntaxResult<SinglePattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<SinglePattern> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2029,9 +1665,7 @@ impl TsConstructorParam {
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![readonly])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEqualValueClause {
@@ -2086,18 +1720,12 @@ pub struct SinglePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SinglePattern {
-	pub fn name(&self) -> SyntaxResult<Name> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![!])
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RestPattern {
@@ -2107,27 +1735,19 @@ impl RestPattern {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignPattern {
-	pub fn key(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ObjectPattern {
@@ -2152,36 +1772,28 @@ impl ArrayPattern {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<Pattern> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExprPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprPattern {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyValuePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl KeyValuePattern {
-	pub fn key(&self) -> SyntaxResult<PropName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<PropName> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -2191,12 +1803,8 @@ pub struct JsVariableDeclarator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclarator {
-	pub fn id(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
-	pub fn init(&self) -> Option<JsEqualValueClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn init(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct WildcardImport {
@@ -2206,12 +1814,8 @@ impl WildcardImport {
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![as])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
+	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamedImports {
@@ -2242,9 +1846,7 @@ pub struct Specifier {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Specifier {
-	pub fn name(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferenceIdentifierMember {
@@ -2275,9 +1877,7 @@ impl JsRestParameter {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExternalModuleRef {
@@ -2320,54 +1920,42 @@ pub struct TsNumber {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNumber {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObject {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObject {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBoolean {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBoolean {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBigint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBigint {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsString {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsString {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsSymbol {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbol {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsVoid {
@@ -2419,21 +2007,15 @@ pub struct TsLiteral {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsLiteral {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPredicate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPredicate {
-	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> {
-		support::required_node(&self.syntax)
-	}
-	pub fn rhs(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> { support::required_node(&self.syntax) }
+	pub fn rhs(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTuple {
@@ -2443,9 +2025,7 @@ impl TsTuple {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> SyntaxResult<TsTupleElement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn elements(&self) -> SyntaxResult<TsTupleElement> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2458,9 +2038,7 @@ impl TsParen {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2470,12 +2048,8 @@ pub struct TsTypeRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeRef {
-	pub fn name(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplate {
@@ -2494,33 +2068,21 @@ impl TsMappedType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> {
-		support::node(&self.syntax)
-	}
-	pub fn minus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [-])
-	}
-	pub fn plus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [+])
-	}
+	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> { support::node(&self.syntax) }
+	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
+	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> {
-		support::required_node(&self.syntax)
-	}
+	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImport {
@@ -2530,18 +2092,12 @@ impl TsImport {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2554,9 +2110,7 @@ impl TsArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2569,9 +2123,7 @@ impl TsIndexedArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2581,42 +2133,32 @@ pub struct TsTypeOperator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperator {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIntersection {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersection {
-	pub fn types(&self) -> AstNodeList<TsType> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUnion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnion {
-	pub fn types(&self) -> AstNodeList<TsType> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsFnType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsFnType {
-	pub fn params(&self) -> SyntaxResult<JsParameterList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsType> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructorType {
@@ -2626,33 +2168,25 @@ impl TsConstructorType {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn params(&self) -> SyntaxResult<JsParameterList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> Option<TsType> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConditionalType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn extends(&self) -> SyntaxResult<TsExtends> {
-		support::required_node(&self.syntax)
-	}
+	pub fn extends(&self) -> SyntaxResult<TsExtends> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObjectType {
@@ -2662,9 +2196,7 @@ impl TsObjectType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsTypeElement> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2677,54 +2209,40 @@ impl TsInfer {
 	pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![infer])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTupleElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleElement {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
-	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [...])
-	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [...]) }
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnumMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplateElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2734,12 +2252,8 @@ pub struct TsMappedTypeReadonly {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonly {
-	pub fn minus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [-])
-	}
-	pub fn plus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [+])
-	}
+	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
+	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
@@ -2749,30 +2263,18 @@ pub struct TsMappedTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeParam {
-	pub fn l_brack_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T!['['])
-	}
-	pub fn name(&self) -> Option<TsTypeName> {
-		support::node(&self.syntax)
-	}
-	pub fn r_brack_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![']'])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
+	pub fn name(&self) -> Option<TsTypeName> { support::node(&self.syntax) }
+	pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeName {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExtends {
@@ -2782,9 +2284,7 @@ impl TsExtends {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleBlock {
@@ -2794,9 +2294,7 @@ impl TsModuleBlock {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn items(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2806,15 +2304,9 @@ pub struct TsTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParam {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn constraint(&self) -> SyntaxResult<TsConstraint> {
-		support::required_node(&self.syntax)
-	}
-	pub fn default(&self) -> SyntaxResult<TsDefault> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn constraint(&self) -> SyntaxResult<TsConstraint> { support::required_node(&self.syntax) }
+	pub fn default(&self) -> SyntaxResult<TsDefault> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstraint {
@@ -2824,9 +2316,7 @@ impl TsConstraint {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsDefault {
@@ -2836,27 +2326,21 @@ impl TsDefault {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsCallSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureDecl {
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructSignatureDecl {
@@ -2866,18 +2350,12 @@ impl TsConstructSignatureDecl {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn colon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [:])
-	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [:]) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPropertySignature {
@@ -2887,18 +2365,14 @@ impl TsPropertySignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMethodSignature {
@@ -2908,12 +2382,8 @@ impl TsMethodSignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn key(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
@@ -2923,26 +2393,20 @@ impl TsMethodSignature {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsQualifiedPath {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedPath {
-	pub fn lhs(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn lhs(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [.])
 	}
-	pub fn rhs(&self) -> SyntaxResult<TsTypeName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn rhs(&self) -> SyntaxResult<TsTypeName> { support::required_node(&self.syntax) }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyStatement {
 	JsBlockStatement(JsBlockStatement),
 	JsEmptyStatement(JsEmptyStatement),
@@ -2982,7 +2446,7 @@ pub enum JsAnyStatement {
 	TsNamespaceExportDecl(TsNamespaceExportDecl),
 	JsUnknownStatement(JsUnknownStatement),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyExpression {
 	JsAnyLiteralExpression(JsAnyLiteralExpression),
 	JsArrayExpression(JsArrayExpression),
@@ -3017,17 +2481,17 @@ pub enum JsAnyExpression {
 	TsConstAssertion(TsConstAssertion),
 	JsUnknownExpression(JsUnknownExpression),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ForHead {
 	JsVariableDeclaration(JsVariableDeclaration),
 	JsAnyExpression(JsAnyExpression),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnySwitchClause {
 	JsCaseClause(JsCaseClause),
 	JsDefaultClause(JsDefaultClause),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum Pattern {
 	SinglePattern(SinglePattern),
 	RestPattern(RestPattern),
@@ -3037,7 +2501,7 @@ pub enum Pattern {
 	ExprPattern(ExprPattern),
 	JsUnknownPattern(JsUnknownPattern),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyLiteralExpression {
 	JsStringLiteralExpression(JsStringLiteralExpression),
 	JsNumberLiteralExpression(JsNumberLiteralExpression),
@@ -3046,38 +2510,38 @@ pub enum JsAnyLiteralExpression {
 	JsNullLiteralExpression(JsNullLiteralExpression),
 	JsRegexLiteralExpression(JsRegexLiteralExpression),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyArrowFunctionParameters {
 	JsParameterList(JsParameterList),
 	JsIdentifierBinding(JsIdentifierBinding),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyArrowFunctionBody {
 	JsAnyExpression(JsAnyExpression),
 	JsFunctionBody(JsFunctionBody),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyArrayElement {
 	JsAnyExpression(JsAnyExpression),
 	SpreadElement(SpreadElement),
 	JsArrayHole(JsArrayHole),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PatternOrExpr {
 	Pattern(Pattern),
 	JsAnyExpression(JsAnyExpression),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyReferenceMember {
 	JsReferenceIdentifierMember(JsReferenceIdentifierMember),
 	JsReferencePrivateMember(JsReferencePrivateMember),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyObjectMemberName {
 	JsLiteralMemberName(JsLiteralMemberName),
 	JsComputedMemberName(JsComputedMemberName),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyObjectMember {
 	JsPropertyObjectMember(JsPropertyObjectMember),
 	JsMethodObjectMember(JsMethodObjectMember),
@@ -3088,7 +2552,7 @@ pub enum JsAnyObjectMember {
 	JsSpread(JsSpread),
 	JsUnknownMember(JsUnknownMember),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PropName {
 	JsComputedMemberName(JsComputedMemberName),
 	JsStringLiteralExpression(JsStringLiteralExpression),
@@ -3097,7 +2561,7 @@ pub enum PropName {
 	Name(Name),
 	JsUnknownBinding(JsUnknownBinding),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyClassMember {
 	JsConstructorClassMember(JsConstructorClassMember),
 	JsPropertyClassMember(JsPropertyClassMember),
@@ -3108,18 +2572,18 @@ pub enum JsAnyClassMember {
 	TsIndexSignature(TsIndexSignature),
 	JsUnknownMember(JsUnknownMember),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyClassMemberName {
 	JsLiteralMemberName(JsLiteralMemberName),
 	JsComputedMemberName(JsComputedMemberName),
 	JsPrivateClassMemberName(JsPrivateClassMemberName),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyConstructorParameter {
 	TsConstructorParam(TsConstructorParam),
 	Pattern(Pattern),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ObjectPatternProp {
 	AssignPattern(AssignPattern),
 	KeyValuePattern(KeyValuePattern),
@@ -3127,7 +2591,7 @@ pub enum ObjectPatternProp {
 	SinglePattern(SinglePattern),
 	JsUnknownPattern(JsUnknownPattern),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsType {
 	TsAny(TsAny),
 	TsUnknown(TsUnknown),
@@ -3161,19 +2625,19 @@ pub enum TsType {
 	TsObjectType(TsObjectType),
 	TsInfer(TsInfer),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ImportClause {
 	WildcardImport(WildcardImport),
 	NamedImports(NamedImports),
 	Name(Name),
 	ImportStringSpecifier(ImportStringSpecifier),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum DefaultDecl {
 	JsFunctionDeclaration(JsFunctionDeclaration),
 	JsClassDeclaration(JsClassDeclaration),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyExportDeclaration {
 	JsFunctionDeclaration(JsFunctionDeclaration),
 	JsClassDeclaration(JsClassDeclaration),
@@ -3184,27 +2648,27 @@ pub enum JsAnyExportDeclaration {
 	TsModuleDecl(TsModuleDecl),
 	TsInterfaceDecl(TsInterfaceDecl),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyParameter {
 	Pattern(Pattern),
 	JsRestParameter(JsRestParameter),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsModuleRef {
 	TsExternalModuleRef(TsExternalModuleRef),
 	TsEntityName(TsEntityName),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsEntityName {
 	TsTypeName(TsTypeName),
 	TsQualifiedPath(TsQualifiedPath),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsThisOrMore {
 	TsThis(TsThis),
 	TsTypeName(TsTypeName),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsTypeElement {
 	TsCallSignatureDecl(TsCallSignatureDecl),
 	TsConstructSignatureDecl(TsConstructSignatureDecl),
@@ -3212,15 +2676,13 @@ pub enum TsTypeElement {
 	TsMethodSignature(TsMethodSignature),
 	TsIndexSignature(TsIndexSignature),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum TsNamespaceBody {
 	TsModuleBlock(TsModuleBlock),
 	TsNamespaceDecl(TsNamespaceDecl),
 }
 impl AstNode for JsUnknownStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3228,9 +2690,7 @@ impl AstNode for JsUnknownStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3240,9 +2700,7 @@ impl std::fmt::Debug for JsUnknownStatement {
 	}
 }
 impl AstNode for JsUnknownExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3250,9 +2708,7 @@ impl AstNode for JsUnknownExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3262,9 +2718,7 @@ impl std::fmt::Debug for JsUnknownExpression {
 	}
 }
 impl AstNode for JsUnknownPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3272,9 +2726,7 @@ impl AstNode for JsUnknownPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3284,9 +2736,7 @@ impl std::fmt::Debug for JsUnknownPattern {
 	}
 }
 impl AstNode for JsUnknownMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3294,9 +2744,7 @@ impl AstNode for JsUnknownMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3306,9 +2754,7 @@ impl std::fmt::Debug for JsUnknownMember {
 	}
 }
 impl AstNode for JsUnknownBinding {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_BINDING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3316,9 +2762,7 @@ impl AstNode for JsUnknownBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3328,9 +2772,7 @@ impl std::fmt::Debug for JsUnknownBinding {
 	}
 }
 impl AstNode for JsUnknownAssignmentTarget {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_ASSIGNMENT_TARGET
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT_TARGET }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3338,9 +2780,7 @@ impl AstNode for JsUnknownAssignmentTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3350,9 +2790,7 @@ impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	}
 }
 impl AstNode for Ident {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IDENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IDENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3360,21 +2798,20 @@ impl AstNode for Ident {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Ident {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Ident")
-			.field("ident_token", &self.ident_token())
+			.field(
+				"ident_token",
+				&support::DebugSyntaxResult(self.ident_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsRoot {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ROOT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ROOT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3382,23 +2819,22 @@ impl AstNode for JsRoot {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRoot {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsRoot")
-			.field("interpreter_token", &self.interpreter_token())
+			.field(
+				"interpreter_token",
+				&support::DebugOptionalNode(self.interpreter_token()),
+			)
 			.field("directives", &self.directives())
 			.field("statements", &self.statements())
 			.finish()
 	}
 }
 impl AstNode for JsDirective {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DIRECTIVE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3406,22 +2842,24 @@ impl AstNode for JsDirective {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDirective {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsDirective")
-			.field("value_token", &self.value_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsBlockStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BLOCK_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3429,23 +2867,25 @@ impl AstNode for JsBlockStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBlockStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsBlockStatement")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("statements", &self.statements())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsEmptyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EMPTY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3453,21 +2893,20 @@ impl AstNode for JsEmptyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEmptyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsEmptyStatement")
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"semicolon_token",
+				&support::DebugSyntaxResult(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsExpressionStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EXPRESSION_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3475,22 +2914,21 @@ impl AstNode for JsExpressionStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsExpressionStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsExpressionStatement")
-			.field("expression", &self.expression())
-			.field("semicolon_token", &self.semicolon_token())
+			.field("expression", &support::DebugSyntaxResult(self.expression()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsIfStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IF_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3498,26 +2936,31 @@ impl AstNode for JsIfStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsIfStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsIfStatement")
-			.field("if_token", &self.if_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("test", &self.test())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("consequent", &self.consequent())
-			.field("else_clause", &self.else_clause())
+			.field("if_token", &support::DebugSyntaxResult(self.if_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("test", &support::DebugSyntaxResult(self.test()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("consequent", &support::DebugSyntaxResult(self.consequent()))
+			.field(
+				"else_clause",
+				&support::DebugOptionalNode(self.else_clause()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsDoWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DO_WHILE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3525,27 +2968,35 @@ impl AstNode for JsDoWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDoWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsDoWhileStatement")
-			.field("do_token", &self.do_token())
-			.field("body", &self.body())
-			.field("while_token", &self.while_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("test", &self.test())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field("do_token", &support::DebugSyntaxResult(self.do_token()))
+			.field("body", &support::DebugSyntaxResult(self.body()))
+			.field(
+				"while_token",
+				&support::DebugSyntaxResult(self.while_token()),
+			)
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("test", &support::DebugSyntaxResult(self.test()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_WHILE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3553,25 +3004,30 @@ impl AstNode for JsWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsWhileStatement")
-			.field("while_token", &self.while_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("test", &self.test())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("body", &self.body())
+			.field(
+				"while_token",
+				&support::DebugSyntaxResult(self.while_token()),
+			)
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("test", &support::DebugSyntaxResult(self.test()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for ForStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3579,27 +3035,29 @@ impl AstNode for ForStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForStmt")
-			.field("for_token", &self.for_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("init", &self.init())
-			.field("test", &self.test())
-			.field("update", &self.update())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("cons", &self.cons())
+			.field("for_token", &support::DebugSyntaxResult(self.for_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("init", &support::DebugOptionalNode(self.init()))
+			.field("test", &support::DebugOptionalNode(self.test()))
+			.field("update", &support::DebugOptionalNode(self.update()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("cons", &support::DebugSyntaxResult(self.cons()))
 			.finish()
 	}
 }
 impl AstNode for ForInStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_IN_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_IN_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3607,27 +3065,29 @@ impl AstNode for ForInStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForInStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForInStmt")
-			.field("for_token", &self.for_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("left", &self.left())
-			.field("in_token", &self.in_token())
-			.field("right", &self.right())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("cons", &self.cons())
+			.field("for_token", &support::DebugSyntaxResult(self.for_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("left", &support::DebugSyntaxResult(self.left()))
+			.field("in_token", &support::DebugSyntaxResult(self.in_token()))
+			.field("right", &support::DebugSyntaxResult(self.right()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("cons", &support::DebugSyntaxResult(self.cons()))
 			.finish()
 	}
 }
 impl AstNode for ForOfStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_OF_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_OF_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3635,27 +3095,29 @@ impl AstNode for ForOfStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForOfStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForOfStmt")
-			.field("for_token", &self.for_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("left", &self.left())
-			.field("of_token", &self.of_token())
-			.field("right", &self.right())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("cons", &self.cons())
+			.field("for_token", &support::DebugSyntaxResult(self.for_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("left", &support::DebugSyntaxResult(self.left()))
+			.field("of_token", &support::DebugSyntaxResult(self.of_token()))
+			.field("right", &support::DebugSyntaxResult(self.right()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("cons", &support::DebugSyntaxResult(self.cons()))
 			.finish()
 	}
 }
 impl AstNode for JsContinueStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONTINUE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3663,23 +3125,28 @@ impl AstNode for JsContinueStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsContinueStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsContinueStatement")
-			.field("continue_token", &self.continue_token())
-			.field("label_token", &self.label_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"continue_token",
+				&support::DebugSyntaxResult(self.continue_token()),
+			)
+			.field(
+				"label_token",
+				&support::DebugOptionalNode(self.label_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsBreakStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BREAK_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3687,23 +3154,28 @@ impl AstNode for JsBreakStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBreakStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsBreakStatement")
-			.field("break_token", &self.break_token())
-			.field("label_token", &self.label_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"break_token",
+				&support::DebugSyntaxResult(self.break_token()),
+			)
+			.field(
+				"label_token",
+				&support::DebugOptionalNode(self.label_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsReturnStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_RETURN_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3711,23 +3183,25 @@ impl AstNode for JsReturnStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReturnStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsReturnStatement")
-			.field("return_token", &self.return_token())
-			.field("argument", &self.argument())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"return_token",
+				&support::DebugSyntaxResult(self.return_token()),
+			)
+			.field("argument", &support::DebugOptionalNode(self.argument()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsWithStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_WITH_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3735,25 +3209,27 @@ impl AstNode for JsWithStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsWithStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsWithStatement")
-			.field("with_token", &self.with_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("object", &self.object())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("body", &self.body())
+			.field("with_token", &support::DebugSyntaxResult(self.with_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("object", &support::DebugSyntaxResult(self.object()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsLabeledStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LABELED_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3761,23 +3237,25 @@ impl AstNode for JsLabeledStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLabeledStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsLabeledStatement")
-			.field("label_token", &self.label_token())
-			.field("colon_token", &self.colon_token())
-			.field("body", &self.body())
+			.field(
+				"label_token",
+				&support::DebugSyntaxResult(self.label_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsSwitchStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SWITCH_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3785,27 +3263,41 @@ impl AstNode for JsSwitchStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSwitchStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSwitchStatement")
-			.field("switch_token", &self.switch_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("discriminant", &self.discriminant())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"switch_token",
+				&support::DebugSyntaxResult(self.switch_token()),
+			)
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field(
+				"discriminant",
+				&support::DebugSyntaxResult(self.discriminant()),
+			)
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("cases", &self.cases())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsThrowStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_THROW_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3813,23 +3305,25 @@ impl AstNode for JsThrowStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsThrowStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsThrowStatement")
-			.field("throw_token", &self.throw_token())
-			.field("argument", &self.argument())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"throw_token",
+				&support::DebugSyntaxResult(self.throw_token()),
+			)
+			.field("argument", &support::DebugSyntaxResult(self.argument()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsTryStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_TRY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3837,23 +3331,22 @@ impl AstNode for JsTryStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsTryStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsTryStatement")
-			.field("try_token", &self.try_token())
-			.field("body", &self.body())
-			.field("catch_clause", &self.catch_clause())
+			.field("try_token", &support::DebugSyntaxResult(self.try_token()))
+			.field("body", &support::DebugSyntaxResult(self.body()))
+			.field(
+				"catch_clause",
+				&support::DebugSyntaxResult(self.catch_clause()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsTryFinallyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_TRY_FINALLY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3861,24 +3354,26 @@ impl AstNode for JsTryFinallyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsTryFinallyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsTryFinallyStatement")
-			.field("try_token", &self.try_token())
-			.field("body", &self.body())
-			.field("catch_clause", &self.catch_clause())
-			.field("finally_clause", &self.finally_clause())
+			.field("try_token", &support::DebugSyntaxResult(self.try_token()))
+			.field("body", &support::DebugSyntaxResult(self.body()))
+			.field(
+				"catch_clause",
+				&support::DebugOptionalNode(self.catch_clause()),
+			)
+			.field(
+				"finally_clause",
+				&support::DebugSyntaxResult(self.finally_clause()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsDebuggerStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DEBUGGER_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3886,22 +3381,24 @@ impl AstNode for JsDebuggerStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDebuggerStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsDebuggerStatement")
-			.field("debugger_token", &self.debugger_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"debugger_token",
+				&support::DebugSyntaxResult(self.debugger_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsFunctionDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3909,28 +3406,39 @@ impl AstNode for JsFunctionDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsFunctionDeclaration")
-			.field("async_token", &self.async_token())
-			.field("function_token", &self.function_token())
-			.field("star_token", &self.star_token())
-			.field("id", &self.id())
-			.field("type_parameters", &self.type_parameters())
-			.field("parameter_list", &self.parameter_list())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field(
+				"async_token",
+				&support::DebugOptionalNode(self.async_token()),
+			)
+			.field(
+				"function_token",
+				&support::DebugSyntaxResult(self.function_token()),
+			)
+			.field("star_token", &support::DebugOptionalNode(self.star_token()))
+			.field("id", &support::DebugSyntaxResult(self.id()))
+			.field(
+				"type_parameters",
+				&support::DebugOptionalNode(self.type_parameters()),
+			)
+			.field(
+				"parameter_list",
+				&support::DebugSyntaxResult(self.parameter_list()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsClassDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CLASS_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3938,27 +3446,38 @@ impl AstNode for JsClassDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsClassDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsClassDeclaration")
-			.field("class_token", &self.class_token())
-			.field("id", &self.id())
-			.field("implements_clause", &self.implements_clause())
-			.field("extends_clause", &self.extends_clause())
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"class_token",
+				&support::DebugSyntaxResult(self.class_token()),
+			)
+			.field("id", &support::DebugSyntaxResult(self.id()))
+			.field(
+				"implements_clause",
+				&support::DebugOptionalNode(self.implements_clause()),
+			)
+			.field(
+				"extends_clause",
+				&support::DebugOptionalNode(self.extends_clause()),
+			)
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsVariableDeclarationStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATION_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3966,22 +3485,24 @@ impl AstNode for JsVariableDeclarationStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclarationStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsVariableDeclarationStatement")
-			.field("declaration", &self.declaration())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"declaration",
+				&support::DebugSyntaxResult(self.declaration()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsEnum {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ENUM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3989,26 +3510,31 @@ impl AstNode for TsEnum {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsEnum {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsEnum")
-			.field("const_token", &self.const_token())
-			.field("enum_token", &self.enum_token())
-			.field("ident", &self.ident())
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"const_token",
+				&support::DebugOptionalNode(self.const_token()),
+			)
+			.field("enum_token", &support::DebugSyntaxResult(self.enum_token()))
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeAliasDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ALIAS_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4016,24 +3542,23 @@ impl AstNode for TsTypeAliasDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeAliasDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeAliasDecl")
-			.field("type_token", &self.type_token())
-			.field("type_params", &self.type_params())
-			.field("eq_token", &self.eq_token())
-			.field("ty", &self.ty())
+			.field("type_token", &support::DebugSyntaxResult(self.type_token()))
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsNamespaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NAMESPACE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4041,24 +3566,23 @@ impl AstNode for TsNamespaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNamespaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNamespaceDecl")
-			.field("declare_token", &self.declare_token())
-			.field("ident", &self.ident())
-			.field("dot_token", &self.dot_token())
-			.field("body", &self.body())
+			.field(
+				"declare_token",
+				&support::DebugSyntaxResult(self.declare_token()),
+			)
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field("dot_token", &support::DebugOptionalNode(self.dot_token()))
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for TsModuleDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MODULE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4066,26 +3590,31 @@ impl AstNode for TsModuleDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsModuleDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsModuleDecl")
-			.field("declare_token", &self.declare_token())
-			.field("global_token", &self.global_token())
-			.field("module_token", &self.module_token())
-			.field("dot_token", &self.dot_token())
-			.field("ident", &self.ident())
-			.field("body", &self.body())
+			.field(
+				"declare_token",
+				&support::DebugSyntaxResult(self.declare_token()),
+			)
+			.field(
+				"global_token",
+				&support::DebugOptionalNode(self.global_token()),
+			)
+			.field(
+				"module_token",
+				&support::DebugSyntaxResult(self.module_token()),
+			)
+			.field("dot_token", &support::DebugOptionalNode(self.dot_token()))
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for TsInterfaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INTERFACE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4093,28 +3622,42 @@ impl AstNode for TsInterfaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsInterfaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsInterfaceDecl")
-			.field("declare_token", &self.declare_token())
-			.field("interface_token", &self.interface_token())
-			.field("type_params", &self.type_params())
-			.field("extends_token", &self.extends_token())
-			.field("extends", &self.extends())
-			.field("l_curly_token", &self.l_curly_token())
-			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"declare_token",
+				&support::DebugOptionalNode(self.declare_token()),
+			)
+			.field(
+				"interface_token",
+				&support::DebugSyntaxResult(self.interface_token()),
+			)
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
+			.field(
+				"extends_token",
+				&support::DebugOptionalNode(self.extends_token()),
+			)
+			.field("extends", &support::DebugOptionalNode(self.extends()))
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
+			.field("members", &support::DebugSyntaxResult(self.members()))
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ImportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4122,28 +3665,39 @@ impl AstNode for ImportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ImportDecl")
-			.field("import_token", &self.import_token())
+			.field(
+				"import_token",
+				&support::DebugSyntaxResult(self.import_token()),
+			)
 			.field("imports", &self.imports())
-			.field("type_token", &self.type_token())
-			.field("from_token", &self.from_token())
-			.field("source_token", &self.source_token())
-			.field("asserted_object", &self.asserted_object())
-			.field("assert_token", &self.assert_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field("from_token", &support::DebugSyntaxResult(self.from_token()))
+			.field(
+				"source_token",
+				&support::DebugSyntaxResult(self.source_token()),
+			)
+			.field(
+				"asserted_object",
+				&support::DebugSyntaxResult(self.asserted_object()),
+			)
+			.field(
+				"assert_token",
+				&support::DebugOptionalNode(self.assert_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ExportNamed {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_NAMED
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_NAMED }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4151,26 +3705,31 @@ impl AstNode for ExportNamed {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportNamed {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExportNamed")
-			.field("export_token", &self.export_token())
-			.field("type_token", &self.type_token())
-			.field("from_token", &self.from_token())
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field("from_token", &support::DebugOptionalNode(self.from_token()))
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("specifiers", &self.specifiers())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ExportDefaultDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DEFAULT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4178,24 +3737,26 @@ impl AstNode for ExportDefaultDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDefaultDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExportDefaultDecl")
-			.field("export_token", &self.export_token())
-			.field("default_token", &self.default_token())
-			.field("type_token", &self.type_token())
-			.field("decl", &self.decl())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field(
+				"default_token",
+				&support::DebugOptionalNode(self.default_token()),
+			)
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field("decl", &support::DebugSyntaxResult(self.decl()))
 			.finish()
 	}
 }
 impl AstNode for ExportDefaultExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DEFAULT_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4203,24 +3764,26 @@ impl AstNode for ExportDefaultExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDefaultExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExportDefaultExpr")
-			.field("export_token", &self.export_token())
-			.field("type_token", &self.type_token())
-			.field("default_token", &self.default_token())
-			.field("expr", &self.expr())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field(
+				"default_token",
+				&support::DebugOptionalNode(self.default_token()),
+			)
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
 			.finish()
 	}
 }
 impl AstNode for ExportWildcard {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_WILDCARD
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_WILDCARD }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4228,27 +3791,29 @@ impl AstNode for ExportWildcard {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportWildcard {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExportWildcard")
-			.field("export_token", &self.export_token())
-			.field("type_token", &self.type_token())
-			.field("star_token", &self.star_token())
-			.field("as_token", &self.as_token())
-			.field("ident", &self.ident())
-			.field("from_token", &self.from_token())
-			.field("source_token", &self.source_token())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field("star_token", &support::DebugSyntaxResult(self.star_token()))
+			.field("as_token", &support::DebugOptionalNode(self.as_token()))
+			.field("ident", &support::DebugOptionalNode(self.ident()))
+			.field("from_token", &support::DebugSyntaxResult(self.from_token()))
+			.field(
+				"source_token",
+				&support::DebugSyntaxResult(self.source_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4256,23 +3821,22 @@ impl AstNode for ExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExportDecl")
-			.field("export_token", &self.export_token())
-			.field("type_token", &self.type_token())
-			.field("decl", &self.decl())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("type_token", &support::DebugOptionalNode(self.type_token()))
+			.field("decl", &support::DebugSyntaxResult(self.decl()))
 			.finish()
 	}
 }
 impl AstNode for TsImportEqualsDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPORT_EQUALS_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4280,26 +3844,31 @@ impl AstNode for TsImportEqualsDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImportEqualsDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsImportEqualsDecl")
-			.field("import_token", &self.import_token())
-			.field("export_token", &self.export_token())
-			.field("ident", &self.ident())
-			.field("eq_token", &self.eq_token())
-			.field("module", &self.module())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"import_token",
+				&support::DebugSyntaxResult(self.import_token()),
+			)
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("module", &support::DebugSyntaxResult(self.module()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsExportAssignment {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXPORT_ASSIGNMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4307,24 +3876,26 @@ impl AstNode for TsExportAssignment {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExportAssignment {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsExportAssignment")
-			.field("export_token", &self.export_token())
-			.field("eq_token", &self.eq_token())
-			.field("expr", &self.expr())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsNamespaceExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NAMESPACE_EXPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_EXPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4332,25 +3903,30 @@ impl AstNode for TsNamespaceExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNamespaceExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNamespaceExportDecl")
-			.field("export_token", &self.export_token())
-			.field("as_token", &self.as_token())
-			.field("namespace_token", &self.namespace_token())
-			.field("ident", &self.ident())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"export_token",
+				&support::DebugSyntaxResult(self.export_token()),
+			)
+			.field("as_token", &support::DebugSyntaxResult(self.as_token()))
+			.field(
+				"namespace_token",
+				&support::DebugSyntaxResult(self.namespace_token()),
+			)
+			.field("ident", &support::DebugOptionalNode(self.ident()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsElseClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ELSE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4358,22 +3934,18 @@ impl AstNode for JsElseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsElseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsElseClause")
-			.field("else_token", &self.else_token())
-			.field("alternate", &self.alternate())
+			.field("else_token", &support::DebugSyntaxResult(self.else_token()))
+			.field("alternate", &support::DebugSyntaxResult(self.alternate()))
 			.finish()
 	}
 }
 impl AstNode for ForStmtInit {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_INIT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_INIT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4381,22 +3953,21 @@ impl AstNode for ForStmtInit {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtInit {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForStmtInit")
-			.field("inner", &self.inner())
-			.field("semicolon_token", &self.semicolon_token())
+			.field("inner", &support::DebugSyntaxResult(self.inner()))
+			.field(
+				"semicolon_token",
+				&support::DebugSyntaxResult(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ForStmtTest {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_TEST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_TEST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4404,22 +3975,21 @@ impl AstNode for ForStmtTest {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtTest {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForStmtTest")
-			.field("expr", &self.expr())
-			.field("semicolon_token", &self.semicolon_token())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
+			.field(
+				"semicolon_token",
+				&support::DebugSyntaxResult(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ForStmtUpdate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_UPDATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_UPDATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4427,21 +3997,17 @@ impl AstNode for ForStmtUpdate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtUpdate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ForStmtUpdate")
-			.field("expr", &self.expr())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
 			.finish()
 	}
 }
 impl AstNode for JsVariableDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4449,22 +4015,18 @@ impl AstNode for JsVariableDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsVariableDeclaration")
-			.field("kind_token", &self.kind_token())
+			.field("kind_token", &support::DebugSyntaxResult(self.kind_token()))
 			.field("declarators", &self.declarators())
 			.finish()
 	}
 }
 impl AstNode for JsCaseClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CASE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4472,24 +4034,23 @@ impl AstNode for JsCaseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCaseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsCaseClause")
-			.field("case_token", &self.case_token())
-			.field("test", &self.test())
-			.field("colon_token", &self.colon_token())
+			.field("case_token", &support::DebugSyntaxResult(self.case_token()))
+			.field("test", &support::DebugSyntaxResult(self.test()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
 			.field("consequent", &self.consequent())
 			.finish()
 	}
 }
 impl AstNode for JsDefaultClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DEFAULT_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4497,23 +4058,25 @@ impl AstNode for JsDefaultClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDefaultClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsDefaultClause")
-			.field("default_token", &self.default_token())
-			.field("colon_token", &self.colon_token())
+			.field(
+				"default_token",
+				&support::DebugSyntaxResult(self.default_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
 			.field("consequent", &self.consequent())
 			.finish()
 	}
 }
 impl AstNode for JsCatchClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CATCH_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4521,23 +4084,25 @@ impl AstNode for JsCatchClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCatchClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsCatchClause")
-			.field("catch_token", &self.catch_token())
-			.field("declaration", &self.declaration())
-			.field("body", &self.body())
+			.field(
+				"catch_token",
+				&support::DebugSyntaxResult(self.catch_token()),
+			)
+			.field(
+				"declaration",
+				&support::DebugOptionalNode(self.declaration()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsFinallyClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FINALLY_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4545,22 +4110,21 @@ impl AstNode for JsFinallyClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFinallyClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsFinallyClause")
-			.field("finally_token", &self.finally_token())
-			.field("body", &self.body())
+			.field(
+				"finally_token",
+				&support::DebugSyntaxResult(self.finally_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsCatchDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CATCH_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4568,23 +4132,25 @@ impl AstNode for JsCatchDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCatchDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsCatchDeclaration")
-			.field("l_paren_token", &self.l_paren_token())
-			.field("binding", &self.binding())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("binding", &support::DebugSyntaxResult(self.binding()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsArrayExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARRAY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4592,23 +4158,25 @@ impl AstNode for JsArrayExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrayExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsArrayExpression")
-			.field("l_brack_token", &self.l_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
 			.field("elements", &self.elements())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsArrowFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARROW_FUNCTION_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4616,25 +4184,36 @@ impl AstNode for JsArrowFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrowFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsArrowFunctionExpression")
-			.field("async_token", &self.async_token())
-			.field("type_parameters", &self.type_parameters())
-			.field("parameter_list", &self.parameter_list())
-			.field("fat_arrow_token", &self.fat_arrow_token())
-			.field("return_type", &self.return_type())
+			.field(
+				"async_token",
+				&support::DebugOptionalNode(self.async_token()),
+			)
+			.field(
+				"type_parameters",
+				&support::DebugOptionalNode(self.type_parameters()),
+			)
+			.field(
+				"parameter_list",
+				&support::DebugOptionalNode(self.parameter_list()),
+			)
+			.field(
+				"fat_arrow_token",
+				&support::DebugSyntaxResult(self.fat_arrow_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsAwaitExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_AWAIT_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4642,22 +4221,21 @@ impl AstNode for JsAwaitExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsAwaitExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsAwaitExpression")
-			.field("await_token", &self.await_token())
-			.field("argument", &self.argument())
+			.field(
+				"await_token",
+				&support::DebugSyntaxResult(self.await_token()),
+			)
+			.field("argument", &support::DebugSyntaxResult(self.argument()))
 			.finish()
 	}
 }
 impl AstNode for JsBinaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BINARY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4665,22 +4243,18 @@ impl AstNode for JsBinaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBinaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsBinaryExpression")
-			.field("left", &self.left())
-			.field("operator", &self.operator())
+			.field("left", &support::DebugSyntaxResult(self.left()))
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
 			.finish()
 	}
 }
 impl AstNode for JsClassExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CLASS_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4688,26 +4262,34 @@ impl AstNode for JsClassExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsClassExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsClassExpression")
-			.field("class_token", &self.class_token())
-			.field("id", &self.id())
-			.field("extends_clause", &self.extends_clause())
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"class_token",
+				&support::DebugSyntaxResult(self.class_token()),
+			)
+			.field("id", &support::DebugOptionalNode(self.id()))
+			.field(
+				"extends_clause",
+				&support::DebugOptionalNode(self.extends_clause()),
+			)
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsConditionalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONDITIONAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4715,23 +4297,25 @@ impl AstNode for JsConditionalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConditionalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsConditionalExpression")
-			.field("test", &self.test())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("colon_token", &self.colon_token())
+			.field("test", &support::DebugSyntaxResult(self.test()))
+			.field(
+				"question_mark_token",
+				&support::DebugSyntaxResult(self.question_mark_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsComputedMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_COMPUTED_MEMBER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4739,27 +4323,29 @@ impl AstNode for JsComputedMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsComputedMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsComputedMemberExpression")
-			.field("object", &self.object())
+			.field("object", &support::DebugSyntaxResult(self.object()))
 			.field(
 				"optional_chain_token_token",
-				&self.optional_chain_token_token(),
+				&support::DebugOptionalNode(self.optional_chain_token_token()),
 			)
-			.field("l_brack_token", &self.l_brack_token())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4767,28 +4353,36 @@ impl AstNode for JsFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsFunctionExpression")
-			.field("async_token", &self.async_token())
-			.field("function_token", &self.function_token())
-			.field("star_token", &self.star_token())
-			.field("id", &self.id())
-			.field("type_parameters", &self.type_parameters())
-			.field("parameters", &self.parameters())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field(
+				"async_token",
+				&support::DebugOptionalNode(self.async_token()),
+			)
+			.field(
+				"function_token",
+				&support::DebugSyntaxResult(self.function_token()),
+			)
+			.field("star_token", &support::DebugOptionalNode(self.star_token()))
+			.field("id", &support::DebugOptionalNode(self.id()))
+			.field(
+				"type_parameters",
+				&support::DebugOptionalNode(self.type_parameters()),
+			)
+			.field("parameters", &support::DebugSyntaxResult(self.parameters()))
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsImportCallExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IMPORT_CALL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4796,24 +4390,29 @@ impl AstNode for JsImportCallExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsImportCallExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsImportCallExpression")
-			.field("import_token", &self.import_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("argument", &self.argument())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"import_token",
+				&support::DebugSyntaxResult(self.import_token()),
+			)
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("argument", &support::DebugSyntaxResult(self.argument()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsLogicalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LOGICAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4821,22 +4420,18 @@ impl AstNode for JsLogicalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLogicalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsLogicalExpression")
-			.field("left", &self.left())
-			.field("operator", &self.operator())
+			.field("left", &support::DebugSyntaxResult(self.left()))
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
 			.finish()
 	}
 }
 impl AstNode for JsObjectExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_OBJECT_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4844,23 +4439,25 @@ impl AstNode for JsObjectExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsObjectExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsObjectExpression")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsParenthesizedExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PARENTHESIZED_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4868,23 +4465,25 @@ impl AstNode for JsParenthesizedExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsParenthesizedExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsParenthesizedExpression")
-			.field("l_paren_token", &self.l_paren_token())
-			.field("expression", &self.expression())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("expression", &support::DebugSyntaxResult(self.expression()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsReferenceIdentifierExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_IDENTIFIER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4892,21 +4491,17 @@ impl AstNode for JsReferenceIdentifierExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferenceIdentifierExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsReferenceIdentifierExpression")
-			.field("name_token", &self.name_token())
+			.field("name_token", &support::DebugSyntaxResult(self.name_token()))
 			.finish()
 	}
 }
 impl AstNode for JsSequenceExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SEQUENCE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4914,22 +4509,21 @@ impl AstNode for JsSequenceExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSequenceExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSequenceExpression")
-			.field("left", &self.left())
-			.field("comma_token", &self.comma_token())
+			.field("left", &support::DebugSyntaxResult(self.left()))
+			.field(
+				"comma_token",
+				&support::DebugSyntaxResult(self.comma_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsStaticMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_STATIC_MEMBER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4937,23 +4531,19 @@ impl AstNode for JsStaticMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsStaticMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsStaticMemberExpression")
-			.field("object", &self.object())
-			.field("operator", &self.operator())
-			.field("member", &self.member())
+			.field("object", &support::DebugSyntaxResult(self.object()))
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
+			.field("member", &support::DebugSyntaxResult(self.member()))
 			.finish()
 	}
 }
 impl AstNode for JsSuperExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SUPER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4961,21 +4551,20 @@ impl AstNode for JsSuperExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSuperExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSuperExpression")
-			.field("super_token", &self.super_token())
+			.field(
+				"super_token",
+				&support::DebugSyntaxResult(self.super_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsThisExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_THIS_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4983,21 +4572,17 @@ impl AstNode for JsThisExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsThisExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsThisExpression")
-			.field("this_token", &self.this_token())
+			.field("this_token", &support::DebugSyntaxResult(self.this_token()))
 			.finish()
 	}
 }
 impl AstNode for JsUnaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNARY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5005,22 +4590,18 @@ impl AstNode for JsUnaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsUnaryExpression")
-			.field("operator", &self.operator())
-			.field("argument", &self.argument())
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
+			.field("argument", &support::DebugSyntaxResult(self.argument()))
 			.finish()
 	}
 }
 impl AstNode for JsPreUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PRE_UPDATE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5028,22 +4609,18 @@ impl AstNode for JsPreUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPreUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsPreUpdateExpression")
-			.field("operator", &self.operator())
-			.field("operand", &self.operand())
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
+			.field("operand", &support::DebugSyntaxResult(self.operand()))
 			.finish()
 	}
 }
 impl AstNode for JsPostUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_POST_UPDATE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5051,22 +4628,18 @@ impl AstNode for JsPostUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPostUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsPostUpdateExpression")
-			.field("operand", &self.operand())
-			.field("operator", &self.operator())
+			.field("operand", &support::DebugSyntaxResult(self.operand()))
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
 			.finish()
 	}
 }
 impl AstNode for JsYieldExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_YIELD_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5074,23 +4647,22 @@ impl AstNode for JsYieldExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsYieldExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsYieldExpression")
-			.field("yield_token", &self.yield_token())
-			.field("star_token", &self.star_token())
-			.field("argument", &self.argument())
+			.field(
+				"yield_token",
+				&support::DebugSyntaxResult(self.yield_token()),
+			)
+			.field("star_token", &support::DebugOptionalNode(self.star_token()))
+			.field("argument", &support::DebugOptionalNode(self.argument()))
 			.finish()
 	}
 }
 impl AstNode for Template {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TEMPLATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TEMPLATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5098,21 +4670,20 @@ impl AstNode for Template {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Template {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Template")
-			.field("backtick_token", &self.backtick_token())
+			.field(
+				"backtick_token",
+				&support::DebugSyntaxResult(self.backtick_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for NewExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NEW_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5120,24 +4691,20 @@ impl AstNode for NewExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NewExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("NewExpr")
-			.field("new_token", &self.new_token())
-			.field("type_args", &self.type_args())
-			.field("object", &self.object())
-			.field("arguments", &self.arguments())
+			.field("new_token", &support::DebugSyntaxResult(self.new_token()))
+			.field("type_args", &support::DebugOptionalNode(self.type_args()))
+			.field("object", &support::DebugSyntaxResult(self.object()))
+			.field("arguments", &support::DebugSyntaxResult(self.arguments()))
 			.finish()
 	}
 }
 impl AstNode for CallExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == CALL_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == CALL_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5145,23 +4712,19 @@ impl AstNode for CallExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for CallExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("CallExpr")
-			.field("type_args", &self.type_args())
-			.field("callee", &self.callee())
-			.field("arguments", &self.arguments())
+			.field("type_args", &support::DebugOptionalNode(self.type_args()))
+			.field("callee", &support::DebugSyntaxResult(self.callee()))
+			.field("arguments", &support::DebugSyntaxResult(self.arguments()))
 			.finish()
 	}
 }
 impl AstNode for AssignExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ASSIGN_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5169,21 +4732,17 @@ impl AstNode for AssignExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for AssignExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("AssignExpr")
-			.field("operator", &self.operator())
+			.field("operator", &support::DebugSyntaxResult(self.operator()))
 			.finish()
 	}
 }
 impl AstNode for NewTarget {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NEW_TARGET
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5191,23 +4750,22 @@ impl AstNode for NewTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NewTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("NewTarget")
-			.field("new_token", &self.new_token())
-			.field("dot_token", &self.dot_token())
-			.field("target_token", &self.target_token())
+			.field("new_token", &support::DebugSyntaxResult(self.new_token()))
+			.field("dot_token", &support::DebugSyntaxResult(self.dot_token()))
+			.field(
+				"target_token",
+				&support::DebugSyntaxResult(self.target_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ImportMeta {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_META
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5215,22 +4773,21 @@ impl AstNode for ImportMeta {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportMeta {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ImportMeta")
-			.field("import_token", &self.import_token())
-			.field("dot_token", &self.dot_token())
+			.field(
+				"import_token",
+				&support::DebugSyntaxResult(self.import_token()),
+			)
+			.field("dot_token", &support::DebugSyntaxResult(self.dot_token()))
 			.finish()
 	}
 }
 impl AstNode for TsNonNull {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NON_NULL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5238,22 +4795,18 @@ impl AstNode for TsNonNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNonNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNonNull")
-			.field("expr", &self.expr())
-			.field("excl_token", &self.excl_token())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
+			.field("excl_token", &support::DebugSyntaxResult(self.excl_token()))
 			.finish()
 	}
 }
 impl AstNode for TsAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ASSERTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5261,25 +4814,27 @@ impl AstNode for TsAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsAssertion")
-			.field("expr", &self.expr())
-			.field("ident", &self.ident())
-			.field("l_angle_token", &self.l_angle_token())
-			.field("ty", &self.ty())
-			.field("r_angle_token", &self.r_angle_token())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field(
+				"l_angle_token",
+				&support::DebugSyntaxResult(self.l_angle_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_angle_token",
+				&support::DebugSyntaxResult(self.r_angle_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsConstAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONST_ASSERTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONST_ASSERTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5287,25 +4842,30 @@ impl AstNode for TsConstAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConstAssertion")
-			.field("expr", &self.expr())
-			.field("ident", &self.ident())
-			.field("l_angle_token", &self.l_angle_token())
-			.field("const_token", &self.const_token())
-			.field("r_angle_token", &self.r_angle_token())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field(
+				"l_angle_token",
+				&support::DebugSyntaxResult(self.l_angle_token()),
+			)
+			.field(
+				"const_token",
+				&support::DebugSyntaxResult(self.const_token()),
+			)
+			.field(
+				"r_angle_token",
+				&support::DebugSyntaxResult(self.r_angle_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ARGS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5313,23 +4873,25 @@ impl AstNode for TsTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeArgs")
-			.field("l_angle_token", &self.l_angle_token())
-			.field("args", &self.args())
-			.field("r_angle_token", &self.r_angle_token())
+			.field(
+				"l_angle_token",
+				&support::DebugSyntaxResult(self.l_angle_token()),
+			)
+			.field("args", &support::DebugSyntaxResult(self.args()))
+			.field(
+				"r_angle_token",
+				&support::DebugSyntaxResult(self.r_angle_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ArgList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ARG_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ARG_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5337,23 +4899,25 @@ impl AstNode for ArgList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ArgList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ArgList")
-			.field("l_paren_token", &self.l_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
 			.field("args", &self.args())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsIdentifierBinding {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IDENTIFIER_BINDING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5361,21 +4925,17 @@ impl AstNode for JsIdentifierBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsIdentifierBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsIdentifierBinding")
-			.field("name_token", &self.name_token())
+			.field("name_token", &support::DebugSyntaxResult(self.name_token()))
 			.finish()
 	}
 }
 impl AstNode for TsTypeParams {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_PARAMS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5383,23 +4943,25 @@ impl AstNode for TsTypeParams {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeParams {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeParams")
-			.field("l_angle_token", &self.l_angle_token())
-			.field("params", &self.params())
-			.field("r_angle_token", &self.r_angle_token())
+			.field(
+				"l_angle_token",
+				&support::DebugOptionalNode(self.l_angle_token()),
+			)
+			.field("params", &support::DebugSyntaxResult(self.params()))
+			.field(
+				"r_angle_token",
+				&support::DebugOptionalNode(self.r_angle_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PARAMETER_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5407,23 +4969,25 @@ impl AstNode for JsParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsParameterList")
-			.field("l_paren_token", &self.l_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
 			.field("parameters", &self.parameters())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeAnnotation {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ANNOTATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5431,22 +4995,21 @@ impl AstNode for TsTypeAnnotation {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeAnnotation {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeAnnotation")
-			.field("colon_token", &self.colon_token())
-			.field("ty", &self.ty())
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for JsFunctionBody {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_BODY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5454,24 +5017,26 @@ impl AstNode for JsFunctionBody {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionBody {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsFunctionBody")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("directives", &self.directives())
 			.field("statements", &self.statements())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for SpreadElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SPREAD_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SPREAD_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5479,22 +5044,21 @@ impl AstNode for SpreadElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for SpreadElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("SpreadElement")
-			.field("dotdotdot_token", &self.dotdotdot_token())
-			.field("element", &self.element())
+			.field(
+				"dotdotdot_token",
+				&support::DebugSyntaxResult(self.dotdotdot_token()),
+			)
+			.field("element", &support::DebugSyntaxResult(self.element()))
 			.finish()
 	}
 }
 impl AstNode for JsArrayHole {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARRAY_HOLE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5502,9 +5066,7 @@ impl AstNode for JsArrayHole {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrayHole {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5512,9 +5074,7 @@ impl std::fmt::Debug for JsArrayHole {
 	}
 }
 impl AstNode for JsLiteralMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LITERAL_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5522,21 +5082,17 @@ impl AstNode for JsLiteralMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLiteralMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsLiteralMemberName")
-			.field("value", &self.value())
+			.field("value", &support::DebugSyntaxResult(self.value()))
 			.finish()
 	}
 }
 impl AstNode for JsComputedMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_COMPUTED_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5544,23 +5100,25 @@ impl AstNode for JsComputedMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsComputedMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsComputedMemberName")
-			.field("l_brack_token", &self.l_brack_token())
-			.field("expression", &self.expression())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field("expression", &support::DebugSyntaxResult(self.expression()))
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PROPERTY_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5568,22 +5126,21 @@ impl AstNode for JsPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsPropertyObjectMember")
-			.field("name", &self.name())
-			.field("colon_token", &self.colon_token())
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsMethodObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_METHOD_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5591,27 +5148,35 @@ impl AstNode for JsMethodObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsMethodObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsMethodObjectMember")
-			.field("async_token", &self.async_token())
-			.field("star_token", &self.star_token())
-			.field("name", &self.name())
-			.field("type_params", &self.type_params())
-			.field("parameter_list", &self.parameter_list())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field(
+				"async_token",
+				&support::DebugOptionalNode(self.async_token()),
+			)
+			.field("star_token", &support::DebugOptionalNode(self.star_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"type_params",
+				&support::DebugOptionalNode(self.type_params()),
+			)
+			.field(
+				"parameter_list",
+				&support::DebugSyntaxResult(self.parameter_list()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsGetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_GETTER_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5619,26 +5184,31 @@ impl AstNode for JsGetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsGetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsGetterObjectMember")
-			.field("get_token", &self.get_token())
-			.field("name", &self.name())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field("get_token", &support::DebugSyntaxResult(self.get_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsSetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SETTER_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5646,26 +5216,28 @@ impl AstNode for JsSetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSetterObjectMember")
-			.field("set_token", &self.set_token())
-			.field("name", &self.name())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("parameter", &self.parameter())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("body", &self.body())
+			.field("set_token", &support::DebugSyntaxResult(self.set_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("parameter", &support::DebugSyntaxResult(self.parameter()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for InitializedProp {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == INITIALIZED_PROP
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == INITIALIZED_PROP }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5673,23 +5245,19 @@ impl AstNode for InitializedProp {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for InitializedProp {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("InitializedProp")
-			.field("key", &self.key())
-			.field("eq_token", &self.eq_token())
-			.field("value", &self.value())
+			.field("key", &support::DebugSyntaxResult(self.key()))
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("value", &support::DebugSyntaxResult(self.value()))
 			.finish()
 	}
 }
 impl AstNode for JsShorthandPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5697,21 +5265,17 @@ impl AstNode for JsShorthandPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsShorthandPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsShorthandPropertyObjectMember")
-			.field("name", &self.name())
+			.field("name", &support::DebugSyntaxResult(self.name()))
 			.finish()
 	}
 }
 impl AstNode for JsSpread {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SPREAD
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5719,22 +5283,21 @@ impl AstNode for JsSpread {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSpread {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSpread")
-			.field("dotdotdot_token", &self.dotdotdot_token())
-			.field("argument", &self.argument())
+			.field(
+				"dotdotdot_token",
+				&support::DebugSyntaxResult(self.dotdotdot_token()),
+			)
+			.field("argument", &support::DebugSyntaxResult(self.argument()))
 			.finish()
 	}
 }
 impl AstNode for JsStringLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_STRING_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5742,21 +5305,20 @@ impl AstNode for JsStringLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsStringLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsStringLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsNumberLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_NUMBER_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5764,21 +5326,20 @@ impl AstNode for JsNumberLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsNumberLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsNumberLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for Name {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5786,21 +5347,20 @@ impl AstNode for Name {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Name {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Name")
-			.field("ident_token", &self.ident_token())
+			.field(
+				"ident_token",
+				&support::DebugSyntaxResult(self.ident_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsImplementsClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPLEMENTS_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5808,22 +5368,21 @@ impl AstNode for TsImplementsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImplementsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsImplementsClause")
-			.field("implements_token", &self.implements_token())
+			.field(
+				"implements_token",
+				&support::DebugSyntaxResult(self.implements_token()),
+			)
 			.field("interfaces", &self.interfaces())
 			.finish()
 	}
 }
 impl AstNode for JsExtendsClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EXTENDS_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5831,22 +5390,24 @@ impl AstNode for JsExtendsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsExtendsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsExtendsClause")
-			.field("extends_token", &self.extends_token())
-			.field("super_class", &self.super_class())
+			.field(
+				"extends_token",
+				&support::DebugSyntaxResult(self.extends_token()),
+			)
+			.field(
+				"super_class",
+				&support::DebugSyntaxResult(self.super_class()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsExprWithTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXPR_WITH_TYPE_ARGS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPR_WITH_TYPE_ARGS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5854,22 +5415,21 @@ impl AstNode for TsExprWithTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExprWithTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsExprWithTypeArgs")
-			.field("item", &self.item())
-			.field("type_params", &self.type_params())
+			.field("item", &support::DebugSyntaxResult(self.item()))
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsPrivateClassMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PRIVATE_CLASS_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5877,22 +5437,18 @@ impl AstNode for JsPrivateClassMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPrivateClassMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsPrivateClassMemberName")
-			.field("hash_token", &self.hash_token())
-			.field("id_token", &self.id_token())
+			.field("hash_token", &support::DebugSyntaxResult(self.hash_token()))
+			.field("id_token", &support::DebugSyntaxResult(self.id_token()))
 			.finish()
 	}
 }
 impl AstNode for JsConstructorClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONSTRUCTOR_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5900,24 +5456,26 @@ impl AstNode for JsConstructorClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConstructorClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsConstructorClassMember")
-			.field("access_modifier", &self.access_modifier())
-			.field("name", &self.name())
-			.field("parameter_list", &self.parameter_list())
-			.field("body", &self.body())
+			.field(
+				"access_modifier",
+				&support::DebugOptionalNode(self.access_modifier()),
+			)
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"parameter_list",
+				&support::DebugSyntaxResult(self.parameter_list()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsPropertyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PROPERTY_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5925,30 +5483,44 @@ impl AstNode for JsPropertyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPropertyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsPropertyClassMember")
-			.field("declare_token", &self.declare_token())
-			.field("access_modifier", &self.access_modifier())
-			.field("abstract_token", &self.abstract_token())
-			.field("static_token", &self.static_token())
-			.field("name", &self.name())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("excl_token", &self.excl_token())
-			.field("ty", &self.ty())
-			.field("value", &self.value())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"declare_token",
+				&support::DebugOptionalNode(self.declare_token()),
+			)
+			.field(
+				"access_modifier",
+				&support::DebugOptionalNode(self.access_modifier()),
+			)
+			.field(
+				"abstract_token",
+				&support::DebugOptionalNode(self.abstract_token()),
+			)
+			.field(
+				"static_token",
+				&support::DebugOptionalNode(self.static_token()),
+			)
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"question_mark_token",
+				&support::DebugOptionalNode(self.question_mark_token()),
+			)
+			.field("excl_token", &support::DebugOptionalNode(self.excl_token()))
+			.field("ty", &support::DebugOptionalNode(self.ty()))
+			.field("value", &support::DebugOptionalNode(self.value()))
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsMethodClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_METHOD_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5956,30 +5528,47 @@ impl AstNode for JsMethodClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsMethodClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsMethodClassMember")
-			.field("access_modifier", &self.access_modifier())
-			.field("static_token", &self.static_token())
-			.field("abstract_token", &self.abstract_token())
-			.field("async_token", &self.async_token())
-			.field("star_token", &self.star_token())
-			.field("name", &self.name())
-			.field("type_parameters", &self.type_parameters())
-			.field("parameter_list", &self.parameter_list())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field(
+				"access_modifier",
+				&support::DebugOptionalNode(self.access_modifier()),
+			)
+			.field(
+				"static_token",
+				&support::DebugOptionalNode(self.static_token()),
+			)
+			.field(
+				"abstract_token",
+				&support::DebugOptionalNode(self.abstract_token()),
+			)
+			.field(
+				"async_token",
+				&support::DebugOptionalNode(self.async_token()),
+			)
+			.field("star_token", &support::DebugOptionalNode(self.star_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"type_parameters",
+				&support::DebugOptionalNode(self.type_parameters()),
+			)
+			.field(
+				"parameter_list",
+				&support::DebugSyntaxResult(self.parameter_list()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsGetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_GETTER_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5987,29 +5576,43 @@ impl AstNode for JsGetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsGetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsGetterClassMember")
-			.field("access_modifier", &self.access_modifier())
-			.field("abstract_token", &self.abstract_token())
-			.field("static_token", &self.static_token())
-			.field("get_token", &self.get_token())
-			.field("name", &self.name())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("return_type", &self.return_type())
-			.field("body", &self.body())
+			.field(
+				"access_modifier",
+				&support::DebugOptionalNode(self.access_modifier()),
+			)
+			.field(
+				"abstract_token",
+				&support::DebugOptionalNode(self.abstract_token()),
+			)
+			.field(
+				"static_token",
+				&support::DebugOptionalNode(self.static_token()),
+			)
+			.field("get_token", &support::DebugSyntaxResult(self.get_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsSetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SETTER_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6017,29 +5620,40 @@ impl AstNode for JsSetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsSetterClassMember")
-			.field("access_modifier", &self.access_modifier())
-			.field("abstract_token", &self.abstract_token())
-			.field("static_token", &self.static_token())
-			.field("set_token", &self.set_token())
-			.field("name", &self.name())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("parameter", &self.parameter())
-			.field("r_paren_token", &self.r_paren_token())
-			.field("body", &self.body())
+			.field(
+				"access_modifier",
+				&support::DebugOptionalNode(self.access_modifier()),
+			)
+			.field(
+				"abstract_token",
+				&support::DebugOptionalNode(self.abstract_token()),
+			)
+			.field(
+				"static_token",
+				&support::DebugOptionalNode(self.static_token()),
+			)
+			.field("set_token", &support::DebugSyntaxResult(self.set_token()))
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("parameter", &support::DebugSyntaxResult(self.parameter()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
+			.field("body", &support::DebugSyntaxResult(self.body()))
 			.finish()
 	}
 }
 impl AstNode for JsEmptyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EMPTY_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6047,21 +5661,20 @@ impl AstNode for JsEmptyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEmptyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsEmptyClassMember")
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"semicolon_token",
+				&support::DebugSyntaxResult(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsIndexSignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INDEX_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6069,26 +5682,34 @@ impl AstNode for TsIndexSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIndexSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsIndexSignature")
-			.field("readonly_token", &self.readonly_token())
-			.field("l_brack_token", &self.l_brack_token())
-			.field("pat", &self.pat())
-			.field("colon_token", &self.colon_token())
-			.field("ty", &self.ty())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"readonly_token",
+				&support::DebugOptionalNode(self.readonly_token()),
+			)
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field("pat", &support::DebugSyntaxResult(self.pat()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsAccessibility {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ACCESSIBILITY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6096,22 +5717,24 @@ impl AstNode for TsAccessibility {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAccessibility {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsAccessibility")
-			.field("private_token", &self.private_token())
-			.field("readonly_token", &self.readonly_token())
+			.field(
+				"private_token",
+				&support::DebugSyntaxResult(self.private_token()),
+			)
+			.field(
+				"readonly_token",
+				&support::DebugSyntaxResult(self.readonly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsConstructorParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONSTRUCTOR_PARAMETER_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6119,23 +5742,25 @@ impl AstNode for JsConstructorParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConstructorParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsConstructorParameterList")
-			.field("l_paren_token", &self.l_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
 			.field("parameters", &self.parameters())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsConstructorParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCTOR_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6143,22 +5768,21 @@ impl AstNode for TsConstructorParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructorParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConstructorParam")
-			.field("readonly_token", &self.readonly_token())
-			.field("pat", &self.pat())
+			.field(
+				"readonly_token",
+				&support::DebugSyntaxResult(self.readonly_token()),
+			)
+			.field("pat", &support::DebugSyntaxResult(self.pat()))
 			.finish()
 	}
 }
 impl AstNode for JsEqualValueClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EQUAL_VALUE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EQUAL_VALUE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6166,22 +5790,18 @@ impl AstNode for JsEqualValueClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEqualValueClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsEqualValueClause")
-			.field("eq_token", &self.eq_token())
-			.field("expression", &self.expression())
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("expression", &support::DebugSyntaxResult(self.expression()))
 			.finish()
 	}
 }
 impl AstNode for JsBigIntLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BIG_INT_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6189,21 +5809,20 @@ impl AstNode for JsBigIntLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBigIntLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsBigIntLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsBooleanLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BOOLEAN_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6211,21 +5830,20 @@ impl AstNode for JsBooleanLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBooleanLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsBooleanLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsNullLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_NULL_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6233,21 +5851,20 @@ impl AstNode for JsNullLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsNullLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsNullLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsRegexLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REGEX_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6255,21 +5872,20 @@ impl AstNode for JsRegexLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRegexLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsRegexLiteralExpression")
-			.field("value_token", &self.value_token())
+			.field(
+				"value_token",
+				&support::DebugSyntaxResult(self.value_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for SinglePattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SINGLE_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SINGLE_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6277,24 +5893,23 @@ impl AstNode for SinglePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for SinglePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("SinglePattern")
-			.field("name", &self.name())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("excl_token", &self.excl_token())
-			.field("ty", &self.ty())
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field(
+				"question_mark_token",
+				&support::DebugOptionalNode(self.question_mark_token()),
+			)
+			.field("excl_token", &support::DebugOptionalNode(self.excl_token()))
+			.field("ty", &support::DebugOptionalNode(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for RestPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == REST_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == REST_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6302,22 +5917,21 @@ impl AstNode for RestPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for RestPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("RestPattern")
-			.field("dotdotdot_token", &self.dotdotdot_token())
-			.field("pat", &self.pat())
+			.field(
+				"dotdotdot_token",
+				&support::DebugSyntaxResult(self.dotdotdot_token()),
+			)
+			.field("pat", &support::DebugSyntaxResult(self.pat()))
 			.finish()
 	}
 }
 impl AstNode for AssignPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ASSIGN_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6325,24 +5939,20 @@ impl AstNode for AssignPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for AssignPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("AssignPattern")
-			.field("key", &self.key())
-			.field("ty", &self.ty())
-			.field("eq_token", &self.eq_token())
-			.field("value", &self.value())
+			.field("key", &support::DebugSyntaxResult(self.key()))
+			.field("ty", &support::DebugOptionalNode(self.ty()))
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("value", &support::DebugSyntaxResult(self.value()))
 			.finish()
 	}
 }
 impl AstNode for ObjectPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == OBJECT_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6350,23 +5960,25 @@ impl AstNode for ObjectPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ObjectPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ObjectPattern")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("elements", &self.elements())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ArrayPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ARRAY_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ARRAY_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6374,25 +5986,27 @@ impl AstNode for ArrayPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ArrayPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ArrayPattern")
-			.field("l_brack_token", &self.l_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
 			.field("elements", &self.elements())
-			.field("r_brack_token", &self.r_brack_token())
-			.field("excl_token", &self.excl_token())
-			.field("ty", &self.ty())
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
+			.field("excl_token", &support::DebugSyntaxResult(self.excl_token()))
+			.field("ty", &support::DebugOptionalNode(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for ExprPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPR_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPR_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6400,21 +6014,17 @@ impl AstNode for ExprPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExprPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ExprPattern")
-			.field("expr", &self.expr())
+			.field("expr", &support::DebugSyntaxResult(self.expr()))
 			.finish()
 	}
 }
 impl AstNode for KeyValuePattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == KEY_VALUE_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == KEY_VALUE_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6422,22 +6032,21 @@ impl AstNode for KeyValuePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for KeyValuePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("KeyValuePattern")
-			.field("key", &self.key())
-			.field("colon_token", &self.colon_token())
+			.field("key", &support::DebugSyntaxResult(self.key()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for JsVariableDeclarator {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATOR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6445,22 +6054,18 @@ impl AstNode for JsVariableDeclarator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclarator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsVariableDeclarator")
-			.field("id", &self.id())
-			.field("init", &self.init())
+			.field("id", &support::DebugSyntaxResult(self.id()))
+			.field("init", &support::DebugOptionalNode(self.init()))
 			.finish()
 	}
 }
 impl AstNode for WildcardImport {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == WILDCARD_IMPORT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == WILDCARD_IMPORT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6468,23 +6073,19 @@ impl AstNode for WildcardImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for WildcardImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("WildcardImport")
-			.field("star_token", &self.star_token())
-			.field("as_token", &self.as_token())
-			.field("ident", &self.ident())
+			.field("star_token", &support::DebugSyntaxResult(self.star_token()))
+			.field("as_token", &support::DebugOptionalNode(self.as_token()))
+			.field("ident", &support::DebugOptionalNode(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for NamedImports {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NAMED_IMPORTS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NAMED_IMPORTS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6492,23 +6093,25 @@ impl AstNode for NamedImports {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NamedImports {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("NamedImports")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("specifiers", &self.specifiers())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for ImportStringSpecifier {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_STRING_SPECIFIER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_STRING_SPECIFIER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6516,21 +6119,20 @@ impl AstNode for ImportStringSpecifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportStringSpecifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("ImportStringSpecifier")
-			.field("source_token", &self.source_token())
+			.field(
+				"source_token",
+				&support::DebugSyntaxResult(self.source_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for Specifier {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SPECIFIER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SPECIFIER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6538,21 +6140,17 @@ impl AstNode for Specifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Specifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Specifier")
-			.field("name", &self.name())
+			.field("name", &support::DebugSyntaxResult(self.name()))
 			.finish()
 	}
 }
 impl AstNode for JsReferenceIdentifierMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_IDENTIFIER_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6560,21 +6158,17 @@ impl AstNode for JsReferenceIdentifierMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferenceIdentifierMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsReferenceIdentifierMember")
-			.field("name_token", &self.name_token())
+			.field("name_token", &support::DebugSyntaxResult(self.name_token()))
 			.finish()
 	}
 }
 impl AstNode for JsReferencePrivateMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_PRIVATE_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_PRIVATE_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6582,22 +6176,18 @@ impl AstNode for JsReferencePrivateMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferencePrivateMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsReferencePrivateMember")
-			.field("hash_token", &self.hash_token())
-			.field("name_token", &self.name_token())
+			.field("hash_token", &support::DebugSyntaxResult(self.hash_token()))
+			.field("name_token", &support::DebugSyntaxResult(self.name_token()))
 			.finish()
 	}
 }
 impl AstNode for JsRestParameter {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REST_PARAMETER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6605,22 +6195,21 @@ impl AstNode for JsRestParameter {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRestParameter {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("JsRestParameter")
-			.field("dotdotdot_token", &self.dotdotdot_token())
-			.field("binding", &self.binding())
+			.field(
+				"dotdotdot_token",
+				&support::DebugSyntaxResult(self.dotdotdot_token()),
+			)
+			.field("binding", &support::DebugSyntaxResult(self.binding()))
 			.finish()
 	}
 }
 impl AstNode for TsExternalModuleRef {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXTERNAL_MODULE_REF
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REF }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6628,24 +6217,32 @@ impl AstNode for TsExternalModuleRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExternalModuleRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsExternalModuleRef")
-			.field("require_token", &self.require_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("module_token", &self.module_token())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"require_token",
+				&support::DebugSyntaxResult(self.require_token()),
+			)
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field(
+				"module_token",
+				&support::DebugSyntaxResult(self.module_token()),
+			)
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsAny {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ANY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6653,21 +6250,17 @@ impl AstNode for TsAny {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAny {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsAny")
-			.field("any_token", &self.any_token())
+			.field("any_token", &support::DebugSyntaxResult(self.any_token()))
 			.finish()
 	}
 }
 impl AstNode for TsUnknown {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNKNOWN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6675,21 +6268,20 @@ impl AstNode for TsUnknown {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUnknown {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsUnknown")
-			.field("unknown_token", &self.unknown_token())
+			.field(
+				"unknown_token",
+				&support::DebugSyntaxResult(self.unknown_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsNumber {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NUMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6697,21 +6289,17 @@ impl AstNode for TsNumber {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNumber {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNumber")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsObject {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_OBJECT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6719,21 +6307,17 @@ impl AstNode for TsObject {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsObject {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsObject")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsBoolean {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_BOOLEAN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6741,21 +6325,17 @@ impl AstNode for TsBoolean {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsBoolean {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsBoolean")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsBigint {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_BIGINT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6763,21 +6343,17 @@ impl AstNode for TsBigint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsBigint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsBigint")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsString {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_STRING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6785,21 +6361,17 @@ impl AstNode for TsString {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsString {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsString")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsSymbol {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_SYMBOL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6807,21 +6379,17 @@ impl AstNode for TsSymbol {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsSymbol {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsSymbol")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsVoid {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_VOID
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6829,21 +6397,17 @@ impl AstNode for TsVoid {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsVoid {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsVoid")
-			.field("void_token", &self.void_token())
+			.field("void_token", &support::DebugSyntaxResult(self.void_token()))
 			.finish()
 	}
 }
 impl AstNode for TsUndefined {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNDEFINED
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6851,21 +6415,20 @@ impl AstNode for TsUndefined {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUndefined {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsUndefined")
-			.field("undefined_token", &self.undefined_token())
+			.field(
+				"undefined_token",
+				&support::DebugSyntaxResult(self.undefined_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsNull {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NULL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6873,21 +6436,17 @@ impl AstNode for TsNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNull")
-			.field("null_token", &self.null_token())
+			.field("null_token", &support::DebugSyntaxResult(self.null_token()))
 			.finish()
 	}
 }
 impl AstNode for TsNever {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NEVER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6895,21 +6454,20 @@ impl AstNode for TsNever {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNever {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsNever")
-			.field("never_token", &self.never_token())
+			.field(
+				"never_token",
+				&support::DebugSyntaxResult(self.never_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsThis {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_THIS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6917,21 +6475,17 @@ impl AstNode for TsThis {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsThis {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsThis")
-			.field("this_token", &self.this_token())
+			.field("this_token", &support::DebugSyntaxResult(self.this_token()))
 			.finish()
 	}
 }
 impl AstNode for TsLiteral {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_LITERAL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_LITERAL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6939,21 +6493,17 @@ impl AstNode for TsLiteral {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsLiteral {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsLiteral")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsPredicate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PREDICATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6961,22 +6511,18 @@ impl AstNode for TsPredicate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsPredicate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsPredicate")
-			.field("lhs", &self.lhs())
-			.field("rhs", &self.rhs())
+			.field("lhs", &support::DebugSyntaxResult(self.lhs()))
+			.field("rhs", &support::DebugSyntaxResult(self.rhs()))
 			.finish()
 	}
 }
 impl AstNode for TsTuple {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TUPLE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6984,23 +6530,25 @@ impl AstNode for TsTuple {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTuple {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTuple")
-			.field("l_brack_token", &self.l_brack_token())
-			.field("elements", &self.elements())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field("elements", &support::DebugSyntaxResult(self.elements()))
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsParen {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PAREN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PAREN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7008,23 +6556,25 @@ impl AstNode for TsParen {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsParen {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsParen")
-			.field("l_paren_token", &self.l_paren_token())
-			.field("ty", &self.ty())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeRef {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_REF
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_REF }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7032,22 +6582,18 @@ impl AstNode for TsTypeRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeRef")
-			.field("name", &self.name())
-			.field("type_args", &self.type_args())
+			.field("name", &support::DebugSyntaxResult(self.name()))
+			.field("type_args", &support::DebugSyntaxResult(self.type_args()))
 			.finish()
 	}
 }
 impl AstNode for TsTemplate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TEMPLATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7055,21 +6601,17 @@ impl AstNode for TsTemplate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTemplate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTemplate")
-			.field("elements", &self.elements())
+			.field("elements", &support::DebugSyntaxResult(self.elements()))
 			.finish()
 	}
 }
 impl AstNode for TsMappedType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7077,30 +6619,47 @@ impl AstNode for TsMappedType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsMappedType")
-			.field("l_curly_token", &self.l_curly_token())
-			.field("readonly_modifier", &self.readonly_modifier())
-			.field("minus_token", &self.minus_token())
-			.field("plus_token", &self.plus_token())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("param", &self.param())
-			.field("colon_token", &self.colon_token())
-			.field("ty", &self.ty())
-			.field("r_curly_token", &self.r_curly_token())
-			.field("semicolon_token", &self.semicolon_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
+			.field(
+				"readonly_modifier",
+				&support::DebugOptionalNode(self.readonly_modifier()),
+			)
+			.field(
+				"minus_token",
+				&support::DebugOptionalNode(self.minus_token()),
+			)
+			.field("plus_token", &support::DebugOptionalNode(self.plus_token()))
+			.field(
+				"question_mark_token",
+				&support::DebugOptionalNode(self.question_mark_token()),
+			)
+			.field("param", &support::DebugSyntaxResult(self.param()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
+			.field(
+				"semicolon_token",
+				&support::DebugOptionalNode(self.semicolon_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsImport {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPORT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7108,26 +6667,31 @@ impl AstNode for TsImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsImport")
-			.field("import_token", &self.import_token())
-			.field("type_args", &self.type_args())
-			.field("dot_token", &self.dot_token())
-			.field("l_paren_token", &self.l_paren_token())
-			.field("qualifier", &self.qualifier())
-			.field("r_paren_token", &self.r_paren_token())
+			.field(
+				"import_token",
+				&support::DebugSyntaxResult(self.import_token()),
+			)
+			.field("type_args", &support::DebugSyntaxResult(self.type_args()))
+			.field("dot_token", &support::DebugOptionalNode(self.dot_token()))
+			.field(
+				"l_paren_token",
+				&support::DebugSyntaxResult(self.l_paren_token()),
+			)
+			.field("qualifier", &support::DebugSyntaxResult(self.qualifier()))
+			.field(
+				"r_paren_token",
+				&support::DebugSyntaxResult(self.r_paren_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsArray {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ARRAY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7135,23 +6699,25 @@ impl AstNode for TsArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsArray")
-			.field("l_brack_token", &self.l_brack_token())
-			.field("ty", &self.ty())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsIndexedArray {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INDEXED_ARRAY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ARRAY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7159,23 +6725,25 @@ impl AstNode for TsIndexedArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIndexedArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsIndexedArray")
-			.field("l_brack_token", &self.l_brack_token())
-			.field("ty", &self.ty())
-			.field("r_brack_token", &self.r_brack_token())
+			.field(
+				"l_brack_token",
+				&support::DebugSyntaxResult(self.l_brack_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_brack_token",
+				&support::DebugSyntaxResult(self.r_brack_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeOperator {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_OPERATOR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7183,21 +6751,17 @@ impl AstNode for TsTypeOperator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeOperator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeOperator")
-			.field("ty", &self.ty())
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsIntersection {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INTERSECTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7205,9 +6769,7 @@ impl AstNode for TsIntersection {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIntersection {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7217,9 +6779,7 @@ impl std::fmt::Debug for TsIntersection {
 	}
 }
 impl AstNode for TsUnion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7227,9 +6787,7 @@ impl AstNode for TsUnion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUnion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7239,9 +6797,7 @@ impl std::fmt::Debug for TsUnion {
 	}
 }
 impl AstNode for TsFnType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_FN_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FN_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7249,23 +6805,25 @@ impl AstNode for TsFnType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsFnType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsFnType")
-			.field("params", &self.params())
-			.field("fat_arrow_token", &self.fat_arrow_token())
-			.field("return_type", &self.return_type())
+			.field("params", &support::DebugSyntaxResult(self.params()))
+			.field(
+				"fat_arrow_token",
+				&support::DebugSyntaxResult(self.fat_arrow_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsConstructorType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCTOR_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7273,24 +6831,26 @@ impl AstNode for TsConstructorType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructorType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConstructorType")
-			.field("new_token", &self.new_token())
-			.field("params", &self.params())
-			.field("colon_token", &self.colon_token())
-			.field("return_type", &self.return_type())
+			.field("new_token", &support::DebugSyntaxResult(self.new_token()))
+			.field("params", &support::DebugSyntaxResult(self.params()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugOptionalNode(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsConditionalType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONDITIONAL_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7298,24 +6858,26 @@ impl AstNode for TsConditionalType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConditionalType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConditionalType")
-			.field("ty", &self.ty())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("colon_token", &self.colon_token())
-			.field("extends", &self.extends())
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"question_mark_token",
+				&support::DebugSyntaxResult(self.question_mark_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("extends", &support::DebugSyntaxResult(self.extends()))
 			.finish()
 	}
 }
 impl AstNode for TsObjectType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_OBJECT_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7323,23 +6885,25 @@ impl AstNode for TsObjectType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsObjectType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsObjectType")
-			.field("l_curly_token", &self.l_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
 			.field("members", &self.members())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsInfer {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INFER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7347,22 +6911,21 @@ impl AstNode for TsInfer {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsInfer {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsInfer")
-			.field("infer_token", &self.infer_token())
-			.field("ident", &self.ident())
+			.field(
+				"infer_token",
+				&support::DebugSyntaxResult(self.infer_token()),
+			)
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsTupleElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TUPLE_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7370,25 +6933,30 @@ impl AstNode for TsTupleElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTupleElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTupleElement")
-			.field("ident", &self.ident())
-			.field("colon_token", &self.colon_token())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("dotdotdot_token", &self.dotdotdot_token())
-			.field("ty", &self.ty())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field(
+				"question_mark_token",
+				&support::DebugSyntaxResult(self.question_mark_token()),
+			)
+			.field(
+				"dotdotdot_token",
+				&support::DebugOptionalNode(self.dotdotdot_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsEnumMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ENUM_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7396,23 +6964,19 @@ impl AstNode for TsEnumMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsEnumMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsEnumMember")
-			.field("ident", &self.ident())
-			.field("eq_token", &self.eq_token())
-			.field("value", &self.value())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("value", &support::DebugSyntaxResult(self.value()))
 			.finish()
 	}
 }
 impl AstNode for TsTemplateElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TEMPLATE_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7420,22 +6984,21 @@ impl AstNode for TsTemplateElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTemplateElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTemplateElement")
-			.field("ty", &self.ty())
-			.field("r_curly_token", &self.r_curly_token())
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsMappedTypeReadonly {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE_READONLY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7443,23 +7006,25 @@ impl AstNode for TsMappedTypeReadonly {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedTypeReadonly {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsMappedTypeReadonly")
-			.field("minus_token", &self.minus_token())
-			.field("plus_token", &self.plus_token())
-			.field("readonly_token", &self.readonly_token())
+			.field(
+				"minus_token",
+				&support::DebugOptionalNode(self.minus_token()),
+			)
+			.field("plus_token", &support::DebugOptionalNode(self.plus_token()))
+			.field(
+				"readonly_token",
+				&support::DebugOptionalNode(self.readonly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsMappedTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7467,25 +7032,27 @@ impl AstNode for TsMappedTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsMappedTypeParam")
-			.field("l_brack_token", &self.l_brack_token())
-			.field("name", &self.name())
-			.field("r_brack_token", &self.r_brack_token())
-			.field("ident", &self.ident())
-			.field("ty", &self.ty())
+			.field(
+				"l_brack_token",
+				&support::DebugOptionalNode(self.l_brack_token()),
+			)
+			.field("name", &support::DebugOptionalNode(self.name()))
+			.field(
+				"r_brack_token",
+				&support::DebugOptionalNode(self.r_brack_token()),
+			)
+			.field("ident", &support::DebugOptionalNode(self.ident()))
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsTypeName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7493,21 +7060,17 @@ impl AstNode for TsTypeName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeName")
-			.field("ident", &self.ident())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
 			.finish()
 	}
 }
 impl AstNode for TsExtends {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXTENDS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7515,22 +7078,21 @@ impl AstNode for TsExtends {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExtends {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsExtends")
-			.field("extends_token", &self.extends_token())
-			.field("ty", &self.ty())
+			.field(
+				"extends_token",
+				&support::DebugSyntaxResult(self.extends_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsModuleBlock {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MODULE_BLOCK
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7538,23 +7100,25 @@ impl AstNode for TsModuleBlock {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsModuleBlock {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsModuleBlock")
-			.field("l_curly_token", &self.l_curly_token())
-			.field("items", &self.items())
-			.field("r_curly_token", &self.r_curly_token())
+			.field(
+				"l_curly_token",
+				&support::DebugSyntaxResult(self.l_curly_token()),
+			)
+			.field("items", &support::DebugSyntaxResult(self.items()))
+			.field(
+				"r_curly_token",
+				&support::DebugSyntaxResult(self.r_curly_token()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7562,23 +7126,19 @@ impl AstNode for TsTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsTypeParam")
-			.field("ident", &self.ident())
-			.field("constraint", &self.constraint())
-			.field("default", &self.default())
+			.field("ident", &support::DebugSyntaxResult(self.ident()))
+			.field("constraint", &support::DebugSyntaxResult(self.constraint()))
+			.field("default", &support::DebugSyntaxResult(self.default()))
 			.finish()
 	}
 }
 impl AstNode for TsConstraint {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRAINT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRAINT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7586,22 +7146,21 @@ impl AstNode for TsConstraint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstraint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConstraint")
-			.field("extends_token", &self.extends_token())
-			.field("ty", &self.ty())
+			.field(
+				"extends_token",
+				&support::DebugSyntaxResult(self.extends_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsDefault {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_DEFAULT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7609,22 +7168,18 @@ impl AstNode for TsDefault {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsDefault {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsDefault")
-			.field("eq_token", &self.eq_token())
-			.field("ty", &self.ty())
+			.field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsCallSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CALL_SIGNATURE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7632,24 +7187,29 @@ impl AstNode for TsCallSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsCallSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsCallSignatureDecl")
-			.field("type_params", &self.type_params())
-			.field("parameters", &self.parameters())
-			.field("colon_token", &self.colon_token())
-			.field("return_type", &self.return_type())
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
+			.field("parameters", &support::DebugSyntaxResult(self.parameters()))
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugSyntaxResult(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsConstructSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCT_SIGNATURE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7657,25 +7217,30 @@ impl AstNode for TsConstructSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsConstructSignatureDecl")
-			.field("new_token", &self.new_token())
-			.field("type_params", &self.type_params())
-			.field("parameters", &self.parameters())
-			.field("colon_token", &self.colon_token())
-			.field("return_type", &self.return_type())
+			.field("new_token", &support::DebugSyntaxResult(self.new_token()))
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
+			.field("parameters", &support::DebugSyntaxResult(self.parameters()))
+			.field(
+				"colon_token",
+				&support::DebugOptionalNode(self.colon_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugSyntaxResult(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsPropertySignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PROPERTY_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7683,25 +7248,30 @@ impl AstNode for TsPropertySignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsPropertySignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsPropertySignature")
-			.field("readonly_token", &self.readonly_token())
-			.field("prop", &self.prop())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("colon_token", &self.colon_token())
-			.field("ty", &self.ty())
+			.field(
+				"readonly_token",
+				&support::DebugOptionalNode(self.readonly_token()),
+			)
+			.field("prop", &support::DebugSyntaxResult(self.prop()))
+			.field(
+				"question_mark_token",
+				&support::DebugSyntaxResult(self.question_mark_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field("ty", &support::DebugSyntaxResult(self.ty()))
 			.finish()
 	}
 }
 impl AstNode for TsMethodSignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_METHOD_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7709,27 +7279,38 @@ impl AstNode for TsMethodSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMethodSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsMethodSignature")
-			.field("readonly_token", &self.readonly_token())
-			.field("key", &self.key())
-			.field("type_params", &self.type_params())
-			.field("parameters", &self.parameters())
-			.field("question_mark_token", &self.question_mark_token())
-			.field("colon_token", &self.colon_token())
-			.field("return_type", &self.return_type())
+			.field(
+				"readonly_token",
+				&support::DebugOptionalNode(self.readonly_token()),
+			)
+			.field("key", &support::DebugSyntaxResult(self.key()))
+			.field(
+				"type_params",
+				&support::DebugSyntaxResult(self.type_params()),
+			)
+			.field("parameters", &support::DebugSyntaxResult(self.parameters()))
+			.field(
+				"question_mark_token",
+				&support::DebugOptionalNode(self.question_mark_token()),
+			)
+			.field(
+				"colon_token",
+				&support::DebugSyntaxResult(self.colon_token()),
+			)
+			.field(
+				"return_type",
+				&support::DebugSyntaxResult(self.return_type()),
+			)
 			.finish()
 	}
 }
 impl AstNode for TsQualifiedPath {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_QUALIFIED_PATH
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_PATH }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7737,28 +7318,22 @@ impl AstNode for TsQualifiedPath {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsQualifiedPath {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("TsQualifiedPath")
-			.field("lhs", &self.lhs())
-			.field("dot_token", &self.dot_token())
-			.field("rhs", &self.rhs())
+			.field("lhs", &support::DebugSyntaxResult(self.lhs()))
+			.field("dot_token", &support::DebugSyntaxResult(self.dot_token()))
+			.field("rhs", &support::DebugSyntaxResult(self.rhs()))
 			.finish()
 	}
 }
 impl From<JsBlockStatement> for JsAnyStatement {
-	fn from(node: JsBlockStatement) -> JsAnyStatement {
-		JsAnyStatement::JsBlockStatement(node)
-	}
+	fn from(node: JsBlockStatement) -> JsAnyStatement { JsAnyStatement::JsBlockStatement(node) }
 }
 impl From<JsEmptyStatement> for JsAnyStatement {
-	fn from(node: JsEmptyStatement) -> JsAnyStatement {
-		JsAnyStatement::JsEmptyStatement(node)
-	}
+	fn from(node: JsEmptyStatement) -> JsAnyStatement { JsAnyStatement::JsEmptyStatement(node) }
 }
 impl From<JsExpressionStatement> for JsAnyStatement {
 	fn from(node: JsExpressionStatement) -> JsAnyStatement {
@@ -7766,34 +7341,22 @@ impl From<JsExpressionStatement> for JsAnyStatement {
 	}
 }
 impl From<JsIfStatement> for JsAnyStatement {
-	fn from(node: JsIfStatement) -> JsAnyStatement {
-		JsAnyStatement::JsIfStatement(node)
-	}
+	fn from(node: JsIfStatement) -> JsAnyStatement { JsAnyStatement::JsIfStatement(node) }
 }
 impl From<JsDoWhileStatement> for JsAnyStatement {
-	fn from(node: JsDoWhileStatement) -> JsAnyStatement {
-		JsAnyStatement::JsDoWhileStatement(node)
-	}
+	fn from(node: JsDoWhileStatement) -> JsAnyStatement { JsAnyStatement::JsDoWhileStatement(node) }
 }
 impl From<JsWhileStatement> for JsAnyStatement {
-	fn from(node: JsWhileStatement) -> JsAnyStatement {
-		JsAnyStatement::JsWhileStatement(node)
-	}
+	fn from(node: JsWhileStatement) -> JsAnyStatement { JsAnyStatement::JsWhileStatement(node) }
 }
 impl From<ForStmt> for JsAnyStatement {
-	fn from(node: ForStmt) -> JsAnyStatement {
-		JsAnyStatement::ForStmt(node)
-	}
+	fn from(node: ForStmt) -> JsAnyStatement { JsAnyStatement::ForStmt(node) }
 }
 impl From<ForInStmt> for JsAnyStatement {
-	fn from(node: ForInStmt) -> JsAnyStatement {
-		JsAnyStatement::ForInStmt(node)
-	}
+	fn from(node: ForInStmt) -> JsAnyStatement { JsAnyStatement::ForInStmt(node) }
 }
 impl From<ForOfStmt> for JsAnyStatement {
-	fn from(node: ForOfStmt) -> JsAnyStatement {
-		JsAnyStatement::ForOfStmt(node)
-	}
+	fn from(node: ForOfStmt) -> JsAnyStatement { JsAnyStatement::ForOfStmt(node) }
 }
 impl From<JsContinueStatement> for JsAnyStatement {
 	fn from(node: JsContinueStatement) -> JsAnyStatement {
@@ -7801,39 +7364,25 @@ impl From<JsContinueStatement> for JsAnyStatement {
 	}
 }
 impl From<JsBreakStatement> for JsAnyStatement {
-	fn from(node: JsBreakStatement) -> JsAnyStatement {
-		JsAnyStatement::JsBreakStatement(node)
-	}
+	fn from(node: JsBreakStatement) -> JsAnyStatement { JsAnyStatement::JsBreakStatement(node) }
 }
 impl From<JsReturnStatement> for JsAnyStatement {
-	fn from(node: JsReturnStatement) -> JsAnyStatement {
-		JsAnyStatement::JsReturnStatement(node)
-	}
+	fn from(node: JsReturnStatement) -> JsAnyStatement { JsAnyStatement::JsReturnStatement(node) }
 }
 impl From<JsWithStatement> for JsAnyStatement {
-	fn from(node: JsWithStatement) -> JsAnyStatement {
-		JsAnyStatement::JsWithStatement(node)
-	}
+	fn from(node: JsWithStatement) -> JsAnyStatement { JsAnyStatement::JsWithStatement(node) }
 }
 impl From<JsLabeledStatement> for JsAnyStatement {
-	fn from(node: JsLabeledStatement) -> JsAnyStatement {
-		JsAnyStatement::JsLabeledStatement(node)
-	}
+	fn from(node: JsLabeledStatement) -> JsAnyStatement { JsAnyStatement::JsLabeledStatement(node) }
 }
 impl From<JsSwitchStatement> for JsAnyStatement {
-	fn from(node: JsSwitchStatement) -> JsAnyStatement {
-		JsAnyStatement::JsSwitchStatement(node)
-	}
+	fn from(node: JsSwitchStatement) -> JsAnyStatement { JsAnyStatement::JsSwitchStatement(node) }
 }
 impl From<JsThrowStatement> for JsAnyStatement {
-	fn from(node: JsThrowStatement) -> JsAnyStatement {
-		JsAnyStatement::JsThrowStatement(node)
-	}
+	fn from(node: JsThrowStatement) -> JsAnyStatement { JsAnyStatement::JsThrowStatement(node) }
 }
 impl From<JsTryStatement> for JsAnyStatement {
-	fn from(node: JsTryStatement) -> JsAnyStatement {
-		JsAnyStatement::JsTryStatement(node)
-	}
+	fn from(node: JsTryStatement) -> JsAnyStatement { JsAnyStatement::JsTryStatement(node) }
 }
 impl From<JsTryFinallyStatement> for JsAnyStatement {
 	fn from(node: JsTryFinallyStatement) -> JsAnyStatement {
@@ -7851,9 +7400,7 @@ impl From<JsFunctionDeclaration> for JsAnyStatement {
 	}
 }
 impl From<JsClassDeclaration> for JsAnyStatement {
-	fn from(node: JsClassDeclaration) -> JsAnyStatement {
-		JsAnyStatement::JsClassDeclaration(node)
-	}
+	fn from(node: JsClassDeclaration) -> JsAnyStatement { JsAnyStatement::JsClassDeclaration(node) }
 }
 impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	fn from(node: JsVariableDeclarationStatement) -> JsAnyStatement {
@@ -7861,69 +7408,43 @@ impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	}
 }
 impl From<TsEnum> for JsAnyStatement {
-	fn from(node: TsEnum) -> JsAnyStatement {
-		JsAnyStatement::TsEnum(node)
-	}
+	fn from(node: TsEnum) -> JsAnyStatement { JsAnyStatement::TsEnum(node) }
 }
 impl From<TsTypeAliasDecl> for JsAnyStatement {
-	fn from(node: TsTypeAliasDecl) -> JsAnyStatement {
-		JsAnyStatement::TsTypeAliasDecl(node)
-	}
+	fn from(node: TsTypeAliasDecl) -> JsAnyStatement { JsAnyStatement::TsTypeAliasDecl(node) }
 }
 impl From<TsNamespaceDecl> for JsAnyStatement {
-	fn from(node: TsNamespaceDecl) -> JsAnyStatement {
-		JsAnyStatement::TsNamespaceDecl(node)
-	}
+	fn from(node: TsNamespaceDecl) -> JsAnyStatement { JsAnyStatement::TsNamespaceDecl(node) }
 }
 impl From<TsModuleDecl> for JsAnyStatement {
-	fn from(node: TsModuleDecl) -> JsAnyStatement {
-		JsAnyStatement::TsModuleDecl(node)
-	}
+	fn from(node: TsModuleDecl) -> JsAnyStatement { JsAnyStatement::TsModuleDecl(node) }
 }
 impl From<TsInterfaceDecl> for JsAnyStatement {
-	fn from(node: TsInterfaceDecl) -> JsAnyStatement {
-		JsAnyStatement::TsInterfaceDecl(node)
-	}
+	fn from(node: TsInterfaceDecl) -> JsAnyStatement { JsAnyStatement::TsInterfaceDecl(node) }
 }
 impl From<ImportDecl> for JsAnyStatement {
-	fn from(node: ImportDecl) -> JsAnyStatement {
-		JsAnyStatement::ImportDecl(node)
-	}
+	fn from(node: ImportDecl) -> JsAnyStatement { JsAnyStatement::ImportDecl(node) }
 }
 impl From<ExportNamed> for JsAnyStatement {
-	fn from(node: ExportNamed) -> JsAnyStatement {
-		JsAnyStatement::ExportNamed(node)
-	}
+	fn from(node: ExportNamed) -> JsAnyStatement { JsAnyStatement::ExportNamed(node) }
 }
 impl From<ExportDefaultDecl> for JsAnyStatement {
-	fn from(node: ExportDefaultDecl) -> JsAnyStatement {
-		JsAnyStatement::ExportDefaultDecl(node)
-	}
+	fn from(node: ExportDefaultDecl) -> JsAnyStatement { JsAnyStatement::ExportDefaultDecl(node) }
 }
 impl From<ExportDefaultExpr> for JsAnyStatement {
-	fn from(node: ExportDefaultExpr) -> JsAnyStatement {
-		JsAnyStatement::ExportDefaultExpr(node)
-	}
+	fn from(node: ExportDefaultExpr) -> JsAnyStatement { JsAnyStatement::ExportDefaultExpr(node) }
 }
 impl From<ExportWildcard> for JsAnyStatement {
-	fn from(node: ExportWildcard) -> JsAnyStatement {
-		JsAnyStatement::ExportWildcard(node)
-	}
+	fn from(node: ExportWildcard) -> JsAnyStatement { JsAnyStatement::ExportWildcard(node) }
 }
 impl From<ExportDecl> for JsAnyStatement {
-	fn from(node: ExportDecl) -> JsAnyStatement {
-		JsAnyStatement::ExportDecl(node)
-	}
+	fn from(node: ExportDecl) -> JsAnyStatement { JsAnyStatement::ExportDecl(node) }
 }
 impl From<TsImportEqualsDecl> for JsAnyStatement {
-	fn from(node: TsImportEqualsDecl) -> JsAnyStatement {
-		JsAnyStatement::TsImportEqualsDecl(node)
-	}
+	fn from(node: TsImportEqualsDecl) -> JsAnyStatement { JsAnyStatement::TsImportEqualsDecl(node) }
 }
 impl From<TsExportAssignment> for JsAnyStatement {
-	fn from(node: TsExportAssignment) -> JsAnyStatement {
-		JsAnyStatement::TsExportAssignment(node)
-	}
+	fn from(node: TsExportAssignment) -> JsAnyStatement { JsAnyStatement::TsExportAssignment(node) }
 }
 impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	fn from(node: TsNamespaceExportDecl) -> JsAnyStatement {
@@ -7931,9 +7452,7 @@ impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	}
 }
 impl From<JsUnknownStatement> for JsAnyStatement {
-	fn from(node: JsUnknownStatement) -> JsAnyStatement {
-		JsAnyStatement::JsUnknownStatement(node)
-	}
+	fn from(node: JsUnknownStatement) -> JsAnyStatement { JsAnyStatement::JsUnknownStatement(node) }
 }
 impl AstNode for JsAnyStatement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8085,10 +7604,51 @@ impl AstNode for JsAnyStatement {
 		}
 	}
 }
-impl From<JsArrayExpression> for JsAnyExpression {
-	fn from(node: JsArrayExpression) -> JsAnyExpression {
-		JsAnyExpression::JsArrayExpression(node)
+impl std::fmt::Debug for JsAnyStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyStatement::JsBlockStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsEmptyStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsExpressionStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsIfStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsDoWhileStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsWhileStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ForStmt(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ForInStmt(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ForOfStmt(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsContinueStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsBreakStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsReturnStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsWithStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsLabeledStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsSwitchStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsThrowStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsTryStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsTryFinallyStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsDebuggerStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsFunctionDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsClassDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsVariableDeclarationStatement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsEnum(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsTypeAliasDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsNamespaceDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsModuleDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsInterfaceDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ImportDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ExportNamed(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ExportDefaultDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ExportDefaultExpr(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ExportWildcard(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::ExportDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsImportEqualsDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsExportAssignment(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::TsNamespaceExportDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyStatement::JsUnknownStatement(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<JsArrayExpression> for JsAnyExpression {
+	fn from(node: JsArrayExpression) -> JsAnyExpression { JsAnyExpression::JsArrayExpression(node) }
 }
 impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	fn from(node: JsArrowFunctionExpression) -> JsAnyExpression {
@@ -8096,9 +7656,7 @@ impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	}
 }
 impl From<JsAwaitExpression> for JsAnyExpression {
-	fn from(node: JsAwaitExpression) -> JsAnyExpression {
-		JsAnyExpression::JsAwaitExpression(node)
-	}
+	fn from(node: JsAwaitExpression) -> JsAnyExpression { JsAnyExpression::JsAwaitExpression(node) }
 }
 impl From<JsBinaryExpression> for JsAnyExpression {
 	fn from(node: JsBinaryExpression) -> JsAnyExpression {
@@ -8106,9 +7664,7 @@ impl From<JsBinaryExpression> for JsAnyExpression {
 	}
 }
 impl From<JsClassExpression> for JsAnyExpression {
-	fn from(node: JsClassExpression) -> JsAnyExpression {
-		JsAnyExpression::JsClassExpression(node)
-	}
+	fn from(node: JsClassExpression) -> JsAnyExpression { JsAnyExpression::JsClassExpression(node) }
 }
 impl From<JsConditionalExpression> for JsAnyExpression {
 	fn from(node: JsConditionalExpression) -> JsAnyExpression {
@@ -8161,19 +7717,13 @@ impl From<JsStaticMemberExpression> for JsAnyExpression {
 	}
 }
 impl From<JsSuperExpression> for JsAnyExpression {
-	fn from(node: JsSuperExpression) -> JsAnyExpression {
-		JsAnyExpression::JsSuperExpression(node)
-	}
+	fn from(node: JsSuperExpression) -> JsAnyExpression { JsAnyExpression::JsSuperExpression(node) }
 }
 impl From<JsThisExpression> for JsAnyExpression {
-	fn from(node: JsThisExpression) -> JsAnyExpression {
-		JsAnyExpression::JsThisExpression(node)
-	}
+	fn from(node: JsThisExpression) -> JsAnyExpression { JsAnyExpression::JsThisExpression(node) }
 }
 impl From<JsUnaryExpression> for JsAnyExpression {
-	fn from(node: JsUnaryExpression) -> JsAnyExpression {
-		JsAnyExpression::JsUnaryExpression(node)
-	}
+	fn from(node: JsUnaryExpression) -> JsAnyExpression { JsAnyExpression::JsUnaryExpression(node) }
 }
 impl From<JsPreUpdateExpression> for JsAnyExpression {
 	fn from(node: JsPreUpdateExpression) -> JsAnyExpression {
@@ -8186,54 +7736,34 @@ impl From<JsPostUpdateExpression> for JsAnyExpression {
 	}
 }
 impl From<JsYieldExpression> for JsAnyExpression {
-	fn from(node: JsYieldExpression) -> JsAnyExpression {
-		JsAnyExpression::JsYieldExpression(node)
-	}
+	fn from(node: JsYieldExpression) -> JsAnyExpression { JsAnyExpression::JsYieldExpression(node) }
 }
 impl From<Template> for JsAnyExpression {
-	fn from(node: Template) -> JsAnyExpression {
-		JsAnyExpression::Template(node)
-	}
+	fn from(node: Template) -> JsAnyExpression { JsAnyExpression::Template(node) }
 }
 impl From<NewExpr> for JsAnyExpression {
-	fn from(node: NewExpr) -> JsAnyExpression {
-		JsAnyExpression::NewExpr(node)
-	}
+	fn from(node: NewExpr) -> JsAnyExpression { JsAnyExpression::NewExpr(node) }
 }
 impl From<CallExpr> for JsAnyExpression {
-	fn from(node: CallExpr) -> JsAnyExpression {
-		JsAnyExpression::CallExpr(node)
-	}
+	fn from(node: CallExpr) -> JsAnyExpression { JsAnyExpression::CallExpr(node) }
 }
 impl From<AssignExpr> for JsAnyExpression {
-	fn from(node: AssignExpr) -> JsAnyExpression {
-		JsAnyExpression::AssignExpr(node)
-	}
+	fn from(node: AssignExpr) -> JsAnyExpression { JsAnyExpression::AssignExpr(node) }
 }
 impl From<NewTarget> for JsAnyExpression {
-	fn from(node: NewTarget) -> JsAnyExpression {
-		JsAnyExpression::NewTarget(node)
-	}
+	fn from(node: NewTarget) -> JsAnyExpression { JsAnyExpression::NewTarget(node) }
 }
 impl From<ImportMeta> for JsAnyExpression {
-	fn from(node: ImportMeta) -> JsAnyExpression {
-		JsAnyExpression::ImportMeta(node)
-	}
+	fn from(node: ImportMeta) -> JsAnyExpression { JsAnyExpression::ImportMeta(node) }
 }
 impl From<TsNonNull> for JsAnyExpression {
-	fn from(node: TsNonNull) -> JsAnyExpression {
-		JsAnyExpression::TsNonNull(node)
-	}
+	fn from(node: TsNonNull) -> JsAnyExpression { JsAnyExpression::TsNonNull(node) }
 }
 impl From<TsAssertion> for JsAnyExpression {
-	fn from(node: TsAssertion) -> JsAnyExpression {
-		JsAnyExpression::TsAssertion(node)
-	}
+	fn from(node: TsAssertion) -> JsAnyExpression { JsAnyExpression::TsAssertion(node) }
 }
 impl From<TsConstAssertion> for JsAnyExpression {
-	fn from(node: TsConstAssertion) -> JsAnyExpression {
-		JsAnyExpression::TsConstAssertion(node)
-	}
+	fn from(node: TsConstAssertion) -> JsAnyExpression { JsAnyExpression::TsConstAssertion(node) }
 }
 impl From<JsUnknownExpression> for JsAnyExpression {
 	fn from(node: JsUnknownExpression) -> JsAnyExpression {
@@ -8391,10 +7921,46 @@ impl AstNode for JsAnyExpression {
 		}
 	}
 }
-impl From<JsVariableDeclaration> for ForHead {
-	fn from(node: JsVariableDeclaration) -> ForHead {
-		ForHead::JsVariableDeclaration(node)
+impl std::fmt::Debug for JsAnyExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyExpression::JsAnyLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsArrayExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsArrowFunctionExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsAwaitExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsBinaryExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsClassExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsConditionalExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsComputedMemberExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsFunctionExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsImportCallExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsLogicalExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsObjectExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsParenthesizedExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsReferenceIdentifierExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsSequenceExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsStaticMemberExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsSuperExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsThisExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsUnaryExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsPreUpdateExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsPostUpdateExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsYieldExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::Template(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::NewExpr(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::CallExpr(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::AssignExpr(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::NewTarget(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::ImportMeta(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::TsNonNull(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::TsAssertion(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::TsConstAssertion(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExpression::JsUnknownExpression(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<JsVariableDeclaration> for ForHead {
+	fn from(node: JsVariableDeclaration) -> ForHead { ForHead::JsVariableDeclaration(node) }
 }
 impl AstNode for ForHead {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8425,20 +7991,22 @@ impl AstNode for ForHead {
 		}
 	}
 }
-impl From<JsCaseClause> for JsAnySwitchClause {
-	fn from(node: JsCaseClause) -> JsAnySwitchClause {
-		JsAnySwitchClause::JsCaseClause(node)
+impl std::fmt::Debug for ForHead {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			ForHead::JsVariableDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			ForHead::JsAnyExpression(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<JsCaseClause> for JsAnySwitchClause {
+	fn from(node: JsCaseClause) -> JsAnySwitchClause { JsAnySwitchClause::JsCaseClause(node) }
 }
 impl From<JsDefaultClause> for JsAnySwitchClause {
-	fn from(node: JsDefaultClause) -> JsAnySwitchClause {
-		JsAnySwitchClause::JsDefaultClause(node)
-	}
+	fn from(node: JsDefaultClause) -> JsAnySwitchClause { JsAnySwitchClause::JsDefaultClause(node) }
 }
 impl AstNode for JsAnySwitchClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			JS_CASE_CLAUSE => JsAnySwitchClause::JsCaseClause(JsCaseClause { syntax }),
@@ -8454,40 +8022,34 @@ impl AstNode for JsAnySwitchClause {
 		}
 	}
 }
-impl From<SinglePattern> for Pattern {
-	fn from(node: SinglePattern) -> Pattern {
-		Pattern::SinglePattern(node)
+impl std::fmt::Debug for JsAnySwitchClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnySwitchClause::JsCaseClause(it) => std::fmt::Debug::fmt(it, f),
+			JsAnySwitchClause::JsDefaultClause(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<SinglePattern> for Pattern {
+	fn from(node: SinglePattern) -> Pattern { Pattern::SinglePattern(node) }
 }
 impl From<RestPattern> for Pattern {
-	fn from(node: RestPattern) -> Pattern {
-		Pattern::RestPattern(node)
-	}
+	fn from(node: RestPattern) -> Pattern { Pattern::RestPattern(node) }
 }
 impl From<AssignPattern> for Pattern {
-	fn from(node: AssignPattern) -> Pattern {
-		Pattern::AssignPattern(node)
-	}
+	fn from(node: AssignPattern) -> Pattern { Pattern::AssignPattern(node) }
 }
 impl From<ObjectPattern> for Pattern {
-	fn from(node: ObjectPattern) -> Pattern {
-		Pattern::ObjectPattern(node)
-	}
+	fn from(node: ObjectPattern) -> Pattern { Pattern::ObjectPattern(node) }
 }
 impl From<ArrayPattern> for Pattern {
-	fn from(node: ArrayPattern) -> Pattern {
-		Pattern::ArrayPattern(node)
-	}
+	fn from(node: ArrayPattern) -> Pattern { Pattern::ArrayPattern(node) }
 }
 impl From<ExprPattern> for Pattern {
-	fn from(node: ExprPattern) -> Pattern {
-		Pattern::ExprPattern(node)
-	}
+	fn from(node: ExprPattern) -> Pattern { Pattern::ExprPattern(node) }
 }
 impl From<JsUnknownPattern> for Pattern {
-	fn from(node: JsUnknownPattern) -> Pattern {
-		Pattern::JsUnknownPattern(node)
-	}
+	fn from(node: JsUnknownPattern) -> Pattern { Pattern::JsUnknownPattern(node) }
 }
 impl AstNode for Pattern {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8521,6 +8083,19 @@ impl AstNode for Pattern {
 			Pattern::ArrayPattern(it) => &it.syntax,
 			Pattern::ExprPattern(it) => &it.syntax,
 			Pattern::JsUnknownPattern(it) => &it.syntax,
+		}
+	}
+}
+impl std::fmt::Debug for Pattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Pattern::SinglePattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::RestPattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::AssignPattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::ObjectPattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::ArrayPattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::ExprPattern(it) => std::fmt::Debug::fmt(it, f),
+			Pattern::JsUnknownPattern(it) => std::fmt::Debug::fmt(it, f),
 		}
 	}
 }
@@ -8611,6 +8186,18 @@ impl AstNode for JsAnyLiteralExpression {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyLiteralExpression::JsStringLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyLiteralExpression::JsNumberLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyLiteralExpression::JsBigIntLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyLiteralExpression::JsBooleanLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyLiteralExpression::JsNullLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyLiteralExpression::JsRegexLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsParameterList> for JsAnyArrowFunctionParameters {
 	fn from(node: JsParameterList) -> JsAnyArrowFunctionParameters {
 		JsAnyArrowFunctionParameters::JsParameterList(node)
@@ -8641,6 +8228,14 @@ impl AstNode for JsAnyArrowFunctionParameters {
 		match self {
 			JsAnyArrowFunctionParameters::JsParameterList(it) => &it.syntax,
 			JsAnyArrowFunctionParameters::JsIdentifierBinding(it) => &it.syntax,
+		}
+	}
+}
+impl std::fmt::Debug for JsAnyArrowFunctionParameters {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyArrowFunctionParameters::JsParameterList(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyArrowFunctionParameters::JsIdentifierBinding(it) => std::fmt::Debug::fmt(it, f),
 		}
 	}
 }
@@ -8676,15 +8271,19 @@ impl AstNode for JsAnyArrowFunctionBody {
 		}
 	}
 }
-impl From<SpreadElement> for JsAnyArrayElement {
-	fn from(node: SpreadElement) -> JsAnyArrayElement {
-		JsAnyArrayElement::SpreadElement(node)
+impl std::fmt::Debug for JsAnyArrowFunctionBody {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyArrowFunctionBody::JsAnyExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyArrowFunctionBody::JsFunctionBody(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
 }
+impl From<SpreadElement> for JsAnyArrayElement {
+	fn from(node: SpreadElement) -> JsAnyArrayElement { JsAnyArrayElement::SpreadElement(node) }
+}
 impl From<JsArrayHole> for JsAnyArrayElement {
-	fn from(node: JsArrayHole) -> JsAnyArrayElement {
-		JsAnyArrayElement::JsArrayHole(node)
-	}
+	fn from(node: JsArrayHole) -> JsAnyArrayElement { JsAnyArrayElement::JsArrayHole(node) }
 }
 impl AstNode for JsAnyArrayElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8715,6 +8314,15 @@ impl AstNode for JsAnyArrayElement {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyArrayElement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyArrayElement::JsAnyExpression(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyArrayElement::SpreadElement(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyArrayElement::JsArrayHole(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl AstNode for PatternOrExpr {
 	fn can_cast(kind: SyntaxKind) -> bool {
 		match kind {
@@ -8736,6 +8344,14 @@ impl AstNode for PatternOrExpr {
 		match self {
 			PatternOrExpr::Pattern(it) => it.syntax(),
 			PatternOrExpr::JsAnyExpression(it) => it.syntax(),
+		}
+	}
+}
+impl std::fmt::Debug for PatternOrExpr {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			PatternOrExpr::Pattern(it) => std::fmt::Debug::fmt(it, f),
+			PatternOrExpr::JsAnyExpression(it) => std::fmt::Debug::fmt(it, f),
 		}
 	}
 }
@@ -8777,6 +8393,14 @@ impl AstNode for JsAnyReferenceMember {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyReferenceMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyReferenceMember::JsReferenceIdentifierMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyReferenceMember::JsReferencePrivateMember(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsLiteralMemberName> for JsAnyObjectMemberName {
 	fn from(node: JsLiteralMemberName) -> JsAnyObjectMemberName {
 		JsAnyObjectMemberName::JsLiteralMemberName(node)
@@ -8810,6 +8434,14 @@ impl AstNode for JsAnyObjectMemberName {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyObjectMemberName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyObjectMemberName::JsLiteralMemberName(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMemberName::JsComputedMemberName(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsPropertyObjectMember> for JsAnyObjectMember {
 	fn from(node: JsPropertyObjectMember) -> JsAnyObjectMember {
 		JsAnyObjectMember::JsPropertyObjectMember(node)
@@ -8831,9 +8463,7 @@ impl From<JsSetterObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<InitializedProp> for JsAnyObjectMember {
-	fn from(node: InitializedProp) -> JsAnyObjectMember {
-		JsAnyObjectMember::InitializedProp(node)
-	}
+	fn from(node: InitializedProp) -> JsAnyObjectMember { JsAnyObjectMember::InitializedProp(node) }
 }
 impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	fn from(node: JsShorthandPropertyObjectMember) -> JsAnyObjectMember {
@@ -8841,14 +8471,10 @@ impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<JsSpread> for JsAnyObjectMember {
-	fn from(node: JsSpread) -> JsAnyObjectMember {
-		JsAnyObjectMember::JsSpread(node)
-	}
+	fn from(node: JsSpread) -> JsAnyObjectMember { JsAnyObjectMember::JsSpread(node) }
 }
 impl From<JsUnknownMember> for JsAnyObjectMember {
-	fn from(node: JsUnknownMember) -> JsAnyObjectMember {
-		JsAnyObjectMember::JsUnknownMember(node)
-	}
+	fn from(node: JsUnknownMember) -> JsAnyObjectMember { JsAnyObjectMember::JsUnknownMember(node) }
 }
 impl AstNode for JsAnyObjectMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8902,10 +8528,22 @@ impl AstNode for JsAnyObjectMember {
 		}
 	}
 }
-impl From<JsComputedMemberName> for PropName {
-	fn from(node: JsComputedMemberName) -> PropName {
-		PropName::JsComputedMemberName(node)
+impl std::fmt::Debug for JsAnyObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyObjectMember::JsPropertyObjectMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsMethodObjectMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsGetterObjectMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsSetterObjectMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::InitializedProp(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsShorthandPropertyObjectMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsSpread(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyObjectMember::JsUnknownMember(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<JsComputedMemberName> for PropName {
+	fn from(node: JsComputedMemberName) -> PropName { PropName::JsComputedMemberName(node) }
 }
 impl From<JsStringLiteralExpression> for PropName {
 	fn from(node: JsStringLiteralExpression) -> PropName {
@@ -8918,19 +8556,13 @@ impl From<JsNumberLiteralExpression> for PropName {
 	}
 }
 impl From<Ident> for PropName {
-	fn from(node: Ident) -> PropName {
-		PropName::Ident(node)
-	}
+	fn from(node: Ident) -> PropName { PropName::Ident(node) }
 }
 impl From<Name> for PropName {
-	fn from(node: Name) -> PropName {
-		PropName::Name(node)
-	}
+	fn from(node: Name) -> PropName { PropName::Name(node) }
 }
 impl From<JsUnknownBinding> for PropName {
-	fn from(node: JsUnknownBinding) -> PropName {
-		PropName::JsUnknownBinding(node)
-	}
+	fn from(node: JsUnknownBinding) -> PropName { PropName::JsUnknownBinding(node) }
 }
 impl AstNode for PropName {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8971,6 +8603,18 @@ impl AstNode for PropName {
 		}
 	}
 }
+impl std::fmt::Debug for PropName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			PropName::JsComputedMemberName(it) => std::fmt::Debug::fmt(it, f),
+			PropName::JsStringLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			PropName::JsNumberLiteralExpression(it) => std::fmt::Debug::fmt(it, f),
+			PropName::Ident(it) => std::fmt::Debug::fmt(it, f),
+			PropName::Name(it) => std::fmt::Debug::fmt(it, f),
+			PropName::JsUnknownBinding(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsConstructorClassMember> for JsAnyClassMember {
 	fn from(node: JsConstructorClassMember) -> JsAnyClassMember {
 		JsAnyClassMember::JsConstructorClassMember(node)
@@ -9002,14 +8646,10 @@ impl From<JsEmptyClassMember> for JsAnyClassMember {
 	}
 }
 impl From<TsIndexSignature> for JsAnyClassMember {
-	fn from(node: TsIndexSignature) -> JsAnyClassMember {
-		JsAnyClassMember::TsIndexSignature(node)
-	}
+	fn from(node: TsIndexSignature) -> JsAnyClassMember { JsAnyClassMember::TsIndexSignature(node) }
 }
 impl From<JsUnknownMember> for JsAnyClassMember {
-	fn from(node: JsUnknownMember) -> JsAnyClassMember {
-		JsAnyClassMember::JsUnknownMember(node)
-	}
+	fn from(node: JsUnknownMember) -> JsAnyClassMember { JsAnyClassMember::JsUnknownMember(node) }
 }
 impl AstNode for JsAnyClassMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9064,6 +8704,20 @@ impl AstNode for JsAnyClassMember {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyClassMember::JsConstructorClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsPropertyClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsMethodClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsGetterClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsSetterClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsEmptyClassMember(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::TsIndexSignature(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMember::JsUnknownMember(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsLiteralMemberName> for JsAnyClassMemberName {
 	fn from(node: JsLiteralMemberName) -> JsAnyClassMemberName {
 		JsAnyClassMemberName::JsLiteralMemberName(node)
@@ -9109,6 +8763,15 @@ impl AstNode for JsAnyClassMemberName {
 		}
 	}
 }
+impl std::fmt::Debug for JsAnyClassMemberName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyClassMemberName::JsLiteralMemberName(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMemberName::JsComputedMemberName(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyClassMemberName::JsPrivateClassMemberName(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<TsConstructorParam> for JsAnyConstructorParameter {
 	fn from(node: TsConstructorParam) -> JsAnyConstructorParameter {
 		JsAnyConstructorParameter::TsConstructorParam(node)
@@ -9143,25 +8806,25 @@ impl AstNode for JsAnyConstructorParameter {
 		}
 	}
 }
-impl From<AssignPattern> for ObjectPatternProp {
-	fn from(node: AssignPattern) -> ObjectPatternProp {
-		ObjectPatternProp::AssignPattern(node)
+impl std::fmt::Debug for JsAnyConstructorParameter {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyConstructorParameter::TsConstructorParam(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyConstructorParameter::Pattern(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<AssignPattern> for ObjectPatternProp {
+	fn from(node: AssignPattern) -> ObjectPatternProp { ObjectPatternProp::AssignPattern(node) }
 }
 impl From<KeyValuePattern> for ObjectPatternProp {
-	fn from(node: KeyValuePattern) -> ObjectPatternProp {
-		ObjectPatternProp::KeyValuePattern(node)
-	}
+	fn from(node: KeyValuePattern) -> ObjectPatternProp { ObjectPatternProp::KeyValuePattern(node) }
 }
 impl From<RestPattern> for ObjectPatternProp {
-	fn from(node: RestPattern) -> ObjectPatternProp {
-		ObjectPatternProp::RestPattern(node)
-	}
+	fn from(node: RestPattern) -> ObjectPatternProp { ObjectPatternProp::RestPattern(node) }
 }
 impl From<SinglePattern> for ObjectPatternProp {
-	fn from(node: SinglePattern) -> ObjectPatternProp {
-		ObjectPatternProp::SinglePattern(node)
-	}
+	fn from(node: SinglePattern) -> ObjectPatternProp { ObjectPatternProp::SinglePattern(node) }
 }
 impl From<JsUnknownPattern> for ObjectPatternProp {
 	fn from(node: JsUnknownPattern) -> ObjectPatternProp {
@@ -9196,160 +8859,109 @@ impl AstNode for ObjectPatternProp {
 		}
 	}
 }
-impl From<TsAny> for TsType {
-	fn from(node: TsAny) -> TsType {
-		TsType::TsAny(node)
+impl std::fmt::Debug for ObjectPatternProp {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			ObjectPatternProp::AssignPattern(it) => std::fmt::Debug::fmt(it, f),
+			ObjectPatternProp::KeyValuePattern(it) => std::fmt::Debug::fmt(it, f),
+			ObjectPatternProp::RestPattern(it) => std::fmt::Debug::fmt(it, f),
+			ObjectPatternProp::SinglePattern(it) => std::fmt::Debug::fmt(it, f),
+			ObjectPatternProp::JsUnknownPattern(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsAny> for TsType {
+	fn from(node: TsAny) -> TsType { TsType::TsAny(node) }
 }
 impl From<TsUnknown> for TsType {
-	fn from(node: TsUnknown) -> TsType {
-		TsType::TsUnknown(node)
-	}
+	fn from(node: TsUnknown) -> TsType { TsType::TsUnknown(node) }
 }
 impl From<TsNumber> for TsType {
-	fn from(node: TsNumber) -> TsType {
-		TsType::TsNumber(node)
-	}
+	fn from(node: TsNumber) -> TsType { TsType::TsNumber(node) }
 }
 impl From<TsObject> for TsType {
-	fn from(node: TsObject) -> TsType {
-		TsType::TsObject(node)
-	}
+	fn from(node: TsObject) -> TsType { TsType::TsObject(node) }
 }
 impl From<TsBoolean> for TsType {
-	fn from(node: TsBoolean) -> TsType {
-		TsType::TsBoolean(node)
-	}
+	fn from(node: TsBoolean) -> TsType { TsType::TsBoolean(node) }
 }
 impl From<TsBigint> for TsType {
-	fn from(node: TsBigint) -> TsType {
-		TsType::TsBigint(node)
-	}
+	fn from(node: TsBigint) -> TsType { TsType::TsBigint(node) }
 }
 impl From<TsString> for TsType {
-	fn from(node: TsString) -> TsType {
-		TsType::TsString(node)
-	}
+	fn from(node: TsString) -> TsType { TsType::TsString(node) }
 }
 impl From<TsSymbol> for TsType {
-	fn from(node: TsSymbol) -> TsType {
-		TsType::TsSymbol(node)
-	}
+	fn from(node: TsSymbol) -> TsType { TsType::TsSymbol(node) }
 }
 impl From<TsVoid> for TsType {
-	fn from(node: TsVoid) -> TsType {
-		TsType::TsVoid(node)
-	}
+	fn from(node: TsVoid) -> TsType { TsType::TsVoid(node) }
 }
 impl From<TsUndefined> for TsType {
-	fn from(node: TsUndefined) -> TsType {
-		TsType::TsUndefined(node)
-	}
+	fn from(node: TsUndefined) -> TsType { TsType::TsUndefined(node) }
 }
 impl From<TsNull> for TsType {
-	fn from(node: TsNull) -> TsType {
-		TsType::TsNull(node)
-	}
+	fn from(node: TsNull) -> TsType { TsType::TsNull(node) }
 }
 impl From<TsNever> for TsType {
-	fn from(node: TsNever) -> TsType {
-		TsType::TsNever(node)
-	}
+	fn from(node: TsNever) -> TsType { TsType::TsNever(node) }
 }
 impl From<TsThis> for TsType {
-	fn from(node: TsThis) -> TsType {
-		TsType::TsThis(node)
-	}
+	fn from(node: TsThis) -> TsType { TsType::TsThis(node) }
 }
 impl From<TsLiteral> for TsType {
-	fn from(node: TsLiteral) -> TsType {
-		TsType::TsLiteral(node)
-	}
+	fn from(node: TsLiteral) -> TsType { TsType::TsLiteral(node) }
 }
 impl From<TsPredicate> for TsType {
-	fn from(node: TsPredicate) -> TsType {
-		TsType::TsPredicate(node)
-	}
+	fn from(node: TsPredicate) -> TsType { TsType::TsPredicate(node) }
 }
 impl From<TsTuple> for TsType {
-	fn from(node: TsTuple) -> TsType {
-		TsType::TsTuple(node)
-	}
+	fn from(node: TsTuple) -> TsType { TsType::TsTuple(node) }
 }
 impl From<TsParen> for TsType {
-	fn from(node: TsParen) -> TsType {
-		TsType::TsParen(node)
-	}
+	fn from(node: TsParen) -> TsType { TsType::TsParen(node) }
 }
 impl From<TsTypeRef> for TsType {
-	fn from(node: TsTypeRef) -> TsType {
-		TsType::TsTypeRef(node)
-	}
+	fn from(node: TsTypeRef) -> TsType { TsType::TsTypeRef(node) }
 }
 impl From<TsTemplate> for TsType {
-	fn from(node: TsTemplate) -> TsType {
-		TsType::TsTemplate(node)
-	}
+	fn from(node: TsTemplate) -> TsType { TsType::TsTemplate(node) }
 }
 impl From<TsMappedType> for TsType {
-	fn from(node: TsMappedType) -> TsType {
-		TsType::TsMappedType(node)
-	}
+	fn from(node: TsMappedType) -> TsType { TsType::TsMappedType(node) }
 }
 impl From<TsImport> for TsType {
-	fn from(node: TsImport) -> TsType {
-		TsType::TsImport(node)
-	}
+	fn from(node: TsImport) -> TsType { TsType::TsImport(node) }
 }
 impl From<TsArray> for TsType {
-	fn from(node: TsArray) -> TsType {
-		TsType::TsArray(node)
-	}
+	fn from(node: TsArray) -> TsType { TsType::TsArray(node) }
 }
 impl From<TsIndexedArray> for TsType {
-	fn from(node: TsIndexedArray) -> TsType {
-		TsType::TsIndexedArray(node)
-	}
+	fn from(node: TsIndexedArray) -> TsType { TsType::TsIndexedArray(node) }
 }
 impl From<TsTypeOperator> for TsType {
-	fn from(node: TsTypeOperator) -> TsType {
-		TsType::TsTypeOperator(node)
-	}
+	fn from(node: TsTypeOperator) -> TsType { TsType::TsTypeOperator(node) }
 }
 impl From<TsIntersection> for TsType {
-	fn from(node: TsIntersection) -> TsType {
-		TsType::TsIntersection(node)
-	}
+	fn from(node: TsIntersection) -> TsType { TsType::TsIntersection(node) }
 }
 impl From<TsUnion> for TsType {
-	fn from(node: TsUnion) -> TsType {
-		TsType::TsUnion(node)
-	}
+	fn from(node: TsUnion) -> TsType { TsType::TsUnion(node) }
 }
 impl From<TsFnType> for TsType {
-	fn from(node: TsFnType) -> TsType {
-		TsType::TsFnType(node)
-	}
+	fn from(node: TsFnType) -> TsType { TsType::TsFnType(node) }
 }
 impl From<TsConstructorType> for TsType {
-	fn from(node: TsConstructorType) -> TsType {
-		TsType::TsConstructorType(node)
-	}
+	fn from(node: TsConstructorType) -> TsType { TsType::TsConstructorType(node) }
 }
 impl From<TsConditionalType> for TsType {
-	fn from(node: TsConditionalType) -> TsType {
-		TsType::TsConditionalType(node)
-	}
+	fn from(node: TsConditionalType) -> TsType { TsType::TsConditionalType(node) }
 }
 impl From<TsObjectType> for TsType {
-	fn from(node: TsObjectType) -> TsType {
-		TsType::TsObjectType(node)
-	}
+	fn from(node: TsObjectType) -> TsType { TsType::TsObjectType(node) }
 }
 impl From<TsInfer> for TsType {
-	fn from(node: TsInfer) -> TsType {
-		TsType::TsInfer(node)
-	}
+	fn from(node: TsInfer) -> TsType { TsType::TsInfer(node) }
 }
 impl AstNode for TsType {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9448,20 +9060,51 @@ impl AstNode for TsType {
 		}
 	}
 }
-impl From<WildcardImport> for ImportClause {
-	fn from(node: WildcardImport) -> ImportClause {
-		ImportClause::WildcardImport(node)
+impl std::fmt::Debug for TsType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsType::TsAny(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsUnknown(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsNumber(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsObject(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsBoolean(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsBigint(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsString(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsSymbol(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsVoid(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsUndefined(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsNull(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsNever(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsThis(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsLiteral(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsPredicate(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsTuple(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsParen(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsTypeRef(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsTemplate(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsMappedType(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsImport(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsArray(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsIndexedArray(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsTypeOperator(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsIntersection(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsUnion(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsFnType(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsConstructorType(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsConditionalType(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsObjectType(it) => std::fmt::Debug::fmt(it, f),
+			TsType::TsInfer(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<WildcardImport> for ImportClause {
+	fn from(node: WildcardImport) -> ImportClause { ImportClause::WildcardImport(node) }
 }
 impl From<NamedImports> for ImportClause {
-	fn from(node: NamedImports) -> ImportClause {
-		ImportClause::NamedImports(node)
-	}
+	fn from(node: NamedImports) -> ImportClause { ImportClause::NamedImports(node) }
 }
 impl From<Name> for ImportClause {
-	fn from(node: Name) -> ImportClause {
-		ImportClause::Name(node)
-	}
+	fn from(node: Name) -> ImportClause { ImportClause::Name(node) }
 }
 impl From<ImportStringSpecifier> for ImportClause {
 	fn from(node: ImportStringSpecifier) -> ImportClause {
@@ -9496,15 +9139,21 @@ impl AstNode for ImportClause {
 		}
 	}
 }
-impl From<JsFunctionDeclaration> for DefaultDecl {
-	fn from(node: JsFunctionDeclaration) -> DefaultDecl {
-		DefaultDecl::JsFunctionDeclaration(node)
+impl std::fmt::Debug for ImportClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			ImportClause::WildcardImport(it) => std::fmt::Debug::fmt(it, f),
+			ImportClause::NamedImports(it) => std::fmt::Debug::fmt(it, f),
+			ImportClause::Name(it) => std::fmt::Debug::fmt(it, f),
+			ImportClause::ImportStringSpecifier(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
 }
+impl From<JsFunctionDeclaration> for DefaultDecl {
+	fn from(node: JsFunctionDeclaration) -> DefaultDecl { DefaultDecl::JsFunctionDeclaration(node) }
+}
 impl From<JsClassDeclaration> for DefaultDecl {
-	fn from(node: JsClassDeclaration) -> DefaultDecl {
-		DefaultDecl::JsClassDeclaration(node)
-	}
+	fn from(node: JsClassDeclaration) -> DefaultDecl { DefaultDecl::JsClassDeclaration(node) }
 }
 impl AstNode for DefaultDecl {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9527,6 +9176,14 @@ impl AstNode for DefaultDecl {
 		}
 	}
 }
+impl std::fmt::Debug for DefaultDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			DefaultDecl::JsFunctionDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			DefaultDecl::JsClassDeclaration(it) => std::fmt::Debug::fmt(it, f),
+		}
+	}
+}
 impl From<JsFunctionDeclaration> for JsAnyExportDeclaration {
 	fn from(node: JsFunctionDeclaration) -> JsAnyExportDeclaration {
 		JsAnyExportDeclaration::JsFunctionDeclaration(node)
@@ -9543,9 +9200,7 @@ impl From<JsVariableDeclarationStatement> for JsAnyExportDeclaration {
 	}
 }
 impl From<TsEnum> for JsAnyExportDeclaration {
-	fn from(node: TsEnum) -> JsAnyExportDeclaration {
-		JsAnyExportDeclaration::TsEnum(node)
-	}
+	fn from(node: TsEnum) -> JsAnyExportDeclaration { JsAnyExportDeclaration::TsEnum(node) }
 }
 impl From<TsTypeAliasDecl> for JsAnyExportDeclaration {
 	fn from(node: TsTypeAliasDecl) -> JsAnyExportDeclaration {
@@ -9620,10 +9275,24 @@ impl AstNode for JsAnyExportDeclaration {
 		}
 	}
 }
-impl From<JsRestParameter> for JsAnyParameter {
-	fn from(node: JsRestParameter) -> JsAnyParameter {
-		JsAnyParameter::JsRestParameter(node)
+impl std::fmt::Debug for JsAnyExportDeclaration {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyExportDeclaration::JsFunctionDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::JsClassDeclaration(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::JsVariableDeclarationStatement(it) => {
+				std::fmt::Debug::fmt(it, f)
+			}
+			JsAnyExportDeclaration::TsEnum(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::TsTypeAliasDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::TsNamespaceDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::TsModuleDecl(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyExportDeclaration::TsInterfaceDecl(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<JsRestParameter> for JsAnyParameter {
+	fn from(node: JsRestParameter) -> JsAnyParameter { JsAnyParameter::JsRestParameter(node) }
 }
 impl AstNode for JsAnyParameter {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9652,10 +9321,16 @@ impl AstNode for JsAnyParameter {
 		}
 	}
 }
-impl From<TsExternalModuleRef> for TsModuleRef {
-	fn from(node: TsExternalModuleRef) -> TsModuleRef {
-		TsModuleRef::TsExternalModuleRef(node)
+impl std::fmt::Debug for JsAnyParameter {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			JsAnyParameter::Pattern(it) => std::fmt::Debug::fmt(it, f),
+			JsAnyParameter::JsRestParameter(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsExternalModuleRef> for TsModuleRef {
+	fn from(node: TsExternalModuleRef) -> TsModuleRef { TsModuleRef::TsExternalModuleRef(node) }
 }
 impl AstNode for TsModuleRef {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9686,20 +9361,22 @@ impl AstNode for TsModuleRef {
 		}
 	}
 }
-impl From<TsTypeName> for TsEntityName {
-	fn from(node: TsTypeName) -> TsEntityName {
-		TsEntityName::TsTypeName(node)
+impl std::fmt::Debug for TsModuleRef {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsModuleRef::TsExternalModuleRef(it) => std::fmt::Debug::fmt(it, f),
+			TsModuleRef::TsEntityName(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsTypeName> for TsEntityName {
+	fn from(node: TsTypeName) -> TsEntityName { TsEntityName::TsTypeName(node) }
 }
 impl From<TsQualifiedPath> for TsEntityName {
-	fn from(node: TsQualifiedPath) -> TsEntityName {
-		TsEntityName::TsQualifiedPath(node)
-	}
+	fn from(node: TsQualifiedPath) -> TsEntityName { TsEntityName::TsQualifiedPath(node) }
 }
 impl AstNode for TsEntityName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_TYPE_NAME => TsEntityName::TsTypeName(TsTypeName { syntax }),
@@ -9715,20 +9392,22 @@ impl AstNode for TsEntityName {
 		}
 	}
 }
-impl From<TsThis> for TsThisOrMore {
-	fn from(node: TsThis) -> TsThisOrMore {
-		TsThisOrMore::TsThis(node)
+impl std::fmt::Debug for TsEntityName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsEntityName::TsTypeName(it) => std::fmt::Debug::fmt(it, f),
+			TsEntityName::TsQualifiedPath(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsThis> for TsThisOrMore {
+	fn from(node: TsThis) -> TsThisOrMore { TsThisOrMore::TsThis(node) }
 }
 impl From<TsTypeName> for TsThisOrMore {
-	fn from(node: TsTypeName) -> TsThisOrMore {
-		TsThisOrMore::TsTypeName(node)
-	}
+	fn from(node: TsTypeName) -> TsThisOrMore { TsThisOrMore::TsTypeName(node) }
 }
 impl AstNode for TsThisOrMore {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_THIS | TS_TYPE_NAME)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_THIS | TS_TYPE_NAME) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_THIS => TsThisOrMore::TsThis(TsThis { syntax }),
@@ -9744,10 +9423,16 @@ impl AstNode for TsThisOrMore {
 		}
 	}
 }
-impl From<TsCallSignatureDecl> for TsTypeElement {
-	fn from(node: TsCallSignatureDecl) -> TsTypeElement {
-		TsTypeElement::TsCallSignatureDecl(node)
+impl std::fmt::Debug for TsThisOrMore {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsThisOrMore::TsThis(it) => std::fmt::Debug::fmt(it, f),
+			TsThisOrMore::TsTypeName(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsCallSignatureDecl> for TsTypeElement {
+	fn from(node: TsCallSignatureDecl) -> TsTypeElement { TsTypeElement::TsCallSignatureDecl(node) }
 }
 impl From<TsConstructSignatureDecl> for TsTypeElement {
 	fn from(node: TsConstructSignatureDecl) -> TsTypeElement {
@@ -9755,19 +9440,13 @@ impl From<TsConstructSignatureDecl> for TsTypeElement {
 	}
 }
 impl From<TsPropertySignature> for TsTypeElement {
-	fn from(node: TsPropertySignature) -> TsTypeElement {
-		TsTypeElement::TsPropertySignature(node)
-	}
+	fn from(node: TsPropertySignature) -> TsTypeElement { TsTypeElement::TsPropertySignature(node) }
 }
 impl From<TsMethodSignature> for TsTypeElement {
-	fn from(node: TsMethodSignature) -> TsTypeElement {
-		TsTypeElement::TsMethodSignature(node)
-	}
+	fn from(node: TsMethodSignature) -> TsTypeElement { TsTypeElement::TsMethodSignature(node) }
 }
 impl From<TsIndexSignature> for TsTypeElement {
-	fn from(node: TsIndexSignature) -> TsTypeElement {
-		TsTypeElement::TsIndexSignature(node)
-	}
+	fn from(node: TsIndexSignature) -> TsTypeElement { TsTypeElement::TsIndexSignature(node) }
 }
 impl AstNode for TsTypeElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9807,20 +9486,25 @@ impl AstNode for TsTypeElement {
 		}
 	}
 }
-impl From<TsModuleBlock> for TsNamespaceBody {
-	fn from(node: TsModuleBlock) -> TsNamespaceBody {
-		TsNamespaceBody::TsModuleBlock(node)
+impl std::fmt::Debug for TsTypeElement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsTypeElement::TsCallSignatureDecl(it) => std::fmt::Debug::fmt(it, f),
+			TsTypeElement::TsConstructSignatureDecl(it) => std::fmt::Debug::fmt(it, f),
+			TsTypeElement::TsPropertySignature(it) => std::fmt::Debug::fmt(it, f),
+			TsTypeElement::TsMethodSignature(it) => std::fmt::Debug::fmt(it, f),
+			TsTypeElement::TsIndexSignature(it) => std::fmt::Debug::fmt(it, f),
+		}
 	}
+}
+impl From<TsModuleBlock> for TsNamespaceBody {
+	fn from(node: TsModuleBlock) -> TsNamespaceBody { TsNamespaceBody::TsModuleBlock(node) }
 }
 impl From<TsNamespaceDecl> for TsNamespaceBody {
-	fn from(node: TsNamespaceDecl) -> TsNamespaceBody {
-		TsNamespaceBody::TsNamespaceDecl(node)
-	}
+	fn from(node: TsNamespaceDecl) -> TsNamespaceBody { TsNamespaceBody::TsNamespaceDecl(node) }
 }
 impl AstNode for TsNamespaceBody {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_MODULE_BLOCK => TsNamespaceBody::TsModuleBlock(TsModuleBlock { syntax }),
@@ -9833,6 +9517,14 @@ impl AstNode for TsNamespaceBody {
 		match self {
 			TsNamespaceBody::TsModuleBlock(it) => &it.syntax,
 			TsNamespaceBody::TsNamespaceDecl(it) => &it.syntax,
+		}
+	}
+}
+impl std::fmt::Debug for TsNamespaceBody {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TsNamespaceBody::TsModuleBlock(it) => std::fmt::Debug::fmt(it, f),
+			TsNamespaceBody::TsNamespaceDecl(it) => std::fmt::Debug::fmt(it, f),
 		}
 	}
 }

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -7,49 +7,61 @@ use crate::{
 	SyntaxKind::{self, *},
 	SyntaxNode, SyntaxResult, SyntaxToken, T,
 };
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownStatement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownPattern {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownMember {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownBinding {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownAssignmentTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownAssignmentTarget {
-	pub fn syntax_element(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn syntax_element(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -58,7 +70,7 @@ impl Ident {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsRoot {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -73,7 +85,7 @@ impl JsRoot {
 		support::node_list(&self.syntax, 1usize)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDirective {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -81,9 +93,11 @@ impl JsDirective {
 	pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBlockStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -98,7 +112,7 @@ impl JsBlockStatement {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEmptyStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -107,7 +121,7 @@ impl JsEmptyStatement {
 		support::required_token(&self.syntax, T ! [;])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsExpressionStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -115,9 +129,11 @@ impl JsExpressionStatement {
 	pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsIfStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -128,16 +144,20 @@ impl JsIfStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 	pub fn consequent(&self) -> SyntaxResult<JsAnyStatement> {
 		support::required_node(&self.syntax)
 	}
-	pub fn else_clause(&self) -> Option<JsElseClause> { support::node(&self.syntax) }
+	pub fn else_clause(&self) -> Option<JsElseClause> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDoWhileStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -145,20 +165,26 @@ impl JsDoWhileStatement {
 	pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![do])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![while])
 	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWhileStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -169,13 +195,17 @@ impl JsWhileStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmt {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -186,15 +216,23 @@ impl ForStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn init(&self) -> Option<ForStmtInit> { support::node(&self.syntax) }
-	pub fn test(&self) -> Option<ForStmtTest> { support::node(&self.syntax) }
-	pub fn update(&self) -> Option<ForStmtUpdate> { support::node(&self.syntax) }
+	pub fn init(&self) -> Option<ForStmtInit> {
+		support::node(&self.syntax)
+	}
+	pub fn test(&self) -> Option<ForStmtTest> {
+		support::node(&self.syntax)
+	}
+	pub fn update(&self) -> Option<ForStmtUpdate> {
+		support::node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForInStmt {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -205,17 +243,23 @@ impl ForInStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
+		support::required_node(&self.syntax)
+	}
 	pub fn in_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![in])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForOfStmt {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -226,17 +270,23 @@ impl ForOfStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
+		support::required_node(&self.syntax)
+	}
 	pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![of])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsContinueStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -244,10 +294,14 @@ impl JsContinueStatement {
 	pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![continue])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn label_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![ident])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBreakStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -255,10 +309,14 @@ impl JsBreakStatement {
 	pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![break])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn label_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![ident])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReturnStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -266,10 +324,14 @@ impl JsReturnStatement {
 	pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![return])
 	}
-	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn argument(&self) -> Option<JsAnyExpression> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWithStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -280,13 +342,17 @@ impl JsWithStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLabeledStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -297,9 +363,11 @@ impl JsLabeledStatement {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSwitchStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -326,7 +394,7 @@ impl JsSwitchStatement {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsThrowStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -334,10 +402,14 @@ impl JsThrowStatement {
 	pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![throw])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsTryStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -345,12 +417,14 @@ impl JsTryStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn catch_clause(&self) -> SyntaxResult<JsCatchClause> {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsTryFinallyStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -358,13 +432,17 @@ impl JsTryFinallyStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
-	pub fn catch_clause(&self) -> Option<JsCatchClause> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
+	pub fn catch_clause(&self) -> Option<JsCatchClause> {
+		support::node(&self.syntax)
+	}
 	pub fn finally_clause(&self) -> SyntaxResult<JsFinallyClause> {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDebuggerStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -372,27 +450,41 @@ impl JsDebuggerStatement {
 	pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![debugger])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionDeclaration {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsClassDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -400,9 +492,15 @@ impl JsClassDeclaration {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
-	pub fn implements_clause(&self) -> Option<TsImplementsClause> { support::node(&self.syntax) }
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
+		support::required_node(&self.syntax)
+	}
+	pub fn implements_clause(&self) -> Option<TsImplementsClause> {
+		support::node(&self.syntax)
+	}
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -413,7 +511,7 @@ impl JsClassDeclaration {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclarationStatement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -421,27 +519,35 @@ impl JsVariableDeclarationStatement {
 	pub fn declaration(&self) -> SyntaxResult<JsVariableDeclaration> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnum {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
-	pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
+	pub fn const_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![const])
+	}
 	pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![enum])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax, 0usize) }
+	pub fn members(&self) -> AstNodeList<TsEnumMember> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeAliasDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -449,13 +555,17 @@ impl TsTypeAliasDecl {
 	pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![type])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -463,11 +573,17 @@ impl TsNamespaceDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -475,35 +591,53 @@ impl TsModuleDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn global_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![global]) }
+	pub fn global_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![global])
+	}
 	pub fn module_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![module])
 	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsInterfaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInterfaceDecl {
-	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
+	pub fn declare_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![declare])
+	}
 	pub fn interface_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![interface])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
-	pub fn extends_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![extends]) }
-	pub fn extends(&self) -> Option<TsExprWithTypeArgs> { support::node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
+	pub fn extends_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![extends])
+	}
+	pub fn extends(&self) -> Option<TsExprWithTypeArgs> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> SyntaxResult<TsTypeElement> { support::required_node(&self.syntax) }
+	pub fn members(&self) -> SyntaxResult<TsTypeElement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ImportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -511,8 +645,12 @@ impl ImportDecl {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax, 0usize) }
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn imports(&self) -> AstNodeList<ImportClause> {
+		support::node_list(&self.syntax, 0usize)
+	}
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -522,10 +660,14 @@ impl ImportDecl {
 	pub fn asserted_object(&self) -> SyntaxResult<JsObjectExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn assert_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![assert]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn assert_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![assert])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportNamed {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -533,8 +675,12 @@ impl ExportNamed {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn from_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![from]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn from_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![from])
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -545,7 +691,7 @@ impl ExportNamed {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDefaultDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -553,11 +699,17 @@ impl ExportDefaultDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn decl(&self) -> SyntaxResult<DefaultDecl> { support::required_node(&self.syntax) }
+	pub fn default_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![default])
+	}
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn decl(&self) -> SyntaxResult<DefaultDecl> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDefaultExpr {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -565,11 +717,17 @@ impl ExportDefaultExpr {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn default_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![default])
+	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportWildcard {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -577,12 +735,18 @@ impl ExportWildcard {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn as_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![as])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -590,7 +754,7 @@ impl ExportWildcard {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -598,12 +762,14 @@ impl ExportDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn decl(&self) -> SyntaxResult<JsAnyExportDeclaration> {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImportEqualsDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -614,14 +780,20 @@ impl TsImportEqualsDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn module(&self) -> SyntaxResult<TsModuleRef> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn module(&self) -> SyntaxResult<TsModuleRef> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExportAssignment {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -632,10 +804,14 @@ impl TsExportAssignment {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceExportDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -649,10 +825,14 @@ impl TsNamespaceExportDecl {
 	pub fn namespace_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![namespace])
 	}
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsElseClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -660,36 +840,44 @@ impl JsElseClause {
 	pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![else])
 	}
-	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtInit {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtInit {
-	pub fn inner(&self) -> SyntaxResult<ForHead> { support::required_node(&self.syntax) }
+	pub fn inner(&self) -> SyntaxResult<ForHead> {
+		support::required_node(&self.syntax)
+	}
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtTest {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtTest {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtUpdate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtUpdate {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -701,7 +889,7 @@ impl JsVariableDeclaration {
 		support::separated_list(&self.syntax, 0usize)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCaseClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -709,7 +897,9 @@ impl JsCaseClause {
 	pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![case])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -717,7 +907,7 @@ impl JsCaseClause {
 		support::node_list(&self.syntax, 0usize)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDefaultClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -732,7 +922,7 @@ impl JsDefaultClause {
 		support::node_list(&self.syntax, 0usize)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCatchClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -740,10 +930,14 @@ impl JsCatchClause {
 	pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![catch])
 	}
-	pub fn declaration(&self) -> Option<JsCatchDeclaration> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn declaration(&self) -> Option<JsCatchDeclaration> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFinallyClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -751,9 +945,11 @@ impl JsFinallyClause {
 	pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![finally])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCatchDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -761,12 +957,14 @@ impl JsCatchDeclaration {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn binding(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrayExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -781,22 +979,28 @@ impl JsArrayExpression {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrowFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsArrowFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> Option<JsAnyArrowFunctionParameters> {
 		support::node(&self.syntax)
 	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAwaitExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -804,14 +1008,18 @@ impl JsAwaitExpression {
 	pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![await])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBinaryExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsBinaryExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(
 			&self.syntax,
@@ -842,7 +1050,7 @@ impl JsBinaryExpression {
 		)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsClassExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -850,8 +1058,12 @@ impl JsClassExpression {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> Option<JsIdentifierBinding> {
+		support::node(&self.syntax)
+	}
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -862,12 +1074,14 @@ impl JsClassExpression {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsConditionalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConditionalExpression {
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
@@ -875,12 +1089,14 @@ impl JsConditionalExpression {
 		support::required_token(&self.syntax, T ! [:])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsComputedMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn optional_chain_token_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?.])
 	}
@@ -891,25 +1107,37 @@ impl JsComputedMemberExpression {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn id(&self) -> Option<JsIdentifierBinding> {
+		support::node(&self.syntax)
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportCallExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -920,22 +1148,26 @@ impl JsImportCallExpression {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLogicalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsLogicalExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [??], T ! [||], T ! [&&]])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsObjectExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -950,7 +1182,7 @@ impl JsObjectExpression {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsParenthesizedExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -965,7 +1197,7 @@ impl JsParenthesizedExpression {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferenceIdentifierExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -974,22 +1206,26 @@ impl JsReferenceIdentifierExpression {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSequenceExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSequenceExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn comma_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [,])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsStaticMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [.], T ! [?.]])
 	}
@@ -997,7 +1233,7 @@ impl JsStaticMemberExpression {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSuperExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1006,7 +1242,7 @@ impl JsSuperExpression {
 		support::required_token(&self.syntax, T![super])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsThisExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1015,7 +1251,7 @@ impl JsThisExpression {
 		support::required_token(&self.syntax, T![this])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnaryExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1034,9 +1270,11 @@ impl JsUnaryExpression {
 			],
 		)
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPreUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1044,19 +1282,23 @@ impl JsPreUpdateExpression {
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPostUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPostUpdateExpression {
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsYieldExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1064,10 +1306,14 @@ impl JsYieldExpression {
 	pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![yield])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn argument(&self) -> Option<JsAnyExpression> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Template {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1076,7 +1322,7 @@ impl Template {
 		support::required_token(&self.syntax, T!['`'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NewExpr {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1084,20 +1330,32 @@ impl NewExpr {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> Option<TsTypeArgs> {
+		support::node(&self.syntax)
+	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn arguments(&self) -> SyntaxResult<ArgList> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CallExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CallExpr {
-	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
-	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> Option<TsTypeArgs> {
+		support::node(&self.syntax)
+	}
+	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn arguments(&self) -> SyntaxResult<ArgList> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignExpr {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1125,7 +1383,7 @@ impl AssignExpr {
 		)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NewTarget {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1140,7 +1398,7 @@ impl NewTarget {
 		support::required_token(&self.syntax, T![target])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ImportMeta {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1152,38 +1410,50 @@ impl ImportMeta {
 		support::required_token(&self.syntax, T ! [.])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNonNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
@@ -1194,7 +1464,7 @@ impl TsConstAssertion {
 		support::required_token(&self.syntax, T ! [>])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1202,12 +1472,14 @@ impl TsTypeArgs {
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn args(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn args(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ArgList {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1222,7 +1494,7 @@ impl ArgList {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsIdentifierBinding {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1231,16 +1503,22 @@ impl JsIdentifierBinding {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeParams {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParams {
-	pub fn l_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [<]) }
-	pub fn params(&self) -> SyntaxResult<TsTypeParam> { support::required_node(&self.syntax) }
-	pub fn r_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [>]) }
+	pub fn l_angle_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [<])
+	}
+	pub fn params(&self) -> SyntaxResult<TsTypeParam> {
+		support::required_node(&self.syntax)
+	}
+	pub fn r_angle_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [>])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsParameterList {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1248,14 +1526,14 @@ impl JsParameterList {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameters(&self) -> AstSeparatedList<Pattern> {
+	pub fn parameters(&self) -> AstSeparatedList<JsAnyParameter> {
 		support::separated_list(&self.syntax, 0usize)
 	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeAnnotation {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1263,9 +1541,11 @@ impl TsTypeAnnotation {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionBody {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1283,7 +1563,7 @@ impl JsFunctionBody {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SpreadElement {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1291,14 +1571,16 @@ impl SpreadElement {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn element(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn element(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrayHole {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayHole {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLiteralMemberName {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1310,7 +1592,7 @@ impl JsLiteralMemberName {
 		)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsComputedMemberName {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1325,7 +1607,7 @@ impl JsComputedMemberName {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPropertyObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1337,24 +1619,34 @@ impl JsPropertyObjectMember {
 		support::required_token(&self.syntax, T ! [:])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsMethodObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodObjectMember {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_params(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn type_params(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1371,10 +1663,14 @@ impl JsGetterObjectMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1388,24 +1684,32 @@ impl JsSetterObjectMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn parameter(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct InitializedProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl InitializedProp {
-	pub fn key(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<Name> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsShorthandPropertyObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1414,7 +1718,7 @@ impl JsShorthandPropertyObjectMember {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSpread {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1422,9 +1726,11 @@ impl JsSpread {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsStringLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1433,7 +1739,7 @@ impl JsStringLiteralExpression {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsNumberLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1442,7 +1748,7 @@ impl JsNumberLiteralExpression {
 		support::required_token(&self.syntax, T![js_number_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Name {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1451,7 +1757,7 @@ impl Name {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImplementsClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1463,7 +1769,7 @@ impl TsImplementsClause {
 		support::separated_list(&self.syntax, 0usize)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsExtendsClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1475,15 +1781,19 @@ impl JsExtendsClause {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExprWithTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
-	pub fn item(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
-	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn item(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPrivateClassMemberName {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1495,72 +1805,110 @@ impl JsPrivateClassMemberName {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsConstructorClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
-	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> { support::required_node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
+	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsConstructorParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPropertyClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyClassMember {
-	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn declare_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![declare])
+	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn value(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn excl_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![!])
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn value(&self) -> Option<JsEqualValueClause> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsMethodClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![get])
 	}
@@ -1573,19 +1921,27 @@ impl JsGetterClassMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![set])
 	}
@@ -1595,13 +1951,17 @@ impl JsSetterClassMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn parameter(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEmptyClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1610,7 +1970,7 @@ impl JsEmptyClassMember {
 		support::required_token(&self.syntax, T ! [;])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIndexSignature {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1621,16 +1981,20 @@ impl TsIndexSignature {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn pat(&self) -> SyntaxResult<SinglePattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<SinglePattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsAccessibility {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1642,7 +2006,7 @@ impl TsAccessibility {
 		support::required_token(&self.syntax, T![readonly])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsConstructorParameterList {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1657,7 +2021,7 @@ impl JsConstructorParameterList {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructorParam {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1665,9 +2029,11 @@ impl TsConstructorParam {
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![readonly])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEqualValueClause {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1679,7 +2045,7 @@ impl JsEqualValueClause {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBigIntLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1688,7 +2054,7 @@ impl JsBigIntLiteralExpression {
 		support::required_token(&self.syntax, T![js_big_int_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBooleanLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1697,7 +2063,7 @@ impl JsBooleanLiteralExpression {
 		support::find_required_token(&self.syntax, &[T![true], T![false]])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsNullLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1706,7 +2072,7 @@ impl JsNullLiteralExpression {
 		support::required_token(&self.syntax, T![null])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsRegexLiteralExpression {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1715,19 +2081,25 @@ impl JsRegexLiteralExpression {
 		support::required_token(&self.syntax, T![js_regex_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct SinglePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SinglePattern {
-	pub fn name(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<Name> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn excl_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![!])
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RestPattern {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1735,21 +2107,29 @@ impl RestPattern {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignPattern {
-	pub fn key(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ObjectPattern {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1764,7 +2144,7 @@ impl ObjectPattern {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ArrayPattern {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1772,41 +2152,53 @@ impl ArrayPattern {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax, 0usize) }
+	pub fn elements(&self) -> AstNodeList<Pattern> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExprPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprPattern {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyValuePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl KeyValuePattern {
-	pub fn key(&self) -> SyntaxResult<PropName> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<PropName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclarator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclarator {
-	pub fn id(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
-	pub fn init(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
+	pub fn init(&self) -> Option<JsEqualValueClause> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct WildcardImport {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1814,10 +2206,14 @@ impl WildcardImport {
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn as_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![as])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamedImports {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1832,7 +2228,7 @@ impl NamedImports {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ImportStringSpecifier {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1841,14 +2237,16 @@ impl ImportStringSpecifier {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Specifier {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Specifier {
-	pub fn name(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferenceIdentifierMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1857,7 +2255,7 @@ impl JsReferenceIdentifierMember {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferencePrivateMember {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1869,7 +2267,7 @@ impl JsReferencePrivateMember {
 		support::required_token(&self.syntax, T![ident])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsRestParameter {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1877,9 +2275,11 @@ impl JsRestParameter {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn binding(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExternalModuleRef {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1897,7 +2297,7 @@ impl TsExternalModuleRef {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsAny {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1906,7 +2306,7 @@ impl TsAny {
 		support::required_token(&self.syntax, T![any])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUnknown {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1915,49 +2315,61 @@ impl TsUnknown {
 		support::required_token(&self.syntax, T![unknown])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNumber {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNumber {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObject {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObject {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBoolean {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBoolean {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBigint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBigint {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsString {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsString {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsSymbol {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbol {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsVoid {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1966,7 +2378,7 @@ impl TsVoid {
 		support::required_token(&self.syntax, T![void])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUndefined {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1975,7 +2387,7 @@ impl TsUndefined {
 		support::required_token(&self.syntax, T![undefined])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNull {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1984,7 +2396,7 @@ impl TsNull {
 		support::required_token(&self.syntax, T![null])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNever {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -1993,7 +2405,7 @@ impl TsNever {
 		support::required_token(&self.syntax, T![never])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsThis {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2002,22 +2414,28 @@ impl TsThis {
 		support::required_token(&self.syntax, T![this])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsLiteral {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsLiteral {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPredicate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPredicate {
-	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> { support::required_node(&self.syntax) }
-	pub fn rhs(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> {
+		support::required_node(&self.syntax)
+	}
+	pub fn rhs(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTuple {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2025,12 +2443,14 @@ impl TsTuple {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> SyntaxResult<TsTupleElement> { support::required_node(&self.syntax) }
+	pub fn elements(&self) -> SyntaxResult<TsTupleElement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsParen {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2038,20 +2458,26 @@ impl TsParen {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeRef {
-	pub fn name(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplate {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2060,7 +2486,7 @@ impl TsTemplate {
 		support::required_node(&self.syntax)
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMappedType {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2068,23 +2494,35 @@ impl TsMappedType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> { support::node(&self.syntax) }
-	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
-	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
+	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> {
+		support::node(&self.syntax)
+	}
+	pub fn minus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [-])
+	}
+	pub fn plus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [+])
+	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> { support::required_node(&self.syntax) }
+	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImport {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2092,17 +2530,23 @@ impl TsImport {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsArray {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2110,12 +2554,14 @@ impl TsArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIndexedArray {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2123,44 +2569,56 @@ impl TsIndexedArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeOperator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperator {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIntersection {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersection {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	pub fn types(&self) -> AstNodeList<TsType> {
+		support::node_list(&self.syntax, 0usize)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUnion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnion {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	pub fn types(&self) -> AstNodeList<TsType> {
+		support::node_list(&self.syntax, 0usize)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsFnType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsFnType {
-	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
+	pub fn params(&self) -> SyntaxResult<JsParameterList> {
+		support::required_node(&self.syntax)
+	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsType> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructorType {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2168,27 +2626,35 @@ impl TsConstructorType {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
+	pub fn params(&self) -> SyntaxResult<JsParameterList> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsType> {
+		support::node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConditionalType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn extends(&self) -> SyntaxResult<TsExtends> { support::required_node(&self.syntax) }
+	pub fn extends(&self) -> SyntaxResult<TsExtends> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObjectType {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2196,12 +2662,14 @@ impl TsObjectType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax, 0usize) }
+	pub fn members(&self) -> AstNodeList<TsTypeElement> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsInfer {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2209,74 +2677,104 @@ impl TsInfer {
 	pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![infer])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTupleElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleElement {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
-	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [...]) }
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [...])
+	}
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnumMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplateElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMappedTypeReadonly {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonly {
-	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
-	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
+	pub fn minus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [-])
+	}
+	pub fn plus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [+])
+	}
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMappedTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeParam {
-	pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
-	pub fn name(&self) -> Option<TsTypeName> { support::node(&self.syntax) }
-	pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn l_brack_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T!['['])
+	}
+	pub fn name(&self) -> Option<TsTypeName> {
+		support::node(&self.syntax)
+	}
+	pub fn r_brack_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![']'])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeName {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExtends {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2284,9 +2782,11 @@ impl TsExtends {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleBlock {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2294,21 +2794,29 @@ impl TsModuleBlock {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn items(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn items(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParam {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn constraint(&self) -> SyntaxResult<TsConstraint> { support::required_node(&self.syntax) }
-	pub fn default(&self) -> SyntaxResult<TsDefault> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn constraint(&self) -> SyntaxResult<TsConstraint> {
+		support::required_node(&self.syntax)
+	}
+	pub fn default(&self) -> SyntaxResult<TsDefault> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstraint {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2316,9 +2824,11 @@ impl TsConstraint {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsDefault {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2326,23 +2836,29 @@ impl TsDefault {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsCallSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureDecl {
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2350,14 +2866,20 @@ impl TsConstructSignatureDecl {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [:]) }
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn colon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [:])
+	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPropertySignature {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2365,16 +2887,20 @@ impl TsPropertySignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMethodSignature {
 	pub(crate) syntax: SyntaxNode,
 }
@@ -2382,8 +2908,12 @@ impl TsMethodSignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn key(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
@@ -2393,18 +2923,24 @@ impl TsMethodSignature {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsQualifiedPath {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedPath {
-	pub fn lhs(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn lhs(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [.])
 	}
-	pub fn rhs(&self) -> SyntaxResult<TsTypeName> { support::required_node(&self.syntax) }
+	pub fn rhs(&self) -> SyntaxResult<TsTypeName> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyStatement {
@@ -2682,7 +3218,9 @@ pub enum TsNamespaceBody {
 	TsNamespaceDecl(TsNamespaceDecl),
 }
 impl AstNode for JsUnknownStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2690,10 +3228,21 @@ impl AstNode for JsUnknownStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownStatement")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for JsUnknownExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2701,10 +3250,21 @@ impl AstNode for JsUnknownExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownExpression")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for JsUnknownPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2712,10 +3272,21 @@ impl AstNode for JsUnknownPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownPattern")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for JsUnknownMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2723,10 +3294,21 @@ impl AstNode for JsUnknownMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownMember")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for JsUnknownBinding {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_BINDING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2734,10 +3316,21 @@ impl AstNode for JsUnknownBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownBinding {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownBinding")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for JsUnknownAssignmentTarget {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT_TARGET }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_ASSIGNMENT_TARGET
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2745,10 +3338,21 @@ impl AstNode for JsUnknownAssignmentTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnknownAssignmentTarget {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnknownAssignmentTarget")
+			.field("syntax_element", &self.syntax_element())
+			.finish()
+	}
 }
 impl AstNode for Ident {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IDENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IDENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2756,10 +3360,21 @@ impl AstNode for Ident {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for Ident {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Ident")
+			.field("ident_token", &self.ident_token())
+			.finish()
+	}
 }
 impl AstNode for JsRoot {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ROOT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ROOT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2767,10 +3382,23 @@ impl AstNode for JsRoot {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsRoot {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsRoot")
+			.field("interpreter_token", &self.interpreter_token())
+			.field("directives", &self.directives())
+			.field("statements", &self.statements())
+			.finish()
+	}
 }
 impl AstNode for JsDirective {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DIRECTIVE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2778,10 +3406,22 @@ impl AstNode for JsDirective {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsDirective {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsDirective")
+			.field("value_token", &self.value_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsBlockStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BLOCK_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2789,10 +3429,23 @@ impl AstNode for JsBlockStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsBlockStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsBlockStatement")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("statements", &self.statements())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for JsEmptyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EMPTY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2800,10 +3453,21 @@ impl AstNode for JsEmptyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsEmptyStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsEmptyStatement")
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsExpressionStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EXPRESSION_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2811,10 +3475,22 @@ impl AstNode for JsExpressionStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsExpressionStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsExpressionStatement")
+			.field("expression", &self.expression())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsIfStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IF_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2822,10 +3498,26 @@ impl AstNode for JsIfStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsIfStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsIfStatement")
+			.field("if_token", &self.if_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("test", &self.test())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("consequent", &self.consequent())
+			.field("else_clause", &self.else_clause())
+			.finish()
+	}
 }
 impl AstNode for JsDoWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DO_WHILE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2833,10 +3525,27 @@ impl AstNode for JsDoWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsDoWhileStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsDoWhileStatement")
+			.field("do_token", &self.do_token())
+			.field("body", &self.body())
+			.field("while_token", &self.while_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("test", &self.test())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_WHILE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2844,10 +3553,25 @@ impl AstNode for JsWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsWhileStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsWhileStatement")
+			.field("while_token", &self.while_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("test", &self.test())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for ForStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2855,10 +3579,27 @@ impl AstNode for ForStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForStmt {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForStmt")
+			.field("for_token", &self.for_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("init", &self.init())
+			.field("test", &self.test())
+			.field("update", &self.update())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("cons", &self.cons())
+			.finish()
+	}
 }
 impl AstNode for ForInStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_IN_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_IN_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2866,10 +3607,27 @@ impl AstNode for ForInStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForInStmt {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForInStmt")
+			.field("for_token", &self.for_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("left", &self.left())
+			.field("in_token", &self.in_token())
+			.field("right", &self.right())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("cons", &self.cons())
+			.finish()
+	}
 }
 impl AstNode for ForOfStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_OF_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_OF_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2877,10 +3635,27 @@ impl AstNode for ForOfStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForOfStmt {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForOfStmt")
+			.field("for_token", &self.for_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("left", &self.left())
+			.field("of_token", &self.of_token())
+			.field("right", &self.right())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("cons", &self.cons())
+			.finish()
+	}
 }
 impl AstNode for JsContinueStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONTINUE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2888,10 +3663,23 @@ impl AstNode for JsContinueStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsContinueStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsContinueStatement")
+			.field("continue_token", &self.continue_token())
+			.field("label_token", &self.label_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsBreakStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BREAK_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2899,10 +3687,23 @@ impl AstNode for JsBreakStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsBreakStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsBreakStatement")
+			.field("break_token", &self.break_token())
+			.field("label_token", &self.label_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsReturnStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_RETURN_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2910,10 +3711,23 @@ impl AstNode for JsReturnStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsReturnStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsReturnStatement")
+			.field("return_token", &self.return_token())
+			.field("argument", &self.argument())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsWithStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_WITH_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2921,10 +3735,25 @@ impl AstNode for JsWithStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsWithStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsWithStatement")
+			.field("with_token", &self.with_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("object", &self.object())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsLabeledStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LABELED_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2932,10 +3761,23 @@ impl AstNode for JsLabeledStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsLabeledStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsLabeledStatement")
+			.field("label_token", &self.label_token())
+			.field("colon_token", &self.colon_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsSwitchStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SWITCH_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2943,10 +3785,27 @@ impl AstNode for JsSwitchStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSwitchStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSwitchStatement")
+			.field("switch_token", &self.switch_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("discriminant", &self.discriminant())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("cases", &self.cases())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for JsThrowStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_THROW_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2954,10 +3813,23 @@ impl AstNode for JsThrowStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsThrowStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsThrowStatement")
+			.field("throw_token", &self.throw_token())
+			.field("argument", &self.argument())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsTryStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_TRY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2965,10 +3837,23 @@ impl AstNode for JsTryStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsTryStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsTryStatement")
+			.field("try_token", &self.try_token())
+			.field("body", &self.body())
+			.field("catch_clause", &self.catch_clause())
+			.finish()
+	}
 }
 impl AstNode for JsTryFinallyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_TRY_FINALLY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2976,10 +3861,24 @@ impl AstNode for JsTryFinallyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsTryFinallyStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsTryFinallyStatement")
+			.field("try_token", &self.try_token())
+			.field("body", &self.body())
+			.field("catch_clause", &self.catch_clause())
+			.field("finally_clause", &self.finally_clause())
+			.finish()
+	}
 }
 impl AstNode for JsDebuggerStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DEBUGGER_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2987,10 +3886,22 @@ impl AstNode for JsDebuggerStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsDebuggerStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsDebuggerStatement")
+			.field("debugger_token", &self.debugger_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsFunctionDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2998,10 +3909,28 @@ impl AstNode for JsFunctionDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsFunctionDeclaration {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsFunctionDeclaration")
+			.field("async_token", &self.async_token())
+			.field("function_token", &self.function_token())
+			.field("star_token", &self.star_token())
+			.field("id", &self.id())
+			.field("type_parameters", &self.type_parameters())
+			.field("parameter_list", &self.parameter_list())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsClassDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CLASS_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3009,10 +3938,27 @@ impl AstNode for JsClassDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsClassDeclaration {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsClassDeclaration")
+			.field("class_token", &self.class_token())
+			.field("id", &self.id())
+			.field("implements_clause", &self.implements_clause())
+			.field("extends_clause", &self.extends_clause())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for JsVariableDeclarationStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATION_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3020,10 +3966,22 @@ impl AstNode for JsVariableDeclarationStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsVariableDeclarationStatement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsVariableDeclarationStatement")
+			.field("declaration", &self.declaration())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for TsEnum {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ENUM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3031,10 +3989,26 @@ impl AstNode for TsEnum {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsEnum {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsEnum")
+			.field("const_token", &self.const_token())
+			.field("enum_token", &self.enum_token())
+			.field("ident", &self.ident())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeAliasDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ALIAS_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3042,10 +4016,24 @@ impl AstNode for TsTypeAliasDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeAliasDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeAliasDecl")
+			.field("type_token", &self.type_token())
+			.field("type_params", &self.type_params())
+			.field("eq_token", &self.eq_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsNamespaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NAMESPACE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3053,10 +4041,24 @@ impl AstNode for TsNamespaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNamespaceDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNamespaceDecl")
+			.field("declare_token", &self.declare_token())
+			.field("ident", &self.ident())
+			.field("dot_token", &self.dot_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for TsModuleDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MODULE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3064,10 +4066,26 @@ impl AstNode for TsModuleDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsModuleDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsModuleDecl")
+			.field("declare_token", &self.declare_token())
+			.field("global_token", &self.global_token())
+			.field("module_token", &self.module_token())
+			.field("dot_token", &self.dot_token())
+			.field("ident", &self.ident())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for TsInterfaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INTERFACE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3075,10 +4093,28 @@ impl AstNode for TsInterfaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsInterfaceDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsInterfaceDecl")
+			.field("declare_token", &self.declare_token())
+			.field("interface_token", &self.interface_token())
+			.field("type_params", &self.type_params())
+			.field("extends_token", &self.extends_token())
+			.field("extends", &self.extends())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for ImportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3086,10 +4122,28 @@ impl AstNode for ImportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ImportDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ImportDecl")
+			.field("import_token", &self.import_token())
+			.field("imports", &self.imports())
+			.field("type_token", &self.type_token())
+			.field("from_token", &self.from_token())
+			.field("source_token", &self.source_token())
+			.field("asserted_object", &self.asserted_object())
+			.field("assert_token", &self.assert_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for ExportNamed {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_NAMED }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_NAMED
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3097,10 +4151,26 @@ impl AstNode for ExportNamed {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExportNamed {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExportNamed")
+			.field("export_token", &self.export_token())
+			.field("type_token", &self.type_token())
+			.field("from_token", &self.from_token())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("specifiers", &self.specifiers())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for ExportDefaultDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DEFAULT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3108,10 +4178,24 @@ impl AstNode for ExportDefaultDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExportDefaultDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExportDefaultDecl")
+			.field("export_token", &self.export_token())
+			.field("default_token", &self.default_token())
+			.field("type_token", &self.type_token())
+			.field("decl", &self.decl())
+			.finish()
+	}
 }
 impl AstNode for ExportDefaultExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DEFAULT_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3119,10 +4203,24 @@ impl AstNode for ExportDefaultExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExportDefaultExpr {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExportDefaultExpr")
+			.field("export_token", &self.export_token())
+			.field("type_token", &self.type_token())
+			.field("default_token", &self.default_token())
+			.field("expr", &self.expr())
+			.finish()
+	}
 }
 impl AstNode for ExportWildcard {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_WILDCARD }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_WILDCARD
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3130,10 +4228,27 @@ impl AstNode for ExportWildcard {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExportWildcard {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExportWildcard")
+			.field("export_token", &self.export_token())
+			.field("type_token", &self.type_token())
+			.field("star_token", &self.star_token())
+			.field("as_token", &self.as_token())
+			.field("ident", &self.ident())
+			.field("from_token", &self.from_token())
+			.field("source_token", &self.source_token())
+			.finish()
+	}
 }
 impl AstNode for ExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3141,10 +4256,23 @@ impl AstNode for ExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExportDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExportDecl")
+			.field("export_token", &self.export_token())
+			.field("type_token", &self.type_token())
+			.field("decl", &self.decl())
+			.finish()
+	}
 }
 impl AstNode for TsImportEqualsDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPORT_EQUALS_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3152,10 +4280,26 @@ impl AstNode for TsImportEqualsDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsImportEqualsDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsImportEqualsDecl")
+			.field("import_token", &self.import_token())
+			.field("export_token", &self.export_token())
+			.field("ident", &self.ident())
+			.field("eq_token", &self.eq_token())
+			.field("module", &self.module())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for TsExportAssignment {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXPORT_ASSIGNMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3163,10 +4307,24 @@ impl AstNode for TsExportAssignment {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsExportAssignment {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsExportAssignment")
+			.field("export_token", &self.export_token())
+			.field("eq_token", &self.eq_token())
+			.field("expr", &self.expr())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for TsNamespaceExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_EXPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NAMESPACE_EXPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3174,10 +4332,25 @@ impl AstNode for TsNamespaceExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNamespaceExportDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNamespaceExportDecl")
+			.field("export_token", &self.export_token())
+			.field("as_token", &self.as_token())
+			.field("namespace_token", &self.namespace_token())
+			.field("ident", &self.ident())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsElseClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ELSE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3185,10 +4358,22 @@ impl AstNode for JsElseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsElseClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsElseClause")
+			.field("else_token", &self.else_token())
+			.field("alternate", &self.alternate())
+			.finish()
+	}
 }
 impl AstNode for ForStmtInit {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_INIT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_INIT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3196,10 +4381,22 @@ impl AstNode for ForStmtInit {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForStmtInit {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForStmtInit")
+			.field("inner", &self.inner())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for ForStmtTest {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_TEST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_TEST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3207,10 +4404,22 @@ impl AstNode for ForStmtTest {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForStmtTest {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForStmtTest")
+			.field("expr", &self.expr())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for ForStmtUpdate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_UPDATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_UPDATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3218,10 +4427,21 @@ impl AstNode for ForStmtUpdate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ForStmtUpdate {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ForStmtUpdate")
+			.field("expr", &self.expr())
+			.finish()
+	}
 }
 impl AstNode for JsVariableDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3229,10 +4449,22 @@ impl AstNode for JsVariableDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsVariableDeclaration {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsVariableDeclaration")
+			.field("kind_token", &self.kind_token())
+			.field("declarators", &self.declarators())
+			.finish()
+	}
 }
 impl AstNode for JsCaseClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CASE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3240,10 +4472,24 @@ impl AstNode for JsCaseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsCaseClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsCaseClause")
+			.field("case_token", &self.case_token())
+			.field("test", &self.test())
+			.field("colon_token", &self.colon_token())
+			.field("consequent", &self.consequent())
+			.finish()
+	}
 }
 impl AstNode for JsDefaultClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DEFAULT_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3251,10 +4497,23 @@ impl AstNode for JsDefaultClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsDefaultClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsDefaultClause")
+			.field("default_token", &self.default_token())
+			.field("colon_token", &self.colon_token())
+			.field("consequent", &self.consequent())
+			.finish()
+	}
 }
 impl AstNode for JsCatchClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CATCH_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3262,10 +4521,23 @@ impl AstNode for JsCatchClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsCatchClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsCatchClause")
+			.field("catch_token", &self.catch_token())
+			.field("declaration", &self.declaration())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsFinallyClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FINALLY_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3273,10 +4545,22 @@ impl AstNode for JsFinallyClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsFinallyClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsFinallyClause")
+			.field("finally_token", &self.finally_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsCatchDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CATCH_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3284,10 +4568,23 @@ impl AstNode for JsCatchDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsCatchDeclaration {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsCatchDeclaration")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("binding", &self.binding())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for JsArrayExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARRAY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3295,10 +4592,23 @@ impl AstNode for JsArrayExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsArrayExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsArrayExpression")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("elements", &self.elements())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for JsArrowFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARROW_FUNCTION_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3306,10 +4616,25 @@ impl AstNode for JsArrowFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsArrowFunctionExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsArrowFunctionExpression")
+			.field("async_token", &self.async_token())
+			.field("type_parameters", &self.type_parameters())
+			.field("parameter_list", &self.parameter_list())
+			.field("fat_arrow_token", &self.fat_arrow_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for JsAwaitExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_AWAIT_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3317,10 +4642,22 @@ impl AstNode for JsAwaitExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsAwaitExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsAwaitExpression")
+			.field("await_token", &self.await_token())
+			.field("argument", &self.argument())
+			.finish()
+	}
 }
 impl AstNode for JsBinaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BINARY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3328,10 +4665,22 @@ impl AstNode for JsBinaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsBinaryExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsBinaryExpression")
+			.field("left", &self.left())
+			.field("operator", &self.operator())
+			.finish()
+	}
 }
 impl AstNode for JsClassExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CLASS_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3339,10 +4688,26 @@ impl AstNode for JsClassExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsClassExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsClassExpression")
+			.field("class_token", &self.class_token())
+			.field("id", &self.id())
+			.field("extends_clause", &self.extends_clause())
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for JsConditionalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONDITIONAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3350,10 +4715,23 @@ impl AstNode for JsConditionalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsConditionalExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsConditionalExpression")
+			.field("test", &self.test())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("colon_token", &self.colon_token())
+			.finish()
+	}
 }
 impl AstNode for JsComputedMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_COMPUTED_MEMBER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3361,10 +4739,27 @@ impl AstNode for JsComputedMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsComputedMemberExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsComputedMemberExpression")
+			.field("object", &self.object())
+			.field(
+				"optional_chain_token_token",
+				&self.optional_chain_token_token(),
+			)
+			.field("l_brack_token", &self.l_brack_token())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for JsFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3372,10 +4767,28 @@ impl AstNode for JsFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsFunctionExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsFunctionExpression")
+			.field("async_token", &self.async_token())
+			.field("function_token", &self.function_token())
+			.field("star_token", &self.star_token())
+			.field("id", &self.id())
+			.field("type_parameters", &self.type_parameters())
+			.field("parameters", &self.parameters())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsImportCallExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IMPORT_CALL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3383,10 +4796,24 @@ impl AstNode for JsImportCallExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsImportCallExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsImportCallExpression")
+			.field("import_token", &self.import_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("argument", &self.argument())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for JsLogicalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LOGICAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3394,10 +4821,22 @@ impl AstNode for JsLogicalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsLogicalExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsLogicalExpression")
+			.field("left", &self.left())
+			.field("operator", &self.operator())
+			.finish()
+	}
 }
 impl AstNode for JsObjectExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_OBJECT_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3405,10 +4844,23 @@ impl AstNode for JsObjectExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsObjectExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsObjectExpression")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for JsParenthesizedExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PARENTHESIZED_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3416,10 +4868,23 @@ impl AstNode for JsParenthesizedExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsParenthesizedExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsParenthesizedExpression")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("expression", &self.expression())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for JsReferenceIdentifierExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_IDENTIFIER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3427,10 +4892,21 @@ impl AstNode for JsReferenceIdentifierExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsReferenceIdentifierExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsReferenceIdentifierExpression")
+			.field("name_token", &self.name_token())
+			.finish()
+	}
 }
 impl AstNode for JsSequenceExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SEQUENCE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3438,10 +4914,22 @@ impl AstNode for JsSequenceExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSequenceExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSequenceExpression")
+			.field("left", &self.left())
+			.field("comma_token", &self.comma_token())
+			.finish()
+	}
 }
 impl AstNode for JsStaticMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_STATIC_MEMBER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3449,10 +4937,23 @@ impl AstNode for JsStaticMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsStaticMemberExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsStaticMemberExpression")
+			.field("object", &self.object())
+			.field("operator", &self.operator())
+			.field("member", &self.member())
+			.finish()
+	}
 }
 impl AstNode for JsSuperExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SUPER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3460,10 +4961,21 @@ impl AstNode for JsSuperExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSuperExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSuperExpression")
+			.field("super_token", &self.super_token())
+			.finish()
+	}
 }
 impl AstNode for JsThisExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_THIS_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3471,10 +4983,21 @@ impl AstNode for JsThisExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsThisExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsThisExpression")
+			.field("this_token", &self.this_token())
+			.finish()
+	}
 }
 impl AstNode for JsUnaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNARY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3482,10 +5005,22 @@ impl AstNode for JsUnaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsUnaryExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsUnaryExpression")
+			.field("operator", &self.operator())
+			.field("argument", &self.argument())
+			.finish()
+	}
 }
 impl AstNode for JsPreUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PRE_UPDATE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3493,10 +5028,22 @@ impl AstNode for JsPreUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsPreUpdateExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsPreUpdateExpression")
+			.field("operator", &self.operator())
+			.field("operand", &self.operand())
+			.finish()
+	}
 }
 impl AstNode for JsPostUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_POST_UPDATE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3504,10 +5051,22 @@ impl AstNode for JsPostUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsPostUpdateExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsPostUpdateExpression")
+			.field("operand", &self.operand())
+			.field("operator", &self.operator())
+			.finish()
+	}
 }
 impl AstNode for JsYieldExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_YIELD_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3515,10 +5074,23 @@ impl AstNode for JsYieldExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsYieldExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsYieldExpression")
+			.field("yield_token", &self.yield_token())
+			.field("star_token", &self.star_token())
+			.field("argument", &self.argument())
+			.finish()
+	}
 }
 impl AstNode for Template {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TEMPLATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TEMPLATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3526,10 +5098,21 @@ impl AstNode for Template {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for Template {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Template")
+			.field("backtick_token", &self.backtick_token())
+			.finish()
+	}
 }
 impl AstNode for NewExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NEW_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3537,10 +5120,24 @@ impl AstNode for NewExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for NewExpr {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("NewExpr")
+			.field("new_token", &self.new_token())
+			.field("type_args", &self.type_args())
+			.field("object", &self.object())
+			.field("arguments", &self.arguments())
+			.finish()
+	}
 }
 impl AstNode for CallExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == CALL_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == CALL_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3548,10 +5145,23 @@ impl AstNode for CallExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for CallExpr {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("CallExpr")
+			.field("type_args", &self.type_args())
+			.field("callee", &self.callee())
+			.field("arguments", &self.arguments())
+			.finish()
+	}
 }
 impl AstNode for AssignExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ASSIGN_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3559,10 +5169,21 @@ impl AstNode for AssignExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for AssignExpr {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("AssignExpr")
+			.field("operator", &self.operator())
+			.finish()
+	}
 }
 impl AstNode for NewTarget {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NEW_TARGET
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3570,10 +5191,23 @@ impl AstNode for NewTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for NewTarget {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("NewTarget")
+			.field("new_token", &self.new_token())
+			.field("dot_token", &self.dot_token())
+			.field("target_token", &self.target_token())
+			.finish()
+	}
 }
 impl AstNode for ImportMeta {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_META
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3581,10 +5215,22 @@ impl AstNode for ImportMeta {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ImportMeta {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ImportMeta")
+			.field("import_token", &self.import_token())
+			.field("dot_token", &self.dot_token())
+			.finish()
+	}
 }
 impl AstNode for TsNonNull {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NON_NULL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3592,10 +5238,22 @@ impl AstNode for TsNonNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNonNull {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNonNull")
+			.field("expr", &self.expr())
+			.field("excl_token", &self.excl_token())
+			.finish()
+	}
 }
 impl AstNode for TsAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ASSERTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3603,10 +5261,25 @@ impl AstNode for TsAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsAssertion {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsAssertion")
+			.field("expr", &self.expr())
+			.field("ident", &self.ident())
+			.field("l_angle_token", &self.l_angle_token())
+			.field("ty", &self.ty())
+			.field("r_angle_token", &self.r_angle_token())
+			.finish()
+	}
 }
 impl AstNode for TsConstAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONST_ASSERTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONST_ASSERTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3614,10 +5287,25 @@ impl AstNode for TsConstAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConstAssertion {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConstAssertion")
+			.field("expr", &self.expr())
+			.field("ident", &self.ident())
+			.field("l_angle_token", &self.l_angle_token())
+			.field("const_token", &self.const_token())
+			.field("r_angle_token", &self.r_angle_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ARGS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3625,10 +5313,23 @@ impl AstNode for TsTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeArgs {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeArgs")
+			.field("l_angle_token", &self.l_angle_token())
+			.field("args", &self.args())
+			.field("r_angle_token", &self.r_angle_token())
+			.finish()
+	}
 }
 impl AstNode for ArgList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ARG_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ARG_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3636,10 +5337,23 @@ impl AstNode for ArgList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ArgList {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ArgList")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("args", &self.args())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for JsIdentifierBinding {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IDENTIFIER_BINDING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3647,10 +5361,21 @@ impl AstNode for JsIdentifierBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsIdentifierBinding {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsIdentifierBinding")
+			.field("name_token", &self.name_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeParams {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_PARAMS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3658,10 +5383,23 @@ impl AstNode for TsTypeParams {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeParams {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeParams")
+			.field("l_angle_token", &self.l_angle_token())
+			.field("params", &self.params())
+			.field("r_angle_token", &self.r_angle_token())
+			.finish()
+	}
 }
 impl AstNode for JsParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PARAMETER_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3669,10 +5407,23 @@ impl AstNode for JsParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsParameterList {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsParameterList")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("parameters", &self.parameters())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeAnnotation {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ANNOTATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3680,10 +5431,22 @@ impl AstNode for TsTypeAnnotation {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeAnnotation {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeAnnotation")
+			.field("colon_token", &self.colon_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for JsFunctionBody {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_BODY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3691,10 +5454,24 @@ impl AstNode for JsFunctionBody {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsFunctionBody {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsFunctionBody")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("directives", &self.directives())
+			.field("statements", &self.statements())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for SpreadElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SPREAD_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SPREAD_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3702,10 +5479,22 @@ impl AstNode for SpreadElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for SpreadElement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("SpreadElement")
+			.field("dotdotdot_token", &self.dotdotdot_token())
+			.field("element", &self.element())
+			.finish()
+	}
 }
 impl AstNode for JsArrayHole {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARRAY_HOLE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3713,10 +5502,19 @@ impl AstNode for JsArrayHole {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsArrayHole {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsArrayHole").finish()
+	}
 }
 impl AstNode for JsLiteralMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LITERAL_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3724,10 +5522,21 @@ impl AstNode for JsLiteralMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsLiteralMemberName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsLiteralMemberName")
+			.field("value", &self.value())
+			.finish()
+	}
 }
 impl AstNode for JsComputedMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_COMPUTED_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3735,10 +5544,23 @@ impl AstNode for JsComputedMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsComputedMemberName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsComputedMemberName")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("expression", &self.expression())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for JsPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PROPERTY_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3746,10 +5568,22 @@ impl AstNode for JsPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsPropertyObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsPropertyObjectMember")
+			.field("name", &self.name())
+			.field("colon_token", &self.colon_token())
+			.finish()
+	}
 }
 impl AstNode for JsMethodObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_METHOD_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3757,10 +5591,27 @@ impl AstNode for JsMethodObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsMethodObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsMethodObjectMember")
+			.field("async_token", &self.async_token())
+			.field("star_token", &self.star_token())
+			.field("name", &self.name())
+			.field("type_params", &self.type_params())
+			.field("parameter_list", &self.parameter_list())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsGetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_GETTER_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3768,10 +5619,26 @@ impl AstNode for JsGetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsGetterObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsGetterObjectMember")
+			.field("get_token", &self.get_token())
+			.field("name", &self.name())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsSetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SETTER_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3779,10 +5646,26 @@ impl AstNode for JsSetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSetterObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSetterObjectMember")
+			.field("set_token", &self.set_token())
+			.field("name", &self.name())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("parameter", &self.parameter())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for InitializedProp {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == INITIALIZED_PROP }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == INITIALIZED_PROP
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3790,10 +5673,23 @@ impl AstNode for InitializedProp {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for InitializedProp {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("InitializedProp")
+			.field("key", &self.key())
+			.field("eq_token", &self.eq_token())
+			.field("value", &self.value())
+			.finish()
+	}
 }
 impl AstNode for JsShorthandPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3801,10 +5697,21 @@ impl AstNode for JsShorthandPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsShorthandPropertyObjectMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsShorthandPropertyObjectMember")
+			.field("name", &self.name())
+			.finish()
+	}
 }
 impl AstNode for JsSpread {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SPREAD
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3812,10 +5719,22 @@ impl AstNode for JsSpread {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSpread {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSpread")
+			.field("dotdotdot_token", &self.dotdotdot_token())
+			.field("argument", &self.argument())
+			.finish()
+	}
 }
 impl AstNode for JsStringLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_STRING_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3823,10 +5742,21 @@ impl AstNode for JsStringLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsStringLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsStringLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for JsNumberLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_NUMBER_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3834,10 +5764,21 @@ impl AstNode for JsNumberLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsNumberLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsNumberLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for Name {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3845,10 +5786,21 @@ impl AstNode for Name {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for Name {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Name")
+			.field("ident_token", &self.ident_token())
+			.finish()
+	}
 }
 impl AstNode for TsImplementsClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPLEMENTS_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3856,10 +5808,22 @@ impl AstNode for TsImplementsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsImplementsClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsImplementsClause")
+			.field("implements_token", &self.implements_token())
+			.field("interfaces", &self.interfaces())
+			.finish()
+	}
 }
 impl AstNode for JsExtendsClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EXTENDS_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3867,10 +5831,22 @@ impl AstNode for JsExtendsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsExtendsClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsExtendsClause")
+			.field("extends_token", &self.extends_token())
+			.field("super_class", &self.super_class())
+			.finish()
+	}
 }
 impl AstNode for TsExprWithTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPR_WITH_TYPE_ARGS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXPR_WITH_TYPE_ARGS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3878,10 +5854,22 @@ impl AstNode for TsExprWithTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsExprWithTypeArgs {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsExprWithTypeArgs")
+			.field("item", &self.item())
+			.field("type_params", &self.type_params())
+			.finish()
+	}
 }
 impl AstNode for JsPrivateClassMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PRIVATE_CLASS_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3889,10 +5877,22 @@ impl AstNode for JsPrivateClassMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsPrivateClassMemberName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsPrivateClassMemberName")
+			.field("hash_token", &self.hash_token())
+			.field("id_token", &self.id_token())
+			.finish()
+	}
 }
 impl AstNode for JsConstructorClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONSTRUCTOR_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3900,10 +5900,24 @@ impl AstNode for JsConstructorClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsConstructorClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsConstructorClassMember")
+			.field("access_modifier", &self.access_modifier())
+			.field("name", &self.name())
+			.field("parameter_list", &self.parameter_list())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsPropertyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PROPERTY_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3911,10 +5925,30 @@ impl AstNode for JsPropertyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsPropertyClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsPropertyClassMember")
+			.field("declare_token", &self.declare_token())
+			.field("access_modifier", &self.access_modifier())
+			.field("abstract_token", &self.abstract_token())
+			.field("static_token", &self.static_token())
+			.field("name", &self.name())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("excl_token", &self.excl_token())
+			.field("ty", &self.ty())
+			.field("value", &self.value())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for JsMethodClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_METHOD_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3922,10 +5956,30 @@ impl AstNode for JsMethodClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsMethodClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsMethodClassMember")
+			.field("access_modifier", &self.access_modifier())
+			.field("static_token", &self.static_token())
+			.field("abstract_token", &self.abstract_token())
+			.field("async_token", &self.async_token())
+			.field("star_token", &self.star_token())
+			.field("name", &self.name())
+			.field("type_parameters", &self.type_parameters())
+			.field("parameter_list", &self.parameter_list())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsGetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_GETTER_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3933,10 +5987,29 @@ impl AstNode for JsGetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsGetterClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsGetterClassMember")
+			.field("access_modifier", &self.access_modifier())
+			.field("abstract_token", &self.abstract_token())
+			.field("static_token", &self.static_token())
+			.field("get_token", &self.get_token())
+			.field("name", &self.name())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("return_type", &self.return_type())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsSetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SETTER_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3944,10 +6017,29 @@ impl AstNode for JsSetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsSetterClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsSetterClassMember")
+			.field("access_modifier", &self.access_modifier())
+			.field("abstract_token", &self.abstract_token())
+			.field("static_token", &self.static_token())
+			.field("set_token", &self.set_token())
+			.field("name", &self.name())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("parameter", &self.parameter())
+			.field("r_paren_token", &self.r_paren_token())
+			.field("body", &self.body())
+			.finish()
+	}
 }
 impl AstNode for JsEmptyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EMPTY_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3955,10 +6047,21 @@ impl AstNode for JsEmptyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsEmptyClassMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsEmptyClassMember")
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for TsIndexSignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INDEX_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3966,10 +6069,26 @@ impl AstNode for TsIndexSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsIndexSignature {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsIndexSignature")
+			.field("readonly_token", &self.readonly_token())
+			.field("l_brack_token", &self.l_brack_token())
+			.field("pat", &self.pat())
+			.field("colon_token", &self.colon_token())
+			.field("ty", &self.ty())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for TsAccessibility {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ACCESSIBILITY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3977,10 +6096,22 @@ impl AstNode for TsAccessibility {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsAccessibility {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsAccessibility")
+			.field("private_token", &self.private_token())
+			.field("readonly_token", &self.readonly_token())
+			.finish()
+	}
 }
 impl AstNode for JsConstructorParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONSTRUCTOR_PARAMETER_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3988,10 +6119,23 @@ impl AstNode for JsConstructorParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsConstructorParameterList {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsConstructorParameterList")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("parameters", &self.parameters())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for TsConstructorParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCTOR_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3999,10 +6143,22 @@ impl AstNode for TsConstructorParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConstructorParam {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConstructorParam")
+			.field("readonly_token", &self.readonly_token())
+			.field("pat", &self.pat())
+			.finish()
+	}
 }
 impl AstNode for JsEqualValueClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EQUAL_VALUE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EQUAL_VALUE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4010,10 +6166,22 @@ impl AstNode for JsEqualValueClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsEqualValueClause {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsEqualValueClause")
+			.field("eq_token", &self.eq_token())
+			.field("expression", &self.expression())
+			.finish()
+	}
 }
 impl AstNode for JsBigIntLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BIG_INT_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4021,10 +6189,21 @@ impl AstNode for JsBigIntLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsBigIntLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsBigIntLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for JsBooleanLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BOOLEAN_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4032,10 +6211,21 @@ impl AstNode for JsBooleanLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsBooleanLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsBooleanLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for JsNullLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_NULL_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4043,10 +6233,21 @@ impl AstNode for JsNullLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsNullLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsNullLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for JsRegexLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REGEX_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4054,10 +6255,21 @@ impl AstNode for JsRegexLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsRegexLiteralExpression {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsRegexLiteralExpression")
+			.field("value_token", &self.value_token())
+			.finish()
+	}
 }
 impl AstNode for SinglePattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SINGLE_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SINGLE_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4065,10 +6277,24 @@ impl AstNode for SinglePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for SinglePattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("SinglePattern")
+			.field("name", &self.name())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("excl_token", &self.excl_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for RestPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == REST_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == REST_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4076,10 +6302,22 @@ impl AstNode for RestPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for RestPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("RestPattern")
+			.field("dotdotdot_token", &self.dotdotdot_token())
+			.field("pat", &self.pat())
+			.finish()
+	}
 }
 impl AstNode for AssignPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ASSIGN_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4087,10 +6325,24 @@ impl AstNode for AssignPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for AssignPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("AssignPattern")
+			.field("key", &self.key())
+			.field("ty", &self.ty())
+			.field("eq_token", &self.eq_token())
+			.field("value", &self.value())
+			.finish()
+	}
 }
 impl AstNode for ObjectPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == OBJECT_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4098,10 +6350,23 @@ impl AstNode for ObjectPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ObjectPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ObjectPattern")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("elements", &self.elements())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for ArrayPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ARRAY_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ARRAY_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4109,10 +6374,25 @@ impl AstNode for ArrayPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ArrayPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ArrayPattern")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("elements", &self.elements())
+			.field("r_brack_token", &self.r_brack_token())
+			.field("excl_token", &self.excl_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for ExprPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPR_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPR_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4120,10 +6400,21 @@ impl AstNode for ExprPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ExprPattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ExprPattern")
+			.field("expr", &self.expr())
+			.finish()
+	}
 }
 impl AstNode for KeyValuePattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == KEY_VALUE_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == KEY_VALUE_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4131,10 +6422,22 @@ impl AstNode for KeyValuePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for KeyValuePattern {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("KeyValuePattern")
+			.field("key", &self.key())
+			.field("colon_token", &self.colon_token())
+			.finish()
+	}
 }
 impl AstNode for JsVariableDeclarator {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATOR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4142,10 +6445,22 @@ impl AstNode for JsVariableDeclarator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsVariableDeclarator {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsVariableDeclarator")
+			.field("id", &self.id())
+			.field("init", &self.init())
+			.finish()
+	}
 }
 impl AstNode for WildcardImport {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == WILDCARD_IMPORT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == WILDCARD_IMPORT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4153,10 +6468,23 @@ impl AstNode for WildcardImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for WildcardImport {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("WildcardImport")
+			.field("star_token", &self.star_token())
+			.field("as_token", &self.as_token())
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for NamedImports {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NAMED_IMPORTS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NAMED_IMPORTS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4164,10 +6492,23 @@ impl AstNode for NamedImports {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for NamedImports {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("NamedImports")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("specifiers", &self.specifiers())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for ImportStringSpecifier {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_STRING_SPECIFIER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_STRING_SPECIFIER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4175,10 +6516,21 @@ impl AstNode for ImportStringSpecifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for ImportStringSpecifier {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ImportStringSpecifier")
+			.field("source_token", &self.source_token())
+			.finish()
+	}
 }
 impl AstNode for Specifier {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SPECIFIER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SPECIFIER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4186,10 +6538,21 @@ impl AstNode for Specifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for Specifier {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Specifier")
+			.field("name", &self.name())
+			.finish()
+	}
 }
 impl AstNode for JsReferenceIdentifierMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_IDENTIFIER_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4197,10 +6560,21 @@ impl AstNode for JsReferenceIdentifierMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsReferenceIdentifierMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsReferenceIdentifierMember")
+			.field("name_token", &self.name_token())
+			.finish()
+	}
 }
 impl AstNode for JsReferencePrivateMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_PRIVATE_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_PRIVATE_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4208,10 +6582,22 @@ impl AstNode for JsReferencePrivateMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsReferencePrivateMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsReferencePrivateMember")
+			.field("hash_token", &self.hash_token())
+			.field("name_token", &self.name_token())
+			.finish()
+	}
 }
 impl AstNode for JsRestParameter {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REST_PARAMETER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4219,10 +6605,22 @@ impl AstNode for JsRestParameter {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for JsRestParameter {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("JsRestParameter")
+			.field("dotdotdot_token", &self.dotdotdot_token())
+			.field("binding", &self.binding())
+			.finish()
+	}
 }
 impl AstNode for TsExternalModuleRef {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REF }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXTERNAL_MODULE_REF
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4230,10 +6628,24 @@ impl AstNode for TsExternalModuleRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsExternalModuleRef {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsExternalModuleRef")
+			.field("require_token", &self.require_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("module_token", &self.module_token())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for TsAny {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ANY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4241,10 +6653,21 @@ impl AstNode for TsAny {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsAny {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsAny")
+			.field("any_token", &self.any_token())
+			.finish()
+	}
 }
 impl AstNode for TsUnknown {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNKNOWN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4252,10 +6675,21 @@ impl AstNode for TsUnknown {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsUnknown {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsUnknown")
+			.field("unknown_token", &self.unknown_token())
+			.finish()
+	}
 }
 impl AstNode for TsNumber {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NUMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4263,10 +6697,21 @@ impl AstNode for TsNumber {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNumber {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNumber")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsObject {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_OBJECT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4274,10 +6719,21 @@ impl AstNode for TsObject {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsObject {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsObject")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsBoolean {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_BOOLEAN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4285,10 +6741,21 @@ impl AstNode for TsBoolean {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsBoolean {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsBoolean")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsBigint {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_BIGINT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4296,10 +6763,21 @@ impl AstNode for TsBigint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsBigint {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsBigint")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsString {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_STRING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4307,10 +6785,21 @@ impl AstNode for TsString {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsString {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsString")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsSymbol {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_SYMBOL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4318,10 +6807,21 @@ impl AstNode for TsSymbol {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsSymbol {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsSymbol")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsVoid {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_VOID
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4329,10 +6829,21 @@ impl AstNode for TsVoid {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsVoid {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsVoid")
+			.field("void_token", &self.void_token())
+			.finish()
+	}
 }
 impl AstNode for TsUndefined {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNDEFINED
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4340,10 +6851,21 @@ impl AstNode for TsUndefined {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsUndefined {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsUndefined")
+			.field("undefined_token", &self.undefined_token())
+			.finish()
+	}
 }
 impl AstNode for TsNull {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NULL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4351,10 +6873,21 @@ impl AstNode for TsNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNull {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNull")
+			.field("null_token", &self.null_token())
+			.finish()
+	}
 }
 impl AstNode for TsNever {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NEVER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4362,10 +6895,21 @@ impl AstNode for TsNever {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsNever {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsNever")
+			.field("never_token", &self.never_token())
+			.finish()
+	}
 }
 impl AstNode for TsThis {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_THIS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4373,10 +6917,21 @@ impl AstNode for TsThis {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsThis {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsThis")
+			.field("this_token", &self.this_token())
+			.finish()
+	}
 }
 impl AstNode for TsLiteral {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_LITERAL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_LITERAL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4384,10 +6939,21 @@ impl AstNode for TsLiteral {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsLiteral {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsLiteral")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsPredicate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PREDICATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4395,10 +6961,22 @@ impl AstNode for TsPredicate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsPredicate {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsPredicate")
+			.field("lhs", &self.lhs())
+			.field("rhs", &self.rhs())
+			.finish()
+	}
 }
 impl AstNode for TsTuple {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TUPLE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4406,10 +6984,23 @@ impl AstNode for TsTuple {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTuple {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTuple")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("elements", &self.elements())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for TsParen {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PAREN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PAREN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4417,10 +7008,23 @@ impl AstNode for TsParen {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsParen {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsParen")
+			.field("l_paren_token", &self.l_paren_token())
+			.field("ty", &self.ty())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeRef {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_REF }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_REF
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4428,10 +7032,22 @@ impl AstNode for TsTypeRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeRef {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeRef")
+			.field("name", &self.name())
+			.field("type_args", &self.type_args())
+			.finish()
+	}
 }
 impl AstNode for TsTemplate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TEMPLATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4439,10 +7055,21 @@ impl AstNode for TsTemplate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTemplate {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTemplate")
+			.field("elements", &self.elements())
+			.finish()
+	}
 }
 impl AstNode for TsMappedType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4450,10 +7077,30 @@ impl AstNode for TsMappedType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsMappedType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsMappedType")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("readonly_modifier", &self.readonly_modifier())
+			.field("minus_token", &self.minus_token())
+			.field("plus_token", &self.plus_token())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("param", &self.param())
+			.field("colon_token", &self.colon_token())
+			.field("ty", &self.ty())
+			.field("r_curly_token", &self.r_curly_token())
+			.field("semicolon_token", &self.semicolon_token())
+			.finish()
+	}
 }
 impl AstNode for TsImport {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPORT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4461,10 +7108,26 @@ impl AstNode for TsImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsImport {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsImport")
+			.field("import_token", &self.import_token())
+			.field("type_args", &self.type_args())
+			.field("dot_token", &self.dot_token())
+			.field("l_paren_token", &self.l_paren_token())
+			.field("qualifier", &self.qualifier())
+			.field("r_paren_token", &self.r_paren_token())
+			.finish()
+	}
 }
 impl AstNode for TsArray {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ARRAY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4472,10 +7135,23 @@ impl AstNode for TsArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsArray {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsArray")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("ty", &self.ty())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for TsIndexedArray {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ARRAY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INDEXED_ARRAY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4483,10 +7159,23 @@ impl AstNode for TsIndexedArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsIndexedArray {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsIndexedArray")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("ty", &self.ty())
+			.field("r_brack_token", &self.r_brack_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeOperator {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_OPERATOR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4494,10 +7183,21 @@ impl AstNode for TsTypeOperator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeOperator {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeOperator")
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsIntersection {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INTERSECTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4505,10 +7205,21 @@ impl AstNode for TsIntersection {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsIntersection {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsIntersection")
+			.field("types", &self.types())
+			.finish()
+	}
 }
 impl AstNode for TsUnion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4516,10 +7227,21 @@ impl AstNode for TsUnion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsUnion {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsUnion")
+			.field("types", &self.types())
+			.finish()
+	}
 }
 impl AstNode for TsFnType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FN_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_FN_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4527,10 +7249,23 @@ impl AstNode for TsFnType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsFnType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsFnType")
+			.field("params", &self.params())
+			.field("fat_arrow_token", &self.fat_arrow_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for TsConstructorType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCTOR_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4538,10 +7273,24 @@ impl AstNode for TsConstructorType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConstructorType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConstructorType")
+			.field("new_token", &self.new_token())
+			.field("params", &self.params())
+			.field("colon_token", &self.colon_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for TsConditionalType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONDITIONAL_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4549,10 +7298,24 @@ impl AstNode for TsConditionalType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConditionalType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConditionalType")
+			.field("ty", &self.ty())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("colon_token", &self.colon_token())
+			.field("extends", &self.extends())
+			.finish()
+	}
 }
 impl AstNode for TsObjectType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_OBJECT_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4560,10 +7323,23 @@ impl AstNode for TsObjectType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsObjectType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsObjectType")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("members", &self.members())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for TsInfer {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INFER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4571,10 +7347,22 @@ impl AstNode for TsInfer {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsInfer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsInfer")
+			.field("infer_token", &self.infer_token())
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsTupleElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TUPLE_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4582,10 +7370,25 @@ impl AstNode for TsTupleElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTupleElement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTupleElement")
+			.field("ident", &self.ident())
+			.field("colon_token", &self.colon_token())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("dotdotdot_token", &self.dotdotdot_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsEnumMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ENUM_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4593,10 +7396,23 @@ impl AstNode for TsEnumMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsEnumMember {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsEnumMember")
+			.field("ident", &self.ident())
+			.field("eq_token", &self.eq_token())
+			.field("value", &self.value())
+			.finish()
+	}
 }
 impl AstNode for TsTemplateElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TEMPLATE_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4604,10 +7420,22 @@ impl AstNode for TsTemplateElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTemplateElement {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTemplateElement")
+			.field("ty", &self.ty())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for TsMappedTypeReadonly {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE_READONLY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4615,10 +7443,23 @@ impl AstNode for TsMappedTypeReadonly {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsMappedTypeReadonly {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsMappedTypeReadonly")
+			.field("minus_token", &self.minus_token())
+			.field("plus_token", &self.plus_token())
+			.field("readonly_token", &self.readonly_token())
+			.finish()
+	}
 }
 impl AstNode for TsMappedTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4626,10 +7467,25 @@ impl AstNode for TsMappedTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsMappedTypeParam {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsMappedTypeParam")
+			.field("l_brack_token", &self.l_brack_token())
+			.field("name", &self.name())
+			.field("r_brack_token", &self.r_brack_token())
+			.field("ident", &self.ident())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsTypeName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4637,10 +7493,21 @@ impl AstNode for TsTypeName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeName {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeName")
+			.field("ident", &self.ident())
+			.finish()
+	}
 }
 impl AstNode for TsExtends {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXTENDS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4648,10 +7515,22 @@ impl AstNode for TsExtends {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsExtends {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsExtends")
+			.field("extends_token", &self.extends_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsModuleBlock {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MODULE_BLOCK
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4659,10 +7538,23 @@ impl AstNode for TsModuleBlock {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsModuleBlock {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsModuleBlock")
+			.field("l_curly_token", &self.l_curly_token())
+			.field("items", &self.items())
+			.field("r_curly_token", &self.r_curly_token())
+			.finish()
+	}
 }
 impl AstNode for TsTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4670,10 +7562,23 @@ impl AstNode for TsTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsTypeParam {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsTypeParam")
+			.field("ident", &self.ident())
+			.field("constraint", &self.constraint())
+			.field("default", &self.default())
+			.finish()
+	}
 }
 impl AstNode for TsConstraint {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRAINT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRAINT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4681,10 +7586,22 @@ impl AstNode for TsConstraint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConstraint {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConstraint")
+			.field("extends_token", &self.extends_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsDefault {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_DEFAULT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4692,10 +7609,22 @@ impl AstNode for TsDefault {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsDefault {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsDefault")
+			.field("eq_token", &self.eq_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsCallSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CALL_SIGNATURE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4703,10 +7632,24 @@ impl AstNode for TsCallSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsCallSignatureDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsCallSignatureDecl")
+			.field("type_params", &self.type_params())
+			.field("parameters", &self.parameters())
+			.field("colon_token", &self.colon_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for TsConstructSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCT_SIGNATURE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4714,10 +7657,25 @@ impl AstNode for TsConstructSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsConstructSignatureDecl {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsConstructSignatureDecl")
+			.field("new_token", &self.new_token())
+			.field("type_params", &self.type_params())
+			.field("parameters", &self.parameters())
+			.field("colon_token", &self.colon_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for TsPropertySignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PROPERTY_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4725,10 +7683,25 @@ impl AstNode for TsPropertySignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsPropertySignature {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsPropertySignature")
+			.field("readonly_token", &self.readonly_token())
+			.field("prop", &self.prop())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("colon_token", &self.colon_token())
+			.field("ty", &self.ty())
+			.finish()
+	}
 }
 impl AstNode for TsMethodSignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_METHOD_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4736,10 +7709,27 @@ impl AstNode for TsMethodSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsMethodSignature {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsMethodSignature")
+			.field("readonly_token", &self.readonly_token())
+			.field("key", &self.key())
+			.field("type_params", &self.type_params())
+			.field("parameters", &self.parameters())
+			.field("question_mark_token", &self.question_mark_token())
+			.field("colon_token", &self.colon_token())
+			.field("return_type", &self.return_type())
+			.finish()
+	}
 }
 impl AstNode for TsQualifiedPath {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_PATH }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_QUALIFIED_PATH
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4747,13 +7737,28 @@ impl AstNode for TsQualifiedPath {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
+}
+impl std::fmt::Debug for TsQualifiedPath {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TsQualifiedPath")
+			.field("lhs", &self.lhs())
+			.field("dot_token", &self.dot_token())
+			.field("rhs", &self.rhs())
+			.finish()
+	}
 }
 impl From<JsBlockStatement> for JsAnyStatement {
-	fn from(node: JsBlockStatement) -> JsAnyStatement { JsAnyStatement::JsBlockStatement(node) }
+	fn from(node: JsBlockStatement) -> JsAnyStatement {
+		JsAnyStatement::JsBlockStatement(node)
+	}
 }
 impl From<JsEmptyStatement> for JsAnyStatement {
-	fn from(node: JsEmptyStatement) -> JsAnyStatement { JsAnyStatement::JsEmptyStatement(node) }
+	fn from(node: JsEmptyStatement) -> JsAnyStatement {
+		JsAnyStatement::JsEmptyStatement(node)
+	}
 }
 impl From<JsExpressionStatement> for JsAnyStatement {
 	fn from(node: JsExpressionStatement) -> JsAnyStatement {
@@ -4761,22 +7766,34 @@ impl From<JsExpressionStatement> for JsAnyStatement {
 	}
 }
 impl From<JsIfStatement> for JsAnyStatement {
-	fn from(node: JsIfStatement) -> JsAnyStatement { JsAnyStatement::JsIfStatement(node) }
+	fn from(node: JsIfStatement) -> JsAnyStatement {
+		JsAnyStatement::JsIfStatement(node)
+	}
 }
 impl From<JsDoWhileStatement> for JsAnyStatement {
-	fn from(node: JsDoWhileStatement) -> JsAnyStatement { JsAnyStatement::JsDoWhileStatement(node) }
+	fn from(node: JsDoWhileStatement) -> JsAnyStatement {
+		JsAnyStatement::JsDoWhileStatement(node)
+	}
 }
 impl From<JsWhileStatement> for JsAnyStatement {
-	fn from(node: JsWhileStatement) -> JsAnyStatement { JsAnyStatement::JsWhileStatement(node) }
+	fn from(node: JsWhileStatement) -> JsAnyStatement {
+		JsAnyStatement::JsWhileStatement(node)
+	}
 }
 impl From<ForStmt> for JsAnyStatement {
-	fn from(node: ForStmt) -> JsAnyStatement { JsAnyStatement::ForStmt(node) }
+	fn from(node: ForStmt) -> JsAnyStatement {
+		JsAnyStatement::ForStmt(node)
+	}
 }
 impl From<ForInStmt> for JsAnyStatement {
-	fn from(node: ForInStmt) -> JsAnyStatement { JsAnyStatement::ForInStmt(node) }
+	fn from(node: ForInStmt) -> JsAnyStatement {
+		JsAnyStatement::ForInStmt(node)
+	}
 }
 impl From<ForOfStmt> for JsAnyStatement {
-	fn from(node: ForOfStmt) -> JsAnyStatement { JsAnyStatement::ForOfStmt(node) }
+	fn from(node: ForOfStmt) -> JsAnyStatement {
+		JsAnyStatement::ForOfStmt(node)
+	}
 }
 impl From<JsContinueStatement> for JsAnyStatement {
 	fn from(node: JsContinueStatement) -> JsAnyStatement {
@@ -4784,25 +7801,39 @@ impl From<JsContinueStatement> for JsAnyStatement {
 	}
 }
 impl From<JsBreakStatement> for JsAnyStatement {
-	fn from(node: JsBreakStatement) -> JsAnyStatement { JsAnyStatement::JsBreakStatement(node) }
+	fn from(node: JsBreakStatement) -> JsAnyStatement {
+		JsAnyStatement::JsBreakStatement(node)
+	}
 }
 impl From<JsReturnStatement> for JsAnyStatement {
-	fn from(node: JsReturnStatement) -> JsAnyStatement { JsAnyStatement::JsReturnStatement(node) }
+	fn from(node: JsReturnStatement) -> JsAnyStatement {
+		JsAnyStatement::JsReturnStatement(node)
+	}
 }
 impl From<JsWithStatement> for JsAnyStatement {
-	fn from(node: JsWithStatement) -> JsAnyStatement { JsAnyStatement::JsWithStatement(node) }
+	fn from(node: JsWithStatement) -> JsAnyStatement {
+		JsAnyStatement::JsWithStatement(node)
+	}
 }
 impl From<JsLabeledStatement> for JsAnyStatement {
-	fn from(node: JsLabeledStatement) -> JsAnyStatement { JsAnyStatement::JsLabeledStatement(node) }
+	fn from(node: JsLabeledStatement) -> JsAnyStatement {
+		JsAnyStatement::JsLabeledStatement(node)
+	}
 }
 impl From<JsSwitchStatement> for JsAnyStatement {
-	fn from(node: JsSwitchStatement) -> JsAnyStatement { JsAnyStatement::JsSwitchStatement(node) }
+	fn from(node: JsSwitchStatement) -> JsAnyStatement {
+		JsAnyStatement::JsSwitchStatement(node)
+	}
 }
 impl From<JsThrowStatement> for JsAnyStatement {
-	fn from(node: JsThrowStatement) -> JsAnyStatement { JsAnyStatement::JsThrowStatement(node) }
+	fn from(node: JsThrowStatement) -> JsAnyStatement {
+		JsAnyStatement::JsThrowStatement(node)
+	}
 }
 impl From<JsTryStatement> for JsAnyStatement {
-	fn from(node: JsTryStatement) -> JsAnyStatement { JsAnyStatement::JsTryStatement(node) }
+	fn from(node: JsTryStatement) -> JsAnyStatement {
+		JsAnyStatement::JsTryStatement(node)
+	}
 }
 impl From<JsTryFinallyStatement> for JsAnyStatement {
 	fn from(node: JsTryFinallyStatement) -> JsAnyStatement {
@@ -4820,7 +7851,9 @@ impl From<JsFunctionDeclaration> for JsAnyStatement {
 	}
 }
 impl From<JsClassDeclaration> for JsAnyStatement {
-	fn from(node: JsClassDeclaration) -> JsAnyStatement { JsAnyStatement::JsClassDeclaration(node) }
+	fn from(node: JsClassDeclaration) -> JsAnyStatement {
+		JsAnyStatement::JsClassDeclaration(node)
+	}
 }
 impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	fn from(node: JsVariableDeclarationStatement) -> JsAnyStatement {
@@ -4828,43 +7861,69 @@ impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	}
 }
 impl From<TsEnum> for JsAnyStatement {
-	fn from(node: TsEnum) -> JsAnyStatement { JsAnyStatement::TsEnum(node) }
+	fn from(node: TsEnum) -> JsAnyStatement {
+		JsAnyStatement::TsEnum(node)
+	}
 }
 impl From<TsTypeAliasDecl> for JsAnyStatement {
-	fn from(node: TsTypeAliasDecl) -> JsAnyStatement { JsAnyStatement::TsTypeAliasDecl(node) }
+	fn from(node: TsTypeAliasDecl) -> JsAnyStatement {
+		JsAnyStatement::TsTypeAliasDecl(node)
+	}
 }
 impl From<TsNamespaceDecl> for JsAnyStatement {
-	fn from(node: TsNamespaceDecl) -> JsAnyStatement { JsAnyStatement::TsNamespaceDecl(node) }
+	fn from(node: TsNamespaceDecl) -> JsAnyStatement {
+		JsAnyStatement::TsNamespaceDecl(node)
+	}
 }
 impl From<TsModuleDecl> for JsAnyStatement {
-	fn from(node: TsModuleDecl) -> JsAnyStatement { JsAnyStatement::TsModuleDecl(node) }
+	fn from(node: TsModuleDecl) -> JsAnyStatement {
+		JsAnyStatement::TsModuleDecl(node)
+	}
 }
 impl From<TsInterfaceDecl> for JsAnyStatement {
-	fn from(node: TsInterfaceDecl) -> JsAnyStatement { JsAnyStatement::TsInterfaceDecl(node) }
+	fn from(node: TsInterfaceDecl) -> JsAnyStatement {
+		JsAnyStatement::TsInterfaceDecl(node)
+	}
 }
 impl From<ImportDecl> for JsAnyStatement {
-	fn from(node: ImportDecl) -> JsAnyStatement { JsAnyStatement::ImportDecl(node) }
+	fn from(node: ImportDecl) -> JsAnyStatement {
+		JsAnyStatement::ImportDecl(node)
+	}
 }
 impl From<ExportNamed> for JsAnyStatement {
-	fn from(node: ExportNamed) -> JsAnyStatement { JsAnyStatement::ExportNamed(node) }
+	fn from(node: ExportNamed) -> JsAnyStatement {
+		JsAnyStatement::ExportNamed(node)
+	}
 }
 impl From<ExportDefaultDecl> for JsAnyStatement {
-	fn from(node: ExportDefaultDecl) -> JsAnyStatement { JsAnyStatement::ExportDefaultDecl(node) }
+	fn from(node: ExportDefaultDecl) -> JsAnyStatement {
+		JsAnyStatement::ExportDefaultDecl(node)
+	}
 }
 impl From<ExportDefaultExpr> for JsAnyStatement {
-	fn from(node: ExportDefaultExpr) -> JsAnyStatement { JsAnyStatement::ExportDefaultExpr(node) }
+	fn from(node: ExportDefaultExpr) -> JsAnyStatement {
+		JsAnyStatement::ExportDefaultExpr(node)
+	}
 }
 impl From<ExportWildcard> for JsAnyStatement {
-	fn from(node: ExportWildcard) -> JsAnyStatement { JsAnyStatement::ExportWildcard(node) }
+	fn from(node: ExportWildcard) -> JsAnyStatement {
+		JsAnyStatement::ExportWildcard(node)
+	}
 }
 impl From<ExportDecl> for JsAnyStatement {
-	fn from(node: ExportDecl) -> JsAnyStatement { JsAnyStatement::ExportDecl(node) }
+	fn from(node: ExportDecl) -> JsAnyStatement {
+		JsAnyStatement::ExportDecl(node)
+	}
 }
 impl From<TsImportEqualsDecl> for JsAnyStatement {
-	fn from(node: TsImportEqualsDecl) -> JsAnyStatement { JsAnyStatement::TsImportEqualsDecl(node) }
+	fn from(node: TsImportEqualsDecl) -> JsAnyStatement {
+		JsAnyStatement::TsImportEqualsDecl(node)
+	}
 }
 impl From<TsExportAssignment> for JsAnyStatement {
-	fn from(node: TsExportAssignment) -> JsAnyStatement { JsAnyStatement::TsExportAssignment(node) }
+	fn from(node: TsExportAssignment) -> JsAnyStatement {
+		JsAnyStatement::TsExportAssignment(node)
+	}
 }
 impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	fn from(node: TsNamespaceExportDecl) -> JsAnyStatement {
@@ -4872,7 +7931,9 @@ impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	}
 }
 impl From<JsUnknownStatement> for JsAnyStatement {
-	fn from(node: JsUnknownStatement) -> JsAnyStatement { JsAnyStatement::JsUnknownStatement(node) }
+	fn from(node: JsUnknownStatement) -> JsAnyStatement {
+		JsAnyStatement::JsUnknownStatement(node)
+	}
 }
 impl AstNode for JsAnyStatement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5025,7 +8086,9 @@ impl AstNode for JsAnyStatement {
 	}
 }
 impl From<JsArrayExpression> for JsAnyExpression {
-	fn from(node: JsArrayExpression) -> JsAnyExpression { JsAnyExpression::JsArrayExpression(node) }
+	fn from(node: JsArrayExpression) -> JsAnyExpression {
+		JsAnyExpression::JsArrayExpression(node)
+	}
 }
 impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	fn from(node: JsArrowFunctionExpression) -> JsAnyExpression {
@@ -5033,7 +8096,9 @@ impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	}
 }
 impl From<JsAwaitExpression> for JsAnyExpression {
-	fn from(node: JsAwaitExpression) -> JsAnyExpression { JsAnyExpression::JsAwaitExpression(node) }
+	fn from(node: JsAwaitExpression) -> JsAnyExpression {
+		JsAnyExpression::JsAwaitExpression(node)
+	}
 }
 impl From<JsBinaryExpression> for JsAnyExpression {
 	fn from(node: JsBinaryExpression) -> JsAnyExpression {
@@ -5041,7 +8106,9 @@ impl From<JsBinaryExpression> for JsAnyExpression {
 	}
 }
 impl From<JsClassExpression> for JsAnyExpression {
-	fn from(node: JsClassExpression) -> JsAnyExpression { JsAnyExpression::JsClassExpression(node) }
+	fn from(node: JsClassExpression) -> JsAnyExpression {
+		JsAnyExpression::JsClassExpression(node)
+	}
 }
 impl From<JsConditionalExpression> for JsAnyExpression {
 	fn from(node: JsConditionalExpression) -> JsAnyExpression {
@@ -5094,13 +8161,19 @@ impl From<JsStaticMemberExpression> for JsAnyExpression {
 	}
 }
 impl From<JsSuperExpression> for JsAnyExpression {
-	fn from(node: JsSuperExpression) -> JsAnyExpression { JsAnyExpression::JsSuperExpression(node) }
+	fn from(node: JsSuperExpression) -> JsAnyExpression {
+		JsAnyExpression::JsSuperExpression(node)
+	}
 }
 impl From<JsThisExpression> for JsAnyExpression {
-	fn from(node: JsThisExpression) -> JsAnyExpression { JsAnyExpression::JsThisExpression(node) }
+	fn from(node: JsThisExpression) -> JsAnyExpression {
+		JsAnyExpression::JsThisExpression(node)
+	}
 }
 impl From<JsUnaryExpression> for JsAnyExpression {
-	fn from(node: JsUnaryExpression) -> JsAnyExpression { JsAnyExpression::JsUnaryExpression(node) }
+	fn from(node: JsUnaryExpression) -> JsAnyExpression {
+		JsAnyExpression::JsUnaryExpression(node)
+	}
 }
 impl From<JsPreUpdateExpression> for JsAnyExpression {
 	fn from(node: JsPreUpdateExpression) -> JsAnyExpression {
@@ -5113,34 +8186,54 @@ impl From<JsPostUpdateExpression> for JsAnyExpression {
 	}
 }
 impl From<JsYieldExpression> for JsAnyExpression {
-	fn from(node: JsYieldExpression) -> JsAnyExpression { JsAnyExpression::JsYieldExpression(node) }
+	fn from(node: JsYieldExpression) -> JsAnyExpression {
+		JsAnyExpression::JsYieldExpression(node)
+	}
 }
 impl From<Template> for JsAnyExpression {
-	fn from(node: Template) -> JsAnyExpression { JsAnyExpression::Template(node) }
+	fn from(node: Template) -> JsAnyExpression {
+		JsAnyExpression::Template(node)
+	}
 }
 impl From<NewExpr> for JsAnyExpression {
-	fn from(node: NewExpr) -> JsAnyExpression { JsAnyExpression::NewExpr(node) }
+	fn from(node: NewExpr) -> JsAnyExpression {
+		JsAnyExpression::NewExpr(node)
+	}
 }
 impl From<CallExpr> for JsAnyExpression {
-	fn from(node: CallExpr) -> JsAnyExpression { JsAnyExpression::CallExpr(node) }
+	fn from(node: CallExpr) -> JsAnyExpression {
+		JsAnyExpression::CallExpr(node)
+	}
 }
 impl From<AssignExpr> for JsAnyExpression {
-	fn from(node: AssignExpr) -> JsAnyExpression { JsAnyExpression::AssignExpr(node) }
+	fn from(node: AssignExpr) -> JsAnyExpression {
+		JsAnyExpression::AssignExpr(node)
+	}
 }
 impl From<NewTarget> for JsAnyExpression {
-	fn from(node: NewTarget) -> JsAnyExpression { JsAnyExpression::NewTarget(node) }
+	fn from(node: NewTarget) -> JsAnyExpression {
+		JsAnyExpression::NewTarget(node)
+	}
 }
 impl From<ImportMeta> for JsAnyExpression {
-	fn from(node: ImportMeta) -> JsAnyExpression { JsAnyExpression::ImportMeta(node) }
+	fn from(node: ImportMeta) -> JsAnyExpression {
+		JsAnyExpression::ImportMeta(node)
+	}
 }
 impl From<TsNonNull> for JsAnyExpression {
-	fn from(node: TsNonNull) -> JsAnyExpression { JsAnyExpression::TsNonNull(node) }
+	fn from(node: TsNonNull) -> JsAnyExpression {
+		JsAnyExpression::TsNonNull(node)
+	}
 }
 impl From<TsAssertion> for JsAnyExpression {
-	fn from(node: TsAssertion) -> JsAnyExpression { JsAnyExpression::TsAssertion(node) }
+	fn from(node: TsAssertion) -> JsAnyExpression {
+		JsAnyExpression::TsAssertion(node)
+	}
 }
 impl From<TsConstAssertion> for JsAnyExpression {
-	fn from(node: TsConstAssertion) -> JsAnyExpression { JsAnyExpression::TsConstAssertion(node) }
+	fn from(node: TsConstAssertion) -> JsAnyExpression {
+		JsAnyExpression::TsConstAssertion(node)
+	}
 }
 impl From<JsUnknownExpression> for JsAnyExpression {
 	fn from(node: JsUnknownExpression) -> JsAnyExpression {
@@ -5299,7 +8392,9 @@ impl AstNode for JsAnyExpression {
 	}
 }
 impl From<JsVariableDeclaration> for ForHead {
-	fn from(node: JsVariableDeclaration) -> ForHead { ForHead::JsVariableDeclaration(node) }
+	fn from(node: JsVariableDeclaration) -> ForHead {
+		ForHead::JsVariableDeclaration(node)
+	}
 }
 impl AstNode for ForHead {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5331,13 +8426,19 @@ impl AstNode for ForHead {
 	}
 }
 impl From<JsCaseClause> for JsAnySwitchClause {
-	fn from(node: JsCaseClause) -> JsAnySwitchClause { JsAnySwitchClause::JsCaseClause(node) }
+	fn from(node: JsCaseClause) -> JsAnySwitchClause {
+		JsAnySwitchClause::JsCaseClause(node)
+	}
 }
 impl From<JsDefaultClause> for JsAnySwitchClause {
-	fn from(node: JsDefaultClause) -> JsAnySwitchClause { JsAnySwitchClause::JsDefaultClause(node) }
+	fn from(node: JsDefaultClause) -> JsAnySwitchClause {
+		JsAnySwitchClause::JsDefaultClause(node)
+	}
 }
 impl AstNode for JsAnySwitchClause {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			JS_CASE_CLAUSE => JsAnySwitchClause::JsCaseClause(JsCaseClause { syntax }),
@@ -5354,25 +8455,39 @@ impl AstNode for JsAnySwitchClause {
 	}
 }
 impl From<SinglePattern> for Pattern {
-	fn from(node: SinglePattern) -> Pattern { Pattern::SinglePattern(node) }
+	fn from(node: SinglePattern) -> Pattern {
+		Pattern::SinglePattern(node)
+	}
 }
 impl From<RestPattern> for Pattern {
-	fn from(node: RestPattern) -> Pattern { Pattern::RestPattern(node) }
+	fn from(node: RestPattern) -> Pattern {
+		Pattern::RestPattern(node)
+	}
 }
 impl From<AssignPattern> for Pattern {
-	fn from(node: AssignPattern) -> Pattern { Pattern::AssignPattern(node) }
+	fn from(node: AssignPattern) -> Pattern {
+		Pattern::AssignPattern(node)
+	}
 }
 impl From<ObjectPattern> for Pattern {
-	fn from(node: ObjectPattern) -> Pattern { Pattern::ObjectPattern(node) }
+	fn from(node: ObjectPattern) -> Pattern {
+		Pattern::ObjectPattern(node)
+	}
 }
 impl From<ArrayPattern> for Pattern {
-	fn from(node: ArrayPattern) -> Pattern { Pattern::ArrayPattern(node) }
+	fn from(node: ArrayPattern) -> Pattern {
+		Pattern::ArrayPattern(node)
+	}
 }
 impl From<ExprPattern> for Pattern {
-	fn from(node: ExprPattern) -> Pattern { Pattern::ExprPattern(node) }
+	fn from(node: ExprPattern) -> Pattern {
+		Pattern::ExprPattern(node)
+	}
 }
 impl From<JsUnknownPattern> for Pattern {
-	fn from(node: JsUnknownPattern) -> Pattern { Pattern::JsUnknownPattern(node) }
+	fn from(node: JsUnknownPattern) -> Pattern {
+		Pattern::JsUnknownPattern(node)
+	}
 }
 impl AstNode for Pattern {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5562,10 +8677,14 @@ impl AstNode for JsAnyArrowFunctionBody {
 	}
 }
 impl From<SpreadElement> for JsAnyArrayElement {
-	fn from(node: SpreadElement) -> JsAnyArrayElement { JsAnyArrayElement::SpreadElement(node) }
+	fn from(node: SpreadElement) -> JsAnyArrayElement {
+		JsAnyArrayElement::SpreadElement(node)
+	}
 }
 impl From<JsArrayHole> for JsAnyArrayElement {
-	fn from(node: JsArrayHole) -> JsAnyArrayElement { JsAnyArrayElement::JsArrayHole(node) }
+	fn from(node: JsArrayHole) -> JsAnyArrayElement {
+		JsAnyArrayElement::JsArrayHole(node)
+	}
 }
 impl AstNode for JsAnyArrayElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5712,7 +8831,9 @@ impl From<JsSetterObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<InitializedProp> for JsAnyObjectMember {
-	fn from(node: InitializedProp) -> JsAnyObjectMember { JsAnyObjectMember::InitializedProp(node) }
+	fn from(node: InitializedProp) -> JsAnyObjectMember {
+		JsAnyObjectMember::InitializedProp(node)
+	}
 }
 impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	fn from(node: JsShorthandPropertyObjectMember) -> JsAnyObjectMember {
@@ -5720,10 +8841,14 @@ impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<JsSpread> for JsAnyObjectMember {
-	fn from(node: JsSpread) -> JsAnyObjectMember { JsAnyObjectMember::JsSpread(node) }
+	fn from(node: JsSpread) -> JsAnyObjectMember {
+		JsAnyObjectMember::JsSpread(node)
+	}
 }
 impl From<JsUnknownMember> for JsAnyObjectMember {
-	fn from(node: JsUnknownMember) -> JsAnyObjectMember { JsAnyObjectMember::JsUnknownMember(node) }
+	fn from(node: JsUnknownMember) -> JsAnyObjectMember {
+		JsAnyObjectMember::JsUnknownMember(node)
+	}
 }
 impl AstNode for JsAnyObjectMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5778,7 +8903,9 @@ impl AstNode for JsAnyObjectMember {
 	}
 }
 impl From<JsComputedMemberName> for PropName {
-	fn from(node: JsComputedMemberName) -> PropName { PropName::JsComputedMemberName(node) }
+	fn from(node: JsComputedMemberName) -> PropName {
+		PropName::JsComputedMemberName(node)
+	}
 }
 impl From<JsStringLiteralExpression> for PropName {
 	fn from(node: JsStringLiteralExpression) -> PropName {
@@ -5791,13 +8918,19 @@ impl From<JsNumberLiteralExpression> for PropName {
 	}
 }
 impl From<Ident> for PropName {
-	fn from(node: Ident) -> PropName { PropName::Ident(node) }
+	fn from(node: Ident) -> PropName {
+		PropName::Ident(node)
+	}
 }
 impl From<Name> for PropName {
-	fn from(node: Name) -> PropName { PropName::Name(node) }
+	fn from(node: Name) -> PropName {
+		PropName::Name(node)
+	}
 }
 impl From<JsUnknownBinding> for PropName {
-	fn from(node: JsUnknownBinding) -> PropName { PropName::JsUnknownBinding(node) }
+	fn from(node: JsUnknownBinding) -> PropName {
+		PropName::JsUnknownBinding(node)
+	}
 }
 impl AstNode for PropName {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -5869,10 +9002,14 @@ impl From<JsEmptyClassMember> for JsAnyClassMember {
 	}
 }
 impl From<TsIndexSignature> for JsAnyClassMember {
-	fn from(node: TsIndexSignature) -> JsAnyClassMember { JsAnyClassMember::TsIndexSignature(node) }
+	fn from(node: TsIndexSignature) -> JsAnyClassMember {
+		JsAnyClassMember::TsIndexSignature(node)
+	}
 }
 impl From<JsUnknownMember> for JsAnyClassMember {
-	fn from(node: JsUnknownMember) -> JsAnyClassMember { JsAnyClassMember::JsUnknownMember(node) }
+	fn from(node: JsUnknownMember) -> JsAnyClassMember {
+		JsAnyClassMember::JsUnknownMember(node)
+	}
 }
 impl AstNode for JsAnyClassMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6007,16 +9144,24 @@ impl AstNode for JsAnyConstructorParameter {
 	}
 }
 impl From<AssignPattern> for ObjectPatternProp {
-	fn from(node: AssignPattern) -> ObjectPatternProp { ObjectPatternProp::AssignPattern(node) }
+	fn from(node: AssignPattern) -> ObjectPatternProp {
+		ObjectPatternProp::AssignPattern(node)
+	}
 }
 impl From<KeyValuePattern> for ObjectPatternProp {
-	fn from(node: KeyValuePattern) -> ObjectPatternProp { ObjectPatternProp::KeyValuePattern(node) }
+	fn from(node: KeyValuePattern) -> ObjectPatternProp {
+		ObjectPatternProp::KeyValuePattern(node)
+	}
 }
 impl From<RestPattern> for ObjectPatternProp {
-	fn from(node: RestPattern) -> ObjectPatternProp { ObjectPatternProp::RestPattern(node) }
+	fn from(node: RestPattern) -> ObjectPatternProp {
+		ObjectPatternProp::RestPattern(node)
+	}
 }
 impl From<SinglePattern> for ObjectPatternProp {
-	fn from(node: SinglePattern) -> ObjectPatternProp { ObjectPatternProp::SinglePattern(node) }
+	fn from(node: SinglePattern) -> ObjectPatternProp {
+		ObjectPatternProp::SinglePattern(node)
+	}
 }
 impl From<JsUnknownPattern> for ObjectPatternProp {
 	fn from(node: JsUnknownPattern) -> ObjectPatternProp {
@@ -6052,97 +9197,159 @@ impl AstNode for ObjectPatternProp {
 	}
 }
 impl From<TsAny> for TsType {
-	fn from(node: TsAny) -> TsType { TsType::TsAny(node) }
+	fn from(node: TsAny) -> TsType {
+		TsType::TsAny(node)
+	}
 }
 impl From<TsUnknown> for TsType {
-	fn from(node: TsUnknown) -> TsType { TsType::TsUnknown(node) }
+	fn from(node: TsUnknown) -> TsType {
+		TsType::TsUnknown(node)
+	}
 }
 impl From<TsNumber> for TsType {
-	fn from(node: TsNumber) -> TsType { TsType::TsNumber(node) }
+	fn from(node: TsNumber) -> TsType {
+		TsType::TsNumber(node)
+	}
 }
 impl From<TsObject> for TsType {
-	fn from(node: TsObject) -> TsType { TsType::TsObject(node) }
+	fn from(node: TsObject) -> TsType {
+		TsType::TsObject(node)
+	}
 }
 impl From<TsBoolean> for TsType {
-	fn from(node: TsBoolean) -> TsType { TsType::TsBoolean(node) }
+	fn from(node: TsBoolean) -> TsType {
+		TsType::TsBoolean(node)
+	}
 }
 impl From<TsBigint> for TsType {
-	fn from(node: TsBigint) -> TsType { TsType::TsBigint(node) }
+	fn from(node: TsBigint) -> TsType {
+		TsType::TsBigint(node)
+	}
 }
 impl From<TsString> for TsType {
-	fn from(node: TsString) -> TsType { TsType::TsString(node) }
+	fn from(node: TsString) -> TsType {
+		TsType::TsString(node)
+	}
 }
 impl From<TsSymbol> for TsType {
-	fn from(node: TsSymbol) -> TsType { TsType::TsSymbol(node) }
+	fn from(node: TsSymbol) -> TsType {
+		TsType::TsSymbol(node)
+	}
 }
 impl From<TsVoid> for TsType {
-	fn from(node: TsVoid) -> TsType { TsType::TsVoid(node) }
+	fn from(node: TsVoid) -> TsType {
+		TsType::TsVoid(node)
+	}
 }
 impl From<TsUndefined> for TsType {
-	fn from(node: TsUndefined) -> TsType { TsType::TsUndefined(node) }
+	fn from(node: TsUndefined) -> TsType {
+		TsType::TsUndefined(node)
+	}
 }
 impl From<TsNull> for TsType {
-	fn from(node: TsNull) -> TsType { TsType::TsNull(node) }
+	fn from(node: TsNull) -> TsType {
+		TsType::TsNull(node)
+	}
 }
 impl From<TsNever> for TsType {
-	fn from(node: TsNever) -> TsType { TsType::TsNever(node) }
+	fn from(node: TsNever) -> TsType {
+		TsType::TsNever(node)
+	}
 }
 impl From<TsThis> for TsType {
-	fn from(node: TsThis) -> TsType { TsType::TsThis(node) }
+	fn from(node: TsThis) -> TsType {
+		TsType::TsThis(node)
+	}
 }
 impl From<TsLiteral> for TsType {
-	fn from(node: TsLiteral) -> TsType { TsType::TsLiteral(node) }
+	fn from(node: TsLiteral) -> TsType {
+		TsType::TsLiteral(node)
+	}
 }
 impl From<TsPredicate> for TsType {
-	fn from(node: TsPredicate) -> TsType { TsType::TsPredicate(node) }
+	fn from(node: TsPredicate) -> TsType {
+		TsType::TsPredicate(node)
+	}
 }
 impl From<TsTuple> for TsType {
-	fn from(node: TsTuple) -> TsType { TsType::TsTuple(node) }
+	fn from(node: TsTuple) -> TsType {
+		TsType::TsTuple(node)
+	}
 }
 impl From<TsParen> for TsType {
-	fn from(node: TsParen) -> TsType { TsType::TsParen(node) }
+	fn from(node: TsParen) -> TsType {
+		TsType::TsParen(node)
+	}
 }
 impl From<TsTypeRef> for TsType {
-	fn from(node: TsTypeRef) -> TsType { TsType::TsTypeRef(node) }
+	fn from(node: TsTypeRef) -> TsType {
+		TsType::TsTypeRef(node)
+	}
 }
 impl From<TsTemplate> for TsType {
-	fn from(node: TsTemplate) -> TsType { TsType::TsTemplate(node) }
+	fn from(node: TsTemplate) -> TsType {
+		TsType::TsTemplate(node)
+	}
 }
 impl From<TsMappedType> for TsType {
-	fn from(node: TsMappedType) -> TsType { TsType::TsMappedType(node) }
+	fn from(node: TsMappedType) -> TsType {
+		TsType::TsMappedType(node)
+	}
 }
 impl From<TsImport> for TsType {
-	fn from(node: TsImport) -> TsType { TsType::TsImport(node) }
+	fn from(node: TsImport) -> TsType {
+		TsType::TsImport(node)
+	}
 }
 impl From<TsArray> for TsType {
-	fn from(node: TsArray) -> TsType { TsType::TsArray(node) }
+	fn from(node: TsArray) -> TsType {
+		TsType::TsArray(node)
+	}
 }
 impl From<TsIndexedArray> for TsType {
-	fn from(node: TsIndexedArray) -> TsType { TsType::TsIndexedArray(node) }
+	fn from(node: TsIndexedArray) -> TsType {
+		TsType::TsIndexedArray(node)
+	}
 }
 impl From<TsTypeOperator> for TsType {
-	fn from(node: TsTypeOperator) -> TsType { TsType::TsTypeOperator(node) }
+	fn from(node: TsTypeOperator) -> TsType {
+		TsType::TsTypeOperator(node)
+	}
 }
 impl From<TsIntersection> for TsType {
-	fn from(node: TsIntersection) -> TsType { TsType::TsIntersection(node) }
+	fn from(node: TsIntersection) -> TsType {
+		TsType::TsIntersection(node)
+	}
 }
 impl From<TsUnion> for TsType {
-	fn from(node: TsUnion) -> TsType { TsType::TsUnion(node) }
+	fn from(node: TsUnion) -> TsType {
+		TsType::TsUnion(node)
+	}
 }
 impl From<TsFnType> for TsType {
-	fn from(node: TsFnType) -> TsType { TsType::TsFnType(node) }
+	fn from(node: TsFnType) -> TsType {
+		TsType::TsFnType(node)
+	}
 }
 impl From<TsConstructorType> for TsType {
-	fn from(node: TsConstructorType) -> TsType { TsType::TsConstructorType(node) }
+	fn from(node: TsConstructorType) -> TsType {
+		TsType::TsConstructorType(node)
+	}
 }
 impl From<TsConditionalType> for TsType {
-	fn from(node: TsConditionalType) -> TsType { TsType::TsConditionalType(node) }
+	fn from(node: TsConditionalType) -> TsType {
+		TsType::TsConditionalType(node)
+	}
 }
 impl From<TsObjectType> for TsType {
-	fn from(node: TsObjectType) -> TsType { TsType::TsObjectType(node) }
+	fn from(node: TsObjectType) -> TsType {
+		TsType::TsObjectType(node)
+	}
 }
 impl From<TsInfer> for TsType {
-	fn from(node: TsInfer) -> TsType { TsType::TsInfer(node) }
+	fn from(node: TsInfer) -> TsType {
+		TsType::TsInfer(node)
+	}
 }
 impl AstNode for TsType {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6242,13 +9449,19 @@ impl AstNode for TsType {
 	}
 }
 impl From<WildcardImport> for ImportClause {
-	fn from(node: WildcardImport) -> ImportClause { ImportClause::WildcardImport(node) }
+	fn from(node: WildcardImport) -> ImportClause {
+		ImportClause::WildcardImport(node)
+	}
 }
 impl From<NamedImports> for ImportClause {
-	fn from(node: NamedImports) -> ImportClause { ImportClause::NamedImports(node) }
+	fn from(node: NamedImports) -> ImportClause {
+		ImportClause::NamedImports(node)
+	}
 }
 impl From<Name> for ImportClause {
-	fn from(node: Name) -> ImportClause { ImportClause::Name(node) }
+	fn from(node: Name) -> ImportClause {
+		ImportClause::Name(node)
+	}
 }
 impl From<ImportStringSpecifier> for ImportClause {
 	fn from(node: ImportStringSpecifier) -> ImportClause {
@@ -6284,10 +9497,14 @@ impl AstNode for ImportClause {
 	}
 }
 impl From<JsFunctionDeclaration> for DefaultDecl {
-	fn from(node: JsFunctionDeclaration) -> DefaultDecl { DefaultDecl::JsFunctionDeclaration(node) }
+	fn from(node: JsFunctionDeclaration) -> DefaultDecl {
+		DefaultDecl::JsFunctionDeclaration(node)
+	}
 }
 impl From<JsClassDeclaration> for DefaultDecl {
-	fn from(node: JsClassDeclaration) -> DefaultDecl { DefaultDecl::JsClassDeclaration(node) }
+	fn from(node: JsClassDeclaration) -> DefaultDecl {
+		DefaultDecl::JsClassDeclaration(node)
+	}
 }
 impl AstNode for DefaultDecl {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6326,7 +9543,9 @@ impl From<JsVariableDeclarationStatement> for JsAnyExportDeclaration {
 	}
 }
 impl From<TsEnum> for JsAnyExportDeclaration {
-	fn from(node: TsEnum) -> JsAnyExportDeclaration { JsAnyExportDeclaration::TsEnum(node) }
+	fn from(node: TsEnum) -> JsAnyExportDeclaration {
+		JsAnyExportDeclaration::TsEnum(node)
+	}
 }
 impl From<TsTypeAliasDecl> for JsAnyExportDeclaration {
 	fn from(node: TsTypeAliasDecl) -> JsAnyExportDeclaration {
@@ -6402,7 +9621,9 @@ impl AstNode for JsAnyExportDeclaration {
 	}
 }
 impl From<JsRestParameter> for JsAnyParameter {
-	fn from(node: JsRestParameter) -> JsAnyParameter { JsAnyParameter::JsRestParameter(node) }
+	fn from(node: JsRestParameter) -> JsAnyParameter {
+		JsAnyParameter::JsRestParameter(node)
+	}
 }
 impl AstNode for JsAnyParameter {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6432,7 +9653,9 @@ impl AstNode for JsAnyParameter {
 	}
 }
 impl From<TsExternalModuleRef> for TsModuleRef {
-	fn from(node: TsExternalModuleRef) -> TsModuleRef { TsModuleRef::TsExternalModuleRef(node) }
+	fn from(node: TsExternalModuleRef) -> TsModuleRef {
+		TsModuleRef::TsExternalModuleRef(node)
+	}
 }
 impl AstNode for TsModuleRef {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6464,13 +9687,19 @@ impl AstNode for TsModuleRef {
 	}
 }
 impl From<TsTypeName> for TsEntityName {
-	fn from(node: TsTypeName) -> TsEntityName { TsEntityName::TsTypeName(node) }
+	fn from(node: TsTypeName) -> TsEntityName {
+		TsEntityName::TsTypeName(node)
+	}
 }
 impl From<TsQualifiedPath> for TsEntityName {
-	fn from(node: TsQualifiedPath) -> TsEntityName { TsEntityName::TsQualifiedPath(node) }
+	fn from(node: TsQualifiedPath) -> TsEntityName {
+		TsEntityName::TsQualifiedPath(node)
+	}
 }
 impl AstNode for TsEntityName {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_TYPE_NAME => TsEntityName::TsTypeName(TsTypeName { syntax }),
@@ -6487,13 +9716,19 @@ impl AstNode for TsEntityName {
 	}
 }
 impl From<TsThis> for TsThisOrMore {
-	fn from(node: TsThis) -> TsThisOrMore { TsThisOrMore::TsThis(node) }
+	fn from(node: TsThis) -> TsThisOrMore {
+		TsThisOrMore::TsThis(node)
+	}
 }
 impl From<TsTypeName> for TsThisOrMore {
-	fn from(node: TsTypeName) -> TsThisOrMore { TsThisOrMore::TsTypeName(node) }
+	fn from(node: TsTypeName) -> TsThisOrMore {
+		TsThisOrMore::TsTypeName(node)
+	}
 }
 impl AstNode for TsThisOrMore {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_THIS | TS_TYPE_NAME) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_THIS | TS_TYPE_NAME)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_THIS => TsThisOrMore::TsThis(TsThis { syntax }),
@@ -6510,7 +9745,9 @@ impl AstNode for TsThisOrMore {
 	}
 }
 impl From<TsCallSignatureDecl> for TsTypeElement {
-	fn from(node: TsCallSignatureDecl) -> TsTypeElement { TsTypeElement::TsCallSignatureDecl(node) }
+	fn from(node: TsCallSignatureDecl) -> TsTypeElement {
+		TsTypeElement::TsCallSignatureDecl(node)
+	}
 }
 impl From<TsConstructSignatureDecl> for TsTypeElement {
 	fn from(node: TsConstructSignatureDecl) -> TsTypeElement {
@@ -6518,13 +9755,19 @@ impl From<TsConstructSignatureDecl> for TsTypeElement {
 	}
 }
 impl From<TsPropertySignature> for TsTypeElement {
-	fn from(node: TsPropertySignature) -> TsTypeElement { TsTypeElement::TsPropertySignature(node) }
+	fn from(node: TsPropertySignature) -> TsTypeElement {
+		TsTypeElement::TsPropertySignature(node)
+	}
 }
 impl From<TsMethodSignature> for TsTypeElement {
-	fn from(node: TsMethodSignature) -> TsTypeElement { TsTypeElement::TsMethodSignature(node) }
+	fn from(node: TsMethodSignature) -> TsTypeElement {
+		TsTypeElement::TsMethodSignature(node)
+	}
 }
 impl From<TsIndexSignature> for TsTypeElement {
-	fn from(node: TsIndexSignature) -> TsTypeElement { TsTypeElement::TsIndexSignature(node) }
+	fn from(node: TsIndexSignature) -> TsTypeElement {
+		TsTypeElement::TsIndexSignature(node)
+	}
 }
 impl AstNode for TsTypeElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -6565,13 +9808,19 @@ impl AstNode for TsTypeElement {
 	}
 }
 impl From<TsModuleBlock> for TsNamespaceBody {
-	fn from(node: TsModuleBlock) -> TsNamespaceBody { TsNamespaceBody::TsModuleBlock(node) }
+	fn from(node: TsModuleBlock) -> TsNamespaceBody {
+		TsNamespaceBody::TsModuleBlock(node)
+	}
 }
 impl From<TsNamespaceDecl> for TsNamespaceBody {
-	fn from(node: TsNamespaceDecl) -> TsNamespaceBody { TsNamespaceBody::TsNamespaceDecl(node) }
+	fn from(node: TsNamespaceDecl) -> TsNamespaceBody {
+		TsNamespaceBody::TsNamespaceDecl(node)
+	}
 }
 impl AstNode for TsNamespaceBody {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_MODULE_BLOCK => TsNamespaceBody::TsModuleBlock(TsModuleBlock { syntax }),

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -893,6 +893,7 @@ fn consume_modifiers(
 	if static_ && !dont_remap_static {
 		p.bump_remap(STATIC_KW);
 	} else if static_ && dont_remap_static {
-		p.bump_any();
+		// Guaranteed to be at the static keyword, parsing a class member must succeed
+		class_member_name(p).ok().unwrap();
 	}
 }

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -127,7 +127,7 @@ pub(super) fn parameters_list(
 			p.eat(T![,]);
 			break;
 		} else {
-			p.expect(T![,]);
+			p.expect_required(T![,]);
 		}
 
 		if p.at(T![...]) {

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -127,7 +127,7 @@ pub(super) fn parameters_list(
 			p.eat(T![,]);
 			break;
 		} else {
-			p.expect_required(T![,]);
+			p.expect(T![,]);
 		}
 
 		if p.at(T![...]) {

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -70,7 +70,8 @@ fn parser_tests() {
 		let parse = try_parse(path.to_str().unwrap(), text);
 		let errors = parse.errors();
 		assert_errors_are_absent(errors, path, &parse.syntax());
-		format!("{:#?}", parse.syntax())
+
+		format!("{:#?}\n\n{:#?}", parse.tree(), parse.syntax())
 	});
 
 	dir_tests(&test_data_dir(), &["inline/err"], "rast", |text, path| {

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -10,10 +10,11 @@
           0: SINGLE_PATTERN@10..11
             0: NAME@10..11
               0: IDENT@10..11 "a" [] []
-          1: JS_UNKNOWN_PATTERN@11..13
+          1: (empty)
+          2: JS_UNKNOWN_PATTERN@11..13
             0: PLUS2@11..13 "++" [] []
-          2: COMMA@13..15 "," [] [Whitespace(" ")]
-          3: SINGLE_PATTERN@15..16
+          3: COMMA@13..15 "," [] [Whitespace(" ")]
+          4: SINGLE_PATTERN@15..16
             0: NAME@15..16
               0: IDENT@15..16 "c" [] []
         2: R_PAREN@16..18 ")" [] [Whitespace(" ")]

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -10,11 +10,10 @@
           0: SINGLE_PATTERN@10..11
             0: NAME@10..11
               0: IDENT@10..11 "a" [] []
-          1: (empty)
-          2: JS_UNKNOWN_PATTERN@11..13
+          1: JS_UNKNOWN_PATTERN@11..13
             0: PLUS2@11..13 "++" [] []
-          3: COMMA@13..15 "," [] [Whitespace(" ")]
-          4: SINGLE_PATTERN@15..16
+          2: COMMA@13..15 "," [] [Whitespace(" ")]
+          3: SINGLE_PATTERN@15..16
             0: NAME@15..16
               0: IDENT@15..16 "c" [] []
         2: R_PAREN@16..18 ")" [] [Whitespace(" ")]

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -20,13 +20,15 @@
         1: LIST@23..37
           0: JS_UNKNOWN_PATTERN@23..24
             0: L_CURLY@23..24 "{" [] []
-          1: JS_UNKNOWN_PATTERN@24..25
+          1: (empty)
+          2: JS_UNKNOWN_PATTERN@24..25
             0: R_CURLY@24..25 "}" [] []
-          2: JS_UNKNOWN_PATTERN@25..35
+          3: JS_UNKNOWN_PATTERN@25..35
             0: FUNCTION_KW@25..35 "function" [Whitespace("\n")] [Whitespace(" ")]
-          3: JS_UNKNOWN_PATTERN@35..36
+          4: (empty)
+          5: JS_UNKNOWN_PATTERN@35..36
             0: STAR@35..36 "*" [] []
-          4: JS_UNKNOWN_PATTERN@36..37
+          6: JS_UNKNOWN_PATTERN@36..37
             0: L_PAREN@36..37 "(" [] []
         2: R_PAREN@37..39 ")" [] [Whitespace(" ")]
       2: JS_FUNCTION_BODY@39..41

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -20,15 +20,13 @@
         1: LIST@23..37
           0: JS_UNKNOWN_PATTERN@23..24
             0: L_CURLY@23..24 "{" [] []
-          1: (empty)
-          2: JS_UNKNOWN_PATTERN@24..25
+          1: JS_UNKNOWN_PATTERN@24..25
             0: R_CURLY@24..25 "}" [] []
-          3: JS_UNKNOWN_PATTERN@25..35
+          2: JS_UNKNOWN_PATTERN@25..35
             0: FUNCTION_KW@25..35 "function" [Whitespace("\n")] [Whitespace(" ")]
-          4: (empty)
-          5: JS_UNKNOWN_PATTERN@35..36
+          3: JS_UNKNOWN_PATTERN@35..36
             0: STAR@35..36 "*" [] []
-          6: JS_UNKNOWN_PATTERN@36..37
+          4: JS_UNKNOWN_PATTERN@36..37
             0: L_PAREN@36..37 "(" [] []
         2: R_PAREN@37..39 ")" [] [Whitespace(" ")]
       2: JS_FUNCTION_BODY@39..41

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -1,323 +1,177 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@0..1 "[" [] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@1..4 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@4..6 "," [] [Whitespace(" ")],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@6..9 "bar" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: None,
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@9..10 "]" [] [],
-                            ),
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@0..1 "[" [] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@1..4 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@10..11 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@11..13 "[" [Whitespace("\n")] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@13..16 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: None,
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@16..17 "]" [] [],
-                            ),
+                        trailing_separator: Some(
+                            COMMA@4..6 "," [] [Whitespace(" ")],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@6..9 "bar" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@17..18 ";" [] [],
-                ),
+                        trailing_separator: None,
+                    },
+                ],
+                r_brack_token: R_BRACK@9..10 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@18..20 "[" [Whitespace("\n")] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@20..21 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@21..24 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: None,
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@24..25 "]" [] [],
-                            ),
+            semicolon_token: SEMICOLON@10..11 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@11..13 "[" [Whitespace("\n")] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@13..16 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@25..26 ";" [] [],
-                ),
+                        trailing_separator: None,
+                    },
+                ],
+                r_brack_token: R_BRACK@16..17 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@26..28 "[" [Whitespace("\n")] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@28..31 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@31..32 "," [] [],
-                                    ),
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@32..33 "]" [] [],
-                            ),
+            semicolon_token: SEMICOLON@17..18 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@18..20 "[" [Whitespace("\n")] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@20..21 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@21..24 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@33..34 ";" [] [],
-                ),
+                        trailing_separator: None,
+                    },
+                ],
+                r_brack_token: R_BRACK@24..25 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@34..36 "[" [Whitespace("\n")] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@36..37 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@37..38 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@38..39 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@39..40 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@40..41 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsAnyExpression(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@41..44 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@44..45 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@45..46 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@46..47 "," [] [],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: JsArrayHole(
-                                        JsArrayHole,
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@47..48 "," [] [],
-                                    ),
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@48..49 "]" [] [],
-                            ),
+            semicolon_token: SEMICOLON@25..26 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@26..28 "[" [Whitespace("\n")] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@28..31 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@49..50 ";" [] [],
-                ),
+                        trailing_separator: Some(
+                            COMMA@31..32 "," [] [],
+                        ),
+                    },
+                ],
+                r_brack_token: R_BRACK@32..33 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrayExpression(
-                        JsArrayExpression {
-                            l_brack_token: Ok(
-                                L_BRACK@50..52 "[" [Whitespace("\n")] [],
-                            ),
-                            elements: [
-                                AstSeparatedElement {
-                                    node: SpreadElement(
-                                        SpreadElement {
-                                            dotdotdot_token: Ok(
-                                                DOT2@52..55 "..." [] [],
-                                            ),
-                                            element: Ok(
-                                                JsReferenceIdentifierExpression(
-                                                    JsReferenceIdentifierExpression {
-                                                        name_token: Ok(
-                                                            IDENT@55..56 "a" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    trailing_separator: Some(
-                                        COMMA@56..58 "," [] [Whitespace(" ")],
-                                    ),
-                                },
-                                AstSeparatedElement {
-                                    node: SpreadElement(
-                                        SpreadElement {
-                                            dotdotdot_token: Ok(
-                                                DOT2@58..61 "..." [] [],
-                                            ),
-                                            element: Ok(
-                                                JsReferenceIdentifierExpression(
-                                                    JsReferenceIdentifierExpression {
-                                                        name_token: Ok(
-                                                            IDENT@61..62 "b" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                    trailing_separator: None,
-                                },
-                            ],
-                            r_brack_token: Ok(
-                                R_BRACK@62..63 "]" [] [],
-                            ),
+            semicolon_token: SEMICOLON@33..34 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@34..36 "[" [Whitespace("\n")] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@36..37 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@37..38 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@38..39 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@39..40 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@40..41 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsReferenceIdentifierExpression {
+                            name_token: IDENT@41..44 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@63..64 ";" [] [],
-                ),
+                        trailing_separator: Some(
+                            COMMA@44..45 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@45..46 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@46..47 "," [] [],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: JsArrayHole,
+                        trailing_separator: Some(
+                            COMMA@47..48 "," [] [],
+                        ),
+                    },
+                ],
+                r_brack_token: R_BRACK@48..49 "]" [] [],
             },
-        ),
+            semicolon_token: SEMICOLON@49..50 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@50..52 "[" [Whitespace("\n")] [],
+                elements: [
+                    AstSeparatedElement {
+                        node: SpreadElement {
+                            dotdotdot_token: DOT2@52..55 "..." [] [],
+                            element: JsReferenceIdentifierExpression {
+                                name_token: IDENT@55..56 "a" [] [],
+                            },
+                        },
+                        trailing_separator: Some(
+                            COMMA@56..58 "," [] [Whitespace(" ")],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: SpreadElement {
+                            dotdotdot_token: DOT2@58..61 "..." [] [],
+                            element: JsReferenceIdentifierExpression {
+                                name_token: IDENT@61..62 "b" [] [],
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+                r_brack_token: R_BRACK@62..63 "]" [] [],
+            },
+            semicolon_token: SEMICOLON@63..64 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -6,20 +6,14 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@0..1 "[" [] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@1..4 "foo" [] [],
-                        },
-                        trailing_separator: Some(
-                            COMMA@4..6 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@6..9 "bar" [] [],
-                        },
-                        trailing_separator: None,
-                    },
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@1..4 "foo" [] [],
+                    }
+                    COMMA@4..6 "," [] [Whitespace(" ")],
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@6..9 "bar" [] [],
+                    }
+                    ,
                 ],
                 r_brack_token: R_BRACK@9..10 "]" [] [],
             },
@@ -29,12 +23,10 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@11..13 "[" [Whitespace("\n")] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@13..16 "foo" [] [],
-                        },
-                        trailing_separator: None,
-                    },
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@13..16 "foo" [] [],
+                    }
+                    ,
                 ],
                 r_brack_token: R_BRACK@16..17 "]" [] [],
             },
@@ -44,18 +36,12 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@18..20 "[" [Whitespace("\n")] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@20..21 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@21..24 "foo" [] [],
-                        },
-                        trailing_separator: None,
-                    },
+                    JsArrayHole
+                    COMMA@20..21 "," [] [],
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@21..24 "foo" [] [],
+                    }
+                    ,
                 ],
                 r_brack_token: R_BRACK@24..25 "]" [] [],
             },
@@ -65,14 +51,10 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@26..28 "[" [Whitespace("\n")] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@28..31 "foo" [] [],
-                        },
-                        trailing_separator: Some(
-                            COMMA@31..32 "," [] [],
-                        ),
-                    },
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@28..31 "foo" [] [],
+                    }
+                    COMMA@31..32 "," [] [],
                 ],
                 r_brack_token: R_BRACK@32..33 "]" [] [],
             },
@@ -82,62 +64,26 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@34..36 "[" [Whitespace("\n")] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@36..37 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@37..38 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@38..39 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@39..40 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@40..41 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsReferenceIdentifierExpression {
-                            name_token: IDENT@41..44 "foo" [] [],
-                        },
-                        trailing_separator: Some(
-                            COMMA@44..45 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@45..46 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@46..47 "," [] [],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsArrayHole,
-                        trailing_separator: Some(
-                            COMMA@47..48 "," [] [],
-                        ),
-                    },
+                    JsArrayHole
+                    COMMA@36..37 "," [] [],
+                    JsArrayHole
+                    COMMA@37..38 "," [] [],
+                    JsArrayHole
+                    COMMA@38..39 "," [] [],
+                    JsArrayHole
+                    COMMA@39..40 "," [] [],
+                    JsArrayHole
+                    COMMA@40..41 "," [] [],
+                    JsReferenceIdentifierExpression {
+                        name_token: IDENT@41..44 "foo" [] [],
+                    }
+                    COMMA@44..45 "," [] [],
+                    JsArrayHole
+                    COMMA@45..46 "," [] [],
+                    JsArrayHole
+                    COMMA@46..47 "," [] [],
+                    JsArrayHole
+                    COMMA@47..48 "," [] [],
                 ],
                 r_brack_token: R_BRACK@48..49 "]" [] [],
             },
@@ -147,26 +93,20 @@ JsRoot {
             expression: JsArrayExpression {
                 l_brack_token: L_BRACK@50..52 "[" [Whitespace("\n")] [],
                 elements: [
-                    AstSeparatedElement {
-                        node: SpreadElement {
-                            dotdotdot_token: DOT2@52..55 "..." [] [],
-                            element: JsReferenceIdentifierExpression {
-                                name_token: IDENT@55..56 "a" [] [],
-                            },
+                    SpreadElement {
+                        dotdotdot_token: DOT2@52..55 "..." [] [],
+                        element: JsReferenceIdentifierExpression {
+                            name_token: IDENT@55..56 "a" [] [],
                         },
-                        trailing_separator: Some(
-                            COMMA@56..58 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: SpreadElement {
-                            dotdotdot_token: DOT2@58..61 "..." [] [],
-                            element: JsReferenceIdentifierExpression {
-                                name_token: IDENT@61..62 "b" [] [],
-                            },
+                    }
+                    COMMA@56..58 "," [] [Whitespace(" ")],
+                    SpreadElement {
+                        dotdotdot_token: DOT2@58..61 "..." [] [],
+                        element: JsReferenceIdentifierExpression {
+                            name_token: IDENT@61..62 "b" [] [],
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
                 r_brack_token: R_BRACK@62..63 "]" [] [],
             },

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -1,3 +1,326 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@0..1 "[" [] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@1..4 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@4..6 "," [] [Whitespace(" ")],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@6..9 "bar" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: None,
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@9..10 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@10..11 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@11..13 "[" [Whitespace("\n")] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@13..16 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: None,
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@16..17 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@17..18 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@18..20 "[" [Whitespace("\n")] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@20..21 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@21..24 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: None,
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@24..25 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@25..26 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@26..28 "[" [Whitespace("\n")] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@28..31 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@31..32 "," [] [],
+                                    ),
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@32..33 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@33..34 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@34..36 "[" [Whitespace("\n")] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@36..37 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@37..38 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@38..39 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@39..40 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@40..41 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsAnyExpression(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@41..44 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@44..45 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@45..46 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@46..47 "," [] [],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: JsArrayHole(
+                                        JsArrayHole,
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@47..48 "," [] [],
+                                    ),
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@48..49 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@49..50 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrayExpression(
+                        JsArrayExpression {
+                            l_brack_token: Ok(
+                                L_BRACK@50..52 "[" [Whitespace("\n")] [],
+                            ),
+                            elements: [
+                                AstSeparatedElement {
+                                    node: SpreadElement(
+                                        SpreadElement {
+                                            dotdotdot_token: Ok(
+                                                DOT2@52..55 "..." [] [],
+                                            ),
+                                            element: Ok(
+                                                JsReferenceIdentifierExpression(
+                                                    JsReferenceIdentifierExpression {
+                                                        name_token: Ok(
+                                                            IDENT@55..56 "a" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    trailing_separator: Some(
+                                        COMMA@56..58 "," [] [Whitespace(" ")],
+                                    ),
+                                },
+                                AstSeparatedElement {
+                                    node: SpreadElement(
+                                        SpreadElement {
+                                            dotdotdot_token: Ok(
+                                                DOT2@58..61 "..." [] [],
+                                            ),
+                                            element: Ok(
+                                                JsReferenceIdentifierExpression(
+                                                    JsReferenceIdentifierExpression {
+                                                        name_token: Ok(
+                                                            IDENT@61..62 "b" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    trailing_separator: None,
+                                },
+                            ],
+                            r_brack_token: Ok(
+                                R_BRACK@62..63 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@63..64 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..65
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -1,3 +1,114 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsIdentifierBinding(
+                                    JsIdentifierBinding {
+                                        name_token: Ok(
+                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@4..7 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsIdentifierBinding(
+                                    JsIdentifierBinding {
+                                        name_token: Ok(
+                                            IDENT@9..16 "yield" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@16..19 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsIdentifierBinding(
+                                    JsIdentifierBinding {
+                                        name_token: Ok(
+                                            IDENT@21..28 "await" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@28..31 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsIdentifierBinding(
+                                    JsIdentifierBinding {
+                                        name_token: Ok(
+                                            IDENT@33..38 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@38..40 "=>" [] [],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..44
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -1,111 +1,55 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsIdentifierBinding(
-                                    JsIdentifierBinding {
-                                        name_token: Ok(
-                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@4..7 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsIdentifierBinding {
+                    name_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@4..7 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsIdentifierBinding(
-                                    JsIdentifierBinding {
-                                        name_token: Ok(
-                                            IDENT@9..16 "yield" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@16..19 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsIdentifierBinding {
+                    name_token: IDENT@9..16 "yield" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@16..19 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsIdentifierBinding(
-                                    JsIdentifierBinding {
-                                        name_token: Ok(
-                                            IDENT@21..28 "await" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@28..31 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsIdentifierBinding {
+                    name_token: IDENT@21..28 "await" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@28..31 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsIdentifierBinding(
-                                    JsIdentifierBinding {
-                                        name_token: Ok(
-                                            IDENT@33..38 "foo" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@38..40 "=>" [] [],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsIdentifierBinding {
+                    name_token: IDENT@33..38 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@38..40 "=>" [] [],
+                return_type: missing (optional),
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -1,3 +1,114 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    AssignExpr(
+                        AssignExpr {
+                            operator: Ok(
+                                PLUSEQ@4..7 "+=" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@20..21 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    AssignExpr(
+                        AssignExpr {
+                            operator: Ok(
+                                MINUSEQ@26..29 "-=" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@32..33 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    AssignExpr(
+                        AssignExpr {
+                            operator: Ok(
+                                EQ@45..47 "=" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@50..51 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsParenthesizedExpression(
+                        JsParenthesizedExpression {
+                            l_paren_token: Ok(
+                                L_PAREN@51..53 "(" [Whitespace("\n")] [],
+                            ),
+                            expression: Ok(
+                                AssignExpr(
+                                    AssignExpr {
+                                        operator: Ok(
+                                            EQ@66..68 "=" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@70..71 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@71..72 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsParenthesizedExpression(
+                        JsParenthesizedExpression {
+                            l_paren_token: Ok(
+                                L_PAREN@72..74 "(" [Whitespace("\n")] [],
+                            ),
+                            expression: Ok(
+                                AssignExpr(
+                                    AssignExpr {
+                                        operator: Ok(
+                                            EQ@94..96 "=" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@98..99 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@99..100 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..101
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -1,111 +1,45 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    AssignExpr(
-                        AssignExpr {
-                            operator: Ok(
-                                PLUSEQ@4..7 "+=" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@20..21 ";" [] [],
-                ),
+        JsExpressionStatement {
+            expression: AssignExpr {
+                operator: PLUSEQ@4..7 "+=" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    AssignExpr(
-                        AssignExpr {
-                            operator: Ok(
-                                MINUSEQ@26..29 "-=" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@32..33 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@20..21 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: AssignExpr {
+                operator: MINUSEQ@26..29 "-=" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    AssignExpr(
-                        AssignExpr {
-                            operator: Ok(
-                                EQ@45..47 "=" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@50..51 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@32..33 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: AssignExpr {
+                operator: EQ@45..47 "=" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsParenthesizedExpression(
-                        JsParenthesizedExpression {
-                            l_paren_token: Ok(
-                                L_PAREN@51..53 "(" [Whitespace("\n")] [],
-                            ),
-                            expression: Ok(
-                                AssignExpr(
-                                    AssignExpr {
-                                        operator: Ok(
-                                            EQ@66..68 "=" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@70..71 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@71..72 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@50..51 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@51..53 "(" [Whitespace("\n")] [],
+                expression: AssignExpr {
+                    operator: EQ@66..68 "=" [] [Whitespace(" ")],
+                },
+                r_paren_token: R_PAREN@70..71 ")" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsParenthesizedExpression(
-                        JsParenthesizedExpression {
-                            l_paren_token: Ok(
-                                L_PAREN@72..74 "(" [Whitespace("\n")] [],
-                            ),
-                            expression: Ok(
-                                AssignExpr(
-                                    AssignExpr {
-                                        operator: Ok(
-                                            EQ@94..96 "=" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@98..99 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@99..100 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@71..72 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@72..74 "(" [Whitespace("\n")] [],
+                expression: AssignExpr {
+                    operator: EQ@94..96 "=" [] [Whitespace(" ")],
+                },
+                r_paren_token: R_PAREN@98..99 ")" [] [],
             },
-        ),
+            semicolon_token: SEMICOLON@99..100 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -1,3 +1,265 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsArrowFunctionExpression(
+                                                    JsArrowFunctionExpression {
+                                                        async_token: Some(
+                                                            ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                                        ),
+                                                        type_parameters: None,
+                                                        parameter_list: Some(
+                                                            JsIdentifierBinding(
+                                                                JsIdentifierBinding {
+                                                                    name_token: Ok(
+                                                                        IDENT@14..18 "foo" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        fat_arrow_token: Ok(
+                                                            FAT_ARROW@18..21 "=>" [] [Whitespace(" ")],
+                                                        ),
+                                                        return_type: None,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@28..30 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@30..32 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsArrowFunctionExpression(
+                                                    JsArrowFunctionExpression {
+                                                        async_token: Some(
+                                                            ASYNC_KW@32..38 "async" [] [Whitespace(" ")],
+                                                        ),
+                                                        type_parameters: None,
+                                                        parameter_list: Some(
+                                                            JsParameterList(
+                                                                JsParameterList {
+                                                                    l_paren_token: Ok(
+                                                                        L_PAREN@38..39 "(" [] [],
+                                                                    ),
+                                                                    parameters: [
+                                                                        AstSeparatedElement {
+                                                                            node: Pattern(
+                                                                                SinglePattern(
+                                                                                    SinglePattern {
+                                                                                        name: Ok(
+                                                                                            Name {
+                                                                                                ident_token: Ok(
+                                                                                                    IDENT@39..42 "bar" [] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                        question_mark_token: None,
+                                                                                        excl_token: None,
+                                                                                        ty: None,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                            trailing_separator: None,
+                                                                        },
+                                                                    ],
+                                                                    r_paren_token: Ok(
+                                                                        R_PAREN@42..44 ")" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        fat_arrow_token: Ok(
+                                                            FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
+                                                        ),
+                                                        return_type: None,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: Some(
+                                ASYNC_KW@49..56 "async" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsParameterList(
+                                    JsParameterList {
+                                        l_paren_token: Ok(
+                                            L_PAREN@56..57 "(" [] [],
+                                        ),
+                                        parameters: [
+                                            AstSeparatedElement {
+                                                node: Pattern(
+                                                    SinglePattern(
+                                                        SinglePattern {
+                                                            name: Ok(
+                                                                Name {
+                                                                    ident_token: Ok(
+                                                                        IDENT@57..60 "foo" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            question_mark_token: None,
+                                                            excl_token: None,
+                                                            ty: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                trailing_separator: Some(
+                                                    COMMA@60..62 "," [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                            AstSeparatedElement {
+                                                node: Pattern(
+                                                    SinglePattern(
+                                                        SinglePattern {
+                                                            name: Ok(
+                                                                Name {
+                                                                    ident_token: Ok(
+                                                                        IDENT@62..65 "bar" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            question_mark_token: None,
+                                                            excl_token: None,
+                                                            ty: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                trailing_separator: Some(
+                                                    COMMA@65..67 "," [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                            AstSeparatedElement {
+                                                node: JsRestParameter(
+                                                    JsRestParameter {
+                                                        dotdotdot_token: Ok(
+                                                            DOT2@67..70 "..." [] [],
+                                                        ),
+                                                        binding: Ok(
+                                                            SinglePattern(
+                                                                SinglePattern {
+                                                                    name: Ok(
+                                                                        Name {
+                                                                            ident_token: Ok(
+                                                                                IDENT@70..73 "baz" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    question_mark_token: None,
+                                                                    excl_token: None,
+                                                                    ty: None,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                trailing_separator: None,
+                                            },
+                                        ],
+                                        r_paren_token: Ok(
+                                            R_PAREN@73..75 ")" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@75..78 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..82
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -1,262 +1,142 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsArrowFunctionExpression(
-                                                    JsArrowFunctionExpression {
-                                                        async_token: Some(
-                                                            ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
-                                                        ),
-                                                        type_parameters: None,
-                                                        parameter_list: Some(
-                                                            JsIdentifierBinding(
-                                                                JsIdentifierBinding {
-                                                                    name_token: Ok(
-                                                                        IDENT@14..18 "foo" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                        fat_arrow_token: Ok(
-                                                            FAT_ARROW@18..21 "=>" [] [Whitespace(" ")],
-                                                        ),
-                                                        return_type: None,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@28..30 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@30..32 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsArrowFunctionExpression(
-                                                    JsArrowFunctionExpression {
-                                                        async_token: Some(
-                                                            ASYNC_KW@32..38 "async" [] [Whitespace(" ")],
-                                                        ),
-                                                        type_parameters: None,
-                                                        parameter_list: Some(
-                                                            JsParameterList(
-                                                                JsParameterList {
-                                                                    l_paren_token: Ok(
-                                                                        L_PAREN@38..39 "(" [] [],
-                                                                    ),
-                                                                    parameters: [
-                                                                        AstSeparatedElement {
-                                                                            node: Pattern(
-                                                                                SinglePattern(
-                                                                                    SinglePattern {
-                                                                                        name: Ok(
-                                                                                            Name {
-                                                                                                ident_token: Ok(
-                                                                                                    IDENT@39..42 "bar" [] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                        question_mark_token: None,
-                                                                                        excl_token: None,
-                                                                                        ty: None,
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                            trailing_separator: None,
-                                                                        },
-                                                                    ],
-                                                                    r_paren_token: Ok(
-                                                                        R_PAREN@42..44 ")" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                        fat_arrow_token: Ok(
-                                                            FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
-                                                        ),
-                                                        return_type: None,
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsArrowFunctionExpression {
+                                    async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                    type_parameters: missing (optional),
+                                    parameter_list: JsIdentifierBinding {
+                                        name_token: IDENT@14..18 "foo" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@18..21 "=>" [] [Whitespace(" ")],
+                                    return_type: missing (optional),
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: Some(
-                                ASYNC_KW@49..56 "async" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsParameterList(
-                                    JsParameterList {
-                                        l_paren_token: Ok(
-                                            L_PAREN@56..57 "(" [] [],
-                                        ),
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@28..30 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@30..32 "=" [] [Whitespace(" ")],
+                                expression: JsArrowFunctionExpression {
+                                    async_token: ASYNC_KW@32..38 "async" [] [Whitespace(" ")],
+                                    type_parameters: missing (optional),
+                                    parameter_list: JsParameterList {
+                                        l_paren_token: L_PAREN@38..39 "(" [] [],
                                         parameters: [
                                             AstSeparatedElement {
-                                                node: Pattern(
-                                                    SinglePattern(
-                                                        SinglePattern {
-                                                            name: Ok(
-                                                                Name {
-                                                                    ident_token: Ok(
-                                                                        IDENT@57..60 "foo" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            question_mark_token: None,
-                                                            excl_token: None,
-                                                            ty: None,
-                                                        },
-                                                    ),
-                                                ),
-                                                trailing_separator: Some(
-                                                    COMMA@60..62 "," [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                            AstSeparatedElement {
-                                                node: Pattern(
-                                                    SinglePattern(
-                                                        SinglePattern {
-                                                            name: Ok(
-                                                                Name {
-                                                                    ident_token: Ok(
-                                                                        IDENT@62..65 "bar" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            question_mark_token: None,
-                                                            excl_token: None,
-                                                            ty: None,
-                                                        },
-                                                    ),
-                                                ),
-                                                trailing_separator: Some(
-                                                    COMMA@65..67 "," [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                            AstSeparatedElement {
-                                                node: JsRestParameter(
-                                                    JsRestParameter {
-                                                        dotdotdot_token: Ok(
-                                                            DOT2@67..70 "..." [] [],
-                                                        ),
-                                                        binding: Ok(
-                                                            SinglePattern(
-                                                                SinglePattern {
-                                                                    name: Ok(
-                                                                        Name {
-                                                                            ident_token: Ok(
-                                                                                IDENT@70..73 "baz" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    question_mark_token: None,
-                                                                    excl_token: None,
-                                                                    ty: None,
-                                                                },
-                                                            ),
-                                                        ),
+                                                node: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@39..42 "bar" [] [],
                                                     },
-                                                ),
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
                                                 trailing_separator: None,
                                             },
                                         ],
-                                        r_paren_token: Ok(
-                                            R_PAREN@73..75 ")" [] [Whitespace(" ")],
-                                        ),
+                                        r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
                                     },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@75..78 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
+                                    fat_arrow_token: FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
+                                    return_type: missing (optional),
+                                },
+                            },
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        trailing_separator: None,
+                    },
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: ASYNC_KW@49..56 "async" [Whitespace("\n")] [Whitespace(" ")],
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@56..57 "(" [] [],
+                    parameters: [
+                        AstSeparatedElement {
+                            node: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@57..60 "foo" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            trailing_separator: Some(
+                                COMMA@60..62 "," [] [Whitespace(" ")],
+                            ),
+                        },
+                        AstSeparatedElement {
+                            node: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@62..65 "bar" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            trailing_separator: Some(
+                                COMMA@65..67 "," [] [Whitespace(" ")],
+                            ),
+                        },
+                        AstSeparatedElement {
+                            node: JsRestParameter {
+                                dotdotdot_token: DOT2@67..70 "..." [] [],
+                                binding: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@70..73 "baz" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@73..75 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@75..78 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -6,31 +6,29 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsArrowFunctionExpression {
-                                    async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
-                                    type_parameters: missing (optional),
-                                    parameter_list: JsIdentifierBinding {
-                                        name_token: IDENT@14..18 "foo" [] [Whitespace(" ")],
-                                    },
-                                    fat_arrow_token: FAT_ARROW@18..21 "=>" [] [Whitespace(" ")],
-                                    return_type: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                type_parameters: missing (optional),
+                                parameter_list: JsIdentifierBinding {
+                                    name_token: IDENT@14..18 "foo" [] [Whitespace(" ")],
                                 },
+                                fat_arrow_token: FAT_ARROW@18..21 "=>" [] [Whitespace(" ")],
+                                return_type: missing (optional),
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),
@@ -39,45 +37,41 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@28..30 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@28..30 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@30..32 "=" [] [Whitespace(" ")],
-                                expression: JsArrowFunctionExpression {
-                                    async_token: ASYNC_KW@32..38 "async" [] [Whitespace(" ")],
-                                    type_parameters: missing (optional),
-                                    parameter_list: JsParameterList {
-                                        l_paren_token: L_PAREN@38..39 "(" [] [],
-                                        parameters: [
-                                            AstSeparatedElement {
-                                                node: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@39..42 "bar" [] [],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
-                                                },
-                                                trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@30..32 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: ASYNC_KW@32..38 "async" [] [Whitespace(" ")],
+                                type_parameters: missing (optional),
+                                parameter_list: JsParameterList {
+                                    l_paren_token: L_PAREN@38..39 "(" [] [],
+                                    parameters: [
+                                        SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@39..42 "bar" [] [],
                                             },
-                                        ],
-                                        r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
-                                    },
-                                    fat_arrow_token: FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
-                                    return_type: missing (optional),
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        }
+                                        ,
+                                    ],
+                                    r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
                                 },
+                                fat_arrow_token: FAT_ARROW@44..47 "=>" [] [Whitespace(" ")],
+                                return_type: missing (optional),
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),
@@ -89,46 +83,36 @@ JsRoot {
                 parameter_list: JsParameterList {
                     l_paren_token: L_PAREN@56..57 "(" [] [],
                     parameters: [
-                        AstSeparatedElement {
-                            node: SinglePattern {
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@57..60 "foo" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        COMMA@60..62 "," [] [Whitespace(" ")],
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@62..65 "bar" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        COMMA@65..67 "," [] [Whitespace(" ")],
+                        JsRestParameter {
+                            dotdotdot_token: DOT2@67..70 "..." [] [],
+                            binding: SinglePattern {
                                 name: Name {
-                                    ident_token: IDENT@57..60 "foo" [] [],
+                                    ident_token: IDENT@70..73 "baz" [] [],
                                 },
                                 question_mark_token: missing (optional),
                                 excl_token: missing (optional),
                                 ty: missing (optional),
                             },
-                            trailing_separator: Some(
-                                COMMA@60..62 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@62..65 "bar" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
-                            },
-                            trailing_separator: Some(
-                                COMMA@65..67 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: JsRestParameter {
-                                dotdotdot_token: DOT2@67..70 "..." [] [],
-                                binding: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@70..73 "baz" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
-                                },
-                            },
-                            trailing_separator: None,
-                        },
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@73..75 ")" [] [Whitespace(" ")],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -6,41 +6,39 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsFunctionExpression {
-                                    async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
-                                    function_token: FUNCTION_KW@14..22 "function" [] [],
-                                    star_token: missing (optional),
-                                    id: missing (optional),
-                                    type_parameters: missing (optional),
-                                    parameters: JsParameterList {
-                                        l_paren_token: L_PAREN@22..23 "(" [] [],
-                                        parameters: [],
-                                        r_paren_token: R_PAREN@23..25 ")" [] [Whitespace(" ")],
-                                    },
-                                    return_type: missing (optional),
-                                    body: JsFunctionBody {
-                                        l_curly_token: L_CURLY@25..26 "{" [] [],
-                                        directives: [],
-                                        statements: [],
-                                        r_curly_token: R_CURLY@26..27 "}" [] [],
-                                    },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsFunctionExpression {
+                                async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                function_token: FUNCTION_KW@14..22 "function" [] [],
+                                star_token: missing (optional),
+                                id: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameterList {
+                                    l_paren_token: L_PAREN@22..23 "(" [] [],
+                                    parameters: [],
+                                    r_paren_token: R_PAREN@23..25 ")" [] [Whitespace(" ")],
+                                },
+                                return_type: missing (optional),
+                                body: JsFunctionBody {
+                                    l_curly_token: L_CURLY@25..26 "{" [] [],
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@26..27 "}" [] [],
                                 },
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@27..28 ";" [] [],
@@ -49,43 +47,41 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@33..35 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@33..35 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@35..37 "=" [] [Whitespace(" ")],
-                                expression: JsFunctionExpression {
-                                    async_token: ASYNC_KW@37..43 "async" [] [Whitespace(" ")],
-                                    function_token: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
-                                    star_token: missing (optional),
-                                    id: JsIdentifierBinding {
-                                        name_token: IDENT@52..55 "foo" [] [],
-                                    },
-                                    type_parameters: missing (optional),
-                                    parameters: JsParameterList {
-                                        l_paren_token: L_PAREN@55..56 "(" [] [],
-                                        parameters: [],
-                                        r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
-                                    },
-                                    return_type: missing (optional),
-                                    body: JsFunctionBody {
-                                        l_curly_token: L_CURLY@58..59 "{" [] [],
-                                        directives: [],
-                                        statements: [],
-                                        r_curly_token: R_CURLY@59..60 "}" [] [],
-                                    },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@35..37 "=" [] [Whitespace(" ")],
+                            expression: JsFunctionExpression {
+                                async_token: ASYNC_KW@37..43 "async" [] [Whitespace(" ")],
+                                function_token: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
+                                star_token: missing (optional),
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@52..55 "foo" [] [],
+                                },
+                                type_parameters: missing (optional),
+                                parameters: JsParameterList {
+                                    l_paren_token: L_PAREN@55..56 "(" [] [],
+                                    parameters: [],
+                                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                },
+                                return_type: missing (optional),
+                                body: JsFunctionBody {
+                                    l_curly_token: L_CURLY@58..59 "{" [] [],
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@59..60 "}" [] [],
                                 },
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@60..61 ";" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -1,179 +1,95 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsFunctionExpression(
-                                                    JsFunctionExpression {
-                                                        async_token: Some(
-                                                            ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
-                                                        ),
-                                                        function_token: Ok(
-                                                            FUNCTION_KW@14..22 "function" [] [],
-                                                        ),
-                                                        star_token: None,
-                                                        id: None,
-                                                        type_parameters: None,
-                                                        parameters: Ok(
-                                                            JsParameterList {
-                                                                l_paren_token: Ok(
-                                                                    L_PAREN@22..23 "(" [] [],
-                                                                ),
-                                                                parameters: [],
-                                                                r_paren_token: Ok(
-                                                                    R_PAREN@23..25 ")" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        return_type: None,
-                                                        body: Ok(
-                                                            JsFunctionBody {
-                                                                l_curly_token: Ok(
-                                                                    L_CURLY@25..26 "{" [] [],
-                                                                ),
-                                                                directives: [],
-                                                                statements: [],
-                                                                r_curly_token: Ok(
-                                                                    R_CURLY@26..27 "}" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@27..28 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@33..35 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@35..37 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsFunctionExpression(
-                                                    JsFunctionExpression {
-                                                        async_token: Some(
-                                                            ASYNC_KW@37..43 "async" [] [Whitespace(" ")],
-                                                        ),
-                                                        function_token: Ok(
-                                                            FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
-                                                        ),
-                                                        star_token: None,
-                                                        id: Some(
-                                                            JsIdentifierBinding {
-                                                                name_token: Ok(
-                                                                    IDENT@52..55 "foo" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        type_parameters: None,
-                                                        parameters: Ok(
-                                                            JsParameterList {
-                                                                l_paren_token: Ok(
-                                                                    L_PAREN@55..56 "(" [] [],
-                                                                ),
-                                                                parameters: [],
-                                                                r_paren_token: Ok(
-                                                                    R_PAREN@56..58 ")" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        return_type: None,
-                                                        body: Ok(
-                                                            JsFunctionBody {
-                                                                l_curly_token: Ok(
-                                                                    L_CURLY@58..59 "{" [] [],
-                                                                ),
-                                                                directives: [],
-                                                                statements: [],
-                                                                r_curly_token: Ok(
-                                                                    R_CURLY@59..60 "}" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsFunctionExpression {
+                                    async_token: ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                    function_token: FUNCTION_KW@14..22 "function" [] [],
+                                    star_token: missing (optional),
+                                    id: missing (optional),
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameterList {
+                                        l_paren_token: L_PAREN@22..23 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@23..25 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type: missing (optional),
+                                    body: JsFunctionBody {
+                                        l_curly_token: L_CURLY@25..26 "{" [] [],
+                                        directives: [],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@26..27 "}" [] [],
+                                    },
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@60..61 ";" [] [],
-                ),
+                ],
             },
-        ),
+            semicolon_token: SEMICOLON@27..28 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@33..35 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@35..37 "=" [] [Whitespace(" ")],
+                                expression: JsFunctionExpression {
+                                    async_token: ASYNC_KW@37..43 "async" [] [Whitespace(" ")],
+                                    function_token: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
+                                    star_token: missing (optional),
+                                    id: JsIdentifierBinding {
+                                        name_token: IDENT@52..55 "foo" [] [],
+                                    },
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameterList {
+                                        l_paren_token: L_PAREN@55..56 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type: missing (optional),
+                                    body: JsFunctionBody {
+                                        l_curly_token: L_CURLY@58..59 "{" [] [],
+                                        directives: [],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@59..60 "}" [] [],
+                                    },
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@60..61 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -1,3 +1,182 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsFunctionExpression(
+                                                    JsFunctionExpression {
+                                                        async_token: Some(
+                                                            ASYNC_KW@8..14 "async" [] [Whitespace(" ")],
+                                                        ),
+                                                        function_token: Ok(
+                                                            FUNCTION_KW@14..22 "function" [] [],
+                                                        ),
+                                                        star_token: None,
+                                                        id: None,
+                                                        type_parameters: None,
+                                                        parameters: Ok(
+                                                            JsParameterList {
+                                                                l_paren_token: Ok(
+                                                                    L_PAREN@22..23 "(" [] [],
+                                                                ),
+                                                                parameters: [],
+                                                                r_paren_token: Ok(
+                                                                    R_PAREN@23..25 ")" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        return_type: None,
+                                                        body: Ok(
+                                                            JsFunctionBody {
+                                                                l_curly_token: Ok(
+                                                                    L_CURLY@25..26 "{" [] [],
+                                                                ),
+                                                                directives: [],
+                                                                statements: [],
+                                                                r_curly_token: Ok(
+                                                                    R_CURLY@26..27 "}" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@27..28 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@33..35 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@35..37 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsFunctionExpression(
+                                                    JsFunctionExpression {
+                                                        async_token: Some(
+                                                            ASYNC_KW@37..43 "async" [] [Whitespace(" ")],
+                                                        ),
+                                                        function_token: Ok(
+                                                            FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
+                                                        ),
+                                                        star_token: None,
+                                                        id: Some(
+                                                            JsIdentifierBinding {
+                                                                name_token: Ok(
+                                                                    IDENT@52..55 "foo" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        type_parameters: None,
+                                                        parameters: Ok(
+                                                            JsParameterList {
+                                                                l_paren_token: Ok(
+                                                                    L_PAREN@55..56 "(" [] [],
+                                                                ),
+                                                                parameters: [],
+                                                                r_paren_token: Ok(
+                                                                    R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        return_type: None,
+                                                        body: Ok(
+                                                            JsFunctionBody {
+                                                                l_curly_token: Ok(
+                                                                    L_CURLY@58..59 "{" [] [],
+                                                                ),
+                                                                directives: [],
+                                                                statements: [],
+                                                                r_curly_token: Ok(
+                                                                    R_CURLY@59..60 "}" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@60..61 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..62
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -1,3 +1,63 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsReferenceIdentifierExpression(
+                                                    JsReferenceIdentifierExpression {
+                                                        name_token: Ok(
+                                                            IDENT@8..13 "async" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@13..14 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..15
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -1,60 +1,34 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsReferenceIdentifierExpression(
-                                                    JsReferenceIdentifierExpression {
-                                                        name_token: Ok(
-                                                            IDENT@8..13 "async" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@8..13 "async" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@13..14 ";" [] [],
-                ),
+                ],
             },
-        ),
+            semicolon_token: SEMICOLON@13..14 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -6,25 +6,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsReferenceIdentifierExpression {
-                                    name_token: IDENT@8..13 "async" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsReferenceIdentifierExpression {
+                                name_token: IDENT@8..13 "async" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@13..14 ";" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -1,123 +1,65 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@11..19 "async" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@19..22 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@22..23 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@23..25 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@25..26 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@26..27 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@27..35 "async" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            star_token: Some(
-                                STAR@35..36 "*" [] [],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@36..39 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@39..40 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@40..42 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@42..43 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@43..44 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@44..46 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@11..19 "async" [Whitespace("\n ")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@19..22 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@22..23 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@23..25 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@25..26 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@26..27 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@27..35 "async" [Whitespace("\n ")] [Whitespace(" ")],
+                    star_token: STAR@35..36 "*" [] [],
+                    name: JsLiteralMemberName {
+                        value: IDENT@36..39 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@39..40 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@40..42 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@42..43 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@43..44 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -1,3 +1,126 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@11..19 "async" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@19..22 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@22..23 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@23..25 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@25..26 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@26..27 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@27..35 "async" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            star_token: Some(
+                                STAR@35..36 "*" [] [],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@36..39 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@39..40 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@40..42 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@42..43 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@43..44 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@44..46 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..47
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/await_expression.rast
@@ -1,223 +1,99 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: Some(
-                    ASYNC_KW@0..6 "async" [] [Whitespace(" ")],
-                ),
-                function_token: Ok(
-                    FUNCTION_KW@6..15 "function" [] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@15..19 "test" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@19..20 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@20..22 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@22..23 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsAwaitExpression(
-                                            JsAwaitExpression {
-                                                await_token: Ok(
-                                                    AWAIT_KW@23..31 "await" [Whitespace("\n\t")] [Whitespace(" ")],
-                                                ),
-                                                argument: Ok(
-                                                    CallExpr(
-                                                        CallExpr {
-                                                            type_args: None,
-                                                            callee: Ok(
-                                                                JsReferenceIdentifierExpression(
-                                                                    JsReferenceIdentifierExpression {
-                                                                        name_token: Ok(
-                                                                            IDENT@31..36 "inner" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            arguments: Ok(
-                                                                ArgList {
-                                                                    l_paren_token: Ok(
-                                                                        L_PAREN@36..37 "(" [] [],
-                                                                    ),
-                                                                    args: [],
-                                                                    r_paren_token: Ok(
-                                                                        R_PAREN@37..38 ")" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@38..39 ";" [] [],
-                                    ),
-                                },
-                            ),
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsBinaryExpression(
-                                            JsBinaryExpression {
-                                                left: Ok(
-                                                    JsAwaitExpression(
-                                                        JsAwaitExpression {
-                                                            await_token: Ok(
-                                                                AWAIT_KW@39..48 "await" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                            ),
-                                                            argument: Ok(
-                                                                JsParenthesizedExpression(
-                                                                    JsParenthesizedExpression {
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@48..49 "(" [] [],
-                                                                        ),
-                                                                        expression: Ok(
-                                                                            CallExpr(
-                                                                                CallExpr {
-                                                                                    type_args: None,
-                                                                                    callee: Ok(
-                                                                                        JsReferenceIdentifierExpression(
-                                                                                            JsReferenceIdentifierExpression {
-                                                                                                name_token: Ok(
-                                                                                                    IDENT@49..54 "inner" [] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    arguments: Ok(
-                                                                                        ArgList {
-                                                                                            l_paren_token: Ok(
-                                                                                                L_PAREN@54..55 "(" [] [],
-                                                                                            ),
-                                                                                            args: [],
-                                                                                            r_paren_token: Ok(
-                                                                                                R_PAREN@55..56 ")" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@56..58 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                operator: Ok(
-                                                    PLUS@58..60 "+" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@73..74 ";" [] [],
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@74..76 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@0..6 "async" [] [Whitespace(" ")],
+            function_token: FUNCTION_KW@6..15 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@15..19 "test" [] [],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: Some(
-                    ASYNC_KW@76..84 "async" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                function_token: Ok(
-                    FUNCTION_KW@84..93 "function" [] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@93..98 "inner" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@98..99 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@99..101 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@101..102 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsReturnStatement(
-                                JsReturnStatement {
-                                    return_token: Ok(
-                                        RETURN_KW@102..111 "return" [Whitespace("\n\t")] [Whitespace(" ")],
-                                    ),
-                                    argument: Some(
-                                        JsAnyLiteralExpression(
-                                            JsNumberLiteralExpression(
-                                                JsNumberLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_NUMBER_LITERAL@111..112 "4" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@112..113 ";" [] [],
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@113..115 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@19..20 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@20..22 ")" [] [Whitespace(" ")],
             },
-        ),
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@22..23 "{" [] [],
+                directives: [],
+                statements: [
+                    JsExpressionStatement {
+                        expression: JsAwaitExpression {
+                            await_token: AWAIT_KW@23..31 "await" [Whitespace("\n\t")] [Whitespace(" ")],
+                            argument: CallExpr {
+                                type_args: missing (optional),
+                                callee: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@31..36 "inner" [] [],
+                                },
+                                arguments: ArgList {
+                                    l_paren_token: L_PAREN@36..37 "(" [] [],
+                                    args: [],
+                                    r_paren_token: R_PAREN@37..38 ")" [] [],
+                                },
+                            },
+                        },
+                        semicolon_token: SEMICOLON@38..39 ";" [] [],
+                    },
+                    JsExpressionStatement {
+                        expression: JsBinaryExpression {
+                            left: JsAwaitExpression {
+                                await_token: AWAIT_KW@39..48 "await" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                argument: JsParenthesizedExpression {
+                                    l_paren_token: L_PAREN@48..49 "(" [] [],
+                                    expression: CallExpr {
+                                        type_args: missing (optional),
+                                        callee: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@49..54 "inner" [] [],
+                                        },
+                                        arguments: ArgList {
+                                            l_paren_token: L_PAREN@54..55 "(" [] [],
+                                            args: [],
+                                            r_paren_token: R_PAREN@55..56 ")" [] [],
+                                        },
+                                    },
+                                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                },
+                            },
+                            operator: PLUS@58..60 "+" [] [Whitespace(" ")],
+                        },
+                        semicolon_token: SEMICOLON@73..74 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@74..76 "}" [Whitespace("\n")] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@76..84 "async" [Whitespace("\n\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@93..98 "inner" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@98..99 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@101..102 "{" [] [],
+                directives: [],
+                statements: [
+                    JsReturnStatement {
+                        return_token: RETURN_KW@102..111 "return" [Whitespace("\n\t")] [Whitespace(" ")],
+                        argument: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@111..112 "4" [] [],
+                        },
+                        semicolon_token: SEMICOLON@112..113 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@113..115 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/await_expression.rast
@@ -1,3 +1,226 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: Some(
+                    ASYNC_KW@0..6 "async" [] [Whitespace(" ")],
+                ),
+                function_token: Ok(
+                    FUNCTION_KW@6..15 "function" [] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@15..19 "test" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@19..20 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@20..22 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@22..23 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsAwaitExpression(
+                                            JsAwaitExpression {
+                                                await_token: Ok(
+                                                    AWAIT_KW@23..31 "await" [Whitespace("\n\t")] [Whitespace(" ")],
+                                                ),
+                                                argument: Ok(
+                                                    CallExpr(
+                                                        CallExpr {
+                                                            type_args: None,
+                                                            callee: Ok(
+                                                                JsReferenceIdentifierExpression(
+                                                                    JsReferenceIdentifierExpression {
+                                                                        name_token: Ok(
+                                                                            IDENT@31..36 "inner" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            arguments: Ok(
+                                                                ArgList {
+                                                                    l_paren_token: Ok(
+                                                                        L_PAREN@36..37 "(" [] [],
+                                                                    ),
+                                                                    args: [],
+                                                                    r_paren_token: Ok(
+                                                                        R_PAREN@37..38 ")" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@38..39 ";" [] [],
+                                    ),
+                                },
+                            ),
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsBinaryExpression(
+                                            JsBinaryExpression {
+                                                left: Ok(
+                                                    JsAwaitExpression(
+                                                        JsAwaitExpression {
+                                                            await_token: Ok(
+                                                                AWAIT_KW@39..48 "await" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                            ),
+                                                            argument: Ok(
+                                                                JsParenthesizedExpression(
+                                                                    JsParenthesizedExpression {
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@48..49 "(" [] [],
+                                                                        ),
+                                                                        expression: Ok(
+                                                                            CallExpr(
+                                                                                CallExpr {
+                                                                                    type_args: None,
+                                                                                    callee: Ok(
+                                                                                        JsReferenceIdentifierExpression(
+                                                                                            JsReferenceIdentifierExpression {
+                                                                                                name_token: Ok(
+                                                                                                    IDENT@49..54 "inner" [] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    arguments: Ok(
+                                                                                        ArgList {
+                                                                                            l_paren_token: Ok(
+                                                                                                L_PAREN@54..55 "(" [] [],
+                                                                                            ),
+                                                                                            args: [],
+                                                                                            r_paren_token: Ok(
+                                                                                                R_PAREN@55..56 ")" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                operator: Ok(
+                                                    PLUS@58..60 "+" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@73..74 ";" [] [],
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@74..76 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: Some(
+                    ASYNC_KW@76..84 "async" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                function_token: Ok(
+                    FUNCTION_KW@84..93 "function" [] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@93..98 "inner" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@98..99 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@99..101 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@101..102 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsReturnStatement(
+                                JsReturnStatement {
+                                    return_token: Ok(
+                                        RETURN_KW@102..111 "return" [Whitespace("\n\t")] [Whitespace(" ")],
+                                    ),
+                                    argument: Some(
+                                        JsAnyLiteralExpression(
+                                            JsNumberLiteralExpression(
+                                                JsNumberLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_NUMBER_LITERAL@111..112 "4" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@112..113 ";" [] [],
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@113..115 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..116
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -1,3 +1,258 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@0..2 "5" [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            operator: Ok(
+                                STAR@2..4 "*" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@5..8 "6" [Whitespace("\n")] [Whitespace(" ")],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            operator: Ok(
+                                STAR2@8..11 "**" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@17..20 "1" [Whitespace("\n")] [Whitespace(" ")],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            operator: Ok(
+                                PLUS@20..22 "+" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@39..42 "1" [Whitespace("\n")] [Whitespace(" ")],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            operator: Ok(
+                                SLASH@42..44 "/" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@45..49 "74" [Whitespace("\n")] [Whitespace(" ")],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            operator: Ok(
+                                IN_KW@49..52 "in" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@55..60 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                INSTANCEOF_KW@60..71 "instanceof" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsLogicalExpression(
+                        JsLogicalExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@76..81 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTION2@81..84 "??" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsBinaryExpression(
+                                    JsBinaryExpression {
+                                        left: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsNumberLiteralExpression(
+                                                                JsNumberLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_NUMBER_LITERAL@87..90 "1" [Whitespace("\n")] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@90..92 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        operator: Ok(
+                                            PLUS@94..96 "+" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                PLUS@98..100 "+" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsBinaryExpression(
+                                    JsBinaryExpression {
+                                        left: Ok(
+                                            JsAnyLiteralExpression(
+                                                JsNumberLiteralExpression(
+                                                    JsNumberLiteralExpression {
+                                                        value_token: Ok(
+                                                            JS_NUMBER_LITERAL@101..104 "5" [Whitespace("\n")] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                        operator: Ok(
+                                            PLUS@104..106 "+" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                MINUS@108..110 "-" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..125
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -1,255 +1,97 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@0..2 "5" [] [Whitespace(" ")],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            operator: Ok(
-                                STAR@2..4 "*" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@0..2 "5" [] [Whitespace(" ")],
+                },
+                operator: STAR@2..4 "*" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@5..8 "6" [Whitespace("\n")] [Whitespace(" ")],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            operator: Ok(
-                                STAR2@8..11 "**" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@5..8 "6" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: STAR2@8..11 "**" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@17..20 "1" [Whitespace("\n")] [Whitespace(" ")],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            operator: Ok(
-                                PLUS@20..22 "+" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@17..20 "1" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: PLUS@20..22 "+" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@39..42 "1" [Whitespace("\n")] [Whitespace(" ")],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            operator: Ok(
-                                SLASH@42..44 "/" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@39..42 "1" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: SLASH@42..44 "/" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@45..49 "74" [Whitespace("\n")] [Whitespace(" ")],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            operator: Ok(
-                                IN_KW@49..52 "in" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@45..49 "74" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: IN_KW@49..52 "in" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@55..60 "foo" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                INSTANCEOF_KW@60..71 "instanceof" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@55..60 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: INSTANCEOF_KW@60..71 "instanceof" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsLogicalExpression(
-                        JsLogicalExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@76..81 "foo" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTION2@81..84 "??" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@76..81 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: QUESTION2@81..84 "??" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsBinaryExpression(
-                                    JsBinaryExpression {
-                                        left: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsNumberLiteralExpression(
-                                                                JsNumberLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_NUMBER_LITERAL@87..90 "1" [Whitespace("\n")] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@90..92 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        operator: Ok(
-                                            PLUS@94..96 "+" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                PLUS@98..100 "+" [] [Whitespace(" ")],
-                            ),
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsBinaryExpression {
+                    left: JsBinaryExpression {
+                        left: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@87..90 "1" [Whitespace("\n")] [Whitespace(" ")],
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        operator: PLUS@90..92 "+" [] [Whitespace(" ")],
+                    },
+                    operator: PLUS@94..96 "+" [] [Whitespace(" ")],
+                },
+                operator: PLUS@98..100 "+" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsBinaryExpression(
-                                    JsBinaryExpression {
-                                        left: Ok(
-                                            JsAnyLiteralExpression(
-                                                JsNumberLiteralExpression(
-                                                    JsNumberLiteralExpression {
-                                                        value_token: Ok(
-                                                            JS_NUMBER_LITERAL@101..104 "5" [Whitespace("\n")] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        ),
-                                        operator: Ok(
-                                            PLUS@104..106 "+" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                MINUS@108..110 "-" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsBinaryExpression {
+                    left: JsNumberLiteralExpression {
+                        value_token: JS_NUMBER_LITERAL@101..104 "5" [Whitespace("\n")] [Whitespace(" ")],
+                    },
+                    operator: PLUS@104..106 "+" [] [Whitespace(" ")],
+                },
+                operator: MINUS@108..110 "-" [] [Whitespace(" ")],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -1,3 +1,96 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsBlockStatement(
+            JsBlockStatement {
+                l_curly_token: Ok(
+                    L_CURLY@0..1 "{" [] [],
+                ),
+                statements: [],
+                r_curly_token: Ok(
+                    R_CURLY@1..2 "}" [] [],
+                ),
+            },
+        ),
+        JsBlockStatement(
+            JsBlockStatement {
+                l_curly_token: Ok(
+                    L_CURLY@2..4 "{" [Whitespace("\n")] [],
+                ),
+                statements: [
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@4..5 "{" [] [],
+                            ),
+                            statements: [
+                                JsBlockStatement(
+                                    JsBlockStatement {
+                                        l_curly_token: Ok(
+                                            L_CURLY@5..6 "{" [] [],
+                                        ),
+                                        statements: [
+                                            JsBlockStatement(
+                                                JsBlockStatement {
+                                                    l_curly_token: Ok(
+                                                        L_CURLY@6..7 "{" [] [],
+                                                    ),
+                                                    statements: [],
+                                                    r_curly_token: Ok(
+                                                        R_CURLY@7..8 "}" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        r_curly_token: Ok(
+                                            R_CURLY@8..9 "}" [] [],
+                                        ),
+                                    },
+                                ),
+                            ],
+                            r_curly_token: Ok(
+                                R_CURLY@9..10 "}" [] [],
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@10..11 "}" [] [],
+                ),
+            },
+        ),
+        JsBlockStatement(
+            JsBlockStatement {
+                l_curly_token: Ok(
+                    L_CURLY@11..14 "{" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                statements: [
+                    JsExpressionStatement(
+                        JsExpressionStatement {
+                            expression: Ok(
+                                AssignExpr(
+                                    AssignExpr {
+                                        operator: Ok(
+                                            EQ@18..20 "=" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            semicolon_token: Some(
+                                SEMICOLON@23..25 ";" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@25..26 "}" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..27
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -1,93 +1,47 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsBlockStatement(
-            JsBlockStatement {
-                l_curly_token: Ok(
-                    L_CURLY@0..1 "{" [] [],
-                ),
-                statements: [],
-                r_curly_token: Ok(
-                    R_CURLY@1..2 "}" [] [],
-                ),
-            },
-        ),
-        JsBlockStatement(
-            JsBlockStatement {
-                l_curly_token: Ok(
-                    L_CURLY@2..4 "{" [Whitespace("\n")] [],
-                ),
-                statements: [
-                    JsBlockStatement(
+        JsBlockStatement {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@1..2 "}" [] [],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@2..4 "{" [Whitespace("\n")] [],
+            statements: [
+                JsBlockStatement {
+                    l_curly_token: L_CURLY@4..5 "{" [] [],
+                    statements: [
                         JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@4..5 "{" [] [],
-                            ),
+                            l_curly_token: L_CURLY@5..6 "{" [] [],
                             statements: [
-                                JsBlockStatement(
-                                    JsBlockStatement {
-                                        l_curly_token: Ok(
-                                            L_CURLY@5..6 "{" [] [],
-                                        ),
-                                        statements: [
-                                            JsBlockStatement(
-                                                JsBlockStatement {
-                                                    l_curly_token: Ok(
-                                                        L_CURLY@6..7 "{" [] [],
-                                                    ),
-                                                    statements: [],
-                                                    r_curly_token: Ok(
-                                                        R_CURLY@7..8 "}" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ],
-                                        r_curly_token: Ok(
-                                            R_CURLY@8..9 "}" [] [],
-                                        ),
-                                    },
-                                ),
+                                JsBlockStatement {
+                                    l_curly_token: L_CURLY@6..7 "{" [] [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@7..8 "}" [] [],
+                                },
                             ],
-                            r_curly_token: Ok(
-                                R_CURLY@9..10 "}" [] [],
-                            ),
+                            r_curly_token: R_CURLY@8..9 "}" [] [],
                         },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@10..11 "}" [] [],
-                ),
-            },
-        ),
-        JsBlockStatement(
-            JsBlockStatement {
-                l_curly_token: Ok(
-                    L_CURLY@11..14 "{" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                statements: [
-                    JsExpressionStatement(
-                        JsExpressionStatement {
-                            expression: Ok(
-                                AssignExpr(
-                                    AssignExpr {
-                                        operator: Ok(
-                                            EQ@18..20 "=" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            semicolon_token: Some(
-                                SEMICOLON@23..25 ";" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@25..26 "}" [] [],
-                ),
-            },
-        ),
+                    ],
+                    r_curly_token: R_CURLY@9..10 "}" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@10..11 "}" [] [],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@11..14 "{" [Whitespace("\n")] [Whitespace(" ")],
+            statements: [
+                JsExpressionStatement {
+                    expression: AssignExpr {
+                        operator: EQ@18..20 "=" [] [Whitespace(" ")],
+                    },
+                    semicolon_token: SEMICOLON@23..25 ";" [] [Whitespace(" ")],
+                },
+            ],
+            r_curly_token: R_CURLY@25..26 "}" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -1,3 +1,160 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@3..4 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@7..8 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@8..12 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@12..13 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@18..19 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@19..23 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@23..24 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@29..30 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsComputedMemberExpression(
+                                    JsComputedMemberExpression {
+                                        object: Ok(
+                                            JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@30..34 "foo" [Whitespace("\n")] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        optional_chain_token_token: None,
+                                        l_brack_token: Ok(
+                                            L_BRACK@34..35 "[" [] [],
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@38..39 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@39..40 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@43..44 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: Some(
+                                QUESTIONDOT@48..50 "?." [] [],
+                            ),
+                            l_brack_token: Ok(
+                                L_BRACK@50..51 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@54..55 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..56
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/bracket_expr.rast
@@ -1,157 +1,67 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@3..4 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@7..8 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@3..4 "[" [] [],
+                r_brack_token: R_BRACK@7..8 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@8..12 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@12..13 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@18..19 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@12..13 "[" [] [],
+                r_brack_token: R_BRACK@18..19 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@19..23 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@23..24 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@29..30 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@19..23 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@23..24 "[" [] [],
+                r_brack_token: R_BRACK@29..30 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsComputedMemberExpression(
-                                    JsComputedMemberExpression {
-                                        object: Ok(
-                                            JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@30..34 "foo" [Whitespace("\n")] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        optional_chain_token_token: None,
-                                        l_brack_token: Ok(
-                                            L_BRACK@34..35 "[" [] [],
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@38..39 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@39..40 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@43..44 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsComputedMemberExpression {
+                    object: JsReferenceIdentifierExpression {
+                        name_token: IDENT@30..34 "foo" [Whitespace("\n")] [],
+                    },
+                    optional_chain_token_token: missing (optional),
+                    l_brack_token: L_BRACK@34..35 "[" [] [],
+                    r_brack_token: R_BRACK@38..39 "]" [] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@39..40 "[" [] [],
+                r_brack_token: R_BRACK@43..44 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: Some(
-                                QUESTIONDOT@48..50 "?." [] [],
-                            ),
-                            l_brack_token: Ok(
-                                L_BRACK@50..51 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@54..55 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: QUESTIONDOT@48..50 "?." [] [],
+                l_brack_token: L_BRACK@50..51 "[" [] [],
+                r_brack_token: R_BRACK@54..55 "]" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -1,3 +1,91 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsLabeledStatement(
+            JsLabeledStatement {
+                label_token: Ok(
+                    IDENT@0..3 "foo" [] [],
+                ),
+                colon_token: Ok(
+                    COLON@3..5 ":" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@5..6 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@6..7 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        JsLabeledStatement(
+            JsLabeledStatement {
+                label_token: Ok(
+                    IDENT@7..12 "rust" [Whitespace("\n")] [],
+                ),
+                colon_token: Ok(
+                    COLON@12..14 ":" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@14..15 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@15..16 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        JsBreakStatement(
+            JsBreakStatement {
+                break_token: Ok(
+                    BREAK_KW@16..22 "break" [Whitespace("\n")] [],
+                ),
+                label_token: None,
+                semicolon_token: Some(
+                    SEMICOLON@22..23 ";" [] [],
+                ),
+            },
+        ),
+        JsBreakStatement(
+            JsBreakStatement {
+                break_token: Ok(
+                    BREAK_KW@23..30 "break" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                label_token: Some(
+                    IDENT@30..33 "foo" [] [],
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@33..34 ";" [] [],
+                ),
+            },
+        ),
+        JsBreakStatement(
+            JsBreakStatement {
+                break_token: Ok(
+                    BREAK_KW@34..41 "break" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                label_token: Some(
+                    IDENT@41..45 "rust" [] [],
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..46
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -1,88 +1,40 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsLabeledStatement(
-            JsLabeledStatement {
-                label_token: Ok(
-                    IDENT@0..3 "foo" [] [],
-                ),
-                colon_token: Ok(
-                    COLON@3..5 ":" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@5..6 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@6..7 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+        JsLabeledStatement {
+            label_token: IDENT@0..3 "foo" [] [],
+            colon_token: COLON@3..5 ":" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@5..6 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@6..7 "}" [] [],
             },
-        ),
-        JsLabeledStatement(
-            JsLabeledStatement {
-                label_token: Ok(
-                    IDENT@7..12 "rust" [Whitespace("\n")] [],
-                ),
-                colon_token: Ok(
-                    COLON@12..14 ":" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@14..15 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@15..16 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+        },
+        JsLabeledStatement {
+            label_token: IDENT@7..12 "rust" [Whitespace("\n")] [],
+            colon_token: COLON@12..14 ":" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@14..15 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@15..16 "}" [] [],
             },
-        ),
-        JsBreakStatement(
-            JsBreakStatement {
-                break_token: Ok(
-                    BREAK_KW@16..22 "break" [Whitespace("\n")] [],
-                ),
-                label_token: None,
-                semicolon_token: Some(
-                    SEMICOLON@22..23 ";" [] [],
-                ),
-            },
-        ),
-        JsBreakStatement(
-            JsBreakStatement {
-                break_token: Ok(
-                    BREAK_KW@23..30 "break" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                label_token: Some(
-                    IDENT@30..33 "foo" [] [],
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@33..34 ";" [] [],
-                ),
-            },
-        ),
-        JsBreakStatement(
-            JsBreakStatement {
-                break_token: Ok(
-                    BREAK_KW@34..41 "break" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                label_token: Some(
-                    IDENT@41..45 "rust" [] [],
-                ),
-                semicolon_token: None,
-            },
-        ),
+        },
+        JsBreakStatement {
+            break_token: BREAK_KW@16..22 "break" [Whitespace("\n")] [],
+            label_token: missing (optional),
+            semicolon_token: SEMICOLON@22..23 ";" [] [],
+        },
+        JsBreakStatement {
+            break_token: BREAK_KW@23..30 "break" [Whitespace("\n")] [Whitespace(" ")],
+            label_token: IDENT@30..33 "foo" [] [],
+            semicolon_token: SEMICOLON@33..34 ";" [] [],
+        },
+        JsBreakStatement {
+            break_token: BREAK_KW@34..41 "break" [Whitespace("\n")] [Whitespace(" ")],
+            label_token: IDENT@41..45 "rust" [] [],
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -1,124 +1,56 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@11..12 "}" [] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@19..23 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: Some(
-                    JsExtendsClause {
-                        extends_token: Ok(
-                            EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
-                        ),
-                        super_class: Ok(
-                            JsReferenceIdentifierExpression(
-                                JsReferenceIdentifierExpression {
-                                    name_token: Ok(
-                                        IDENT@31..35 "bar" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@35..36 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@36..37 "}" [] [],
-                ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@11..12 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@44..48 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: Some(
-                    JsExtendsClause {
-                        extends_token: Ok(
-                            EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
-                        ),
-                        super_class: Ok(
-                            JsStaticMemberExpression(
-                                JsStaticMemberExpression {
-                                    object: Ok(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@56..59 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    operator: Ok(
-                                        DOT@59..60 "." [] [],
-                                    ),
-                                    member: Ok(
-                                        JsReferenceIdentifierMember(
-                                            JsReferenceIdentifierMember {
-                                                name_token: Ok(
-                                                    IDENT@60..64 "bar" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@64..65 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@65..66 "}" [] [],
-                ),
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@31..35 "bar" [] [Whitespace(" ")],
+                },
             },
-        ),
+            l_curly_token: L_CURLY@35..36 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@36..37 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@44..48 "foo" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
+                super_class: JsStaticMemberExpression {
+                    object: JsReferenceIdentifierExpression {
+                        name_token: IDENT@56..59 "foo" [] [],
+                    },
+                    operator: DOT@59..60 "." [] [],
+                    member: JsReferenceIdentifierMember {
+                        name_token: IDENT@60..64 "bar" [] [Whitespace(" ")],
+                    },
+                },
+            },
+            l_curly_token: L_CURLY@64..65 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@65..66 "}" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/class_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_decl.rast
@@ -1,3 +1,127 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@11..12 "}" [] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@19..23 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: Some(
+                    JsExtendsClause {
+                        extends_token: Ok(
+                            EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
+                        ),
+                        super_class: Ok(
+                            JsReferenceIdentifierExpression(
+                                JsReferenceIdentifierExpression {
+                                    name_token: Ok(
+                                        IDENT@31..35 "bar" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@35..36 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@36..37 "}" [] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@44..48 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: Some(
+                    JsExtendsClause {
+                        extends_token: Ok(
+                            EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
+                        ),
+                        super_class: Ok(
+                            JsStaticMemberExpression(
+                                JsStaticMemberExpression {
+                                    object: Ok(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@56..59 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    operator: Ok(
+                                        DOT@59..60 "." [] [],
+                                    ),
+                                    member: Ok(
+                                        JsReferenceIdentifierMember(
+                                            JsReferenceIdentifierMember {
+                                                name_token: Ok(
+                                                    IDENT@60..64 "bar" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@64..65 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@65..66 "}" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..67
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
@@ -1,124 +1,56 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@11..12 "}" [] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@19..23 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: Some(
-                    JsExtendsClause {
-                        extends_token: Ok(
-                            EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
-                        ),
-                        super_class: Ok(
-                            JsReferenceIdentifierExpression(
-                                JsReferenceIdentifierExpression {
-                                    name_token: Ok(
-                                        IDENT@31..35 "bar" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@35..36 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@36..37 "}" [] [],
-                ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@11..12 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@44..48 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: Some(
-                    JsExtendsClause {
-                        extends_token: Ok(
-                            EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
-                        ),
-                        super_class: Ok(
-                            JsStaticMemberExpression(
-                                JsStaticMemberExpression {
-                                    object: Ok(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@56..59 "foo" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    operator: Ok(
-                                        DOT@59..60 "." [] [],
-                                    ),
-                                    member: Ok(
-                                        JsReferenceIdentifierMember(
-                                            JsReferenceIdentifierMember {
-                                                name_token: Ok(
-                                                    IDENT@60..64 "bar" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@64..65 "{" [] [],
-                ),
-                members: [],
-                r_curly_token: Ok(
-                    R_CURLY@65..66 "}" [] [],
-                ),
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@31..35 "bar" [] [Whitespace(" ")],
+                },
             },
-        ),
+            l_curly_token: L_CURLY@35..36 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@36..37 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@44..48 "foo" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
+                super_class: JsStaticMemberExpression {
+                    object: JsReferenceIdentifierExpression {
+                        name_token: IDENT@56..59 "foo" [] [],
+                    },
+                    operator: DOT@59..60 "." [] [],
+                    member: JsReferenceIdentifierMember {
+                        name_token: IDENT@60..64 "bar" [] [Whitespace(" ")],
+                    },
+                },
+            },
+            l_curly_token: L_CURLY@64..65 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@65..66 "}" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
@@ -1,3 +1,127 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@11..12 "}" [] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@19..23 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: Some(
+                    JsExtendsClause {
+                        extends_token: Ok(
+                            EXTENDS_KW@23..31 "extends" [] [Whitespace(" ")],
+                        ),
+                        super_class: Ok(
+                            JsReferenceIdentifierExpression(
+                                JsReferenceIdentifierExpression {
+                                    name_token: Ok(
+                                        IDENT@31..35 "bar" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@35..36 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@36..37 "}" [] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@44..48 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: Some(
+                    JsExtendsClause {
+                        extends_token: Ok(
+                            EXTENDS_KW@48..56 "extends" [] [Whitespace(" ")],
+                        ),
+                        super_class: Ok(
+                            JsStaticMemberExpression(
+                                JsStaticMemberExpression {
+                                    object: Ok(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@56..59 "foo" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    operator: Ok(
+                                        DOT@59..60 "." [] [],
+                                    ),
+                                    member: Ok(
+                                        JsReferenceIdentifierMember(
+                                            JsReferenceIdentifierMember {
+                                                name_token: Ok(
+                                                    IDENT@60..64 "bar" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@64..65 "{" [] [],
+                ),
+                members: [],
+                r_curly_token: Ok(
+                    R_CURLY@65..66 "}" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..67
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -1,3 +1,170 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..12 "{" [] [Whitespace(" ")],
+                ),
+                members: [
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@12..13 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@13..14 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@14..15 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@15..16 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@16..17 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@17..18 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@18..19 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@19..20 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@20..21 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@21..23 ";" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@23..27 "get" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@27..30 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@30..31 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@31..33 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@33..34 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@34..35 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@35..36 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@36..37 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@37..38 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsEmptyClassMember(
+                        JsEmptyClassMember {
+                            semicolon_token: Ok(
+                                SEMICOLON@38..39 ";" [] [],
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@39..40 "}" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..41
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -1,167 +1,79 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..12 "{" [] [Whitespace(" ")],
-                ),
-                members: [
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@12..13 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@13..14 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@14..15 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@15..16 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@16..17 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@17..18 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@18..19 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@19..20 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@20..21 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@21..23 ";" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@23..27 "get" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@27..30 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@30..31 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@31..33 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@33..34 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@34..35 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@35..36 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@36..37 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@37..38 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsEmptyClassMember(
-                        JsEmptyClassMember {
-                            semicolon_token: Ok(
-                                SEMICOLON@38..39 ";" [] [],
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@39..40 "}" [] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..12 "{" [] [Whitespace(" ")],
+            members: [
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@12..13 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@13..14 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@14..15 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@15..16 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@16..17 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@17..18 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@18..19 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@19..20 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@20..21 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@21..23 ";" [] [Whitespace(" ")],
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@23..27 "get" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@27..30 "foo" [] [],
+                    },
+                    l_paren_token: L_PAREN@30..31 "(" [] [],
+                    r_paren_token: R_PAREN@31..33 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@33..34 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@34..35 "}" [] [],
+                    },
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@35..36 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@36..37 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@37..38 ";" [] [],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@38..39 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@39..40 "}" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -1,3 +1,201 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsClassExpression(
+                                                    JsClassExpression {
+                                                        class_token: Ok(
+                                                            CLASS_KW@8..14 "class" [] [Whitespace(" ")],
+                                                        ),
+                                                        id: None,
+                                                        extends_clause: None,
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@14..15 "{" [] [],
+                                                        ),
+                                                        members: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@15..16 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@16..17 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@22..24 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@24..26 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsClassExpression(
+                                                    JsClassExpression {
+                                                        class_token: Ok(
+                                                            CLASS_KW@26..32 "class" [] [Whitespace(" ")],
+                                                        ),
+                                                        id: Some(
+                                                            JsIdentifierBinding {
+                                                                name_token: Ok(
+                                                                    IDENT@32..36 "foo" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        extends_clause: None,
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@36..37 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            JsConstructorClassMember(
+                                                                JsConstructorClassMember {
+                                                                    access_modifier: None,
+                                                                    name: Ok(
+                                                                        JsLiteralMemberName {
+                                                                            value: Ok(
+                                                                                IDENT@37..50 "constructor" [Whitespace("\n ")] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    parameter_list: Ok(
+                                                                        JsConstructorParameterList {
+                                                                            l_paren_token: Ok(
+                                                                                L_PAREN@50..51 "(" [] [],
+                                                                            ),
+                                                                            parameters: [],
+                                                                            r_paren_token: Ok(
+                                                                                R_PAREN@51..53 ")" [] [Whitespace(" ")],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    body: Ok(
+                                                                        JsFunctionBody {
+                                                                            l_curly_token: Ok(
+                                                                                L_CURLY@53..54 "{" [] [],
+                                                                            ),
+                                                                            directives: [],
+                                                                            statements: [],
+                                                                            r_curly_token: Ok(
+                                                                                R_CURLY@54..55 "}" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@55..57 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@57..61 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@61..62 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@70..71 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..72
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -1,198 +1,102 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsClassExpression(
-                                                    JsClassExpression {
-                                                        class_token: Ok(
-                                                            CLASS_KW@8..14 "class" [] [Whitespace(" ")],
-                                                        ),
-                                                        id: None,
-                                                        extends_clause: None,
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@14..15 "{" [] [],
-                                                        ),
-                                                        members: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@15..16 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@16..17 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@22..24 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@24..26 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsClassExpression(
-                                                    JsClassExpression {
-                                                        class_token: Ok(
-                                                            CLASS_KW@26..32 "class" [] [Whitespace(" ")],
-                                                        ),
-                                                        id: Some(
-                                                            JsIdentifierBinding {
-                                                                name_token: Ok(
-                                                                    IDENT@32..36 "foo" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        extends_clause: None,
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@36..37 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            JsConstructorClassMember(
-                                                                JsConstructorClassMember {
-                                                                    access_modifier: None,
-                                                                    name: Ok(
-                                                                        JsLiteralMemberName {
-                                                                            value: Ok(
-                                                                                IDENT@37..50 "constructor" [Whitespace("\n ")] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    parameter_list: Ok(
-                                                                        JsConstructorParameterList {
-                                                                            l_paren_token: Ok(
-                                                                                L_PAREN@50..51 "(" [] [],
-                                                                            ),
-                                                                            parameters: [],
-                                                                            r_paren_token: Ok(
-                                                                                R_PAREN@51..53 ")" [] [Whitespace(" ")],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    body: Ok(
-                                                                        JsFunctionBody {
-                                                                            l_curly_token: Ok(
-                                                                                L_CURLY@53..54 "{" [] [],
-                                                                            ),
-                                                                            directives: [],
-                                                                            statements: [],
-                                                                            r_curly_token: Ok(
-                                                                                R_CURLY@54..55 "}" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@55..57 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsClassExpression {
+                                    class_token: CLASS_KW@8..14 "class" [] [Whitespace(" ")],
+                                    id: missing (optional),
+                                    extends_clause: missing (optional),
+                                    l_curly_token: L_CURLY@14..15 "{" [] [],
+                                    members: [],
+                                    r_curly_token: R_CURLY@15..16 "}" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@57..61 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@61..62 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@70..71 "]" [] [],
-                            ),
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        trailing_separator: None,
+                    },
+                ],
             },
-        ),
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@22..24 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@24..26 "=" [] [Whitespace(" ")],
+                                expression: JsClassExpression {
+                                    class_token: CLASS_KW@26..32 "class" [] [Whitespace(" ")],
+                                    id: JsIdentifierBinding {
+                                        name_token: IDENT@32..36 "foo" [] [Whitespace(" ")],
+                                    },
+                                    extends_clause: missing (optional),
+                                    l_curly_token: L_CURLY@36..37 "{" [] [],
+                                    members: [
+                                        JsConstructorClassMember {
+                                            access_modifier: missing (optional),
+                                            name: JsLiteralMemberName {
+                                                value: IDENT@37..50 "constructor" [Whitespace("\n ")] [],
+                                            },
+                                            parameter_list: JsConstructorParameterList {
+                                                l_paren_token: L_PAREN@50..51 "(" [] [],
+                                                parameters: [],
+                                                r_paren_token: R_PAREN@51..53 ")" [] [Whitespace(" ")],
+                                            },
+                                            body: JsFunctionBody {
+                                                l_curly_token: L_CURLY@53..54 "{" [] [],
+                                                directives: [],
+                                                statements: [],
+                                                r_curly_token: R_CURLY@54..55 "}" [] [],
+                                            },
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@55..57 "}" [Whitespace("\n")] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@57..61 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@61..62 "[" [] [],
+                r_brack_token: R_BRACK@70..71 "]" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -6,30 +6,28 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsClassExpression {
-                                    class_token: CLASS_KW@8..14 "class" [] [Whitespace(" ")],
-                                    id: missing (optional),
-                                    extends_clause: missing (optional),
-                                    l_curly_token: L_CURLY@14..15 "{" [] [],
-                                    members: [],
-                                    r_curly_token: R_CURLY@15..16 "}" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsClassExpression {
+                                class_token: CLASS_KW@8..14 "class" [] [Whitespace(" ")],
+                                id: missing (optional),
+                                extends_clause: missing (optional),
+                                l_curly_token: L_CURLY@14..15 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@15..16 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@16..17 ";" [] [],
@@ -38,50 +36,48 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@22..24 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@22..24 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@24..26 "=" [] [Whitespace(" ")],
-                                expression: JsClassExpression {
-                                    class_token: CLASS_KW@26..32 "class" [] [Whitespace(" ")],
-                                    id: JsIdentifierBinding {
-                                        name_token: IDENT@32..36 "foo" [] [Whitespace(" ")],
-                                    },
-                                    extends_clause: missing (optional),
-                                    l_curly_token: L_CURLY@36..37 "{" [] [],
-                                    members: [
-                                        JsConstructorClassMember {
-                                            access_modifier: missing (optional),
-                                            name: JsLiteralMemberName {
-                                                value: IDENT@37..50 "constructor" [Whitespace("\n ")] [],
-                                            },
-                                            parameter_list: JsConstructorParameterList {
-                                                l_paren_token: L_PAREN@50..51 "(" [] [],
-                                                parameters: [],
-                                                r_paren_token: R_PAREN@51..53 ")" [] [Whitespace(" ")],
-                                            },
-                                            body: JsFunctionBody {
-                                                l_curly_token: L_CURLY@53..54 "{" [] [],
-                                                directives: [],
-                                                statements: [],
-                                                r_curly_token: R_CURLY@54..55 "}" [] [],
-                                            },
-                                        },
-                                    ],
-                                    r_curly_token: R_CURLY@55..57 "}" [Whitespace("\n")] [],
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@24..26 "=" [] [Whitespace(" ")],
+                            expression: JsClassExpression {
+                                class_token: CLASS_KW@26..32 "class" [] [Whitespace(" ")],
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@32..36 "foo" [] [Whitespace(" ")],
                                 },
+                                extends_clause: missing (optional),
+                                l_curly_token: L_CURLY@36..37 "{" [] [],
+                                members: [
+                                    JsConstructorClassMember {
+                                        access_modifier: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@37..50 "constructor" [Whitespace("\n ")] [],
+                                        },
+                                        parameter_list: JsConstructorParameterList {
+                                            l_paren_token: L_PAREN@50..51 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@51..53 ")" [] [Whitespace(" ")],
+                                        },
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@53..54 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@54..55 "}" [] [],
+                                        },
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@55..57 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
@@ -1,3 +1,160 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@3..4 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@7..8 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@8..12 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@12..13 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@18..19 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@19..23 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@23..24 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@29..30 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsComputedMemberExpression(
+                                    JsComputedMemberExpression {
+                                        object: Ok(
+                                            JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@30..34 "foo" [Whitespace("\n")] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        optional_chain_token_token: None,
+                                        l_brack_token: Ok(
+                                            L_BRACK@34..35 "[" [] [],
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@38..39 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@39..40 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@43..44 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: Some(
+                                QUESTIONDOT@48..50 "?." [] [],
+                            ),
+                            l_brack_token: Ok(
+                                L_BRACK@50..51 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@54..55 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..56
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
@@ -1,157 +1,67 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@3..4 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@7..8 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@3..4 "[" [] [],
+                r_brack_token: R_BRACK@7..8 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@8..12 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@12..13 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@18..19 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@12..13 "[" [] [],
+                r_brack_token: R_BRACK@18..19 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@19..23 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@23..24 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@29..30 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@19..23 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@23..24 "[" [] [],
+                r_brack_token: R_BRACK@29..30 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsComputedMemberExpression(
-                                    JsComputedMemberExpression {
-                                        object: Ok(
-                                            JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@30..34 "foo" [Whitespace("\n")] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        optional_chain_token_token: None,
-                                        l_brack_token: Ok(
-                                            L_BRACK@34..35 "[" [] [],
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@38..39 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@39..40 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@43..44 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsComputedMemberExpression {
+                    object: JsReferenceIdentifierExpression {
+                        name_token: IDENT@30..34 "foo" [Whitespace("\n")] [],
+                    },
+                    optional_chain_token_token: missing (optional),
+                    l_brack_token: L_BRACK@34..35 "[" [] [],
+                    r_brack_token: R_BRACK@38..39 "]" [] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@39..40 "[" [] [],
+                r_brack_token: R_BRACK@43..44 "]" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            optional_chain_token_token: Some(
-                                QUESTIONDOT@48..50 "?." [] [],
-                            ),
-                            l_brack_token: Ok(
-                                L_BRACK@50..51 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@54..55 "]" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: QUESTIONDOT@48..50 "?." [] [],
+                l_brack_token: L_BRACK@50..51 "[" [] [],
+                r_brack_token: R_BRACK@54..55 "]" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -1,59 +1,27 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsConditionalExpression(
-                        JsConditionalExpression {
-                            test: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: Ok(
-                                QUESTION@4..6 "?" [] [Whitespace(" ")],
-                            ),
-                            colon_token: Ok(
-                                COLON@10..12 ":" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsConditionalExpression {
+                test: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@4..6 "?" [] [Whitespace(" ")],
+                colon_token: COLON@10..12 ":" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsConditionalExpression(
-                        JsConditionalExpression {
-                            test: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@15..20 "foo" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: Ok(
-                                QUESTION@20..22 "?" [] [Whitespace(" ")],
-                            ),
-                            colon_token: Ok(
-                                COLON@26..28 ":" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsConditionalExpression {
+                test: JsReferenceIdentifierExpression {
+                    name_token: IDENT@15..20 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@20..22 "?" [] [Whitespace(" ")],
+                colon_token: COLON@26..28 ":" [] [Whitespace(" ")],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -1,3 +1,62 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsConditionalExpression(
+                        JsConditionalExpression {
+                            test: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: Ok(
+                                QUESTION@4..6 "?" [] [Whitespace(" ")],
+                            ),
+                            colon_token: Ok(
+                                COLON@10..12 ":" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsConditionalExpression(
+                        JsConditionalExpression {
+                            test: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@15..20 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: Ok(
+                                QUESTION@20..22 "?" [] [Whitespace(" ")],
+                            ),
+                            colon_token: Ok(
+                                COLON@26..28 ":" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..44
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
@@ -1,199 +1,103 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "Foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsConstructorClassMember(
-                        JsConstructorClassMember {
-                            access_modifier: None,
-                            name: Ok(
-                                JsLiteralMemberName {
-                                    value: Ok(
-                                        IDENT@11..24 "constructor" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                            parameter_list: Ok(
-                                JsConstructorParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@24..25 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@25..26 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@26..28 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@28..29 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    AssignExpr(
-                                                        AssignExpr {
-                                                            operator: Ok(
-                                                                EQ@39..41 "=" [] [Whitespace(" ")],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@42..43 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    r_curly_token: Ok(
-                                        R_CURLY@43..46 "}" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@46..48 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "Foo" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@48..56 "class" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@56..60 "Bar" [] [Whitespace(" ")],
-                        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsConstructorClassMember {
+                    access_modifier: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@11..24 "constructor" [Whitespace("\n\t")] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@60..61 "{" [] [],
-                ),
-                members: [
-                    JsConstructorClassMember(
-                        JsConstructorClassMember {
-                            access_modifier: None,
-                            name: Ok(
-                                JsLiteralMemberName {
-                                    value: Ok(
-                                        JS_STRING_LITERAL@61..76 "\"constructor\"" [Whitespace("\n\t")] [],
-                                    ),
+                    parameter_list: JsConstructorParameterList {
+                        l_paren_token: L_PAREN@24..25 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@25..26 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
                                 },
-                            ),
-                            parameter_list: Ok(
-                                JsConstructorParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@76..77 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@77..78 "b" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@78..80 ")" [] [Whitespace(" ")],
-                                    ),
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                    },
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@28..29 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: AssignExpr {
+                                    operator: EQ@39..41 "=" [] [Whitespace(" ")],
                                 },
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@80..81 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    AssignExpr(
-                                                        AssignExpr {
-                                                            operator: Ok(
-                                                                EQ@91..93 "=" [] [Whitespace(" ")],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@94..95 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    r_curly_token: Ok(
-                                        R_CURLY@95..98 "}" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@98..100 "}" [Whitespace("\n")] [],
-                ),
+                                semicolon_token: SEMICOLON@42..43 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@43..46 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@46..48 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@48..56 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@56..60 "Bar" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@60..61 "{" [] [],
+            members: [
+                JsConstructorClassMember {
+                    access_modifier: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@61..76 "\"constructor\"" [Whitespace("\n\t")] [],
+                    },
+                    parameter_list: JsConstructorParameterList {
+                        l_paren_token: L_PAREN@76..77 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@77..78 "b" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@78..80 ")" [] [Whitespace(" ")],
+                    },
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@80..81 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: AssignExpr {
+                                    operator: EQ@91..93 "=" [] [Whitespace(" ")],
+                                },
+                                semicolon_token: SEMICOLON@94..95 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@95..98 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@98..100 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
@@ -19,17 +19,15 @@ JsRoot {
                     parameter_list: JsConstructorParameterList {
                         l_paren_token: L_PAREN@24..25 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@25..26 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@25..26 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
                     },
@@ -67,17 +65,15 @@ JsRoot {
                     parameter_list: JsConstructorParameterList {
                         l_paren_token: L_PAREN@76..77 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@77..78 "b" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@77..78 "b" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@78..80 ")" [] [Whitespace(" ")],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
@@ -1,3 +1,202 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "Foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsConstructorClassMember(
+                        JsConstructorClassMember {
+                            access_modifier: None,
+                            name: Ok(
+                                JsLiteralMemberName {
+                                    value: Ok(
+                                        IDENT@11..24 "constructor" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                            parameter_list: Ok(
+                                JsConstructorParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@24..25 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@25..26 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@28..29 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    AssignExpr(
+                                                        AssignExpr {
+                                                            operator: Ok(
+                                                                EQ@39..41 "=" [] [Whitespace(" ")],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@42..43 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    r_curly_token: Ok(
+                                        R_CURLY@43..46 "}" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@46..48 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@48..56 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@56..60 "Bar" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@60..61 "{" [] [],
+                ),
+                members: [
+                    JsConstructorClassMember(
+                        JsConstructorClassMember {
+                            access_modifier: None,
+                            name: Ok(
+                                JsLiteralMemberName {
+                                    value: Ok(
+                                        JS_STRING_LITERAL@61..76 "\"constructor\"" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                            parameter_list: Ok(
+                                JsConstructorParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@76..77 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@77..78 "b" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@78..80 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@80..81 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    AssignExpr(
+                                                        AssignExpr {
+                                                            operator: Ok(
+                                                                EQ@91..93 "=" [] [Whitespace(" ")],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@94..95 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    r_curly_token: Ok(
+                                        R_CURLY@95..98 "}" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@98..100 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..101
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -1,3 +1,104 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsLabeledStatement(
+            JsLabeledStatement {
+                label_token: Ok(
+                    IDENT@0..3 "foo" [] [],
+                ),
+                colon_token: Ok(
+                    COLON@3..5 ":" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@5..6 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@6..7 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        JsWhileStatement(
+            JsWhileStatement {
+                while_token: Ok(
+                    WHILE_KW@7..14 "while" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@14..15 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@15..19 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@21..22 "{" [] [],
+                            ),
+                            statements: [
+                                JsContinueStatement(
+                                    JsContinueStatement {
+                                        continue_token: Ok(
+                                            CONTINUE_KW@22..33 "continue" [Whitespace("\n  ")] [],
+                                        ),
+                                        label_token: None,
+                                        semicolon_token: Some(
+                                            SEMICOLON@33..34 ";" [] [],
+                                        ),
+                                    },
+                                ),
+                                JsContinueStatement(
+                                    JsContinueStatement {
+                                        continue_token: Ok(
+                                            CONTINUE_KW@34..46 "continue" [Whitespace("\n  ")] [Whitespace(" ")],
+                                        ),
+                                        label_token: Some(
+                                            IDENT@46..49 "foo" [] [],
+                                        ),
+                                        semicolon_token: Some(
+                                            SEMICOLON@49..50 ";" [] [],
+                                        ),
+                                    },
+                                ),
+                                JsContinueStatement(
+                                    JsContinueStatement {
+                                        continue_token: Ok(
+                                            CONTINUE_KW@50..61 "continue" [Whitespace("\n  ")] [],
+                                        ),
+                                        label_token: None,
+                                        semicolon_token: None,
+                                    },
+                                ),
+                            ],
+                            r_curly_token: Ok(
+                                R_CURLY@61..63 "}" [Whitespace("\n")] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..64
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -1,101 +1,45 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsLabeledStatement(
-            JsLabeledStatement {
-                label_token: Ok(
-                    IDENT@0..3 "foo" [] [],
-                ),
-                colon_token: Ok(
-                    COLON@3..5 ":" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@5..6 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@6..7 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+        JsLabeledStatement {
+            label_token: IDENT@0..3 "foo" [] [],
+            colon_token: COLON@3..5 ":" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@5..6 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@6..7 "}" [] [],
             },
-        ),
-        JsWhileStatement(
-            JsWhileStatement {
-                while_token: Ok(
-                    WHILE_KW@7..14 "while" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@14..15 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@15..19 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@19..21 ")" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@21..22 "{" [] [],
-                            ),
-                            statements: [
-                                JsContinueStatement(
-                                    JsContinueStatement {
-                                        continue_token: Ok(
-                                            CONTINUE_KW@22..33 "continue" [Whitespace("\n  ")] [],
-                                        ),
-                                        label_token: None,
-                                        semicolon_token: Some(
-                                            SEMICOLON@33..34 ";" [] [],
-                                        ),
-                                    },
-                                ),
-                                JsContinueStatement(
-                                    JsContinueStatement {
-                                        continue_token: Ok(
-                                            CONTINUE_KW@34..46 "continue" [Whitespace("\n  ")] [Whitespace(" ")],
-                                        ),
-                                        label_token: Some(
-                                            IDENT@46..49 "foo" [] [],
-                                        ),
-                                        semicolon_token: Some(
-                                            SEMICOLON@49..50 ";" [] [],
-                                        ),
-                                    },
-                                ),
-                                JsContinueStatement(
-                                    JsContinueStatement {
-                                        continue_token: Ok(
-                                            CONTINUE_KW@50..61 "continue" [Whitespace("\n  ")] [],
-                                        ),
-                                        label_token: None,
-                                        semicolon_token: None,
-                                    },
-                                ),
-                            ],
-                            r_curly_token: Ok(
-                                R_CURLY@61..63 "}" [Whitespace("\n")] [],
-                            ),
-                        },
-                    ),
-                ),
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@7..14 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@14..15 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@15..19 "true" [] [],
             },
-        ),
+            r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@21..22 "{" [] [],
+                statements: [
+                    JsContinueStatement {
+                        continue_token: CONTINUE_KW@22..33 "continue" [Whitespace("\n  ")] [],
+                        label_token: missing (optional),
+                        semicolon_token: SEMICOLON@33..34 ";" [] [],
+                    },
+                    JsContinueStatement {
+                        continue_token: CONTINUE_KW@34..46 "continue" [Whitespace("\n  ")] [Whitespace(" ")],
+                        label_token: IDENT@46..49 "foo" [] [],
+                        semicolon_token: SEMICOLON@49..50 ";" [] [],
+                    },
+                    JsContinueStatement {
+                        continue_token: CONTINUE_KW@50..61 "continue" [Whitespace("\n  ")] [],
+                        label_token: missing (optional),
+                        semicolon_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@61..63 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -1,17 +1,11 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsDebuggerStatement(
-            JsDebuggerStatement {
-                debugger_token: Ok(
-                    DEBUGGER_KW@0..8 "debugger" [] [],
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@8..9 ";" [] [],
-                ),
-            },
-        ),
+        JsDebuggerStatement {
+            debugger_token: DEBUGGER_KW@0..8 "debugger" [] [],
+            semicolon_token: SEMICOLON@8..9 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -1,3 +1,20 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsDebuggerStatement(
+            JsDebuggerStatement {
+                debugger_token: Ok(
+                    DEBUGGER_KW@0..8 "debugger" [] [],
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@8..9 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..10
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/directives.rast
+++ b/crates/rslint_parser/test_data/inline/ok/directives.rast
@@ -1,3 +1,450 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [
+        JsDirective {
+            value_token: Ok(
+                JS_STRING_LITERAL@0..20 "\"use new\"" [Comments("// SCRIPT"), Whitespace("\n\n")] [],
+            ),
+            semicolon_token: None,
+        },
+    ],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@20..26 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@26..28 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@28..30 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@30..32 "10" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@32..33 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsStringLiteralExpression(
+                            JsStringLiteralExpression {
+                                value_token: Ok(
+                                    JS_STRING_LITERAL@33..47 "\"use strict\"" [Whitespace("\n\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@47..67 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@67..78 "function" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@78..82 "test" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@82..83 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@83..85 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@85..86 "{" [] [],
+                        ),
+                        directives: [
+                            JsDirective {
+                                value_token: Ok(
+                                    JS_STRING_LITERAL@86..100 "'use strict'" [Whitespace("\n\t")] [],
+                                ),
+                                semicolon_token: Some(
+                                    SEMICOLON@100..101 ";" [] [],
+                                ),
+                            },
+                        ],
+                        statements: [
+                            JsVariableDeclarationStatement(
+                                JsVariableDeclarationStatement {
+                                    declaration: Ok(
+                                        JsVariableDeclaration {
+                                            kind_token: Ok(
+                                                LET_KW@101..108 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                            ),
+                                            declarators: [
+                                                AstSeparatedElement {
+                                                    node: JsVariableDeclarator {
+                                                        id: Ok(
+                                                            SinglePattern(
+                                                                SinglePattern {
+                                                                    name: Ok(
+                                                                        Name {
+                                                                            ident_token: Ok(
+                                                                                IDENT@108..110 "a" [] [Whitespace(" ")],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    question_mark_token: None,
+                                                                    excl_token: None,
+                                                                    ty: None,
+                                                                },
+                                                            ),
+                                                        ),
+                                                        init: Some(
+                                                            JsEqualValueClause {
+                                                                eq_token: Ok(
+                                                                    EQ@110..112 "=" [] [Whitespace(" ")],
+                                                                ),
+                                                                expression: Ok(
+                                                                    JsAnyLiteralExpression(
+                                                                        JsNumberLiteralExpression(
+                                                                            JsNumberLiteralExpression {
+                                                                                value_token: Ok(
+                                                                                    JS_NUMBER_LITERAL@112..114 "10" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                    trailing_separator: None,
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@114..115 ";" [] [],
+                                    ),
+                                },
+                            ),
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsStringLiteralExpression(
+                                                JsStringLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_STRING_LITERAL@115..130 "'use strict'" [Whitespace("\n\n\t")] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@130..150 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@150..152 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsParenthesizedExpression(
+                        JsParenthesizedExpression {
+                            l_paren_token: Ok(
+                                L_PAREN@152..155 "(" [Whitespace("\n\n")] [],
+                            ),
+                            expression: Ok(
+                                JsFunctionExpression(
+                                    JsFunctionExpression {
+                                        async_token: None,
+                                        function_token: Ok(
+                                            FUNCTION_KW@155..164 "function" [] [Whitespace(" ")],
+                                        ),
+                                        star_token: None,
+                                        id: None,
+                                        type_parameters: None,
+                                        parameters: Ok(
+                                            JsParameterList {
+                                                l_paren_token: Ok(
+                                                    L_PAREN@164..165 "(" [] [],
+                                                ),
+                                                parameters: [],
+                                                r_paren_token: Ok(
+                                                    R_PAREN@165..167 ")" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                        return_type: None,
+                                        body: Ok(
+                                            JsFunctionBody {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@167..168 "{" [] [],
+                                                ),
+                                                directives: [
+                                                    JsDirective {
+                                                        value_token: Ok(
+                                                            JS_STRING_LITERAL@168..182 "\"use strict\"" [Whitespace("\n\t")] [],
+                                                        ),
+                                                        semicolon_token: Some(
+                                                            SEMICOLON@182..183 ";" [] [],
+                                                        ),
+                                                    },
+                                                ],
+                                                statements: [
+                                                    JsVariableDeclarationStatement(
+                                                        JsVariableDeclarationStatement {
+                                                            declaration: Ok(
+                                                                JsVariableDeclaration {
+                                                                    kind_token: Ok(
+                                                                        LET_KW@183..190 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                                    ),
+                                                                    declarators: [
+                                                                        AstSeparatedElement {
+                                                                            node: JsVariableDeclarator {
+                                                                                id: Ok(
+                                                                                    SinglePattern(
+                                                                                        SinglePattern {
+                                                                                            name: Ok(
+                                                                                                Name {
+                                                                                                    ident_token: Ok(
+                                                                                                        IDENT@190..192 "a" [] [Whitespace(" ")],
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            question_mark_token: None,
+                                                                                            excl_token: None,
+                                                                                            ty: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ),
+                                                                                init: Some(
+                                                                                    JsEqualValueClause {
+                                                                                        eq_token: Ok(
+                                                                                            EQ@192..194 "=" [] [Whitespace(" ")],
+                                                                                        ),
+                                                                                        expression: Ok(
+                                                                                            JsAnyLiteralExpression(
+                                                                                                JsNumberLiteralExpression(
+                                                                                                    JsNumberLiteralExpression {
+                                                                                                        value_token: Ok(
+                                                                                                            JS_NUMBER_LITERAL@194..196 "10" [] [],
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                            trailing_separator: None,
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ),
+                                                            semicolon_token: Some(
+                                                                SEMICOLON@196..197 ";" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                    JsExpressionStatement(
+                                                        JsExpressionStatement {
+                                                            expression: Ok(
+                                                                JsAnyLiteralExpression(
+                                                                    JsStringLiteralExpression(
+                                                                        JsStringLiteralExpression {
+                                                                            value_token: Ok(
+                                                                                JS_STRING_LITERAL@197..212 "\"use strict\"" [Whitespace("\n\n\t")] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            ),
+                                                            semicolon_token: Some(
+                                                                SEMICOLON@212..232 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@232..234 "}" [Whitespace("\n")] [],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@234..235 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@235..236 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@236..242 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@242..244 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@244..246 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsArrowFunctionExpression(
+                                                    JsArrowFunctionExpression {
+                                                        async_token: None,
+                                                        type_parameters: None,
+                                                        parameter_list: Some(
+                                                            JsParameterList(
+                                                                JsParameterList {
+                                                                    l_paren_token: Ok(
+                                                                        L_PAREN@246..247 "(" [] [],
+                                                                    ),
+                                                                    parameters: [],
+                                                                    r_paren_token: Ok(
+                                                                        R_PAREN@247..249 ")" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        fat_arrow_token: Ok(
+                                                            FAT_ARROW@249..252 "=>" [] [Whitespace(" ")],
+                                                        ),
+                                                        return_type: None,
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsBlockStatement(
+            JsBlockStatement {
+                l_curly_token: Ok(
+                    L_CURLY@320..323 "{" [Whitespace("\n\n")] [],
+                ),
+                statements: [
+                    JsExpressionStatement(
+                        JsExpressionStatement {
+                            expression: Ok(
+                                JsAnyLiteralExpression(
+                                    JsStringLiteralExpression(
+                                        JsStringLiteralExpression {
+                                            value_token: Ok(
+                                                JS_STRING_LITERAL@323..337 "\"use strict\"" [Whitespace("\n\t")] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            semicolon_token: Some(
+                                SEMICOLON@337..357 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@357..359 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..360
   0: (empty)
   1: LIST@0..20

--- a/crates/rslint_parser/test_data/inline/ok/directives.rast
+++ b/crates/rslint_parser/test_data/inline/ok/directives.rast
@@ -11,25 +11,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@20..26 "let" [Whitespace("\n\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@30..32 "10" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@30..32 "10" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@32..33 ";" [] [],
@@ -67,25 +65,23 @@ JsRoot {
                         declaration: JsVariableDeclaration {
                             kind_token: LET_KW@101..108 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
                             declarators: [
-                                AstSeparatedElement {
-                                    node: JsVariableDeclarator {
-                                        id: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@108..110 "a" [] [Whitespace(" ")],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
+                                JsVariableDeclarator {
+                                    id: SinglePattern {
+                                        name: Name {
+                                            ident_token: IDENT@108..110 "a" [] [Whitespace(" ")],
                                         },
-                                        init: JsEqualValueClause {
-                                            eq_token: EQ@110..112 "=" [] [Whitespace(" ")],
-                                            expression: JsNumberLiteralExpression {
-                                                value_token: JS_NUMBER_LITERAL@112..114 "10" [] [],
-                                            },
+                                        question_mark_token: missing (optional),
+                                        excl_token: missing (optional),
+                                        ty: missing (optional),
+                                    },
+                                    init: JsEqualValueClause {
+                                        eq_token: EQ@110..112 "=" [] [Whitespace(" ")],
+                                        expression: JsNumberLiteralExpression {
+                                            value_token: JS_NUMBER_LITERAL@112..114 "10" [] [],
                                         },
                                     },
-                                    trailing_separator: None,
-                                },
+                                }
+                                ,
                             ],
                         },
                         semicolon_token: SEMICOLON@114..115 ";" [] [],
@@ -128,25 +124,23 @@ JsRoot {
                                 declaration: JsVariableDeclaration {
                                     kind_token: LET_KW@183..190 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
                                     declarators: [
-                                        AstSeparatedElement {
-                                            node: JsVariableDeclarator {
-                                                id: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@190..192 "a" [] [Whitespace(" ")],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
+                                        JsVariableDeclarator {
+                                            id: SinglePattern {
+                                                name: Name {
+                                                    ident_token: IDENT@190..192 "a" [] [Whitespace(" ")],
                                                 },
-                                                init: JsEqualValueClause {
-                                                    eq_token: EQ@192..194 "=" [] [Whitespace(" ")],
-                                                    expression: JsNumberLiteralExpression {
-                                                        value_token: JS_NUMBER_LITERAL@194..196 "10" [] [],
-                                                    },
+                                                question_mark_token: missing (optional),
+                                                excl_token: missing (optional),
+                                                ty: missing (optional),
+                                            },
+                                            init: JsEqualValueClause {
+                                                eq_token: EQ@192..194 "=" [] [Whitespace(" ")],
+                                                expression: JsNumberLiteralExpression {
+                                                    value_token: JS_NUMBER_LITERAL@194..196 "10" [] [],
                                                 },
                                             },
-                                            trailing_separator: None,
-                                        },
+                                        }
+                                        ,
                                     ],
                                 },
                                 semicolon_token: SEMICOLON@196..197 ";" [] [],
@@ -169,33 +163,31 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@236..242 "let" [Whitespace("\n\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@242..244 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@242..244 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@244..246 "=" [] [Whitespace(" ")],
-                                expression: JsArrowFunctionExpression {
-                                    async_token: missing (optional),
-                                    type_parameters: missing (optional),
-                                    parameter_list: JsParameterList {
-                                        l_paren_token: L_PAREN@246..247 "(" [] [],
-                                        parameters: [],
-                                        r_paren_token: R_PAREN@247..249 ")" [] [Whitespace(" ")],
-                                    },
-                                    fat_arrow_token: FAT_ARROW@249..252 "=>" [] [Whitespace(" ")],
-                                    return_type: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@244..246 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: missing (optional),
+                                parameter_list: JsParameterList {
+                                    l_paren_token: L_PAREN@246..247 "(" [] [],
+                                    parameters: [],
+                                    r_paren_token: R_PAREN@247..249 ")" [] [Whitespace(" ")],
                                 },
+                                fat_arrow_token: FAT_ARROW@249..252 "=>" [] [Whitespace(" ")],
+                                return_type: missing (optional),
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/directives.rast
+++ b/crates/rslint_parser/test_data/inline/ok/directives.rast
@@ -1,447 +1,217 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [
         JsDirective {
-            value_token: Ok(
-                JS_STRING_LITERAL@0..20 "\"use new\"" [Comments("// SCRIPT"), Whitespace("\n\n")] [],
-            ),
-            semicolon_token: None,
+            value_token: JS_STRING_LITERAL@0..20 "\"use new\"" [Comments("// SCRIPT"), Whitespace("\n\n")] [],
+            semicolon_token: missing (optional),
         },
     ],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@20..26 "let" [Whitespace("\n\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@26..28 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@28..30 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@30..32 "10" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@20..26 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@32..33 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsStringLiteralExpression(
-                            JsStringLiteralExpression {
-                                value_token: Ok(
-                                    JS_STRING_LITERAL@33..47 "\"use strict\"" [Whitespace("\n\n")] [],
-                                ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@30..32 "10" [] [],
+                                },
                             },
-                        ),
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@47..67 ";" [] [Whitespace(" "), Comments("// not a directive")],
-                ),
-            },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@67..78 "function" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@78..82 "test" [] [],
-                        ),
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@82..83 "(" [] [],
-                        ),
+                ],
+            },
+            semicolon_token: SEMICOLON@32..33 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsStringLiteralExpression {
+                value_token: JS_STRING_LITERAL@33..47 "\"use strict\"" [Whitespace("\n\n")] [],
+            },
+            semicolon_token: SEMICOLON@47..67 ";" [] [Whitespace(" "), Comments("// not a directive")],
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@67..78 "function" [Whitespace("\n\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@78..82 "test" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@82..83 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@83..85 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@85..86 "{" [] [],
+                directives: [
+                    JsDirective {
+                        value_token: JS_STRING_LITERAL@86..100 "'use strict'" [Whitespace("\n\t")] [],
+                        semicolon_token: SEMICOLON@100..101 ";" [] [],
+                    },
+                ],
+                statements: [
+                    JsVariableDeclarationStatement {
+                        declaration: JsVariableDeclaration {
+                            kind_token: LET_KW@101..108 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            declarators: [
+                                AstSeparatedElement {
+                                    node: JsVariableDeclarator {
+                                        id: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@108..110 "a" [] [Whitespace(" ")],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        init: JsEqualValueClause {
+                                            eq_token: EQ@110..112 "=" [] [Whitespace(" ")],
+                                            expression: JsNumberLiteralExpression {
+                                                value_token: JS_NUMBER_LITERAL@112..114 "10" [] [],
+                                            },
+                                        },
+                                    },
+                                    trailing_separator: None,
+                                },
+                            ],
+                        },
+                        semicolon_token: SEMICOLON@114..115 ";" [] [],
+                    },
+                    JsExpressionStatement {
+                        expression: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@115..130 "'use strict'" [Whitespace("\n\n\t")] [],
+                        },
+                        semicolon_token: SEMICOLON@130..150 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                    },
+                ],
+                r_curly_token: R_CURLY@150..152 "}" [Whitespace("\n")] [],
+            },
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@152..155 "(" [Whitespace("\n\n")] [],
+                expression: JsFunctionExpression {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@155..164 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameterList {
+                        l_paren_token: L_PAREN@164..165 "(" [] [],
                         parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@83..85 ")" [] [Whitespace(" ")],
-                        ),
+                        r_paren_token: R_PAREN@165..167 ")" [] [Whitespace(" ")],
                     },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@85..86 "{" [] [],
-                        ),
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@167..168 "{" [] [],
                         directives: [
                             JsDirective {
-                                value_token: Ok(
-                                    JS_STRING_LITERAL@86..100 "'use strict'" [Whitespace("\n\t")] [],
-                                ),
-                                semicolon_token: Some(
-                                    SEMICOLON@100..101 ";" [] [],
-                                ),
+                                value_token: JS_STRING_LITERAL@168..182 "\"use strict\"" [Whitespace("\n\t")] [],
+                                semicolon_token: SEMICOLON@182..183 ";" [] [],
                             },
                         ],
                         statements: [
-                            JsVariableDeclarationStatement(
-                                JsVariableDeclarationStatement {
-                                    declaration: Ok(
-                                        JsVariableDeclaration {
-                                            kind_token: Ok(
-                                                LET_KW@101..108 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                            ),
-                                            declarators: [
-                                                AstSeparatedElement {
-                                                    node: JsVariableDeclarator {
-                                                        id: Ok(
-                                                            SinglePattern(
-                                                                SinglePattern {
-                                                                    name: Ok(
-                                                                        Name {
-                                                                            ident_token: Ok(
-                                                                                IDENT@108..110 "a" [] [Whitespace(" ")],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    question_mark_token: None,
-                                                                    excl_token: None,
-                                                                    ty: None,
-                                                                },
-                                                            ),
-                                                        ),
-                                                        init: Some(
-                                                            JsEqualValueClause {
-                                                                eq_token: Ok(
-                                                                    EQ@110..112 "=" [] [Whitespace(" ")],
-                                                                ),
-                                                                expression: Ok(
-                                                                    JsAnyLiteralExpression(
-                                                                        JsNumberLiteralExpression(
-                                                                            JsNumberLiteralExpression {
-                                                                                value_token: Ok(
-                                                                                    JS_NUMBER_LITERAL@112..114 "10" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
+                            JsVariableDeclarationStatement {
+                                declaration: JsVariableDeclaration {
+                                    kind_token: LET_KW@183..190 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                    declarators: [
+                                        AstSeparatedElement {
+                                            node: JsVariableDeclarator {
+                                                id: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@190..192 "a" [] [Whitespace(" ")],
                                                     },
-                                                    trailing_separator: None,
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@114..115 ";" [] [],
-                                    ),
-                                },
-                            ),
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsStringLiteralExpression(
-                                                JsStringLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_STRING_LITERAL@115..130 "'use strict'" [Whitespace("\n\n\t")] [],
-                                                    ),
+                                                init: JsEqualValueClause {
+                                                    eq_token: EQ@192..194 "=" [] [Whitespace(" ")],
+                                                    expression: JsNumberLiteralExpression {
+                                                        value_token: JS_NUMBER_LITERAL@194..196 "10" [] [],
+                                                    },
                                                 },
-                                            ),
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@130..150 ";" [] [Whitespace(" "), Comments("// not a directive")],
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@150..152 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsParenthesizedExpression(
-                        JsParenthesizedExpression {
-                            l_paren_token: Ok(
-                                L_PAREN@152..155 "(" [Whitespace("\n\n")] [],
-                            ),
-                            expression: Ok(
-                                JsFunctionExpression(
-                                    JsFunctionExpression {
-                                        async_token: None,
-                                        function_token: Ok(
-                                            FUNCTION_KW@155..164 "function" [] [Whitespace(" ")],
-                                        ),
-                                        star_token: None,
-                                        id: None,
-                                        type_parameters: None,
-                                        parameters: Ok(
-                                            JsParameterList {
-                                                l_paren_token: Ok(
-                                                    L_PAREN@164..165 "(" [] [],
-                                                ),
-                                                parameters: [],
-                                                r_paren_token: Ok(
-                                                    R_PAREN@165..167 ")" [] [Whitespace(" ")],
-                                                ),
                                             },
-                                        ),
-                                        return_type: None,
-                                        body: Ok(
-                                            JsFunctionBody {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@167..168 "{" [] [],
-                                                ),
-                                                directives: [
-                                                    JsDirective {
-                                                        value_token: Ok(
-                                                            JS_STRING_LITERAL@168..182 "\"use strict\"" [Whitespace("\n\t")] [],
-                                                        ),
-                                                        semicolon_token: Some(
-                                                            SEMICOLON@182..183 ";" [] [],
-                                                        ),
-                                                    },
-                                                ],
-                                                statements: [
-                                                    JsVariableDeclarationStatement(
-                                                        JsVariableDeclarationStatement {
-                                                            declaration: Ok(
-                                                                JsVariableDeclaration {
-                                                                    kind_token: Ok(
-                                                                        LET_KW@183..190 "let" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                                    ),
-                                                                    declarators: [
-                                                                        AstSeparatedElement {
-                                                                            node: JsVariableDeclarator {
-                                                                                id: Ok(
-                                                                                    SinglePattern(
-                                                                                        SinglePattern {
-                                                                                            name: Ok(
-                                                                                                Name {
-                                                                                                    ident_token: Ok(
-                                                                                                        IDENT@190..192 "a" [] [Whitespace(" ")],
-                                                                                                    ),
-                                                                                                },
-                                                                                            ),
-                                                                                            question_mark_token: None,
-                                                                                            excl_token: None,
-                                                                                            ty: None,
-                                                                                        },
-                                                                                    ),
-                                                                                ),
-                                                                                init: Some(
-                                                                                    JsEqualValueClause {
-                                                                                        eq_token: Ok(
-                                                                                            EQ@192..194 "=" [] [Whitespace(" ")],
-                                                                                        ),
-                                                                                        expression: Ok(
-                                                                                            JsAnyLiteralExpression(
-                                                                                                JsNumberLiteralExpression(
-                                                                                                    JsNumberLiteralExpression {
-                                                                                                        value_token: Ok(
-                                                                                                            JS_NUMBER_LITERAL@194..196 "10" [] [],
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ),
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            },
-                                                                            trailing_separator: None,
-                                                                        },
-                                                                    ],
-                                                                },
-                                                            ),
-                                                            semicolon_token: Some(
-                                                                SEMICOLON@196..197 ";" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                    JsExpressionStatement(
-                                                        JsExpressionStatement {
-                                                            expression: Ok(
-                                                                JsAnyLiteralExpression(
-                                                                    JsStringLiteralExpression(
-                                                                        JsStringLiteralExpression {
-                                                                            value_token: Ok(
-                                                                                JS_STRING_LITERAL@197..212 "\"use strict\"" [Whitespace("\n\n\t")] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            ),
-                                                            semicolon_token: Some(
-                                                                SEMICOLON@212..232 ";" [] [Whitespace(" "), Comments("// not a directive")],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@232..234 "}" [Whitespace("\n")] [],
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@234..235 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@235..236 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@236..242 "let" [Whitespace("\n\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@242..244 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@244..246 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsArrowFunctionExpression(
-                                                    JsArrowFunctionExpression {
-                                                        async_token: None,
-                                                        type_parameters: None,
-                                                        parameter_list: Some(
-                                                            JsParameterList(
-                                                                JsParameterList {
-                                                                    l_paren_token: Ok(
-                                                                        L_PAREN@246..247 "(" [] [],
-                                                                    ),
-                                                                    parameters: [],
-                                                                    r_paren_token: Ok(
-                                                                        R_PAREN@247..249 ")" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                        fat_arrow_token: Ok(
-                                                            FAT_ARROW@249..252 "=>" [] [Whitespace(" ")],
-                                                        ),
-                                                        return_type: None,
-                                                    },
-                                                ),
-                                            ),
+                                            trailing_separator: None,
                                         },
-                                    ),
+                                    ],
                                 },
-                                trailing_separator: None,
+                                semicolon_token: SEMICOLON@196..197 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@197..212 "\"use strict\"" [Whitespace("\n\n\t")] [],
+                                },
+                                semicolon_token: SEMICOLON@212..232 ";" [] [Whitespace(" "), Comments("// not a directive")],
                             },
                         ],
+                        r_curly_token: R_CURLY@232..234 "}" [Whitespace("\n")] [],
                     },
-                ),
-                semicolon_token: None,
+                },
+                r_paren_token: R_PAREN@234..235 ")" [] [],
             },
-        ),
-        JsBlockStatement(
-            JsBlockStatement {
-                l_curly_token: Ok(
-                    L_CURLY@320..323 "{" [Whitespace("\n\n")] [],
-                ),
-                statements: [
-                    JsExpressionStatement(
-                        JsExpressionStatement {
-                            expression: Ok(
-                                JsAnyLiteralExpression(
-                                    JsStringLiteralExpression(
-                                        JsStringLiteralExpression {
-                                            value_token: Ok(
-                                                JS_STRING_LITERAL@323..337 "\"use strict\"" [Whitespace("\n\t")] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            semicolon_token: Some(
-                                SEMICOLON@337..357 ";" [] [Whitespace(" "), Comments("// not a directive")],
-                            ),
+            semicolon_token: SEMICOLON@235..236 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@236..242 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@242..244 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@244..246 "=" [] [Whitespace(" ")],
+                                expression: JsArrowFunctionExpression {
+                                    async_token: missing (optional),
+                                    type_parameters: missing (optional),
+                                    parameter_list: JsParameterList {
+                                        l_paren_token: L_PAREN@246..247 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@247..249 ")" [] [Whitespace(" ")],
+                                    },
+                                    fat_arrow_token: FAT_ARROW@249..252 "=>" [] [Whitespace(" ")],
+                                    return_type: missing (optional),
+                                },
+                            },
                         },
-                    ),
+                        trailing_separator: None,
+                    },
                 ],
-                r_curly_token: Ok(
-                    R_CURLY@357..359 "}" [Whitespace("\n")] [],
-                ),
             },
-        ),
+            semicolon_token: missing (optional),
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@320..323 "{" [Whitespace("\n\n")] [],
+            statements: [
+                JsExpressionStatement {
+                    expression: JsStringLiteralExpression {
+                        value_token: JS_STRING_LITERAL@323..337 "\"use strict\"" [Whitespace("\n\t")] [],
+                    },
+                    semicolon_token: SEMICOLON@337..357 ";" [] [Whitespace(" "), Comments("// not a directive")],
+                },
+            ],
+            r_curly_token: R_CURLY@357..359 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -1,3 +1,367 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsDoWhileStatement(
+            JsDoWhileStatement {
+                do_token: Ok(
+                    DO_KW@0..3 "do" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsExpressionStatement(
+                        JsExpressionStatement {
+                            expression: Ok(
+                                CallExpr(
+                                    CallExpr {
+                                        type_args: None,
+                                        callee: Ok(
+                                            JsStaticMemberExpression(
+                                                JsStaticMemberExpression {
+                                                    object: Ok(
+                                                        JsReferenceIdentifierExpression(
+                                                            JsReferenceIdentifierExpression {
+                                                                name_token: Ok(
+                                                                    IDENT@3..10 "console" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        DOT@10..11 "." [] [],
+                                                    ),
+                                                    member: Ok(
+                                                        JsReferenceIdentifierMember(
+                                                            JsReferenceIdentifierMember {
+                                                                name_token: Ok(
+                                                                    IDENT@11..14 "log" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        arguments: Ok(
+                                            ArgList {
+                                                l_paren_token: Ok(
+                                                    L_PAREN@14..15 "(" [] [],
+                                                ),
+                                                args: [
+                                                    AstSeparatedElement {
+                                                        node: JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@15..21 "\"test\"" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_paren_token: Ok(
+                                                    R_PAREN@21..22 ")" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                            semicolon_token: Some(
+                                SEMICOLON@22..24 ";" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                while_token: Ok(
+                    WHILE_KW@24..29 "while" [] [],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@29..30 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@30..34 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@34..35 ")" [] [],
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsDoWhileStatement(
+            JsDoWhileStatement {
+                do_token: Ok(
+                    DO_KW@35..40 "do" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@40..41 "{" [] [],
+                            ),
+                            statements: [
+                                JsExpressionStatement(
+                                    JsExpressionStatement {
+                                        expression: Ok(
+                                            CallExpr(
+                                                CallExpr {
+                                                    type_args: None,
+                                                    callee: Ok(
+                                                        JsStaticMemberExpression(
+                                                            JsStaticMemberExpression {
+                                                                object: Ok(
+                                                                    JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@41..50 "console" [Whitespace("\n\t")] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                operator: Ok(
+                                                                    DOT@50..51 "." [] [],
+                                                                ),
+                                                                member: Ok(
+                                                                    JsReferenceIdentifierMember(
+                                                                        JsReferenceIdentifierMember {
+                                                                            name_token: Ok(
+                                                                                IDENT@51..54 "log" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    arguments: Ok(
+                                                        ArgList {
+                                                            l_paren_token: Ok(
+                                                                L_PAREN@54..55 "(" [] [],
+                                                            ),
+                                                            args: [
+                                                                AstSeparatedElement {
+                                                                    node: JsAnyLiteralExpression(
+                                                                        JsStringLiteralExpression(
+                                                                            JsStringLiteralExpression {
+                                                                                value_token: Ok(
+                                                                                    JS_STRING_LITERAL@55..61 "\"test\"" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ),
+                                                                    trailing_separator: None,
+                                                                },
+                                                            ],
+                                                            r_paren_token: Ok(
+                                                                R_PAREN@61..62 ")" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        semicolon_token: None,
+                                    },
+                                ),
+                            ],
+                            r_curly_token: Ok(
+                                R_CURLY@62..65 "}" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                while_token: Ok(
+                    WHILE_KW@65..71 "while" [] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@71..72 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@72..76 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@76..77 ")" [] [],
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@77..78 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@78..84 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@84..86 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@86..88 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@88..89 "1" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@89..90 ";" [] [],
+                ),
+            },
+        ),
+        JsDoWhileStatement(
+            JsDoWhileStatement {
+                do_token: Ok(
+                    DO_KW@90..93 "do" [Whitespace("\n")] [],
+                ),
+                body: Ok(
+                    JsDoWhileStatement(
+                        JsDoWhileStatement {
+                            do_token: Ok(
+                                DO_KW@93..98 "do" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsBlockStatement(
+                                    JsBlockStatement {
+                                        l_curly_token: Ok(
+                                            L_CURLY@98..99 "{" [] [],
+                                        ),
+                                        statements: [
+                                            JsExpressionStatement(
+                                                JsExpressionStatement {
+                                                    expression: Ok(
+                                                        AssignExpr(
+                                                            AssignExpr {
+                                                                operator: Ok(
+                                                                    EQ@104..106 "=" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    semicolon_token: None,
+                                                },
+                                            ),
+                                        ],
+                                        r_curly_token: Ok(
+                                            R_CURLY@111..115 "}" [Whitespace("\n\t")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            while_token: Ok(
+                                WHILE_KW@115..120 "while" [] [],
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@120..121 "(" [] [],
+                            ),
+                            test: Ok(
+                                JsBinaryExpression(
+                                    JsBinaryExpression {
+                                        left: Ok(
+                                            JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@121..123 "a" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        operator: Ok(
+                                            L_ANGLE@123..125 "<" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@126..127 ")" [] [],
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                ),
+                while_token: Ok(
+                    WHILE_KW@127..134 "while" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@134..135 "(" [] [],
+                ),
+                test: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@135..137 "a" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                L_ANGLE@137..139 "<" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@142..143 ")" [] [],
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..144
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -1,364 +1,152 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsDoWhileStatement(
-            JsDoWhileStatement {
-                do_token: Ok(
-                    DO_KW@0..3 "do" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsExpressionStatement(
-                        JsExpressionStatement {
-                            expression: Ok(
-                                CallExpr(
-                                    CallExpr {
-                                        type_args: None,
-                                        callee: Ok(
-                                            JsStaticMemberExpression(
-                                                JsStaticMemberExpression {
-                                                    object: Ok(
-                                                        JsReferenceIdentifierExpression(
-                                                            JsReferenceIdentifierExpression {
-                                                                name_token: Ok(
-                                                                    IDENT@3..10 "console" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        DOT@10..11 "." [] [],
-                                                    ),
-                                                    member: Ok(
-                                                        JsReferenceIdentifierMember(
-                                                            JsReferenceIdentifierMember {
-                                                                name_token: Ok(
-                                                                    IDENT@11..14 "log" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        arguments: Ok(
-                                            ArgList {
-                                                l_paren_token: Ok(
-                                                    L_PAREN@14..15 "(" [] [],
-                                                ),
-                                                args: [
-                                                    AstSeparatedElement {
-                                                        node: JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@15..21 "\"test\"" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_paren_token: Ok(
-                                                    R_PAREN@21..22 ")" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ),
-                            ),
-                            semicolon_token: Some(
-                                SEMICOLON@22..24 ";" [] [Whitespace(" ")],
-                            ),
+        JsDoWhileStatement {
+            do_token: DO_KW@0..3 "do" [] [Whitespace(" ")],
+            body: JsExpressionStatement {
+                expression: CallExpr {
+                    type_args: missing (optional),
+                    callee: JsStaticMemberExpression {
+                        object: JsReferenceIdentifierExpression {
+                            name_token: IDENT@3..10 "console" [] [],
                         },
-                    ),
-                ),
-                while_token: Ok(
-                    WHILE_KW@24..29 "while" [] [],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@29..30 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@30..34 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@34..35 ")" [] [],
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsDoWhileStatement(
-            JsDoWhileStatement {
-                do_token: Ok(
-                    DO_KW@35..40 "do" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@40..41 "{" [] [],
-                            ),
-                            statements: [
-                                JsExpressionStatement(
-                                    JsExpressionStatement {
-                                        expression: Ok(
-                                            CallExpr(
-                                                CallExpr {
-                                                    type_args: None,
-                                                    callee: Ok(
-                                                        JsStaticMemberExpression(
-                                                            JsStaticMemberExpression {
-                                                                object: Ok(
-                                                                    JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@41..50 "console" [Whitespace("\n\t")] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                operator: Ok(
-                                                                    DOT@50..51 "." [] [],
-                                                                ),
-                                                                member: Ok(
-                                                                    JsReferenceIdentifierMember(
-                                                                        JsReferenceIdentifierMember {
-                                                                            name_token: Ok(
-                                                                                IDENT@51..54 "log" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    arguments: Ok(
-                                                        ArgList {
-                                                            l_paren_token: Ok(
-                                                                L_PAREN@54..55 "(" [] [],
-                                                            ),
-                                                            args: [
-                                                                AstSeparatedElement {
-                                                                    node: JsAnyLiteralExpression(
-                                                                        JsStringLiteralExpression(
-                                                                            JsStringLiteralExpression {
-                                                                                value_token: Ok(
-                                                                                    JS_STRING_LITERAL@55..61 "\"test\"" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                    trailing_separator: None,
-                                                                },
-                                                            ],
-                                                            r_paren_token: Ok(
-                                                                R_PAREN@61..62 ")" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        semicolon_token: None,
-                                    },
-                                ),
-                            ],
-                            r_curly_token: Ok(
-                                R_CURLY@62..65 "}" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
+                        operator: DOT@10..11 "." [] [],
+                        member: JsReferenceIdentifierMember {
+                            name_token: IDENT@11..14 "log" [] [],
                         },
-                    ),
-                ),
-                while_token: Ok(
-                    WHILE_KW@65..71 "while" [] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@71..72 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@72..76 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@76..77 ")" [] [],
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@77..78 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@78..84 "let" [Whitespace("\n\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
+                    },
+                    arguments: ArgList {
+                        l_paren_token: L_PAREN@14..15 "(" [] [],
+                        args: [
                             AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@84..86 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@86..88 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@88..89 "1" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                                node: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@15..21 "\"test\"" [] [],
                                 },
                                 trailing_separator: None,
                             },
                         ],
+                        r_paren_token: R_PAREN@21..22 ")" [] [],
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@89..90 ";" [] [],
-                ),
+                },
+                semicolon_token: SEMICOLON@22..24 ";" [] [Whitespace(" ")],
             },
-        ),
-        JsDoWhileStatement(
-            JsDoWhileStatement {
-                do_token: Ok(
-                    DO_KW@90..93 "do" [Whitespace("\n")] [],
-                ),
-                body: Ok(
-                    JsDoWhileStatement(
-                        JsDoWhileStatement {
-                            do_token: Ok(
-                                DO_KW@93..98 "do" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsBlockStatement(
-                                    JsBlockStatement {
-                                        l_curly_token: Ok(
-                                            L_CURLY@98..99 "{" [] [],
-                                        ),
-                                        statements: [
-                                            JsExpressionStatement(
-                                                JsExpressionStatement {
-                                                    expression: Ok(
-                                                        AssignExpr(
-                                                            AssignExpr {
-                                                                operator: Ok(
-                                                                    EQ@104..106 "=" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    semicolon_token: None,
-                                                },
-                                            ),
-                                        ],
-                                        r_curly_token: Ok(
-                                            R_CURLY@111..115 "}" [Whitespace("\n\t")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            while_token: Ok(
-                                WHILE_KW@115..120 "while" [] [],
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@120..121 "(" [] [],
-                            ),
-                            test: Ok(
-                                JsBinaryExpression(
-                                    JsBinaryExpression {
-                                        left: Ok(
-                                            JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@121..123 "a" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        operator: Ok(
-                                            L_ANGLE@123..125 "<" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@126..127 ")" [] [],
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                ),
-                while_token: Ok(
-                    WHILE_KW@127..134 "while" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@134..135 "(" [] [],
-                ),
-                test: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@135..137 "a" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                L_ANGLE@137..139 "<" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@142..143 ")" [] [],
-                ),
-                semicolon_token: None,
+            while_token: WHILE_KW@24..29 "while" [] [],
+            l_paren_token: L_PAREN@29..30 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@30..34 "true" [] [],
             },
-        ),
+            r_paren_token: R_PAREN@34..35 ")" [] [],
+            semicolon_token: missing (optional),
+        },
+        JsDoWhileStatement {
+            do_token: DO_KW@35..40 "do" [Whitespace("\n\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@40..41 "{" [] [],
+                statements: [
+                    JsExpressionStatement {
+                        expression: CallExpr {
+                            type_args: missing (optional),
+                            callee: JsStaticMemberExpression {
+                                object: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@41..50 "console" [Whitespace("\n\t")] [],
+                                },
+                                operator: DOT@50..51 "." [] [],
+                                member: JsReferenceIdentifierMember {
+                                    name_token: IDENT@51..54 "log" [] [],
+                                },
+                            },
+                            arguments: ArgList {
+                                l_paren_token: L_PAREN@54..55 "(" [] [],
+                                args: [
+                                    AstSeparatedElement {
+                                        node: JsStringLiteralExpression {
+                                            value_token: JS_STRING_LITERAL@55..61 "\"test\"" [] [],
+                                        },
+                                        trailing_separator: None,
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@61..62 ")" [] [],
+                            },
+                        },
+                        semicolon_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@62..65 "}" [Whitespace("\n")] [Whitespace(" ")],
+            },
+            while_token: WHILE_KW@65..71 "while" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@71..72 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@72..76 "true" [] [],
+            },
+            r_paren_token: R_PAREN@76..77 ")" [] [],
+            semicolon_token: SEMICOLON@77..78 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@78..84 "let" [Whitespace("\n\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@84..86 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@88..89 "1" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@89..90 ";" [] [],
+        },
+        JsDoWhileStatement {
+            do_token: DO_KW@90..93 "do" [Whitespace("\n")] [],
+            body: JsDoWhileStatement {
+                do_token: DO_KW@93..98 "do" [Whitespace("\n\t")] [Whitespace(" ")],
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@98..99 "{" [] [],
+                    statements: [
+                        JsExpressionStatement {
+                            expression: AssignExpr {
+                                operator: EQ@104..106 "=" [] [Whitespace(" ")],
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@111..115 "}" [Whitespace("\n\t")] [Whitespace(" ")],
+                },
+                while_token: WHILE_KW@115..120 "while" [] [],
+                l_paren_token: L_PAREN@120..121 "(" [] [],
+                test: JsBinaryExpression {
+                    left: JsReferenceIdentifierExpression {
+                        name_token: IDENT@121..123 "a" [] [Whitespace(" ")],
+                    },
+                    operator: L_ANGLE@123..125 "<" [] [Whitespace(" ")],
+                },
+                r_paren_token: R_PAREN@126..127 ")" [] [],
+                semicolon_token: missing (optional),
+            },
+            while_token: WHILE_KW@127..134 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@134..135 "(" [] [],
+            test: JsBinaryExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@135..137 "a" [] [Whitespace(" ")],
+                },
+                operator: L_ANGLE@137..139 "<" [] [Whitespace(" ")],
+            },
+            r_paren_token: R_PAREN@142..143 ")" [] [],
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -19,12 +19,10 @@ JsRoot {
                     arguments: ArgList {
                         l_paren_token: L_PAREN@14..15 "(" [] [],
                         args: [
-                            AstSeparatedElement {
-                                node: JsStringLiteralExpression {
-                                    value_token: JS_STRING_LITERAL@15..21 "\"test\"" [] [],
-                                },
-                                trailing_separator: None,
-                            },
+                            JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@15..21 "\"test\"" [] [],
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@21..22 ")" [] [],
                     },
@@ -59,12 +57,10 @@ JsRoot {
                             arguments: ArgList {
                                 l_paren_token: L_PAREN@54..55 "(" [] [],
                                 args: [
-                                    AstSeparatedElement {
-                                        node: JsStringLiteralExpression {
-                                            value_token: JS_STRING_LITERAL@55..61 "\"test\"" [] [],
-                                        },
-                                        trailing_separator: None,
-                                    },
+                                    JsStringLiteralExpression {
+                                        value_token: JS_STRING_LITERAL@55..61 "\"test\"" [] [],
+                                    }
+                                    ,
                                 ],
                                 r_paren_token: R_PAREN@61..62 ")" [] [],
                             },
@@ -86,25 +82,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@78..84 "let" [Whitespace("\n\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@84..86 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@84..86 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@88..89 "1" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@88..89 "1" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@89..90 ";" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -1,199 +1,79 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@3..4 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@4..7 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                operator: DOT@3..4 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@4..7 "bar" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@7..11 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@11..12 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@12..17 "await" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@7..11 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@11..12 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@12..17 "await" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@17..21 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@21..22 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@22..27 "yield" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@17..21 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@21..22 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@22..27 "yield" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@27..31 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@31..32 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@32..35 "for" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@27..31 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@31..32 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@32..35 "for" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@35..39 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTIONDOT@39..41 "?." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@41..44 "for" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@35..39 "foo" [Whitespace("\n")] [],
+                },
+                operator: QUESTIONDOT@39..41 "?." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@41..44 "for" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTIONDOT@48..50 "?." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@50..53 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                },
+                operator: QUESTIONDOT@48..50 "?." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@50..53 "bar" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -1,3 +1,202 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@3..4 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@4..7 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@7..11 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@11..12 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@12..17 "await" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@17..21 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@21..22 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@22..27 "yield" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@27..31 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@31..32 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@32..35 "for" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@35..39 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTIONDOT@39..41 "?." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@41..44 "for" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTIONDOT@48..50 "?." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@50..53 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..54
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -1,14 +1,10 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsEmptyStatement(
-            JsEmptyStatement {
-                semicolon_token: Ok(
-                    SEMICOLON@0..1 ";" [] [],
-                ),
-            },
-        ),
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@0..1 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -1,3 +1,17 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsEmptyStatement(
+            JsEmptyStatement {
+                semicolon_token: Ok(
+                    SEMICOLON@0..1 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..2
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -1,3 +1,35 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        ExportDecl(
+            ExportDecl {
+                export_token: Ok(
+                    EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+                ),
+                type_token: None,
+                decl: Err(
+                    MissingRequiredChild(
+                        0: EXPORT_DECL@0..26
+                          0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+                          1: EXPORT_NAMED@7..26
+                            0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
+                            1: LIST@9..13
+                              0: SPECIFIER@9..13
+                                0: NAME@9..13
+                                  0: IDENT@9..13 "foo" [] [Whitespace(" ")]
+                            2: R_CURLY@13..15 "}" [] [Whitespace(" ")]
+                            3: FROM_KW@15..20 "from" [] [Whitespace(" ")]
+                            4: JS_STRING_LITERAL@20..25 "\"bla\"" [] []
+                            5: SEMICOLON@25..26 ";" [] []
+                        ,
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..27
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/export.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export.rast
@@ -1,32 +1,12 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        ExportDecl(
-            ExportDecl {
-                export_token: Ok(
-                    EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
-                ),
-                type_token: None,
-                decl: Err(
-                    MissingRequiredChild(
-                        0: EXPORT_DECL@0..26
-                          0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-                          1: EXPORT_NAMED@7..26
-                            0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
-                            1: LIST@9..13
-                              0: SPECIFIER@9..13
-                                0: NAME@9..13
-                                  0: IDENT@9..13 "foo" [] [Whitespace(" ")]
-                            2: R_CURLY@13..15 "}" [] [Whitespace(" ")]
-                            3: FROM_KW@15..20 "from" [] [Whitespace(" ")]
-                            4: JS_STRING_LITERAL@20..25 "\"bla\"" [] []
-                            5: SEMICOLON@25..26 ";" [] []
-                        ,
-                    ),
-                ),
-            },
-        ),
+        ExportDecl {
+            export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+            type_token: missing (optional),
+            decl: missing (required),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -1,3 +1,422 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        ForStmt(
+            ForStmt {
+                for_token: Ok(
+                    FOR_KW@0..4 "for" [] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@4..5 "(" [] [],
+                ),
+                init: Some(
+                    ForStmtInit {
+                        inner: Ok(
+                            JsVariableDeclaration(
+                                JsVariableDeclaration {
+                                    kind_token: Ok(
+                                        LET_KW@5..9 "let" [] [Whitespace(" ")],
+                                    ),
+                                    declarators: [
+                                        AstSeparatedElement {
+                                            node: JsVariableDeclarator {
+                                                id: Ok(
+                                                    SinglePattern(
+                                                        SinglePattern {
+                                                            name: Ok(
+                                                                Name {
+                                                                    ident_token: Ok(
+                                                                        IDENT@9..11 "i" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            question_mark_token: None,
+                                                            excl_token: None,
+                                                            ty: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                init: Some(
+                                                    JsEqualValueClause {
+                                                        eq_token: Ok(
+                                                            EQ@11..13 "=" [] [Whitespace(" ")],
+                                                        ),
+                                                        expression: Ok(
+                                                            JsAnyLiteralExpression(
+                                                                JsNumberLiteralExpression(
+                                                                    JsNumberLiteralExpression {
+                                                                        value_token: Ok(
+                                                                            JS_NUMBER_LITERAL@13..14 "5" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                },
+                            ),
+                        ),
+                        semicolon_token: Err(
+                            MissingRequiredChild(
+                                2: FOR_STMT_INIT@5..14
+                                  0: JS_VARIABLE_DECLARATION@5..14
+                                    0: LET_KW@5..9 "let" [] [Whitespace(" ")]
+                                    1: LIST@9..14
+                                      0: JS_VARIABLE_DECLARATOR@9..14
+                                        0: SINGLE_PATTERN@9..11
+                                          0: NAME@9..11
+                                            0: IDENT@9..11 "i" [] [Whitespace(" ")]
+                                        1: JS_EQUAL_VALUE_CLAUSE@11..14
+                                          0: EQ@11..13 "=" [] [Whitespace(" ")]
+                                          1: JS_NUMBER_LITERAL_EXPRESSION@13..14
+                                            0: JS_NUMBER_LITERAL@13..14 "5" [] []
+                                ,
+                            ),
+                        ),
+                    },
+                ),
+                test: Some(
+                    ForStmtTest {
+                        expr: Ok(
+                            JsBinaryExpression(
+                                JsBinaryExpression {
+                                    left: Ok(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@16..18 "i" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    operator: Ok(
+                                        L_ANGLE@18..20 "<" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                        ),
+                        semicolon_token: Err(
+                            MissingRequiredChild(
+                                4: FOR_STMT_TEST@16..22
+                                  0: JS_BINARY_EXPRESSION@16..22
+                                    0: JS_REFERENCE_IDENTIFIER_EXPRESSION@16..18
+                                      0: IDENT@16..18 "i" [] [Whitespace(" ")]
+                                    1: L_ANGLE@18..20 "<" [] [Whitespace(" ")]
+                                    2: JS_NUMBER_LITERAL_EXPRESSION@20..22
+                                      0: JS_NUMBER_LITERAL@20..22 "10" [] []
+                                ,
+                            ),
+                        ),
+                    },
+                ),
+                update: Some(
+                    ForStmtUpdate {
+                        expr: Ok(
+                            JsPostUpdateExpression(
+                                JsPostUpdateExpression {
+                                    operand: Ok(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@24..25 "i" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    operator: Ok(
+                                        PLUS2@25..27 "++" [] [],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                ),
+                cons: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@29..30 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@30..31 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        ForOfStmt(
+            ForOfStmt {
+                for_token: Ok(
+                    FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@36..37 "(" [] [],
+                ),
+                left: Ok(
+                    ForStmtInit {
+                        inner: Ok(
+                            JsVariableDeclaration(
+                                JsVariableDeclaration {
+                                    kind_token: Ok(
+                                        LET_KW@37..41 "let" [] [Whitespace(" ")],
+                                    ),
+                                    declarators: [
+                                        AstSeparatedElement {
+                                            node: JsVariableDeclarator {
+                                                id: Ok(
+                                                    ObjectPattern(
+                                                        ObjectPattern {
+                                                            l_curly_token: Ok(
+                                                                L_CURLY@41..43 "{" [] [Whitespace(" ")],
+                                                            ),
+                                                            elements: [
+                                                                AstSeparatedElement {
+                                                                    node: SinglePattern(
+                                                                        SinglePattern {
+                                                                            name: Ok(
+                                                                                Name {
+                                                                                    ident_token: Ok(
+                                                                                        IDENT@43..46 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            question_mark_token: None,
+                                                                            excl_token: None,
+                                                                            ty: None,
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: Some(
+                                                                        COMMA@46..48 "," [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                                AstSeparatedElement {
+                                                                    node: SinglePattern(
+                                                                        SinglePattern {
+                                                                            name: Ok(
+                                                                                Name {
+                                                                                    ident_token: Ok(
+                                                                                        IDENT@48..52 "bar" [] [Whitespace(" ")],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            question_mark_token: None,
+                                                                            excl_token: None,
+                                                                            ty: None,
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: None,
+                                                                },
+                                                            ],
+                                                            r_curly_token: Ok(
+                                                                R_CURLY@52..54 "}" [] [Whitespace(" ")],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                init: None,
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                },
+                            ),
+                        ),
+                        semicolon_token: Err(
+                            MissingRequiredChild(
+                                2: FOR_STMT_INIT@37..54
+                                  0: JS_VARIABLE_DECLARATION@37..54
+                                    0: LET_KW@37..41 "let" [] [Whitespace(" ")]
+                                    1: LIST@41..54
+                                      0: JS_VARIABLE_DECLARATOR@41..54
+                                        0: OBJECT_PATTERN@41..54
+                                          0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
+                                          1: LIST@43..52
+                                            0: SINGLE_PATTERN@43..46
+                                              0: NAME@43..46
+                                                0: IDENT@43..46 "foo" [] []
+                                            1: COMMA@46..48 "," [] [Whitespace(" ")]
+                                            2: SINGLE_PATTERN@48..52
+                                              0: NAME@48..52
+                                                0: IDENT@48..52 "bar" [] [Whitespace(" ")]
+                                          2: R_CURLY@52..54 "}" [] [Whitespace(" ")]
+                                ,
+                            ),
+                        ),
+                    },
+                ),
+                of_token: Err(
+                    MissingRequiredChild(
+                        1: FOR_OF_STMT@31..63
+                          0: FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")]
+                          1: L_PAREN@36..37 "(" [] []
+                          2: FOR_STMT_INIT@37..54
+                            0: JS_VARIABLE_DECLARATION@37..54
+                              0: LET_KW@37..41 "let" [] [Whitespace(" ")]
+                              1: LIST@41..54
+                                0: JS_VARIABLE_DECLARATOR@41..54
+                                  0: OBJECT_PATTERN@41..54
+                                    0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
+                                    1: LIST@43..52
+                                      0: SINGLE_PATTERN@43..46
+                                        0: NAME@43..46
+                                          0: IDENT@43..46 "foo" [] []
+                                      1: COMMA@46..48 "," [] [Whitespace(" ")]
+                                      2: SINGLE_PATTERN@48..52
+                                        0: NAME@48..52
+                                          0: IDENT@48..52 "bar" [] [Whitespace(" ")]
+                                    2: R_CURLY@52..54 "}" [] [Whitespace(" ")]
+                          3: IDENT@54..57 "of" [] [Whitespace(" ")]
+                          4: JS_OBJECT_EXPRESSION@57..59
+                            0: L_CURLY@57..58 "{" [] []
+                            1: LIST@58..58
+                            2: R_CURLY@58..59 "}" [] []
+                          5: R_PAREN@59..61 ")" [] [Whitespace(" ")]
+                          6: JS_BLOCK_STATEMENT@61..63
+                            0: L_CURLY@61..62 "{" [] []
+                            1: LIST@62..62
+                            2: R_CURLY@62..63 "}" [] []
+                        ,
+                    ),
+                ),
+                right: Ok(
+                    JsObjectExpression(
+                        JsObjectExpression {
+                            l_curly_token: Ok(
+                                L_CURLY@57..58 "{" [] [],
+                            ),
+                            members: [],
+                            r_curly_token: Ok(
+                                R_CURLY@58..59 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@59..61 ")" [] [Whitespace(" ")],
+                ),
+                cons: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@61..62 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@62..63 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        ForInStmt(
+            ForInStmt {
+                for_token: Ok(
+                    FOR_KW@63..68 "for" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@68..69 "(" [] [],
+                ),
+                left: Ok(
+                    ForStmtInit {
+                        inner: Ok(
+                            JsAnyExpression(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@69..73 "foo" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        semicolon_token: Err(
+                            MissingRequiredChild(
+                                2: FOR_STMT_INIT@69..73
+                                  0: JS_REFERENCE_IDENTIFIER_EXPRESSION@69..73
+                                    0: IDENT@69..73 "foo" [] [Whitespace(" ")]
+                                ,
+                            ),
+                        ),
+                    },
+                ),
+                in_token: Ok(
+                    IN_KW@73..76 "in" [] [Whitespace(" ")],
+                ),
+                right: Ok(
+                    JsObjectExpression(
+                        JsObjectExpression {
+                            l_curly_token: Ok(
+                                L_CURLY@76..77 "{" [] [],
+                            ),
+                            members: [],
+                            r_curly_token: Ok(
+                                R_CURLY@77..78 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@78..80 ")" [] [Whitespace(" ")],
+                ),
+                cons: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@80..81 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@81..82 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        ForStmt(
+            ForStmt {
+                for_token: Ok(
+                    FOR_KW@82..87 "for" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@87..88 "(" [] [],
+                ),
+                init: None,
+                test: None,
+                update: None,
+                r_paren_token: Ok(
+                    R_PAREN@90..92 ")" [] [Whitespace(" ")],
+                ),
+                cons: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@92..93 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@93..94 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..95
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -1,419 +1,156 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        ForStmt(
-            ForStmt {
-                for_token: Ok(
-                    FOR_KW@0..4 "for" [] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@4..5 "(" [] [],
-                ),
-                init: Some(
-                    ForStmtInit {
-                        inner: Ok(
-                            JsVariableDeclaration(
-                                JsVariableDeclaration {
-                                    kind_token: Ok(
-                                        LET_KW@5..9 "let" [] [Whitespace(" ")],
-                                    ),
-                                    declarators: [
-                                        AstSeparatedElement {
-                                            node: JsVariableDeclarator {
-                                                id: Ok(
-                                                    SinglePattern(
-                                                        SinglePattern {
-                                                            name: Ok(
-                                                                Name {
-                                                                    ident_token: Ok(
-                                                                        IDENT@9..11 "i" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            question_mark_token: None,
-                                                            excl_token: None,
-                                                            ty: None,
-                                                        },
-                                                    ),
-                                                ),
-                                                init: Some(
-                                                    JsEqualValueClause {
-                                                        eq_token: Ok(
-                                                            EQ@11..13 "=" [] [Whitespace(" ")],
-                                                        ),
-                                                        expression: Ok(
-                                                            JsAnyLiteralExpression(
-                                                                JsNumberLiteralExpression(
-                                                                    JsNumberLiteralExpression {
-                                                                        value_token: Ok(
-                                                                            JS_NUMBER_LITERAL@13..14 "5" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        ),
-                                                    },
-                                                ),
-                                            },
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                },
-                            ),
-                        ),
-                        semicolon_token: Err(
-                            MissingRequiredChild(
-                                2: FOR_STMT_INIT@5..14
-                                  0: JS_VARIABLE_DECLARATION@5..14
-                                    0: LET_KW@5..9 "let" [] [Whitespace(" ")]
-                                    1: LIST@9..14
-                                      0: JS_VARIABLE_DECLARATOR@9..14
-                                        0: SINGLE_PATTERN@9..11
-                                          0: NAME@9..11
-                                            0: IDENT@9..11 "i" [] [Whitespace(" ")]
-                                        1: JS_EQUAL_VALUE_CLAUSE@11..14
-                                          0: EQ@11..13 "=" [] [Whitespace(" ")]
-                                          1: JS_NUMBER_LITERAL_EXPRESSION@13..14
-                                            0: JS_NUMBER_LITERAL@13..14 "5" [] []
-                                ,
-                            ),
-                        ),
-                    },
-                ),
-                test: Some(
-                    ForStmtTest {
-                        expr: Ok(
-                            JsBinaryExpression(
-                                JsBinaryExpression {
-                                    left: Ok(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@16..18 "i" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    operator: Ok(
-                                        L_ANGLE@18..20 "<" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                        ),
-                        semicolon_token: Err(
-                            MissingRequiredChild(
-                                4: FOR_STMT_TEST@16..22
-                                  0: JS_BINARY_EXPRESSION@16..22
-                                    0: JS_REFERENCE_IDENTIFIER_EXPRESSION@16..18
-                                      0: IDENT@16..18 "i" [] [Whitespace(" ")]
-                                    1: L_ANGLE@18..20 "<" [] [Whitespace(" ")]
-                                    2: JS_NUMBER_LITERAL_EXPRESSION@20..22
-                                      0: JS_NUMBER_LITERAL@20..22 "10" [] []
-                                ,
-                            ),
-                        ),
-                    },
-                ),
-                update: Some(
-                    ForStmtUpdate {
-                        expr: Ok(
-                            JsPostUpdateExpression(
-                                JsPostUpdateExpression {
-                                    operand: Ok(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@24..25 "i" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    operator: Ok(
-                                        PLUS2@25..27 "++" [] [],
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@27..29 ")" [] [Whitespace(" ")],
-                ),
-                cons: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@29..30 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@30..31 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
-            },
-        ),
-        ForOfStmt(
-            ForOfStmt {
-                for_token: Ok(
-                    FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@36..37 "(" [] [],
-                ),
-                left: Ok(
-                    ForStmtInit {
-                        inner: Ok(
-                            JsVariableDeclaration(
-                                JsVariableDeclaration {
-                                    kind_token: Ok(
-                                        LET_KW@37..41 "let" [] [Whitespace(" ")],
-                                    ),
-                                    declarators: [
-                                        AstSeparatedElement {
-                                            node: JsVariableDeclarator {
-                                                id: Ok(
-                                                    ObjectPattern(
-                                                        ObjectPattern {
-                                                            l_curly_token: Ok(
-                                                                L_CURLY@41..43 "{" [] [Whitespace(" ")],
-                                                            ),
-                                                            elements: [
-                                                                AstSeparatedElement {
-                                                                    node: SinglePattern(
-                                                                        SinglePattern {
-                                                                            name: Ok(
-                                                                                Name {
-                                                                                    ident_token: Ok(
-                                                                                        IDENT@43..46 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            question_mark_token: None,
-                                                                            excl_token: None,
-                                                                            ty: None,
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: Some(
-                                                                        COMMA@46..48 "," [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                                AstSeparatedElement {
-                                                                    node: SinglePattern(
-                                                                        SinglePattern {
-                                                                            name: Ok(
-                                                                                Name {
-                                                                                    ident_token: Ok(
-                                                                                        IDENT@48..52 "bar" [] [Whitespace(" ")],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            question_mark_token: None,
-                                                                            excl_token: None,
-                                                                            ty: None,
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: None,
-                                                                },
-                                                            ],
-                                                            r_curly_token: Ok(
-                                                                R_CURLY@52..54 "}" [] [Whitespace(" ")],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                init: None,
-                                            },
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                },
-                            ),
-                        ),
-                        semicolon_token: Err(
-                            MissingRequiredChild(
-                                2: FOR_STMT_INIT@37..54
-                                  0: JS_VARIABLE_DECLARATION@37..54
-                                    0: LET_KW@37..41 "let" [] [Whitespace(" ")]
-                                    1: LIST@41..54
-                                      0: JS_VARIABLE_DECLARATOR@41..54
-                                        0: OBJECT_PATTERN@41..54
-                                          0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
-                                          1: LIST@43..52
-                                            0: SINGLE_PATTERN@43..46
-                                              0: NAME@43..46
-                                                0: IDENT@43..46 "foo" [] []
-                                            1: COMMA@46..48 "," [] [Whitespace(" ")]
-                                            2: SINGLE_PATTERN@48..52
-                                              0: NAME@48..52
-                                                0: IDENT@48..52 "bar" [] [Whitespace(" ")]
-                                          2: R_CURLY@52..54 "}" [] [Whitespace(" ")]
-                                ,
-                            ),
-                        ),
-                    },
-                ),
-                of_token: Err(
-                    MissingRequiredChild(
-                        1: FOR_OF_STMT@31..63
-                          0: FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")]
-                          1: L_PAREN@36..37 "(" [] []
-                          2: FOR_STMT_INIT@37..54
-                            0: JS_VARIABLE_DECLARATION@37..54
-                              0: LET_KW@37..41 "let" [] [Whitespace(" ")]
-                              1: LIST@41..54
-                                0: JS_VARIABLE_DECLARATOR@41..54
-                                  0: OBJECT_PATTERN@41..54
-                                    0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
-                                    1: LIST@43..52
-                                      0: SINGLE_PATTERN@43..46
-                                        0: NAME@43..46
-                                          0: IDENT@43..46 "foo" [] []
-                                      1: COMMA@46..48 "," [] [Whitespace(" ")]
-                                      2: SINGLE_PATTERN@48..52
-                                        0: NAME@48..52
-                                          0: IDENT@48..52 "bar" [] [Whitespace(" ")]
-                                    2: R_CURLY@52..54 "}" [] [Whitespace(" ")]
-                          3: IDENT@54..57 "of" [] [Whitespace(" ")]
-                          4: JS_OBJECT_EXPRESSION@57..59
-                            0: L_CURLY@57..58 "{" [] []
-                            1: LIST@58..58
-                            2: R_CURLY@58..59 "}" [] []
-                          5: R_PAREN@59..61 ")" [] [Whitespace(" ")]
-                          6: JS_BLOCK_STATEMENT@61..63
-                            0: L_CURLY@61..62 "{" [] []
-                            1: LIST@62..62
-                            2: R_CURLY@62..63 "}" [] []
-                        ,
-                    ),
-                ),
-                right: Ok(
-                    JsObjectExpression(
-                        JsObjectExpression {
-                            l_curly_token: Ok(
-                                L_CURLY@57..58 "{" [] [],
-                            ),
-                            members: [],
-                            r_curly_token: Ok(
-                                R_CURLY@58..59 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@59..61 ")" [] [Whitespace(" ")],
-                ),
-                cons: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@61..62 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@62..63 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
-            },
-        ),
-        ForInStmt(
-            ForInStmt {
-                for_token: Ok(
-                    FOR_KW@63..68 "for" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@68..69 "(" [] [],
-                ),
-                left: Ok(
-                    ForStmtInit {
-                        inner: Ok(
-                            JsAnyExpression(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@69..73 "foo" [] [Whitespace(" ")],
-                                        ),
+        ForStmt {
+            for_token: FOR_KW@0..4 "for" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@4..5 "(" [] [],
+            init: ForStmtInit {
+                inner: JsVariableDeclaration {
+                    kind_token: LET_KW@5..9 "let" [] [Whitespace(" ")],
+                    declarators: [
+                        AstSeparatedElement {
+                            node: JsVariableDeclarator {
+                                id: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@9..11 "i" [] [Whitespace(" ")],
                                     },
-                                ),
-                            ),
-                        ),
-                        semicolon_token: Err(
-                            MissingRequiredChild(
-                                2: FOR_STMT_INIT@69..73
-                                  0: JS_REFERENCE_IDENTIFIER_EXPRESSION@69..73
-                                    0: IDENT@69..73 "foo" [] [Whitespace(" ")]
-                                ,
-                            ),
-                        ),
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                init: JsEqualValueClause {
+                                    eq_token: EQ@11..13 "=" [] [Whitespace(" ")],
+                                    expression: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@13..14 "5" [] [],
+                                    },
+                                },
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                },
+                semicolon_token: missing (required),
+            },
+            test: ForStmtTest {
+                expr: JsBinaryExpression {
+                    left: JsReferenceIdentifierExpression {
+                        name_token: IDENT@16..18 "i" [] [Whitespace(" ")],
                     },
-                ),
-                in_token: Ok(
-                    IN_KW@73..76 "in" [] [Whitespace(" ")],
-                ),
-                right: Ok(
-                    JsObjectExpression(
-                        JsObjectExpression {
-                            l_curly_token: Ok(
-                                L_CURLY@76..77 "{" [] [],
-                            ),
-                            members: [],
-                            r_curly_token: Ok(
-                                R_CURLY@77..78 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@78..80 ")" [] [Whitespace(" ")],
-                ),
-                cons: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@80..81 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@81..82 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+                    operator: L_ANGLE@18..20 "<" [] [Whitespace(" ")],
+                },
+                semicolon_token: missing (required),
             },
-        ),
-        ForStmt(
-            ForStmt {
-                for_token: Ok(
-                    FOR_KW@82..87 "for" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@87..88 "(" [] [],
-                ),
-                init: None,
-                test: None,
-                update: None,
-                r_paren_token: Ok(
-                    R_PAREN@90..92 ")" [] [Whitespace(" ")],
-                ),
-                cons: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@92..93 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@93..94 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+            update: ForStmtUpdate {
+                expr: JsPostUpdateExpression {
+                    operand: JsReferenceIdentifierExpression {
+                        name_token: IDENT@24..25 "i" [] [],
+                    },
+                    operator: PLUS2@25..27 "++" [] [],
+                },
             },
-        ),
+            r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+            cons: JsBlockStatement {
+                l_curly_token: L_CURLY@29..30 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@30..31 "}" [] [],
+            },
+        },
+        ForOfStmt {
+            for_token: FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@36..37 "(" [] [],
+            left: ForStmtInit {
+                inner: JsVariableDeclaration {
+                    kind_token: LET_KW@37..41 "let" [] [Whitespace(" ")],
+                    declarators: [
+                        AstSeparatedElement {
+                            node: JsVariableDeclarator {
+                                id: ObjectPattern {
+                                    l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],
+                                    elements: [
+                                        AstSeparatedElement {
+                                            node: SinglePattern {
+                                                name: Name {
+                                                    ident_token: IDENT@43..46 "foo" [] [],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                excl_token: missing (optional),
+                                                ty: missing (optional),
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@46..48 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: SinglePattern {
+                                                name: Name {
+                                                    ident_token: IDENT@48..52 "bar" [] [Whitespace(" ")],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                excl_token: missing (optional),
+                                                ty: missing (optional),
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
+                                },
+                                init: missing (optional),
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                },
+                semicolon_token: missing (required),
+            },
+            of_token: missing (required),
+            right: JsObjectExpression {
+                l_curly_token: L_CURLY@57..58 "{" [] [],
+                members: [],
+                r_curly_token: R_CURLY@58..59 "}" [] [],
+            },
+            r_paren_token: R_PAREN@59..61 ")" [] [Whitespace(" ")],
+            cons: JsBlockStatement {
+                l_curly_token: L_CURLY@61..62 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@62..63 "}" [] [],
+            },
+        },
+        ForInStmt {
+            for_token: FOR_KW@63..68 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@68..69 "(" [] [],
+            left: ForStmtInit {
+                inner: JsReferenceIdentifierExpression {
+                    name_token: IDENT@69..73 "foo" [] [Whitespace(" ")],
+                },
+                semicolon_token: missing (required),
+            },
+            in_token: IN_KW@73..76 "in" [] [Whitespace(" ")],
+            right: JsObjectExpression {
+                l_curly_token: L_CURLY@76..77 "{" [] [],
+                members: [],
+                r_curly_token: R_CURLY@77..78 "}" [] [],
+            },
+            r_paren_token: R_PAREN@78..80 ")" [] [Whitespace(" ")],
+            cons: JsBlockStatement {
+                l_curly_token: L_CURLY@80..81 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@81..82 "}" [] [],
+            },
+        },
+        ForStmt {
+            for_token: FOR_KW@82..87 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@87..88 "(" [] [],
+            init: missing (optional),
+            test: missing (optional),
+            update: missing (optional),
+            r_paren_token: R_PAREN@90..92 ")" [] [Whitespace(" ")],
+            cons: JsBlockStatement {
+                l_curly_token: L_CURLY@92..93 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@93..94 "}" [] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -9,25 +9,23 @@ JsRoot {
                 inner: JsVariableDeclaration {
                     kind_token: LET_KW@5..9 "let" [] [Whitespace(" ")],
                     declarators: [
-                        AstSeparatedElement {
-                            node: JsVariableDeclarator {
-                                id: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@9..11 "i" [] [Whitespace(" ")],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                        JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@9..11 "i" [] [Whitespace(" ")],
                                 },
-                                init: JsEqualValueClause {
-                                    eq_token: EQ@11..13 "=" [] [Whitespace(" ")],
-                                    expression: JsNumberLiteralExpression {
-                                        value_token: JS_NUMBER_LITERAL@13..14 "5" [] [],
-                                    },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@11..13 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@13..14 "5" [] [],
                                 },
                             },
-                            trailing_separator: None,
-                        },
+                        }
+                        ,
                     ],
                 },
                 semicolon_token: missing (required),
@@ -63,42 +61,34 @@ JsRoot {
                 inner: JsVariableDeclaration {
                     kind_token: LET_KW@37..41 "let" [] [Whitespace(" ")],
                     declarators: [
-                        AstSeparatedElement {
-                            node: JsVariableDeclarator {
-                                id: ObjectPattern {
-                                    l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],
-                                    elements: [
-                                        AstSeparatedElement {
-                                            node: SinglePattern {
-                                                name: Name {
-                                                    ident_token: IDENT@43..46 "foo" [] [],
-                                                },
-                                                question_mark_token: missing (optional),
-                                                excl_token: missing (optional),
-                                                ty: missing (optional),
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@46..48 "," [] [Whitespace(" ")],
-                                            ),
+                        JsVariableDeclarator {
+                            id: ObjectPattern {
+                                l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],
+                                elements: [
+                                    SinglePattern {
+                                        name: Name {
+                                            ident_token: IDENT@43..46 "foo" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: SinglePattern {
-                                                name: Name {
-                                                    ident_token: IDENT@48..52 "bar" [] [Whitespace(" ")],
-                                                },
-                                                question_mark_token: missing (optional),
-                                                excl_token: missing (optional),
-                                                ty: missing (optional),
-                                            },
-                                            trailing_separator: None,
+                                        question_mark_token: missing (optional),
+                                        excl_token: missing (optional),
+                                        ty: missing (optional),
+                                    }
+                                    COMMA@46..48 "," [] [Whitespace(" ")],
+                                    SinglePattern {
+                                        name: Name {
+                                            ident_token: IDENT@48..52 "bar" [] [Whitespace(" ")],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
-                                },
-                                init: missing (optional),
+                                        question_mark_token: missing (optional),
+                                        excl_token: missing (optional),
+                                        ty: missing (optional),
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
                             },
-                            trailing_separator: None,
-                        },
+                            init: missing (optional),
+                        }
+                        ,
                     ],
                 },
                 semicolon_token: missing (required),

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -55,17 +55,15 @@ JsRoot {
             parameter_list: JsParameterList {
                 l_paren_token: L_PAREN@49..50 "(" [] [],
                 parameters: [
-                    AstSeparatedElement {
-                        node: SinglePattern {
-                            name: Name {
-                                ident_token: IDENT@50..55 "await" [] [],
-                            },
-                            question_mark_token: missing (optional),
-                            excl_token: missing (optional),
-                            ty: missing (optional),
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@50..55 "await" [] [],
                         },
-                        trailing_separator: None,
-                    },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
                 ],
                 r_paren_token: R_PAREN@55..57 ")" [] [Whitespace(" ")],
             },

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -1,310 +1,156 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@9..12 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@12..13 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@13..15 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@15..16 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@16..17 "}" [] [],
-                        ),
-                    },
-                ),
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@17..27 "function" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                star_token: Some(
-                    STAR@27..28 "*" [] [],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@28..31 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@31..32 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@32..34 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@34..35 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@35..36 "}" [] [],
-                        ),
-                    },
-                ),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@13..15 ")" [] [Whitespace(" ")],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@36..46 "function" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@46..49 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@49..50 "(" [] [],
-                        ),
-                        parameters: [
-                            AstSeparatedElement {
-                                node: Pattern(
-                                    SinglePattern(
-                                        SinglePattern {
-                                            name: Ok(
-                                                Name {
-                                                    ident_token: Ok(
-                                                        IDENT@50..55 "await" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            question_mark_token: None,
-                                            excl_token: None,
-                                            ty: None,
-                                        },
-                                    ),
-                                ),
-                                trailing_separator: None,
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@15..16 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@16..17 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@17..27 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: STAR@27..28 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@28..31 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@31..32 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@32..34 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@34..35 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@35..36 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@36..46 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@46..49 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@49..50 "(" [] [],
+                parameters: [
+                    AstSeparatedElement {
+                        node: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@50..55 "await" [] [],
                             },
-                        ],
-                        r_paren_token: Ok(
-                            R_PAREN@55..57 ")" [] [Whitespace(" ")],
-                        ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@57..58 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@58..59 "}" [] [],
-                        ),
-                    },
-                ),
+                ],
+                r_paren_token: R_PAREN@55..57 ")" [] [Whitespace(" ")],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: Some(
-                    ASYNC_KW@59..66 "async" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                function_token: Ok(
-                    FUNCTION_KW@66..75 "function" [] [Whitespace(" ")],
-                ),
-                star_token: Some(
-                    STAR@75..76 "*" [] [],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@76..79 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@79..80 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@80..82 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@82..83 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@83..84 "}" [] [],
-                        ),
-                    },
-                ),
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@57..58 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@58..59 "}" [] [],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: Some(
-                    ASYNC_KW@84..91 "async" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                function_token: Ok(
-                    FUNCTION_KW@91..100 "function" [] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@100..103 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@103..104 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@104..106 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@106..107 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@107..108 "}" [] [],
-                        ),
-                    },
-                ),
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@59..66 "async" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@66..75 "function" [] [Whitespace(" ")],
+            star_token: STAR@75..76 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@76..79 "foo" [] [],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@108..118 "function" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                star_token: Some(
-                    STAR@118..119 "*" [] [],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@119..122 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@122..123 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@123..125 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@125..126 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsYieldExpression(
-                                            JsYieldExpression {
-                                                yield_token: Ok(
-                                                    YIELD_KW@126..135 "yield" [Whitespace("\n  ")] [Whitespace(" ")],
-                                                ),
-                                                star_token: None,
-                                                argument: Some(
-                                                    JsReferenceIdentifierExpression(
-                                                        JsReferenceIdentifierExpression {
-                                                            name_token: Ok(
-                                                                IDENT@135..138 "foo" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@138..139 ";" [] [],
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@139..141 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@79..80 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@80..82 ")" [] [Whitespace(" ")],
             },
-        ),
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@82..83 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@83..84 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@84..91 "async" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@91..100 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@100..103 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@103..104 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@104..106 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@106..107 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@107..108 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@108..118 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: STAR@118..119 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@119..122 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@122..123 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@123..125 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@125..126 "{" [] [],
+                directives: [],
+                statements: [
+                    JsExpressionStatement {
+                        expression: JsYieldExpression {
+                            yield_token: YIELD_KW@126..135 "yield" [Whitespace("\n  ")] [Whitespace(" ")],
+                            star_token: missing (optional),
+                            argument: JsReferenceIdentifierExpression {
+                                name_token: IDENT@135..138 "foo" [] [],
+                            },
+                        },
+                        semicolon_token: SEMICOLON@138..139 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@139..141 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -1,3 +1,313 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@9..12 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@12..13 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@13..15 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@15..16 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@16..17 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@17..27 "function" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                star_token: Some(
+                    STAR@27..28 "*" [] [],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@28..31 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@31..32 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@32..34 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@34..35 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@35..36 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@36..46 "function" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@46..49 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@49..50 "(" [] [],
+                        ),
+                        parameters: [
+                            AstSeparatedElement {
+                                node: Pattern(
+                                    SinglePattern(
+                                        SinglePattern {
+                                            name: Ok(
+                                                Name {
+                                                    ident_token: Ok(
+                                                        IDENT@50..55 "await" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            question_mark_token: None,
+                                            excl_token: None,
+                                            ty: None,
+                                        },
+                                    ),
+                                ),
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: Ok(
+                            R_PAREN@55..57 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@57..58 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@58..59 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: Some(
+                    ASYNC_KW@59..66 "async" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                function_token: Ok(
+                    FUNCTION_KW@66..75 "function" [] [Whitespace(" ")],
+                ),
+                star_token: Some(
+                    STAR@75..76 "*" [] [],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@76..79 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@79..80 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@80..82 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@82..83 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@83..84 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: Some(
+                    ASYNC_KW@84..91 "async" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                function_token: Ok(
+                    FUNCTION_KW@91..100 "function" [] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@100..103 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@103..104 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@104..106 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@106..107 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@107..108 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@108..118 "function" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                star_token: Some(
+                    STAR@118..119 "*" [] [],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@119..122 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@122..123 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@123..125 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@125..126 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsYieldExpression(
+                                            JsYieldExpression {
+                                                yield_token: Ok(
+                                                    YIELD_KW@126..135 "yield" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                ),
+                                                star_token: None,
+                                                argument: Some(
+                                                    JsReferenceIdentifierExpression(
+                                                        JsReferenceIdentifierExpression {
+                                                            name_token: Ok(
+                                                                IDENT@135..138 "foo" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@138..139 ";" [] [],
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@139..141 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..142
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -6,41 +6,39 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsFunctionExpression {
-                                    async_token: missing (optional),
-                                    function_token: FUNCTION_KW@8..16 "function" [] [],
-                                    star_token: missing (optional),
-                                    id: missing (optional),
-                                    type_parameters: missing (optional),
-                                    parameters: JsParameterList {
-                                        l_paren_token: L_PAREN@16..17 "(" [] [],
-                                        parameters: [],
-                                        r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
-                                    },
-                                    return_type: missing (optional),
-                                    body: JsFunctionBody {
-                                        l_curly_token: L_CURLY@19..20 "{" [] [],
-                                        directives: [],
-                                        statements: [],
-                                        r_curly_token: R_CURLY@20..21 "}" [] [],
-                                    },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsFunctionExpression {
+                                async_token: missing (optional),
+                                function_token: FUNCTION_KW@8..16 "function" [] [],
+                                star_token: missing (optional),
+                                id: missing (optional),
+                                type_parameters: missing (optional),
+                                parameters: JsParameterList {
+                                    l_paren_token: L_PAREN@16..17 "(" [] [],
+                                    parameters: [],
+                                    r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
+                                },
+                                return_type: missing (optional),
+                                body: JsFunctionBody {
+                                    l_curly_token: L_CURLY@19..20 "{" [] [],
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@20..21 "}" [] [],
                                 },
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),
@@ -49,43 +47,41 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@26..28 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@26..28 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
-                                expression: JsFunctionExpression {
-                                    async_token: missing (optional),
-                                    function_token: FUNCTION_KW@30..39 "function" [] [Whitespace(" ")],
-                                    star_token: missing (optional),
-                                    id: JsIdentifierBinding {
-                                        name_token: IDENT@39..42 "foo" [] [],
-                                    },
-                                    type_parameters: missing (optional),
-                                    parameters: JsParameterList {
-                                        l_paren_token: L_PAREN@42..43 "(" [] [],
-                                        parameters: [],
-                                        r_paren_token: R_PAREN@43..45 ")" [] [Whitespace(" ")],
-                                    },
-                                    return_type: missing (optional),
-                                    body: JsFunctionBody {
-                                        l_curly_token: L_CURLY@45..46 "{" [] [],
-                                        directives: [],
-                                        statements: [],
-                                        r_curly_token: R_CURLY@46..47 "}" [] [],
-                                    },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                            expression: JsFunctionExpression {
+                                async_token: missing (optional),
+                                function_token: FUNCTION_KW@30..39 "function" [] [Whitespace(" ")],
+                                star_token: missing (optional),
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@39..42 "foo" [] [],
+                                },
+                                type_parameters: missing (optional),
+                                parameters: JsParameterList {
+                                    l_paren_token: L_PAREN@42..43 "(" [] [],
+                                    parameters: [],
+                                    r_paren_token: R_PAREN@43..45 ")" [] [Whitespace(" ")],
+                                },
+                                return_type: missing (optional),
+                                body: JsFunctionBody {
+                                    l_curly_token: L_CURLY@45..46 "{" [] [],
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@46..47 "}" [] [],
                                 },
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -1,3 +1,174 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsFunctionExpression(
+                                                    JsFunctionExpression {
+                                                        async_token: None,
+                                                        function_token: Ok(
+                                                            FUNCTION_KW@8..16 "function" [] [],
+                                                        ),
+                                                        star_token: None,
+                                                        id: None,
+                                                        type_parameters: None,
+                                                        parameters: Ok(
+                                                            JsParameterList {
+                                                                l_paren_token: Ok(
+                                                                    L_PAREN@16..17 "(" [] [],
+                                                                ),
+                                                                parameters: [],
+                                                                r_paren_token: Ok(
+                                                                    R_PAREN@17..19 ")" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        return_type: None,
+                                                        body: Ok(
+                                                            JsFunctionBody {
+                                                                l_curly_token: Ok(
+                                                                    L_CURLY@19..20 "{" [] [],
+                                                                ),
+                                                                directives: [],
+                                                                statements: [],
+                                                                r_curly_token: Ok(
+                                                                    R_CURLY@20..21 "}" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@26..28 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@28..30 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsFunctionExpression(
+                                                    JsFunctionExpression {
+                                                        async_token: None,
+                                                        function_token: Ok(
+                                                            FUNCTION_KW@30..39 "function" [] [Whitespace(" ")],
+                                                        ),
+                                                        star_token: None,
+                                                        id: Some(
+                                                            JsIdentifierBinding {
+                                                                name_token: Ok(
+                                                                    IDENT@39..42 "foo" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        type_parameters: None,
+                                                        parameters: Ok(
+                                                            JsParameterList {
+                                                                l_paren_token: Ok(
+                                                                    L_PAREN@42..43 "(" [] [],
+                                                                ),
+                                                                parameters: [],
+                                                                r_paren_token: Ok(
+                                                                    R_PAREN@43..45 ")" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        return_type: None,
+                                                        body: Ok(
+                                                            JsFunctionBody {
+                                                                l_curly_token: Ok(
+                                                                    L_CURLY@45..46 "{" [] [],
+                                                                ),
+                                                                directives: [],
+                                                                statements: [],
+                                                                r_curly_token: Ok(
+                                                                    R_CURLY@46..47 "}" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..48
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -1,171 +1,95 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsFunctionExpression(
-                                                    JsFunctionExpression {
-                                                        async_token: None,
-                                                        function_token: Ok(
-                                                            FUNCTION_KW@8..16 "function" [] [],
-                                                        ),
-                                                        star_token: None,
-                                                        id: None,
-                                                        type_parameters: None,
-                                                        parameters: Ok(
-                                                            JsParameterList {
-                                                                l_paren_token: Ok(
-                                                                    L_PAREN@16..17 "(" [] [],
-                                                                ),
-                                                                parameters: [],
-                                                                r_paren_token: Ok(
-                                                                    R_PAREN@17..19 ")" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        return_type: None,
-                                                        body: Ok(
-                                                            JsFunctionBody {
-                                                                l_curly_token: Ok(
-                                                                    L_CURLY@19..20 "{" [] [],
-                                                                ),
-                                                                directives: [],
-                                                                statements: [],
-                                                                r_curly_token: Ok(
-                                                                    R_CURLY@20..21 "}" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@26..28 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@28..30 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsFunctionExpression(
-                                                    JsFunctionExpression {
-                                                        async_token: None,
-                                                        function_token: Ok(
-                                                            FUNCTION_KW@30..39 "function" [] [Whitespace(" ")],
-                                                        ),
-                                                        star_token: None,
-                                                        id: Some(
-                                                            JsIdentifierBinding {
-                                                                name_token: Ok(
-                                                                    IDENT@39..42 "foo" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        type_parameters: None,
-                                                        parameters: Ok(
-                                                            JsParameterList {
-                                                                l_paren_token: Ok(
-                                                                    L_PAREN@42..43 "(" [] [],
-                                                                ),
-                                                                parameters: [],
-                                                                r_paren_token: Ok(
-                                                                    R_PAREN@43..45 ")" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        return_type: None,
-                                                        body: Ok(
-                                                            JsFunctionBody {
-                                                                l_curly_token: Ok(
-                                                                    L_CURLY@45..46 "{" [] [],
-                                                                ),
-                                                                directives: [],
-                                                                statements: [],
-                                                                r_curly_token: Ok(
-                                                                    R_CURLY@46..47 "}" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsFunctionExpression {
+                                    async_token: missing (optional),
+                                    function_token: FUNCTION_KW@8..16 "function" [] [],
+                                    star_token: missing (optional),
+                                    id: missing (optional),
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameterList {
+                                        l_paren_token: L_PAREN@16..17 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type: missing (optional),
+                                    body: JsFunctionBody {
+                                        l_curly_token: L_CURLY@19..20 "{" [] [],
+                                        directives: [],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@20..21 "}" [] [],
+                                    },
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@26..28 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                                expression: JsFunctionExpression {
+                                    async_token: missing (optional),
+                                    function_token: FUNCTION_KW@30..39 "function" [] [Whitespace(" ")],
+                                    star_token: missing (optional),
+                                    id: JsIdentifierBinding {
+                                        name_token: IDENT@39..42 "foo" [] [],
+                                    },
+                                    type_parameters: missing (optional),
+                                    parameters: JsParameterList {
+                                        l_paren_token: L_PAREN@42..43 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@43..45 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type: missing (optional),
+                                    body: JsFunctionBody {
+                                        l_curly_token: L_CURLY@45..46 "{" [] [],
+                                        directives: [],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@46..47 "}" [] [],
+                                    },
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
@@ -1,3 +1,485 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..14 "Getters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@14..15 "{" [] [],
+                ),
+                members: [
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@15..21 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@21..24 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@24..25 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@25..27 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@27..28 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@28..29 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@29..35 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@35..41 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@41..42 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@42..44 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@44..45 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@45..46 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@46..55 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            get_token: Ok(
+                                GET_KW@55..59 "get" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@59..62 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@62..63 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@63..65 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@65..66 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@66..67 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@67..73 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_STRING_LITERAL@73..78 "\"baz\"" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@78..79 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@79..81 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@81..82 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@82..83 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@83..89 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsComputedMemberName(
+                                    JsComputedMemberName {
+                                        l_brack_token: Ok(
+                                            L_BRACK@89..90 "[" [] [],
+                                        ),
+                                        expression: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@90..94 "\"a\"" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@94..96 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@99..100 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@100..101 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@101..103 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@103..104 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@104..105 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@105..111 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_NUMBER_LITERAL@111..112 "5" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@112..113 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@113..115 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@115..116 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@116..117 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@117..123 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@123..124 "#" [] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@124..131 "private" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@131..132 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@132..134 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@134..135 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@135..136 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@136..138 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@138..145 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@145..156 "NotGetters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@156..157 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@157..162 "get" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@162..163 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@163..165 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@165..166 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@166..167 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@167..175 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@175..178 "get" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@178..179 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@179..181 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@181..182 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@182..183 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@183..192 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@192..195 "get" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@195..196 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@196..198 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@198..199 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@199..200 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@200..202 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..203
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
@@ -1,482 +1,234 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..14 "Getters" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@14..15 "{" [] [],
-                ),
-                members: [
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@15..21 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@21..24 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@24..25 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@25..27 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@27..28 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@28..29 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@29..35 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@35..41 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@41..42 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@42..44 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@44..45 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@45..46 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@46..55 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            get_token: Ok(
-                                GET_KW@55..59 "get" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@59..62 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@62..63 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@63..65 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@65..66 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@66..67 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@67..73 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_STRING_LITERAL@73..78 "\"baz\"" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@78..79 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@79..81 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@81..82 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@82..83 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@83..89 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsComputedMemberName(
-                                    JsComputedMemberName {
-                                        l_brack_token: Ok(
-                                            L_BRACK@89..90 "[" [] [],
-                                        ),
-                                        expression: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@90..94 "\"a\"" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@94..96 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@99..100 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@100..101 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@101..103 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@103..104 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@104..105 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@105..111 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_NUMBER_LITERAL@111..112 "5" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@112..113 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@113..115 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@115..116 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@116..117 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@117..123 "get" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@123..124 "#" [] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@124..131 "private" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@131..132 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@132..134 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@134..135 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@135..136 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@136..138 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..14 "Getters" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@138..145 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@145..156 "NotGetters" [] [Whitespace(" ")],
-                        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@14..15 "{" [] [],
+            members: [
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@15..21 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@21..24 "foo" [] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@156..157 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@157..162 "get" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@162..163 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@163..165 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@165..166 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@166..167 "}" [] [],
-                                    ),
-                                },
-                            ),
+                    l_paren_token: L_PAREN@24..25 "(" [] [],
+                    r_paren_token: R_PAREN@25..27 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@27..28 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@28..29 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@29..35 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@35..41 "static" [] [],
+                    },
+                    l_paren_token: L_PAREN@41..42 "(" [] [],
+                    r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@44..45 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@45..46 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@46..55 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    get_token: GET_KW@55..59 "get" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@59..62 "bar" [] [],
+                    },
+                    l_paren_token: L_PAREN@62..63 "(" [] [],
+                    r_paren_token: R_PAREN@63..65 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@65..66 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@66..67 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@67..73 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@73..78 "\"baz\"" [] [],
+                    },
+                    l_paren_token: L_PAREN@78..79 "(" [] [],
+                    r_paren_token: R_PAREN@79..81 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@81..82 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@82..83 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@83..89 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@89..90 "[" [] [],
+                        expression: JsBinaryExpression {
+                            left: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@90..94 "\"a\"" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@94..96 "+" [] [Whitespace(" ")],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@167..175 "async" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@175..178 "get" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@178..179 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@179..181 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@181..182 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@182..183 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@183..192 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@192..195 "get" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@195..196 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@196..198 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@198..199 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@199..200 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@200..202 "}" [Whitespace("\n")] [],
-                ),
+                        r_brack_token: R_BRACK@99..100 "]" [] [],
+                    },
+                    l_paren_token: L_PAREN@100..101 "(" [] [],
+                    r_paren_token: R_PAREN@101..103 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@103..104 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@104..105 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@105..111 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@111..112 "5" [] [],
+                    },
+                    l_paren_token: L_PAREN@112..113 "(" [] [],
+                    r_paren_token: R_PAREN@113..115 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@115..116 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@116..117 "}" [] [],
+                    },
+                },
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@117..123 "get" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@123..124 "#" [] [],
+                        id_token: IDENT@124..131 "private" [] [],
+                    },
+                    l_paren_token: L_PAREN@131..132 "(" [] [],
+                    r_paren_token: R_PAREN@132..134 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@134..135 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@135..136 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@136..138 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@138..145 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@145..156 "NotGetters" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@156..157 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@157..162 "get" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@162..163 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@163..165 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@165..166 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@166..167 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@167..175 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@175..178 "get" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@178..179 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@179..181 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@181..182 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@182..183 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@183..192 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@192..195 "get" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@195..196 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@196..198 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@198..199 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@199..200 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@200..202 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
@@ -6,181 +6,161 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsGetterObjectMember {
-                                                get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@15..18 "foo" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@18..19 "(" [] [],
-                                                r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@21..22 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
-                                                            argument: JsReferenceIdentifierExpression {
-                                                                name_token: IDENT@33..36 "foo" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@36..37 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@40..41 "," [] [],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsGetterObjectMember {
+                                        get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@15..18 "foo" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsGetterObjectMember {
-                                                get_token: GET_KW@41..48 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: JS_STRING_LITERAL@48..53 "\"bar\"" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@53..54 "(" [] [],
-                                                r_paren_token: R_PAREN@54..56 ")" [] [Whitespace(" ")],
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@56..57 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@57..67 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                            argument: JsStringLiteralExpression {
-                                                                value_token: JS_STRING_LITERAL@67..72 "\"bar\"" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@72..73 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@73..76 "}" [Whitespace("\n ")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@76..77 "," [] [],
-                                            ),
-                                        },
-                                        AstSeparatedElement {
-                                            node: JsGetterObjectMember {
-                                                get_token: GET_KW@77..84 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@84..85 "[" [] [],
-                                                    expression: JsBinaryExpression {
-                                                        left: JsStringLiteralExpression {
-                                                            value_token: JS_STRING_LITERAL@85..89 "\"a\"" [] [Whitespace(" ")],
-                                                        },
-                                                        operator: PLUS@89..91 "+" [] [Whitespace(" ")],
+                                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                                        r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@21..22 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                    argument: JsReferenceIdentifierExpression {
+                                                        name_token: IDENT@33..36 "foo" [] [],
                                                     },
-                                                    r_brack_token: R_BRACK@94..95 "]" [] [],
+                                                    semicolon_token: SEMICOLON@36..37 ";" [] [],
                                                 },
-                                                l_paren_token: L_PAREN@95..96 "(" [] [],
-                                                r_paren_token: R_PAREN@96..98 ")" [] [Whitespace(" ")],
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@98..99 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@99..109 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                            argument: JsBinaryExpression {
-                                                                left: JsStringLiteralExpression {
-                                                                    value_token: JS_STRING_LITERAL@109..113 "\"a\"" [] [Whitespace(" ")],
-                                                                },
-                                                                operator: PLUS@113..115 "+" [] [Whitespace(" ")],
-                                                            },
-                                                            semicolon_token: missing (optional),
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@118..121 "}" [Whitespace("\n ")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@121..122 "," [] [],
-                                            ),
+                                            ],
+                                            r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsGetterObjectMember {
-                                                get_token: GET_KW@122..129 "get" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: JS_NUMBER_LITERAL@129..130 "5" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@130..131 "(" [] [],
-                                                r_paren_token: R_PAREN@131..133 ")" [] [Whitespace(" ")],
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@133..134 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@134..144 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                            argument: JsNumberLiteralExpression {
-                                                                value_token: JS_NUMBER_LITERAL@144..145 "5" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@145..146 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@149..150 "," [] [],
-                                            ),
+                                    }
+                                    COMMA@40..41 "," [] [],
+                                    JsGetterObjectMember {
+                                        get_token: GET_KW@41..48 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: JS_STRING_LITERAL@48..53 "\"bar\"" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@150..156 "get" [Whitespace("\n\n\t")] [],
+                                        l_paren_token: L_PAREN@53..54 "(" [] [],
+                                        r_paren_token: R_PAREN@54..56 ")" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@56..57 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@57..67 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                    argument: JsStringLiteralExpression {
+                                                        value_token: JS_STRING_LITERAL@67..72 "\"bar\"" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@72..73 ";" [] [],
                                                 },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@156..157 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@157..159 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@159..160 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@160..170 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                            argument: JsStringLiteralExpression {
-                                                                value_token: JS_STRING_LITERAL@170..205 "\"This is a method and not a getter\"" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@205..206 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@206..209 "}" [Whitespace("\n\t")] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                                            ],
+                                            r_curly_token: R_CURLY@73..76 "}" [Whitespace("\n ")] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@209..211 "}" [Whitespace("\n")] [],
-                                },
+                                    }
+                                    COMMA@76..77 "," [] [],
+                                    JsGetterObjectMember {
+                                        get_token: GET_KW@77..84 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@84..85 "[" [] [],
+                                            expression: JsBinaryExpression {
+                                                left: JsStringLiteralExpression {
+                                                    value_token: JS_STRING_LITERAL@85..89 "\"a\"" [] [Whitespace(" ")],
+                                                },
+                                                operator: PLUS@89..91 "+" [] [Whitespace(" ")],
+                                            },
+                                            r_brack_token: R_BRACK@94..95 "]" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@95..96 "(" [] [],
+                                        r_paren_token: R_PAREN@96..98 ")" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@98..99 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@99..109 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                    argument: JsBinaryExpression {
+                                                        left: JsStringLiteralExpression {
+                                                            value_token: JS_STRING_LITERAL@109..113 "\"a\"" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@113..115 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    semicolon_token: missing (optional),
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@118..121 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    COMMA@121..122 "," [] [],
+                                    JsGetterObjectMember {
+                                        get_token: GET_KW@122..129 "get" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@129..130 "5" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@130..131 "(" [] [],
+                                        r_paren_token: R_PAREN@131..133 ")" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@133..134 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@134..144 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                    argument: JsNumberLiteralExpression {
+                                                        value_token: JS_NUMBER_LITERAL@144..145 "5" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@145..146 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
+                                        },
+                                    }
+                                    COMMA@149..150 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@150..156 "get" [Whitespace("\n\n\t")] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@156..157 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@157..159 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@159..160 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@160..170 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                    argument: JsStringLiteralExpression {
+                                                        value_token: JS_STRING_LITERAL@170..205 "\"This is a method and not a getter\"" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@205..206 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@206..209 "}" [Whitespace("\n\t")] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@209..211 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
@@ -1,3 +1,407 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsGetterObjectMember(
+                                                                    JsGetterObjectMember {
+                                                                        get_token: Ok(
+                                                                            GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@15..18 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@18..19 "(" [] [],
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@21..22 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsReferenceIdentifierExpression(
+                                                                                                    JsReferenceIdentifierExpression {
+                                                                                                        name_token: Ok(
+                                                                                                            IDENT@33..36 "foo" [] [],
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@36..37 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@37..40 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@40..41 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsGetterObjectMember(
+                                                                    JsGetterObjectMember {
+                                                                        get_token: Ok(
+                                                                            GET_KW@41..48 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_STRING_LITERAL@48..53 "\"bar\"" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@53..54 "(" [] [],
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@54..56 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@56..57 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@57..67 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsAnyLiteralExpression(
+                                                                                                    JsStringLiteralExpression(
+                                                                                                        JsStringLiteralExpression {
+                                                                                                            value_token: Ok(
+                                                                                                                JS_STRING_LITERAL@67..72 "\"bar\"" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@72..73 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@73..76 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@76..77 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsGetterObjectMember(
+                                                                    JsGetterObjectMember {
+                                                                        get_token: Ok(
+                                                                            GET_KW@77..84 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@84..85 "[" [] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsBinaryExpression(
+                                                                                            JsBinaryExpression {
+                                                                                                left: Ok(
+                                                                                                    JsAnyLiteralExpression(
+                                                                                                        JsStringLiteralExpression(
+                                                                                                            JsStringLiteralExpression {
+                                                                                                                value_token: Ok(
+                                                                                                                    JS_STRING_LITERAL@85..89 "\"a\"" [] [Whitespace(" ")],
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ),
+                                                                                                operator: Ok(
+                                                                                                    PLUS@89..91 "+" [] [Whitespace(" ")],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@94..95 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@95..96 "(" [] [],
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@96..98 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@98..99 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@99..109 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsBinaryExpression(
+                                                                                                    JsBinaryExpression {
+                                                                                                        left: Ok(
+                                                                                                            JsAnyLiteralExpression(
+                                                                                                                JsStringLiteralExpression(
+                                                                                                                    JsStringLiteralExpression {
+                                                                                                                        value_token: Ok(
+                                                                                                                            JS_STRING_LITERAL@109..113 "\"a\"" [] [Whitespace(" ")],
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                            ),
+                                                                                                        ),
+                                                                                                        operator: Ok(
+                                                                                                            PLUS@113..115 "+" [] [Whitespace(" ")],
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@118..121 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@121..122 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsGetterObjectMember(
+                                                                    JsGetterObjectMember {
+                                                                        get_token: Ok(
+                                                                            GET_KW@122..129 "get" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_NUMBER_LITERAL@129..130 "5" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@130..131 "(" [] [],
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@131..133 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@133..134 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@134..144 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsAnyLiteralExpression(
+                                                                                                    JsNumberLiteralExpression(
+                                                                                                        JsNumberLiteralExpression {
+                                                                                                            value_token: Ok(
+                                                                                                                JS_NUMBER_LITERAL@144..145 "5" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@145..146 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@149..150 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@150..156 "get" [Whitespace("\n\n\t")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@156..157 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@157..159 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@159..160 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@160..170 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsAnyLiteralExpression(
+                                                                                                    JsStringLiteralExpression(
+                                                                                                        JsStringLiteralExpression {
+                                                                                                            value_token: Ok(
+                                                                                                                JS_STRING_LITERAL@170..205 "\"This is a method and not a getter\"" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@205..206 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@206..209 "}" [Whitespace("\n\t")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@209..211 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..212
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
@@ -1,404 +1,190 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsGetterObjectMember {
+                                                get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@15..18 "foo" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@18..19 "(" [] [],
+                                                r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@21..22 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                            argument: JsReferenceIdentifierExpression {
+                                                                name_token: IDENT@33..36 "foo" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@36..37 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsGetterObjectMember(
-                                                                    JsGetterObjectMember {
-                                                                        get_token: Ok(
-                                                                            GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@15..18 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@18..19 "(" [] [],
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@19..21 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@21..22 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsReferenceIdentifierExpression(
-                                                                                                    JsReferenceIdentifierExpression {
-                                                                                                        name_token: Ok(
-                                                                                                            IDENT@33..36 "foo" [] [],
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@36..37 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@37..40 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@40..41 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsGetterObjectMember(
-                                                                    JsGetterObjectMember {
-                                                                        get_token: Ok(
-                                                                            GET_KW@41..48 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_STRING_LITERAL@48..53 "\"bar\"" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@53..54 "(" [] [],
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@54..56 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@56..57 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@57..67 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsAnyLiteralExpression(
-                                                                                                    JsStringLiteralExpression(
-                                                                                                        JsStringLiteralExpression {
-                                                                                                            value_token: Ok(
-                                                                                                                JS_STRING_LITERAL@67..72 "\"bar\"" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@72..73 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@73..76 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@76..77 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsGetterObjectMember(
-                                                                    JsGetterObjectMember {
-                                                                        get_token: Ok(
-                                                                            GET_KW@77..84 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@84..85 "[" [] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsBinaryExpression(
-                                                                                            JsBinaryExpression {
-                                                                                                left: Ok(
-                                                                                                    JsAnyLiteralExpression(
-                                                                                                        JsStringLiteralExpression(
-                                                                                                            JsStringLiteralExpression {
-                                                                                                                value_token: Ok(
-                                                                                                                    JS_STRING_LITERAL@85..89 "\"a\"" [] [Whitespace(" ")],
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                ),
-                                                                                                operator: Ok(
-                                                                                                    PLUS@89..91 "+" [] [Whitespace(" ")],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@94..95 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@95..96 "(" [] [],
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@96..98 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@98..99 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@99..109 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsBinaryExpression(
-                                                                                                    JsBinaryExpression {
-                                                                                                        left: Ok(
-                                                                                                            JsAnyLiteralExpression(
-                                                                                                                JsStringLiteralExpression(
-                                                                                                                    JsStringLiteralExpression {
-                                                                                                                        value_token: Ok(
-                                                                                                                            JS_STRING_LITERAL@109..113 "\"a\"" [] [Whitespace(" ")],
-                                                                                                                        ),
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ),
-                                                                                                        ),
-                                                                                                        operator: Ok(
-                                                                                                            PLUS@113..115 "+" [] [Whitespace(" ")],
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: None,
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@118..121 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@121..122 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsGetterObjectMember(
-                                                                    JsGetterObjectMember {
-                                                                        get_token: Ok(
-                                                                            GET_KW@122..129 "get" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_NUMBER_LITERAL@129..130 "5" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@130..131 "(" [] [],
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@131..133 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@133..134 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@134..144 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsAnyLiteralExpression(
-                                                                                                    JsNumberLiteralExpression(
-                                                                                                        JsNumberLiteralExpression {
-                                                                                                            value_token: Ok(
-                                                                                                                JS_NUMBER_LITERAL@144..145 "5" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@145..146 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@149..150 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@150..156 "get" [Whitespace("\n\n\t")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@156..157 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@157..159 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@159..160 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@160..170 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsAnyLiteralExpression(
-                                                                                                    JsStringLiteralExpression(
-                                                                                                        JsStringLiteralExpression {
-                                                                                                            value_token: Ok(
-                                                                                                                JS_STRING_LITERAL@170..205 "\"This is a method and not a getter\"" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@205..206 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@206..209 "}" [Whitespace("\n\t")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@209..211 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@40..41 "," [] [],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsGetterObjectMember {
+                                                get_token: GET_KW@41..48 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: JS_STRING_LITERAL@48..53 "\"bar\"" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@53..54 "(" [] [],
+                                                r_paren_token: R_PAREN@54..56 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@56..57 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@57..67 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                            argument: JsStringLiteralExpression {
+                                                                value_token: JS_STRING_LITERAL@67..72 "\"bar\"" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@72..73 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@73..76 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@76..77 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsGetterObjectMember {
+                                                get_token: GET_KW@77..84 "get" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@84..85 "[" [] [],
+                                                    expression: JsBinaryExpression {
+                                                        left: JsStringLiteralExpression {
+                                                            value_token: JS_STRING_LITERAL@85..89 "\"a\"" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@89..91 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    r_brack_token: R_BRACK@94..95 "]" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@95..96 "(" [] [],
+                                                r_paren_token: R_PAREN@96..98 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@98..99 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@99..109 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                            argument: JsBinaryExpression {
+                                                                left: JsStringLiteralExpression {
+                                                                    value_token: JS_STRING_LITERAL@109..113 "\"a\"" [] [Whitespace(" ")],
+                                                                },
+                                                                operator: PLUS@113..115 "+" [] [Whitespace(" ")],
+                                                            },
+                                                            semicolon_token: missing (optional),
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@118..121 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@121..122 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsGetterObjectMember {
+                                                get_token: GET_KW@122..129 "get" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: JS_NUMBER_LITERAL@129..130 "5" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@130..131 "(" [] [],
+                                                r_paren_token: R_PAREN@131..133 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@133..134 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@134..144 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                            argument: JsNumberLiteralExpression {
+                                                                value_token: JS_NUMBER_LITERAL@144..145 "5" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@145..146 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@149..150 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@150..156 "get" [Whitespace("\n\n\t")] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@156..157 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@157..159 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@159..160 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@160..170 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                            argument: JsStringLiteralExpression {
+                                                                value_token: JS_STRING_LITERAL@170..205 "\"This is a method and not a getter\"" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@205..206 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@206..209 "}" [Whitespace("\n\t")] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@209..211 "}" [Whitespace("\n")] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -19,12 +19,10 @@ JsRoot {
                 arguments: ArgList {
                     l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
                     args: [
-                        AstSeparatedElement {
-                            node: JsReferenceIdentifierExpression {
-                                name_token: IDENT@9..12 "foo" [] [],
-                            },
-                            trailing_separator: None,
-                        },
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@9..12 "foo" [] [],
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@12..13 ")" [] [],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -1,3 +1,77 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    CallExpr(
+                        CallExpr {
+                            type_args: None,
+                            callee: Ok(
+                                JsParenthesizedExpression(
+                                    JsParenthesizedExpression {
+                                        l_paren_token: Ok(
+                                            L_PAREN@0..1 "(" [] [],
+                                        ),
+                                        expression: Ok(
+                                            JsParenthesizedExpression(
+                                                JsParenthesizedExpression {
+                                                    l_paren_token: Ok(
+                                                        L_PAREN@1..2 "(" [] [],
+                                                    ),
+                                                    expression: Ok(
+                                                        JsReferenceIdentifierExpression(
+                                                            JsReferenceIdentifierExpression {
+                                                                name_token: Ok(
+                                                                    IDENT@2..5 "foo" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    r_paren_token: Ok(
+                                                        R_PAREN@5..6 ")" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_paren_token: Ok(
+                                            R_PAREN@6..7 ")" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Ok(
+                                ArgList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                                    ),
+                                    args: [
+                                        AstSeparatedElement {
+                                            node: JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@9..12 "foo" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@12..13 ")" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -1,74 +1,36 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    CallExpr(
-                        CallExpr {
-                            type_args: None,
-                            callee: Ok(
-                                JsParenthesizedExpression(
-                                    JsParenthesizedExpression {
-                                        l_paren_token: Ok(
-                                            L_PAREN@0..1 "(" [] [],
-                                        ),
-                                        expression: Ok(
-                                            JsParenthesizedExpression(
-                                                JsParenthesizedExpression {
-                                                    l_paren_token: Ok(
-                                                        L_PAREN@1..2 "(" [] [],
-                                                    ),
-                                                    expression: Ok(
-                                                        JsReferenceIdentifierExpression(
-                                                            JsReferenceIdentifierExpression {
-                                                                name_token: Ok(
-                                                                    IDENT@2..5 "foo" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    r_paren_token: Ok(
-                                                        R_PAREN@5..6 ")" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_paren_token: Ok(
-                                            R_PAREN@6..7 ")" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arguments: Ok(
-                                ArgList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@7..9 "(" [Whitespace("\n")] [],
-                                    ),
-                                    args: [
-                                        AstSeparatedElement {
-                                            node: JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@9..12 "foo" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@12..13 ")" [] [],
-                                    ),
-                                },
-                            ),
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsParenthesizedExpression {
+                    l_paren_token: L_PAREN@0..1 "(" [] [],
+                    expression: JsParenthesizedExpression {
+                        l_paren_token: L_PAREN@1..2 "(" [] [],
+                        expression: JsReferenceIdentifierExpression {
+                            name_token: IDENT@2..5 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        r_paren_token: R_PAREN@5..6 ")" [] [],
+                    },
+                    r_paren_token: R_PAREN@6..7 ")" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                    args: [
+                        AstSeparatedElement {
+                            node: JsReferenceIdentifierExpression {
+                                name_token: IDENT@9..12 "foo" [] [],
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@12..13 ")" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -1,55 +1,25 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsReferenceIdentifierExpression(
-                        JsReferenceIdentifierExpression {
-                            name_token: Ok(
-                                IDENT@0..3 "foo" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@3..4 ";" [] [],
-                ),
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@0..3 "foo" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsReferenceIdentifierExpression(
-                        JsReferenceIdentifierExpression {
-                            name_token: Ok(
-                                IDENT@4..10 "yield" [Whitespace("\n")] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@10..11 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@3..4 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@4..10 "yield" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsReferenceIdentifierExpression(
-                        JsReferenceIdentifierExpression {
-                            name_token: Ok(
-                                IDENT@11..17 "await" [Whitespace("\n")] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@17..18 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@10..11 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@11..17 "await" [Whitespace("\n")] [],
             },
-        ),
+            semicolon_token: SEMICOLON@17..18 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -1,3 +1,58 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsReferenceIdentifierExpression(
+                        JsReferenceIdentifierExpression {
+                            name_token: Ok(
+                                IDENT@0..3 "foo" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@3..4 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsReferenceIdentifierExpression(
+                        JsReferenceIdentifierExpression {
+                            name_token: Ok(
+                                IDENT@4..10 "yield" [Whitespace("\n")] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@10..11 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsReferenceIdentifierExpression(
+                        JsReferenceIdentifierExpression {
+                            name_token: Ok(
+                                IDENT@11..17 "await" [Whitespace("\n")] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@17..18 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..19
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -1,3 +1,249 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsIfStatement(
+            JsIfStatement {
+                if_token: Ok(
+                    IF_KW@0..3 "if" [] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@3..4 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@4..8 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@8..10 ")" [] [Whitespace(" ")],
+                ),
+                consequent: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@10..11 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@11..13 "}" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                else_clause: Some(
+                    JsElseClause {
+                        else_token: Ok(
+                            ELSE_KW@13..18 "else" [] [Whitespace(" ")],
+                        ),
+                        alternate: Ok(
+                            JsBlockStatement(
+                                JsBlockStatement {
+                                    l_curly_token: Ok(
+                                        L_CURLY@18..19 "{" [] [],
+                                    ),
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@19..20 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsIfStatement(
+            JsIfStatement {
+                if_token: Ok(
+                    IF_KW@20..24 "if" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@24..25 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@25..29 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@29..31 ")" [] [Whitespace(" ")],
+                ),
+                consequent: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@31..32 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@32..33 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                else_clause: None,
+            },
+        ),
+        JsIfStatement(
+            JsIfStatement {
+                if_token: Ok(
+                    IF_KW@33..37 "if" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@37..38 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@38..42 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@42..44 ")" [] [Whitespace(" ")],
+                ),
+                consequent: Ok(
+                    JsExpressionStatement(
+                        JsExpressionStatement {
+                            expression: Ok(
+                                JsAnyLiteralExpression(
+                                    JsBooleanLiteralExpression(
+                                        JsBooleanLiteralExpression {
+                                            value_token: Ok(
+                                                FALSE_KW@44..49 "false" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                ),
+                else_clause: None,
+            },
+        ),
+        JsIfStatement(
+            JsIfStatement {
+                if_token: Ok(
+                    IF_KW@49..53 "if" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@53..54 "(" [] [],
+                ),
+                test: Ok(
+                    JsReferenceIdentifierExpression(
+                        JsReferenceIdentifierExpression {
+                            name_token: Ok(
+                                IDENT@54..57 "bar" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@57..59 ")" [] [Whitespace(" ")],
+                ),
+                consequent: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@59..60 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@60..62 "}" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                else_clause: Some(
+                    JsElseClause {
+                        else_token: Ok(
+                            ELSE_KW@62..67 "else" [] [Whitespace(" ")],
+                        ),
+                        alternate: Ok(
+                            JsIfStatement(
+                                JsIfStatement {
+                                    if_token: Ok(
+                                        IF_KW@67..70 "if" [] [Whitespace(" ")],
+                                    ),
+                                    l_paren_token: Ok(
+                                        L_PAREN@70..71 "(" [] [],
+                                    ),
+                                    test: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsBooleanLiteralExpression(
+                                                JsBooleanLiteralExpression {
+                                                    value_token: Ok(
+                                                        TRUE_KW@71..75 "true" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                    r_paren_token: Ok(
+                                        R_PAREN@75..77 ")" [] [Whitespace(" ")],
+                                    ),
+                                    consequent: Ok(
+                                        JsBlockStatement(
+                                            JsBlockStatement {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@77..78 "{" [] [],
+                                                ),
+                                                statements: [],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@78..80 "}" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    else_clause: Some(
+                                        JsElseClause {
+                                            else_token: Ok(
+                                                ELSE_KW@80..85 "else" [] [Whitespace(" ")],
+                                            ),
+                                            alternate: Ok(
+                                                JsBlockStatement(
+                                                    JsBlockStatement {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@85..86 "{" [] [],
+                                                        ),
+                                                        statements: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@86..87 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..88
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -1,246 +1,94 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsIfStatement(
-            JsIfStatement {
-                if_token: Ok(
-                    IF_KW@0..3 "if" [] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@3..4 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@4..8 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@8..10 ")" [] [Whitespace(" ")],
-                ),
-                consequent: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@10..11 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@11..13 "}" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                else_clause: Some(
-                    JsElseClause {
-                        else_token: Ok(
-                            ELSE_KW@13..18 "else" [] [Whitespace(" ")],
-                        ),
-                        alternate: Ok(
-                            JsBlockStatement(
-                                JsBlockStatement {
-                                    l_curly_token: Ok(
-                                        L_CURLY@18..19 "{" [] [],
-                                    ),
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@19..20 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        ),
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsBlockStatement {
+                l_curly_token: L_CURLY@10..11 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@11..13 "}" [] [Whitespace(" ")],
+            },
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@13..18 "else" [] [Whitespace(" ")],
+                alternate: JsBlockStatement {
+                    l_curly_token: L_CURLY@18..19 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@19..20 "}" [] [],
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@20..24 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@24..25 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@25..29 "true" [] [],
+            },
+            r_paren_token: R_PAREN@29..31 ")" [] [Whitespace(" ")],
+            consequent: JsBlockStatement {
+                l_curly_token: L_CURLY@31..32 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@32..33 "}" [] [],
+            },
+            else_clause: missing (optional),
+        },
+        JsIfStatement {
+            if_token: IF_KW@33..37 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@37..38 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@38..42 "true" [] [],
+            },
+            r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
+            consequent: JsExpressionStatement {
+                expression: JsBooleanLiteralExpression {
+                    value_token: FALSE_KW@44..49 "false" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+            else_clause: missing (optional),
+        },
+        JsIfStatement {
+            if_token: IF_KW@49..53 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@53..54 "(" [] [],
+            test: JsReferenceIdentifierExpression {
+                name_token: IDENT@54..57 "bar" [] [],
+            },
+            r_paren_token: R_PAREN@57..59 ")" [] [Whitespace(" ")],
+            consequent: JsBlockStatement {
+                l_curly_token: L_CURLY@59..60 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@60..62 "}" [] [Whitespace(" ")],
+            },
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@62..67 "else" [] [Whitespace(" ")],
+                alternate: JsIfStatement {
+                    if_token: IF_KW@67..70 "if" [] [Whitespace(" ")],
+                    l_paren_token: L_PAREN@70..71 "(" [] [],
+                    test: JsBooleanLiteralExpression {
+                        value_token: TRUE_KW@71..75 "true" [] [],
                     },
-                ),
-            },
-        ),
-        JsIfStatement(
-            JsIfStatement {
-                if_token: Ok(
-                    IF_KW@20..24 "if" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@24..25 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@25..29 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@29..31 ")" [] [Whitespace(" ")],
-                ),
-                consequent: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@31..32 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@32..33 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                else_clause: None,
-            },
-        ),
-        JsIfStatement(
-            JsIfStatement {
-                if_token: Ok(
-                    IF_KW@33..37 "if" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@37..38 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@38..42 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@42..44 ")" [] [Whitespace(" ")],
-                ),
-                consequent: Ok(
-                    JsExpressionStatement(
-                        JsExpressionStatement {
-                            expression: Ok(
-                                JsAnyLiteralExpression(
-                                    JsBooleanLiteralExpression(
-                                        JsBooleanLiteralExpression {
-                                            value_token: Ok(
-                                                FALSE_KW@44..49 "false" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                ),
-                else_clause: None,
-            },
-        ),
-        JsIfStatement(
-            JsIfStatement {
-                if_token: Ok(
-                    IF_KW@49..53 "if" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@53..54 "(" [] [],
-                ),
-                test: Ok(
-                    JsReferenceIdentifierExpression(
-                        JsReferenceIdentifierExpression {
-                            name_token: Ok(
-                                IDENT@54..57 "bar" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@57..59 ")" [] [Whitespace(" ")],
-                ),
-                consequent: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@59..60 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@60..62 "}" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                else_clause: Some(
-                    JsElseClause {
-                        else_token: Ok(
-                            ELSE_KW@62..67 "else" [] [Whitespace(" ")],
-                        ),
-                        alternate: Ok(
-                            JsIfStatement(
-                                JsIfStatement {
-                                    if_token: Ok(
-                                        IF_KW@67..70 "if" [] [Whitespace(" ")],
-                                    ),
-                                    l_paren_token: Ok(
-                                        L_PAREN@70..71 "(" [] [],
-                                    ),
-                                    test: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsBooleanLiteralExpression(
-                                                JsBooleanLiteralExpression {
-                                                    value_token: Ok(
-                                                        TRUE_KW@71..75 "true" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                    r_paren_token: Ok(
-                                        R_PAREN@75..77 ")" [] [Whitespace(" ")],
-                                    ),
-                                    consequent: Ok(
-                                        JsBlockStatement(
-                                            JsBlockStatement {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@77..78 "{" [] [],
-                                                ),
-                                                statements: [],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@78..80 "}" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    else_clause: Some(
-                                        JsElseClause {
-                                            else_token: Ok(
-                                                ELSE_KW@80..85 "else" [] [Whitespace(" ")],
-                                            ),
-                                            alternate: Ok(
-                                                JsBlockStatement(
-                                                    JsBlockStatement {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@85..86 "{" [] [],
-                                                        ),
-                                                        statements: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@86..87 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ),
-                        ),
+                    r_paren_token: R_PAREN@75..77 ")" [] [Whitespace(" ")],
+                    consequent: JsBlockStatement {
+                        l_curly_token: L_CURLY@77..78 "{" [] [],
+                        statements: [],
+                        r_curly_token: R_CURLY@78..80 "}" [] [Whitespace(" ")],
                     },
-                ),
+                    else_clause: JsElseClause {
+                        else_token: ELSE_KW@80..85 "else" [] [Whitespace(" ")],
+                        alternate: JsBlockStatement {
+                            l_curly_token: L_CURLY@85..86 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@86..87 "}" [] [],
+                        },
+                    },
+                },
             },
-        ),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -1,3 +1,41 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsImportCallExpression(
+                        JsImportCallExpression {
+                            import_token: Ok(
+                                IMPORT_KW@0..6 "import" [] [],
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@6..7 "(" [] [],
+                            ),
+                            argument: Ok(
+                                JsAnyLiteralExpression(
+                                    JsStringLiteralExpression(
+                                        JsStringLiteralExpression {
+                                            value_token: Ok(
+                                                JS_STRING_LITERAL@7..12 "\"foo\"" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@12..13 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -1,38 +1,18 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsImportCallExpression(
-                        JsImportCallExpression {
-                            import_token: Ok(
-                                IMPORT_KW@0..6 "import" [] [],
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@6..7 "(" [] [],
-                            ),
-                            argument: Ok(
-                                JsAnyLiteralExpression(
-                                    JsStringLiteralExpression(
-                                        JsStringLiteralExpression {
-                                            value_token: Ok(
-                                                JS_STRING_LITERAL@7..12 "\"foo\"" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@12..13 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsImportCallExpression {
+                import_token: IMPORT_KW@0..6 "import" [] [],
+                l_paren_token: L_PAREN@6..7 "(" [] [],
+                argument: JsStringLiteralExpression {
+                    value_token: JS_STRING_LITERAL@7..12 "\"foo\"" [] [],
+                },
+                r_paren_token: R_PAREN@12..13 ")" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -1,54 +1,23 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        ImportDecl(
-            ImportDecl {
-                import_token: Ok(
-                    IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
-                ),
-                imports: [
-                    WildcardImport(
-                        WildcardImport {
-                            star_token: Ok(
-                                STAR@7..9 "*" [] [Whitespace(" ")],
-                            ),
-                            as_token: Some(
-                                AS_KW@9..12 "as" [] [Whitespace(" ")],
-                            ),
-                            ident: None,
-                        },
-                    ),
-                ],
-                type_token: None,
-                from_token: Ok(
-                    FROM_KW@16..21 "from" [] [Whitespace(" ")],
-                ),
-                source_token: Ok(
-                    JS_STRING_LITERAL@21..26 "\"bla\"" [] [],
-                ),
-                asserted_object: Err(
-                    MissingRequiredChild(
-                        0: IMPORT_DECL@0..27
-                          0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
-                          1: LIST@7..16
-                            0: WILDCARD_IMPORT@7..16
-                              0: STAR@7..9 "*" [] [Whitespace(" ")]
-                              1: AS_KW@9..12 "as" [] [Whitespace(" ")]
-                              2: NAME@12..16
-                                0: IDENT@12..16 "foo" [] [Whitespace(" ")]
-                          2: FROM_KW@16..21 "from" [] [Whitespace(" ")]
-                          3: JS_STRING_LITERAL@21..26 "\"bla\"" [] []
-                          4: SEMICOLON@26..27 ";" [] []
-                        ,
-                    ),
-                ),
-                assert_token: None,
-                semicolon_token: Some(
-                    SEMICOLON@26..27 ";" [] [],
-                ),
-            },
-        ),
+        ImportDecl {
+            import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+            imports: [
+                WildcardImport {
+                    star_token: STAR@7..9 "*" [] [Whitespace(" ")],
+                    as_token: AS_KW@9..12 "as" [] [Whitespace(" ")],
+                    ident: missing (optional),
+                },
+            ],
+            type_token: missing (optional),
+            from_token: FROM_KW@16..21 "from" [] [Whitespace(" ")],
+            source_token: JS_STRING_LITERAL@21..26 "\"bla\"" [] [],
+            asserted_object: missing (required),
+            assert_token: missing (optional),
+            semicolon_token: SEMICOLON@26..27 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -1,3 +1,57 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        ImportDecl(
+            ImportDecl {
+                import_token: Ok(
+                    IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+                ),
+                imports: [
+                    WildcardImport(
+                        WildcardImport {
+                            star_token: Ok(
+                                STAR@7..9 "*" [] [Whitespace(" ")],
+                            ),
+                            as_token: Some(
+                                AS_KW@9..12 "as" [] [Whitespace(" ")],
+                            ),
+                            ident: None,
+                        },
+                    ),
+                ],
+                type_token: None,
+                from_token: Ok(
+                    FROM_KW@16..21 "from" [] [Whitespace(" ")],
+                ),
+                source_token: Ok(
+                    JS_STRING_LITERAL@21..26 "\"bla\"" [] [],
+                ),
+                asserted_object: Err(
+                    MissingRequiredChild(
+                        0: IMPORT_DECL@0..27
+                          0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
+                          1: LIST@7..16
+                            0: WILDCARD_IMPORT@7..16
+                              0: STAR@7..9 "*" [] [Whitespace(" ")]
+                              1: AS_KW@9..12 "as" [] [Whitespace(" ")]
+                              2: NAME@12..16
+                                0: IDENT@12..16 "foo" [] [Whitespace(" ")]
+                          2: FROM_KW@16..21 "from" [] [Whitespace(" ")]
+                          3: JS_STRING_LITERAL@21..26 "\"bla\"" [] []
+                          4: SEMICOLON@26..27 ";" [] []
+                        ,
+                    ),
+                ),
+                assert_token: None,
+                semicolon_token: Some(
+                    SEMICOLON@26..27 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..28
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -1,24 +1,14 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    ImportMeta(
-                        ImportMeta {
-                            import_token: Ok(
-                                IMPORT_KW@0..6 "import" [] [],
-                            ),
-                            dot_token: Ok(
-                                DOT@6..7 "." [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: ImportMeta {
+                import_token: IMPORT_KW@0..6 "import" [] [],
+                dot_token: DOT@6..7 "." [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -1,3 +1,27 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    ImportMeta(
+                        ImportMeta {
+                            import_token: Ok(
+                                IMPORT_KW@0..6 "import" [] [],
+                            ),
+                            dot_token: Ok(
+                                DOT@6..7 "." [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
@@ -19,12 +19,10 @@ JsRoot {
                 arguments: ArgList {
                     l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
                     args: [
-                        AstSeparatedElement {
-                            node: JsReferenceIdentifierExpression {
-                                name_token: IDENT@9..12 "foo" [] [],
-                            },
-                            trailing_separator: None,
-                        },
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@9..12 "foo" [] [],
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@12..13 ")" [] [],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
@@ -1,3 +1,77 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    CallExpr(
+                        CallExpr {
+                            type_args: None,
+                            callee: Ok(
+                                JsParenthesizedExpression(
+                                    JsParenthesizedExpression {
+                                        l_paren_token: Ok(
+                                            L_PAREN@0..1 "(" [] [],
+                                        ),
+                                        expression: Ok(
+                                            JsParenthesizedExpression(
+                                                JsParenthesizedExpression {
+                                                    l_paren_token: Ok(
+                                                        L_PAREN@1..2 "(" [] [],
+                                                    ),
+                                                    expression: Ok(
+                                                        JsReferenceIdentifierExpression(
+                                                            JsReferenceIdentifierExpression {
+                                                                name_token: Ok(
+                                                                    IDENT@2..5 "foo" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    r_paren_token: Ok(
+                                                        R_PAREN@5..6 ")" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_paren_token: Ok(
+                                            R_PAREN@6..7 ")" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Ok(
+                                ArgList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                                    ),
+                                    args: [
+                                        AstSeparatedElement {
+                                            node: JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@9..12 "foo" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@12..13 ")" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
@@ -1,74 +1,36 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    CallExpr(
-                        CallExpr {
-                            type_args: None,
-                            callee: Ok(
-                                JsParenthesizedExpression(
-                                    JsParenthesizedExpression {
-                                        l_paren_token: Ok(
-                                            L_PAREN@0..1 "(" [] [],
-                                        ),
-                                        expression: Ok(
-                                            JsParenthesizedExpression(
-                                                JsParenthesizedExpression {
-                                                    l_paren_token: Ok(
-                                                        L_PAREN@1..2 "(" [] [],
-                                                    ),
-                                                    expression: Ok(
-                                                        JsReferenceIdentifierExpression(
-                                                            JsReferenceIdentifierExpression {
-                                                                name_token: Ok(
-                                                                    IDENT@2..5 "foo" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    r_paren_token: Ok(
-                                                        R_PAREN@5..6 ")" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_paren_token: Ok(
-                                            R_PAREN@6..7 ")" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arguments: Ok(
-                                ArgList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@7..9 "(" [Whitespace("\n")] [],
-                                    ),
-                                    args: [
-                                        AstSeparatedElement {
-                                            node: JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@9..12 "foo" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@12..13 ")" [] [],
-                                    ),
-                                },
-                            ),
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsParenthesizedExpression {
+                    l_paren_token: L_PAREN@0..1 "(" [] [],
+                    expression: JsParenthesizedExpression {
+                        l_paren_token: L_PAREN@1..2 "(" [] [],
+                        expression: JsReferenceIdentifierExpression {
+                            name_token: IDENT@2..5 "foo" [] [],
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        r_paren_token: R_PAREN@5..6 ")" [] [],
+                    },
+                    r_paren_token: R_PAREN@6..7 ")" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                    args: [
+                        AstSeparatedElement {
+                            node: JsReferenceIdentifierExpression {
+                                name_token: IDENT@9..12 "foo" [] [],
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@12..13 ")" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
@@ -1,246 +1,90 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
-                            ),
-                            argument: Ok(
-                                JsComputedMemberExpression(
-                                    JsComputedMemberExpression {
-                                        object: Ok(
-                                            JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@7..8 "a" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        optional_chain_token_token: None,
-                                        l_brack_token: Ok(
-                                            L_BRACK@8..9 "[" [] [],
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@15..16 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@16..17 ";" [] [],
-                ),
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
+                argument: JsComputedMemberExpression {
+                    object: JsReferenceIdentifierExpression {
+                        name_token: IDENT@7..8 "a" [] [],
+                    },
+                    optional_chain_token_token: missing (optional),
+                    l_brack_token: L_BRACK@8..9 "[" [] [],
+                    r_brack_token: R_BRACK@15..16 "]" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                VOID_KW@17..23 "void" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            argument: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@23..24 "a" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@24..25 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: VOID_KW@17..23 "void" [Whitespace("\n")] [Whitespace(" ")],
+                argument: JsReferenceIdentifierExpression {
+                    name_token: IDENT@23..24 "a" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                TYPEOF_KW@25..33 "typeof" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            argument: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@33..34 "a" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@34..35 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@24..25 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: TYPEOF_KW@25..33 "typeof" [Whitespace("\n")] [Whitespace(" ")],
+                argument: JsReferenceIdentifierExpression {
+                    name_token: IDENT@33..34 "a" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                PLUS@35..37 "+" [Whitespace("\n")] [],
-                            ),
-                            argument: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@37..38 "1" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@38..39 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@34..35 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: PLUS@35..37 "+" [Whitespace("\n")] [],
+                argument: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@37..38 "1" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                MINUS@39..41 "-" [Whitespace("\n")] [],
-                            ),
-                            argument: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@41..42 "1" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@42..43 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@38..39 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: MINUS@39..41 "-" [Whitespace("\n")] [],
+                argument: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@41..42 "1" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                TILDE@43..45 "~" [Whitespace("\n")] [],
-                            ),
-                            argument: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@45..46 "1" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@46..47 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@42..43 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: TILDE@43..45 "~" [Whitespace("\n")] [],
+                argument: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@45..46 "1" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsUnaryExpression(
-                        JsUnaryExpression {
-                            operator: Ok(
-                                BANG@47..49 "!" [Whitespace("\n")] [],
-                            ),
-                            argument: Ok(
-                                JsAnyLiteralExpression(
-                                    JsBooleanLiteralExpression(
-                                        JsBooleanLiteralExpression {
-                                            value_token: Ok(
-                                                TRUE_KW@49..53 "true" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@53..54 ";" [] [],
-                ),
+            semicolon_token: SEMICOLON@46..47 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnaryExpression {
+                operator: BANG@47..49 "!" [Whitespace("\n")] [],
+                argument: JsBooleanLiteralExpression {
+                    value_token: TRUE_KW@49..53 "true" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsBinaryExpression(
-                        JsBinaryExpression {
-                            left: Ok(
-                                JsBinaryExpression(
-                                    JsBinaryExpression {
-                                        left: Ok(
-                                            JsUnaryExpression(
-                                                JsUnaryExpression {
-                                                    operator: Ok(
-                                                        MINUS@54..57 "-" [Whitespace("\n\n")] [],
-                                                    ),
-                                                    argument: Ok(
-                                                        JsReferenceIdentifierExpression(
-                                                            JsReferenceIdentifierExpression {
-                                                                name_token: Ok(
-                                                                    IDENT@57..59 "a" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        operator: Ok(
-                                            PLUS@59..61 "+" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                PLUS@64..66 "+" [] [Whitespace(" ")],
-                            ),
+            semicolon_token: SEMICOLON@53..54 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsBinaryExpression {
+                    left: JsUnaryExpression {
+                        operator: MINUS@54..57 "-" [Whitespace("\n\n")] [],
+                        argument: JsReferenceIdentifierExpression {
+                            name_token: IDENT@57..59 "a" [] [Whitespace(" ")],
                         },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@68..69 ";" [] [],
-                ),
+                    },
+                    operator: PLUS@59..61 "+" [] [Whitespace(" ")],
+                },
+                operator: PLUS@64..66 "+" [] [Whitespace(" ")],
             },
-        ),
+            semicolon_token: SEMICOLON@68..69 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
@@ -1,3 +1,249 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
+                            ),
+                            argument: Ok(
+                                JsComputedMemberExpression(
+                                    JsComputedMemberExpression {
+                                        object: Ok(
+                                            JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@7..8 "a" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        optional_chain_token_token: None,
+                                        l_brack_token: Ok(
+                                            L_BRACK@8..9 "[" [] [],
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@15..16 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@16..17 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                VOID_KW@17..23 "void" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            argument: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@23..24 "a" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@24..25 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                TYPEOF_KW@25..33 "typeof" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            argument: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@33..34 "a" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@34..35 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                PLUS@35..37 "+" [Whitespace("\n")] [],
+                            ),
+                            argument: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@37..38 "1" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@38..39 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                MINUS@39..41 "-" [Whitespace("\n")] [],
+                            ),
+                            argument: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@41..42 "1" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@42..43 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                TILDE@43..45 "~" [Whitespace("\n")] [],
+                            ),
+                            argument: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@45..46 "1" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@46..47 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsUnaryExpression(
+                        JsUnaryExpression {
+                            operator: Ok(
+                                BANG@47..49 "!" [Whitespace("\n")] [],
+                            ),
+                            argument: Ok(
+                                JsAnyLiteralExpression(
+                                    JsBooleanLiteralExpression(
+                                        JsBooleanLiteralExpression {
+                                            value_token: Ok(
+                                                TRUE_KW@49..53 "true" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@53..54 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsBinaryExpression(
+                        JsBinaryExpression {
+                            left: Ok(
+                                JsBinaryExpression(
+                                    JsBinaryExpression {
+                                        left: Ok(
+                                            JsUnaryExpression(
+                                                JsUnaryExpression {
+                                                    operator: Ok(
+                                                        MINUS@54..57 "-" [Whitespace("\n\n")] [],
+                                                    ),
+                                                    argument: Ok(
+                                                        JsReferenceIdentifierExpression(
+                                                            JsReferenceIdentifierExpression {
+                                                                name_token: Ok(
+                                                                    IDENT@57..59 "a" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        operator: Ok(
+                                            PLUS@59..61 "+" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                PLUS@64..66 "+" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@68..69 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..70
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -1,119 +1,49 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsNumberLiteralExpression(
-                            JsNumberLiteralExpression {
-                                value_token: Ok(
-                                    JS_NUMBER_LITERAL@0..1 "5" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsNumberLiteralExpression {
+                value_token: JS_NUMBER_LITERAL@0..1 "5" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@1..6 "true" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@1..6 "true" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    FALSE_KW@6..12 "false" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBooleanLiteralExpression {
+                value_token: FALSE_KW@6..12 "false" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsBigIntLiteralExpression(
-                            JsBigIntLiteralExpression {
-                                value_token: Ok(
-                                    JS_BIG_INT_LITERAL@12..15 "5n" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBigIntLiteralExpression {
+                value_token: JS_BIG_INT_LITERAL@12..15 "5n" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsStringLiteralExpression(
-                            JsStringLiteralExpression {
-                                value_token: Ok(
-                                    JS_STRING_LITERAL@15..21 "\"foo\"" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStringLiteralExpression {
+                value_token: JS_STRING_LITERAL@15..21 "\"foo\"" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsStringLiteralExpression(
-                            JsStringLiteralExpression {
-                                value_token: Ok(
-                                    JS_STRING_LITERAL@21..27 "'bar'" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStringLiteralExpression {
+                value_token: JS_STRING_LITERAL@21..27 "'bar'" [Whitespace("\n")] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsAnyLiteralExpression(
-                        JsNullLiteralExpression(
-                            JsNullLiteralExpression {
-                                value_token: Ok(
-                                    NULL_KW@27..32 "null" [Whitespace("\n")] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsNullLiteralExpression {
+                value_token: NULL_KW@27..32 "null" [Whitespace("\n")] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -1,3 +1,122 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsNumberLiteralExpression(
+                            JsNumberLiteralExpression {
+                                value_token: Ok(
+                                    JS_NUMBER_LITERAL@0..1 "5" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@1..6 "true" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    FALSE_KW@6..12 "false" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsBigIntLiteralExpression(
+                            JsBigIntLiteralExpression {
+                                value_token: Ok(
+                                    JS_BIG_INT_LITERAL@12..15 "5n" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsStringLiteralExpression(
+                            JsStringLiteralExpression {
+                                value_token: Ok(
+                                    JS_STRING_LITERAL@15..21 "\"foo\"" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsStringLiteralExpression(
+                            JsStringLiteralExpression {
+                                value_token: Ok(
+                                    JS_STRING_LITERAL@21..27 "'bar'" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsAnyLiteralExpression(
+                        JsNullLiteralExpression(
+                            JsNullLiteralExpression {
+                                value_token: Ok(
+                                    NULL_KW@27..32 "null" [Whitespace("\n")] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..33
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
@@ -1,76 +1,34 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsLogicalExpression(
-                        JsLogicalExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTION2@4..7 "??" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
+                },
+                operator: QUESTION2@4..7 "??" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsLogicalExpression(
-                        JsLogicalExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@10..13 "a" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                PIPE2@13..16 "||" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@10..13 "a" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: PIPE2@13..16 "||" [] [Whitespace(" ")],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsLogicalExpression(
-                        JsLogicalExpression {
-                            left: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@17..20 "a" [Whitespace("\n")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                AMP2@20..23 "&&" [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@17..20 "a" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: AMP2@20..23 "&&" [] [Whitespace(" ")],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
@@ -1,3 +1,79 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsLogicalExpression(
+                        JsLogicalExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..4 "foo" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTION2@4..7 "??" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsLogicalExpression(
+                        JsLogicalExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@10..13 "a" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                PIPE2@13..16 "||" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsLogicalExpression(
+                        JsLogicalExpression {
+                            left: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@17..20 "a" [Whitespace("\n")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                AMP2@20..23 "&&" [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..25
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
@@ -221,7 +221,9 @@ JsRoot {
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
-                    name: missing (required),
+                    name: JsLiteralMemberName {
+                        value: IDENT@196..230 "static" [Whitespace("\n\t"), Comments("// Methods called static"), Whitespace("\n\t")] [],
+                    },
                     type_parameters: missing (optional),
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@230..231 "(" [] [],
@@ -702,7 +704,8 @@ JsRoot {
       2: L_CURLY@195..196 "{" [] []
       3: LIST@196..367
         0: JS_METHOD_CLASS_MEMBER@196..235
-          0: IDENT@196..230 "static" [Whitespace("\n\t"), Comments("// Methods called static"), Whitespace("\n\t")] []
+          0: JS_LITERAL_MEMBER_NAME@196..230
+            0: IDENT@196..230 "static" [Whitespace("\n\t"), Comments("// Methods called static"), Whitespace("\n\t")] []
           1: JS_PARAMETER_LIST@230..233
             0: L_PAREN@230..231 "(" [] []
             1: LIST@231..231

--- a/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
@@ -1,1149 +1,578 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..11 "Test" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@11..12 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@12..20 "method" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@20..21 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@21..23 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@23..24 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@24..25 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@25..33 "async" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@33..44 "asyncMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@44..45 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@45..47 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@47..48 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@48..49 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@49..56 "async" [Whitespace("\n\t")] [],
-                            ),
-                            star_token: Some(
-                                STAR@56..58 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@58..78 "asyncGeneratorMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@78..79 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@79..81 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@81..82 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@82..83 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: Some(
-                                STAR@83..87 "*" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@87..102 "generatorMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@102..103 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@103..105 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@105..106 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@106..107 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_STRING_LITERAL@107..115 "\"foo\"" [Whitespace("\n\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@115..116 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@116..118 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@118..119 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@119..120 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsComputedMemberName(
-                                    JsComputedMemberName {
-                                        l_brack_token: Ok(
-                                            L_BRACK@120..123 "[" [Whitespace("\n\t")] [],
-                                        ),
-                                        expression: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@123..129 "\"foo\"" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@129..131 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@136..137 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@137..138 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@138..140 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@140..141 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@141..142 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_NUMBER_LITERAL@142..145 "5" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@145..146 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@146..148 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@148..149 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@149..150 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@150..154 "#" [Whitespace("\n\n\t")] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@154..161 "private" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@161..162 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@162..164 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@164..165 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@165..166 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@166..168 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..11 "Test" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@168..176 "class" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@176..195 "ContextualKeywords" [] [Whitespace(" ")],
-                        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@11..12 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@12..20 "method" [Whitespace("\n\t")] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@195..196 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Err(
-                                MissingRequiredChild(
-                                    0: JS_METHOD_CLASS_MEMBER@196..235
-                                      0: IDENT@196..230 "static" [Whitespace("\n\t"), Comments("// Methods called static"), Whitespace("\n\t")] []
-                                      1: JS_PARAMETER_LIST@230..233
-                                        0: L_PAREN@230..231 "(" [] []
-                                        1: LIST@231..231
-                                        2: R_PAREN@231..233 ")" [] [Whitespace(" ")]
-                                      2: JS_FUNCTION_BODY@233..235
-                                        0: L_CURLY@233..234 "{" [] []
-                                        1: LIST@234..234
-                                        2: LIST@234..234
-                                        3: R_CURLY@234..235 "}" [] []
-                                    ,
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@230..231 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@231..233 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@233..234 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@234..235 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@235..243 "async" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@243..249 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@249..250 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@250..252 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@252..253 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@253..254 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: Some(
-                                STAR@254..258 "*" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@258..264 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@264..265 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@265..267 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@267..268 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@268..269 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@269..276 "async" [Whitespace("\n\t")] [],
-                            ),
-                            star_token: Some(
-                                STAR@276..278 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@278..284 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@284..285 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@285..287 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@287..288 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@288..289 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@289..299 "declare" [Whitespace("\n\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@299..300 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@300..302 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@302..303 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@303..304 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@304..310 "get" [Whitespace("\n\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@310..311 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@311..313 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@313..314 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@314..336 "}" [] [Whitespace(" "), Comments("// Method called get")],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@336..341 "set" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@341..342 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@342..344 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@344..345 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@345..367 "}" [] [Whitespace(" "), Comments("// Method called set")],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@367..369 "}" [Whitespace("\n")] [],
-                ),
-            },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@369..377 "class" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@377..384 "Static" [] [Whitespace(" ")],
-                        ),
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@20..21 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@21..23 ")" [] [Whitespace(" ")],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@384..385 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@385..394 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@394..400 "method" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@400..401 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@401..403 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@403..404 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@404..405 "}" [] [],
-                                    ),
-                                },
-                            ),
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@23..24 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@24..25 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@25..33 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@33..44 "asyncMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@44..45 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@45..47 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@47..48 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@48..49 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@49..56 "async" [Whitespace("\n\t")] [],
+                    star_token: STAR@56..58 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@58..78 "asyncGeneratorMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@78..79 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@79..81 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@81..82 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@82..83 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@83..87 "*" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@87..102 "generatorMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@102..103 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@103..105 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@105..106 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@106..107 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@107..115 "\"foo\"" [Whitespace("\n\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@115..116 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@116..118 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@118..119 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@119..120 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@120..123 "[" [Whitespace("\n\t")] [],
+                        expression: JsBinaryExpression {
+                            left: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@123..129 "\"foo\"" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@129..131 "+" [] [Whitespace(" ")],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@405..414 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@414..420 "async" [] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@420..431 "asyncMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@431..432 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@432..434 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@434..435 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@435..436 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@436..445 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@445..450 "async" [] [],
-                            ),
-                            star_token: Some(
-                                STAR@450..452 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@452..472 "asyncGeneratorMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@472..473 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@473..475 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@475..476 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@476..477 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@477..486 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: Some(
-                                STAR@486..488 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@488..503 "generatorMethod" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@503..504 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@504..506 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@506..507 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@507..508 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@508..518 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@518..524 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@524..525 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@525..527 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@527..528 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@528..529 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@529..538 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@538..544 "async" [] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@544..550 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@550..551 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@551..553 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@553..554 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@554..555 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@555..564 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@564..569 "async" [] [],
-                            ),
-                            star_token: Some(
-                                STAR@569..571 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@571..577 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@577..578 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@578..580 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@580..581 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@581..582 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@582..591 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: Some(
-                                STAR@591..593 "*" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@593..599 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@599..600 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@600..602 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@602..603 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@603..604 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@604..606 "}" [Whitespace("\n")] [],
-                ),
+                        r_brack_token: R_BRACK@136..137 "]" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@137..138 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@138..140 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@140..141 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@141..142 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@142..145 "5" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@145..146 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@146..148 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@148..149 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@149..150 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@150..154 "#" [Whitespace("\n\n\t")] [],
+                        id_token: IDENT@154..161 "private" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@161..162 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@162..164 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@164..165 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@165..166 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@166..168 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@168..176 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@176..195 "ContextualKeywords" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@195..196 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: missing (required),
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@230..231 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@231..233 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@233..234 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@234..235 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@235..243 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@243..249 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@249..250 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@250..252 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@252..253 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@253..254 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@254..258 "*" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@258..264 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@264..265 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@265..267 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@267..268 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@268..269 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@269..276 "async" [Whitespace("\n\t")] [],
+                    star_token: STAR@276..278 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@278..284 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@284..285 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@285..287 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@287..288 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@288..289 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@289..299 "declare" [Whitespace("\n\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@299..300 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@300..302 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@302..303 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@303..304 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@304..310 "get" [Whitespace("\n\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@310..311 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@311..313 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@313..314 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@314..336 "}" [] [Whitespace(" "), Comments("// Method called get")],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@336..341 "set" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@341..342 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@342..344 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@344..345 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@345..367 "}" [] [Whitespace(" "), Comments("// Method called set")],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@367..369 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@369..377 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@377..384 "Static" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@384..385 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@385..394 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@394..400 "method" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@400..401 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@401..403 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@403..404 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@404..405 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@405..414 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@414..420 "async" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@420..431 "asyncMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@431..432 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@432..434 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@434..435 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@435..436 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@436..445 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@445..450 "async" [] [],
+                    star_token: STAR@450..452 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@452..472 "asyncGeneratorMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@472..473 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@473..475 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@475..476 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@476..477 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@477..486 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@486..488 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@488..503 "generatorMethod" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@503..504 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@504..506 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@506..507 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@507..508 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@508..518 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@518..524 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@524..525 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@525..527 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@527..528 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@528..529 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@529..538 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@538..544 "async" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@544..550 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@550..551 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@551..553 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@553..554 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@554..555 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@555..564 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@564..569 "async" [] [],
+                    star_token: STAR@569..571 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@571..577 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@577..578 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@578..580 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@580..581 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@581..582 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@582..591 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@591..593 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@593..599 "static" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@599..600 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@600..602 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@602..603 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@603..604 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@604..606 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
@@ -1,3 +1,1152 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..11 "Test" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@11..12 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@12..20 "method" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@20..21 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@23..24 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@24..25 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@25..33 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@33..44 "asyncMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@44..45 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@45..47 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@47..48 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@48..49 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@49..56 "async" [Whitespace("\n\t")] [],
+                            ),
+                            star_token: Some(
+                                STAR@56..58 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@58..78 "asyncGeneratorMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@78..79 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@79..81 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@81..82 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@82..83 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: Some(
+                                STAR@83..87 "*" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@87..102 "generatorMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@102..103 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@103..105 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@105..106 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@106..107 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_STRING_LITERAL@107..115 "\"foo\"" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@115..116 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@116..118 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@118..119 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@119..120 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsComputedMemberName(
+                                    JsComputedMemberName {
+                                        l_brack_token: Ok(
+                                            L_BRACK@120..123 "[" [Whitespace("\n\t")] [],
+                                        ),
+                                        expression: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@123..129 "\"foo\"" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@129..131 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@136..137 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@137..138 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@138..140 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@140..141 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@141..142 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_NUMBER_LITERAL@142..145 "5" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@145..146 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@146..148 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@148..149 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@149..150 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@150..154 "#" [Whitespace("\n\n\t")] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@154..161 "private" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@161..162 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@162..164 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@164..165 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@165..166 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@166..168 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@168..176 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@176..195 "ContextualKeywords" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@195..196 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Err(
+                                MissingRequiredChild(
+                                    0: JS_METHOD_CLASS_MEMBER@196..235
+                                      0: IDENT@196..230 "static" [Whitespace("\n\t"), Comments("// Methods called static"), Whitespace("\n\t")] []
+                                      1: JS_PARAMETER_LIST@230..233
+                                        0: L_PAREN@230..231 "(" [] []
+                                        1: LIST@231..231
+                                        2: R_PAREN@231..233 ")" [] [Whitespace(" ")]
+                                      2: JS_FUNCTION_BODY@233..235
+                                        0: L_CURLY@233..234 "{" [] []
+                                        1: LIST@234..234
+                                        2: LIST@234..234
+                                        3: R_CURLY@234..235 "}" [] []
+                                    ,
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@230..231 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@231..233 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@233..234 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@234..235 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@235..243 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@243..249 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@249..250 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@250..252 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@252..253 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@253..254 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: Some(
+                                STAR@254..258 "*" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@258..264 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@264..265 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@265..267 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@267..268 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@268..269 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@269..276 "async" [Whitespace("\n\t")] [],
+                            ),
+                            star_token: Some(
+                                STAR@276..278 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@278..284 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@284..285 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@285..287 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@287..288 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@288..289 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@289..299 "declare" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@299..300 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@300..302 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@302..303 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@303..304 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@304..310 "get" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@310..311 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@311..313 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@313..314 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@314..336 "}" [] [Whitespace(" "), Comments("// Method called get")],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@336..341 "set" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@341..342 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@342..344 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@344..345 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@345..367 "}" [] [Whitespace(" "), Comments("// Method called set")],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@367..369 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@369..377 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@377..384 "Static" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@384..385 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@385..394 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@394..400 "method" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@400..401 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@401..403 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@403..404 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@404..405 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@405..414 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@414..420 "async" [] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@420..431 "asyncMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@431..432 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@432..434 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@434..435 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@435..436 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@436..445 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@445..450 "async" [] [],
+                            ),
+                            star_token: Some(
+                                STAR@450..452 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@452..472 "asyncGeneratorMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@472..473 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@473..475 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@475..476 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@476..477 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@477..486 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: Some(
+                                STAR@486..488 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@488..503 "generatorMethod" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@503..504 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@504..506 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@506..507 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@507..508 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@508..518 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@518..524 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@524..525 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@525..527 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@527..528 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@528..529 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@529..538 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@538..544 "async" [] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@544..550 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@550..551 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@551..553 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@553..554 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@554..555 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@555..564 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@564..569 "async" [] [],
+                            ),
+                            star_token: Some(
+                                STAR@569..571 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@571..577 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@577..578 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@578..580 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@580..581 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@581..582 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@582..591 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: Some(
+                                STAR@591..593 "*" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@593..599 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@599..600 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@600..602 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@602..603 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@603..604 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@604..606 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..607
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -1,69 +1,37 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsGetterClassMember(
-                        JsGetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            get_token: Ok(
-                                GET_KW@11..17 "get" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@17..20 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@20..21 "(" [] [],
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@21..23 ")" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@23..24 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@24..25 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@25..27 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@11..17 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@17..20 "bar" [] [],
+                    },
+                    l_paren_token: L_PAREN@20..21 "(" [] [],
+                    r_paren_token: R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@23..24 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@24..25 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@25..27 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/method_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_getter.rast
@@ -1,3 +1,72 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsGetterClassMember(
+                        JsGetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            get_token: Ok(
+                                GET_KW@11..17 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@17..20 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@20..21 "(" [] [],
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@23..24 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@24..25 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@25..27 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..28
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -1,3 +1,87 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@11..17 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@17..20 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@20..21 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@21..22 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@24..25 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@25..26 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@26..28 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..29
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/method_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_setter.rast
@@ -1,84 +1,44 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@11..17 "set" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@17..20 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@20..21 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@21..22 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@22..24 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@24..25 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@25..26 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@26..28 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@11..17 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@17..20 "bar" [] [],
+                    },
+                    l_paren_token: L_PAREN@20..21 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@21..22 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@24..25 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@25..26 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@26..28 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -1,3 +1,339 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    NewExpr(
+                        NewExpr {
+                            new_token: Ok(
+                                NEW_KW@0..4 "new" [] [Whitespace(" ")],
+                            ),
+                            type_args: None,
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@4..7 "Foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Ok(
+                                ArgList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@7..8 "(" [] [],
+                                    ),
+                                    args: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@8..9 ")" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    NewExpr(
+                        NewExpr {
+                            new_token: Ok(
+                                NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            type_args: None,
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@14..17 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Err(
+                                MissingRequiredChild(
+                                    0: NEW_EXPR@9..17
+                                      0: NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")]
+                                      1: JS_REFERENCE_IDENTIFIER_EXPRESSION@14..17
+                                        0: IDENT@14..17 "foo" [] []
+                                    ,
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@17..18 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    NewTarget(
+                        NewTarget {
+                            new_token: Ok(
+                                NEW_KW@18..22 "new" [Whitespace("\n")] [],
+                            ),
+                            dot_token: Ok(
+                                DOT@22..23 "." [] [],
+                            ),
+                            target_token: Err(
+                                MissingRequiredChild(
+                                    0: NEW_TARGET@18..29
+                                      0: NEW_KW@18..22 "new" [Whitespace("\n")] []
+                                      1: DOT@22..23 "." [] []
+                                      2: IDENT@23..29 "target" [] []
+                                    ,
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    NewExpr(
+                        NewExpr {
+                            new_token: Ok(
+                                NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            type_args: None,
+                            object: Ok(
+                                NewExpr(
+                                    NewExpr {
+                                        new_token: Ok(
+                                            NEW_KW@34..38 "new" [] [Whitespace(" ")],
+                                        ),
+                                        type_args: None,
+                                        object: Ok(
+                                            NewExpr(
+                                                NewExpr {
+                                                    new_token: Ok(
+                                                        NEW_KW@38..42 "new" [] [Whitespace(" ")],
+                                                    ),
+                                                    type_args: None,
+                                                    object: Ok(
+                                                        NewExpr(
+                                                            NewExpr {
+                                                                new_token: Ok(
+                                                                    NEW_KW@42..46 "new" [] [Whitespace(" ")],
+                                                                ),
+                                                                type_args: None,
+                                                                object: Ok(
+                                                                    JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@46..49 "Foo" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                arguments: Ok(
+                                                                    ArgList {
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@49..50 "(" [] [],
+                                                                        ),
+                                                                        args: [],
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@50..51 ")" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    arguments: Err(
+                                                        MissingRequiredChild(
+                                                            1: NEW_EXPR@38..51
+                                                              0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
+                                                              1: NEW_EXPR@42..51
+                                                                0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
+                                                                1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
+                                                                  0: IDENT@46..49 "Foo" [] []
+                                                                2: ARG_LIST@49..51
+                                                                  0: L_PAREN@49..50 "(" [] []
+                                                                  1: LIST@50..50
+                                                                  2: R_PAREN@50..51 ")" [] []
+                                                            ,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        arguments: Err(
+                                            MissingRequiredChild(
+                                                1: NEW_EXPR@34..51
+                                                  0: NEW_KW@34..38 "new" [] [Whitespace(" ")]
+                                                  1: NEW_EXPR@38..51
+                                                    0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
+                                                    1: NEW_EXPR@42..51
+                                                      0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
+                                                      1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
+                                                        0: IDENT@46..49 "Foo" [] []
+                                                      2: ARG_LIST@49..51
+                                                        0: L_PAREN@49..50 "(" [] []
+                                                        1: LIST@50..50
+                                                        2: R_PAREN@50..51 ")" [] []
+                                                ,
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Err(
+                                MissingRequiredChild(
+                                    0: NEW_EXPR@29..51
+                                      0: NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")]
+                                      1: NEW_EXPR@34..51
+                                        0: NEW_KW@34..38 "new" [] [Whitespace(" ")]
+                                        1: NEW_EXPR@38..51
+                                          0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
+                                          1: NEW_EXPR@42..51
+                                            0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
+                                            1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
+                                              0: IDENT@46..49 "Foo" [] []
+                                            2: ARG_LIST@49..51
+                                              0: L_PAREN@49..50 "(" [] []
+                                              1: LIST@50..50
+                                              2: R_PAREN@50..51 ")" [] []
+                                    ,
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@51..52 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    NewExpr(
+                        NewExpr {
+                            new_token: Ok(
+                                NEW_KW@52..57 "new" [Whitespace("\n")] [Whitespace(" ")],
+                            ),
+                            type_args: None,
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@57..60 "Foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Ok(
+                                ArgList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@60..61 "(" [] [],
+                                    ),
+                                    args: [
+                                        AstSeparatedElement {
+                                            node: JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@61..64 "bar" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: Some(
+                                                COMMA@64..66 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsReferenceIdentifierExpression(
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: Ok(
+                                                        IDENT@66..69 "baz" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: Some(
+                                                COMMA@69..71 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsNumberLiteralExpression(
+                                                                JsNumberLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@73..75 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: Some(
+                                                COMMA@76..78 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsComputedMemberExpression(
+                                                            JsComputedMemberExpression {
+                                                                object: Ok(
+                                                                    JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@78..81 "foo" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                optional_chain_token_token: None,
+                                                                l_brack_token: Ok(
+                                                                    L_BRACK@81..82 "[" [] [],
+                                                                ),
+                                                                r_brack_token: Ok(
+                                                                    R_BRACK@85..87 "]" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@87..89 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@111..112 ")" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..113
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -76,47 +76,33 @@ JsRoot {
                 arguments: ArgList {
                     l_paren_token: L_PAREN@60..61 "(" [] [],
                     args: [
-                        AstSeparatedElement {
-                            node: JsReferenceIdentifierExpression {
-                                name_token: IDENT@61..64 "bar" [] [],
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@61..64 "bar" [] [],
+                        }
+                        COMMA@64..66 "," [] [Whitespace(" ")],
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@66..69 "baz" [] [],
+                        }
+                        COMMA@69..71 "," [] [Whitespace(" ")],
+                        JsBinaryExpression {
+                            left: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
                             },
-                            trailing_separator: Some(
-                                COMMA@64..66 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: JsReferenceIdentifierExpression {
-                                name_token: IDENT@66..69 "baz" [] [],
-                            },
-                            trailing_separator: Some(
-                                COMMA@69..71 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: JsBinaryExpression {
-                                left: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
+                            operator: PLUS@73..75 "+" [] [Whitespace(" ")],
+                        }
+                        COMMA@76..78 "," [] [Whitespace(" ")],
+                        JsBinaryExpression {
+                            left: JsComputedMemberExpression {
+                                object: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@78..81 "foo" [] [],
                                 },
-                                operator: PLUS@73..75 "+" [] [Whitespace(" ")],
+                                optional_chain_token_token: missing (optional),
+                                l_brack_token: L_BRACK@81..82 "[" [] [],
+                                r_brack_token: R_BRACK@85..87 "]" [] [Whitespace(" ")],
                             },
-                            trailing_separator: Some(
-                                COMMA@76..78 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: JsBinaryExpression {
-                                left: JsComputedMemberExpression {
-                                    object: JsReferenceIdentifierExpression {
-                                        name_token: IDENT@78..81 "foo" [] [],
-                                    },
-                                    optional_chain_token_token: missing (optional),
-                                    l_brack_token: L_BRACK@81..82 "[" [] [],
-                                    r_brack_token: R_BRACK@85..87 "]" [] [Whitespace(" ")],
-                                },
-                                operator: PLUS@87..89 "+" [] [Whitespace(" ")],
-                            },
-                            trailing_separator: None,
-                        },
+                            operator: PLUS@87..89 "+" [] [Whitespace(" ")],
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@111..112 ")" [] [],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -1,336 +1,128 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    NewExpr(
-                        NewExpr {
-                            new_token: Ok(
-                                NEW_KW@0..4 "new" [] [Whitespace(" ")],
+        JsExpressionStatement {
+            expression: NewExpr {
+                new_token: NEW_KW@0..4 "new" [] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@4..7 "Foo" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@7..8 "(" [] [],
+                    args: [],
+                    r_paren_token: R_PAREN@8..9 ")" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: NewExpr {
+                new_token: NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@14..17 "foo" [] [],
+                },
+                arguments: missing (required),
+            },
+            semicolon_token: SEMICOLON@17..18 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: NewTarget {
+                new_token: NEW_KW@18..22 "new" [Whitespace("\n")] [],
+                dot_token: DOT@22..23 "." [] [],
+                target_token: missing (required),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: NewExpr {
+                new_token: NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: NewExpr {
+                    new_token: NEW_KW@34..38 "new" [] [Whitespace(" ")],
+                    type_args: missing (optional),
+                    object: NewExpr {
+                        new_token: NEW_KW@38..42 "new" [] [Whitespace(" ")],
+                        type_args: missing (optional),
+                        object: NewExpr {
+                            new_token: NEW_KW@42..46 "new" [] [Whitespace(" ")],
+                            type_args: missing (optional),
+                            object: JsReferenceIdentifierExpression {
+                                name_token: IDENT@46..49 "Foo" [] [],
+                            },
+                            arguments: ArgList {
+                                l_paren_token: L_PAREN@49..50 "(" [] [],
+                                args: [],
+                                r_paren_token: R_PAREN@50..51 ")" [] [],
+                            },
+                        },
+                        arguments: missing (required),
+                    },
+                    arguments: missing (required),
+                },
+                arguments: missing (required),
+            },
+            semicolon_token: SEMICOLON@51..52 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: NewExpr {
+                new_token: NEW_KW@52..57 "new" [Whitespace("\n")] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@57..60 "Foo" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@60..61 "(" [] [],
+                    args: [
+                        AstSeparatedElement {
+                            node: JsReferenceIdentifierExpression {
+                                name_token: IDENT@61..64 "bar" [] [],
+                            },
+                            trailing_separator: Some(
+                                COMMA@64..66 "," [] [Whitespace(" ")],
                             ),
-                            type_args: None,
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@4..7 "Foo" [] [],
-                                        ),
-                                    },
-                                ),
+                        },
+                        AstSeparatedElement {
+                            node: JsReferenceIdentifierExpression {
+                                name_token: IDENT@66..69 "baz" [] [],
+                            },
+                            trailing_separator: Some(
+                                COMMA@69..71 "," [] [Whitespace(" ")],
                             ),
-                            arguments: Ok(
-                                ArgList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@7..8 "(" [] [],
-                                    ),
-                                    args: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@8..9 ")" [] [],
-                                    ),
+                        },
+                        AstSeparatedElement {
+                            node: JsBinaryExpression {
+                                left: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
                                 },
+                                operator: PLUS@73..75 "+" [] [Whitespace(" ")],
+                            },
+                            trailing_separator: Some(
+                                COMMA@76..78 "," [] [Whitespace(" ")],
                             ),
                         },
-                    ),
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    NewExpr(
-                        NewExpr {
-                            new_token: Ok(
-                                NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            type_args: None,
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@14..17 "foo" [] [],
-                                        ),
+                        AstSeparatedElement {
+                            node: JsBinaryExpression {
+                                left: JsComputedMemberExpression {
+                                    object: JsReferenceIdentifierExpression {
+                                        name_token: IDENT@78..81 "foo" [] [],
                                     },
-                                ),
-                            ),
-                            arguments: Err(
-                                MissingRequiredChild(
-                                    0: NEW_EXPR@9..17
-                                      0: NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")]
-                                      1: JS_REFERENCE_IDENTIFIER_EXPRESSION@14..17
-                                        0: IDENT@14..17 "foo" [] []
-                                    ,
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@17..18 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    NewTarget(
-                        NewTarget {
-                            new_token: Ok(
-                                NEW_KW@18..22 "new" [Whitespace("\n")] [],
-                            ),
-                            dot_token: Ok(
-                                DOT@22..23 "." [] [],
-                            ),
-                            target_token: Err(
-                                MissingRequiredChild(
-                                    0: NEW_TARGET@18..29
-                                      0: NEW_KW@18..22 "new" [Whitespace("\n")] []
-                                      1: DOT@22..23 "." [] []
-                                      2: IDENT@23..29 "target" [] []
-                                    ,
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    NewExpr(
-                        NewExpr {
-                            new_token: Ok(
-                                NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            type_args: None,
-                            object: Ok(
-                                NewExpr(
-                                    NewExpr {
-                                        new_token: Ok(
-                                            NEW_KW@34..38 "new" [] [Whitespace(" ")],
-                                        ),
-                                        type_args: None,
-                                        object: Ok(
-                                            NewExpr(
-                                                NewExpr {
-                                                    new_token: Ok(
-                                                        NEW_KW@38..42 "new" [] [Whitespace(" ")],
-                                                    ),
-                                                    type_args: None,
-                                                    object: Ok(
-                                                        NewExpr(
-                                                            NewExpr {
-                                                                new_token: Ok(
-                                                                    NEW_KW@42..46 "new" [] [Whitespace(" ")],
-                                                                ),
-                                                                type_args: None,
-                                                                object: Ok(
-                                                                    JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@46..49 "Foo" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                arguments: Ok(
-                                                                    ArgList {
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@49..50 "(" [] [],
-                                                                        ),
-                                                                        args: [],
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@50..51 ")" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    arguments: Err(
-                                                        MissingRequiredChild(
-                                                            1: NEW_EXPR@38..51
-                                                              0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
-                                                              1: NEW_EXPR@42..51
-                                                                0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
-                                                                1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
-                                                                  0: IDENT@46..49 "Foo" [] []
-                                                                2: ARG_LIST@49..51
-                                                                  0: L_PAREN@49..50 "(" [] []
-                                                                  1: LIST@50..50
-                                                                  2: R_PAREN@50..51 ")" [] []
-                                                            ,
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        arguments: Err(
-                                            MissingRequiredChild(
-                                                1: NEW_EXPR@34..51
-                                                  0: NEW_KW@34..38 "new" [] [Whitespace(" ")]
-                                                  1: NEW_EXPR@38..51
-                                                    0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
-                                                    1: NEW_EXPR@42..51
-                                                      0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
-                                                      1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
-                                                        0: IDENT@46..49 "Foo" [] []
-                                                      2: ARG_LIST@49..51
-                                                        0: L_PAREN@49..50 "(" [] []
-                                                        1: LIST@50..50
-                                                        2: R_PAREN@50..51 ")" [] []
-                                                ,
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arguments: Err(
-                                MissingRequiredChild(
-                                    0: NEW_EXPR@29..51
-                                      0: NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")]
-                                      1: NEW_EXPR@34..51
-                                        0: NEW_KW@34..38 "new" [] [Whitespace(" ")]
-                                        1: NEW_EXPR@38..51
-                                          0: NEW_KW@38..42 "new" [] [Whitespace(" ")]
-                                          1: NEW_EXPR@42..51
-                                            0: NEW_KW@42..46 "new" [] [Whitespace(" ")]
-                                            1: JS_REFERENCE_IDENTIFIER_EXPRESSION@46..49
-                                              0: IDENT@46..49 "Foo" [] []
-                                            2: ARG_LIST@49..51
-                                              0: L_PAREN@49..50 "(" [] []
-                                              1: LIST@50..50
-                                              2: R_PAREN@50..51 ")" [] []
-                                    ,
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@51..52 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    NewExpr(
-                        NewExpr {
-                            new_token: Ok(
-                                NEW_KW@52..57 "new" [Whitespace("\n")] [Whitespace(" ")],
-                            ),
-                            type_args: None,
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@57..60 "Foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arguments: Ok(
-                                ArgList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@60..61 "(" [] [],
-                                    ),
-                                    args: [
-                                        AstSeparatedElement {
-                                            node: JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@61..64 "bar" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: Some(
-                                                COMMA@64..66 "," [] [Whitespace(" ")],
-                                            ),
-                                        },
-                                        AstSeparatedElement {
-                                            node: JsReferenceIdentifierExpression(
-                                                JsReferenceIdentifierExpression {
-                                                    name_token: Ok(
-                                                        IDENT@66..69 "baz" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: Some(
-                                                COMMA@69..71 "," [] [Whitespace(" ")],
-                                            ),
-                                        },
-                                        AstSeparatedElement {
-                                            node: JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsNumberLiteralExpression(
-                                                                JsNumberLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@73..75 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: Some(
-                                                COMMA@76..78 "," [] [Whitespace(" ")],
-                                            ),
-                                        },
-                                        AstSeparatedElement {
-                                            node: JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsComputedMemberExpression(
-                                                            JsComputedMemberExpression {
-                                                                object: Ok(
-                                                                    JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@78..81 "foo" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                optional_chain_token_token: None,
-                                                                l_brack_token: Ok(
-                                                                    L_BRACK@81..82 "[" [] [],
-                                                                ),
-                                                                r_brack_token: Ok(
-                                                                    R_BRACK@85..87 "]" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@87..89 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@111..112 ")" [] [],
-                                    ),
+                                    optional_chain_token_token: missing (optional),
+                                    l_brack_token: L_BRACK@81..82 "[" [] [],
+                                    r_brack_token: R_BRACK@85..87 "]" [] [Whitespace(" ")],
                                 },
-                            ),
+                                operator: PLUS@87..89 "+" [] [Whitespace(" ")],
+                            },
+                            trailing_separator: None,
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                    ],
+                    r_paren_token: R_PAREN@111..112 ")" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -6,47 +6,39 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: ObjectPattern {
-                                l_curly_token: L_CURLY@4..6 "{" [] [Whitespace(" ")],
-                                elements: [
-                                    AstSeparatedElement {
-                                        node: KeyValuePattern {
-                                            key: Name {
-                                                ident_token: IDENT@6..13 "default" [] [],
-                                            },
-                                            colon_token: COLON@13..15 ":" [] [Whitespace(" ")],
-                                        },
-                                        trailing_separator: Some(
-                                            COMMA@18..20 "," [] [Whitespace(" ")],
-                                        ),
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@4..6 "{" [] [Whitespace(" ")],
+                            elements: [
+                                KeyValuePattern {
+                                    key: Name {
+                                        ident_token: IDENT@6..13 "default" [] [],
                                     },
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@20..24 "bar" [] [Whitespace(" ")],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: None,
+                                    colon_token: COLON@13..15 ":" [] [Whitespace(" ")],
+                                }
+                                COMMA@18..20 "," [] [Whitespace(" ")],
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@20..24 "bar" [] [Whitespace(" ")],
                                     },
-                                ],
-                                r_curly_token: R_CURLY@24..26 "}" [] [Whitespace(" ")],
-                            },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@26..28 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@28..29 "{" [] [],
-                                    members: [],
-                                    r_curly_token: R_CURLY@29..30 "}" [] [],
-                                },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@24..26 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@26..28 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@28..29 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@29..30 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),
@@ -55,56 +47,48 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: ObjectPattern {
-                                l_curly_token: L_CURLY@35..37 "{" [] [Whitespace(" ")],
-                                elements: [
-                                    AstSeparatedElement {
-                                        node: AssignPattern {
-                                            key: SinglePattern {
-                                                name: Name {
-                                                    ident_token: IDENT@37..41 "foo" [] [Whitespace(" ")],
-                                                },
-                                                question_mark_token: missing (optional),
-                                                excl_token: missing (optional),
-                                                ty: missing (optional),
-                                            },
-                                            ty: missing (optional),
-                                            eq_token: EQ@41..43 "=" [] [Whitespace(" ")],
-                                            value: JsReferenceIdentifierExpression {
-                                                name_token: IDENT@43..46 "bar" [] [],
-                                            },
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@35..37 "{" [] [Whitespace(" ")],
+                            elements: [
+                                AssignPattern {
+                                    key: SinglePattern {
+                                        name: Name {
+                                            ident_token: IDENT@37..41 "foo" [] [Whitespace(" ")],
                                         },
-                                        trailing_separator: Some(
-                                            COMMA@46..48 "," [] [Whitespace(" ")],
-                                        ),
+                                        question_mark_token: missing (optional),
+                                        excl_token: missing (optional),
+                                        ty: missing (optional),
                                     },
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@48..52 "baz" [] [Whitespace(" ")],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: None,
+                                    ty: missing (optional),
+                                    eq_token: EQ@41..43 "=" [] [Whitespace(" ")],
+                                    value: JsReferenceIdentifierExpression {
+                                        name_token: IDENT@43..46 "bar" [] [],
                                     },
-                                ],
-                                r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
-                            },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@54..56 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@56..57 "{" [] [],
-                                    members: [],
-                                    r_curly_token: R_CURLY@57..58 "}" [] [],
-                                },
+                                }
+                                COMMA@46..48 "," [] [Whitespace(" ")],
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@48..52 "baz" [] [Whitespace(" ")],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@54..56 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@56..57 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@57..58 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -1,206 +1,114 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        ObjectPattern(
-                                            ObjectPattern {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@4..6 "{" [] [Whitespace(" ")],
-                                                ),
-                                                elements: [
-                                                    AstSeparatedElement {
-                                                        node: KeyValuePattern(
-                                                            KeyValuePattern {
-                                                                key: Ok(
-                                                                    Name(
-                                                                        Name {
-                                                                            ident_token: Ok(
-                                                                                IDENT@6..13 "default" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                colon_token: Ok(
-                                                                    COLON@13..15 ":" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        trailing_separator: Some(
-                                                            COMMA@18..20 "," [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                    AstSeparatedElement {
-                                                        node: SinglePattern(
-                                                            SinglePattern {
-                                                                name: Ok(
-                                                                    Name {
-                                                                        ident_token: Ok(
-                                                                            IDENT@20..24 "bar" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                question_mark_token: None,
-                                                                excl_token: None,
-                                                                ty: None,
-                                                            },
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@24..26 "}" [] [Whitespace(" ")],
-                                                ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: ObjectPattern {
+                                l_curly_token: L_CURLY@4..6 "{" [] [Whitespace(" ")],
+                                elements: [
+                                    AstSeparatedElement {
+                                        node: KeyValuePattern {
+                                            key: Name {
+                                                ident_token: IDENT@6..13 "default" [] [],
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@26..28 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@28..29 "{" [] [],
-                                                        ),
-                                                        members: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@29..30 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
+                                            colon_token: COLON@13..15 ":" [] [Whitespace(" ")],
                                         },
-                                    ),
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
-                    },
-                ),
-                semicolon_token: None,
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        ObjectPattern(
-                                            ObjectPattern {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@35..37 "{" [] [Whitespace(" ")],
-                                                ),
-                                                elements: [
-                                                    AstSeparatedElement {
-                                                        node: AssignPattern(
-                                                            AssignPattern {
-                                                                key: Ok(
-                                                                    SinglePattern(
-                                                                        SinglePattern {
-                                                                            name: Ok(
-                                                                                Name {
-                                                                                    ident_token: Ok(
-                                                                                        IDENT@37..41 "foo" [] [Whitespace(" ")],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            question_mark_token: None,
-                                                                            excl_token: None,
-                                                                            ty: None,
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                ty: None,
-                                                                eq_token: Ok(
-                                                                    EQ@41..43 "=" [] [Whitespace(" ")],
-                                                                ),
-                                                                value: Ok(
-                                                                    JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@43..46 "bar" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                            },
-                                                        ),
-                                                        trailing_separator: Some(
-                                                            COMMA@46..48 "," [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                    AstSeparatedElement {
-                                                        node: SinglePattern(
-                                                            SinglePattern {
-                                                                name: Ok(
-                                                                    Name {
-                                                                        ident_token: Ok(
-                                                                            IDENT@48..52 "baz" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                question_mark_token: None,
-                                                                excl_token: None,
-                                                                ty: None,
-                                                            },
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@52..54 "}" [] [Whitespace(" ")],
-                                                ),
+                                        trailing_separator: Some(
+                                            COMMA@18..20 "," [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@20..24 "bar" [] [Whitespace(" ")],
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@54..56 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@56..57 "{" [] [],
-                                                        ),
-                                                        members: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@57..58 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
                                         },
-                                    ),
-                                },
-                                trailing_separator: None,
+                                        trailing_separator: None,
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@24..26 "}" [] [Whitespace(" ")],
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@26..28 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@28..29 "{" [] [],
+                                    members: [],
+                                    r_curly_token: R_CURLY@29..30 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: ObjectPattern {
+                                l_curly_token: L_CURLY@35..37 "{" [] [Whitespace(" ")],
+                                elements: [
+                                    AstSeparatedElement {
+                                        node: AssignPattern {
+                                            key: SinglePattern {
+                                                name: Name {
+                                                    ident_token: IDENT@37..41 "foo" [] [Whitespace(" ")],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                excl_token: missing (optional),
+                                                ty: missing (optional),
+                                            },
+                                            ty: missing (optional),
+                                            eq_token: EQ@41..43 "=" [] [Whitespace(" ")],
+                                            value: JsReferenceIdentifierExpression {
+                                                name_token: IDENT@43..46 "bar" [] [],
+                                            },
+                                        },
+                                        trailing_separator: Some(
+                                            COMMA@46..48 "," [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@48..52 "baz" [] [Whitespace(" ")],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        trailing_separator: None,
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@52..54 "}" [] [Whitespace(" ")],
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@54..56 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@56..57 "{" [] [],
+                                    members: [],
+                                    r_curly_token: R_CURLY@57..58 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_binding_prop.rast
@@ -1,3 +1,209 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        ObjectPattern(
+                                            ObjectPattern {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@4..6 "{" [] [Whitespace(" ")],
+                                                ),
+                                                elements: [
+                                                    AstSeparatedElement {
+                                                        node: KeyValuePattern(
+                                                            KeyValuePattern {
+                                                                key: Ok(
+                                                                    Name(
+                                                                        Name {
+                                                                            ident_token: Ok(
+                                                                                IDENT@6..13 "default" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                colon_token: Ok(
+                                                                    COLON@13..15 ":" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        trailing_separator: Some(
+                                                            COMMA@18..20 "," [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                    AstSeparatedElement {
+                                                        node: SinglePattern(
+                                                            SinglePattern {
+                                                                name: Ok(
+                                                                    Name {
+                                                                        ident_token: Ok(
+                                                                            IDENT@20..24 "bar" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                question_mark_token: None,
+                                                                excl_token: None,
+                                                                ty: None,
+                                                            },
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@24..26 "}" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@26..28 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@28..29 "{" [] [],
+                                                        ),
+                                                        members: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@29..30 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        ObjectPattern(
+                                            ObjectPattern {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@35..37 "{" [] [Whitespace(" ")],
+                                                ),
+                                                elements: [
+                                                    AstSeparatedElement {
+                                                        node: AssignPattern(
+                                                            AssignPattern {
+                                                                key: Ok(
+                                                                    SinglePattern(
+                                                                        SinglePattern {
+                                                                            name: Ok(
+                                                                                Name {
+                                                                                    ident_token: Ok(
+                                                                                        IDENT@37..41 "foo" [] [Whitespace(" ")],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            question_mark_token: None,
+                                                                            excl_token: None,
+                                                                            ty: None,
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                ty: None,
+                                                                eq_token: Ok(
+                                                                    EQ@41..43 "=" [] [Whitespace(" ")],
+                                                                ),
+                                                                value: Ok(
+                                                                    JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@43..46 "bar" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                        trailing_separator: Some(
+                                                            COMMA@46..48 "," [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                    AstSeparatedElement {
+                                                        node: SinglePattern(
+                                                            SinglePattern {
+                                                                name: Ok(
+                                                                    Name {
+                                                                        ident_token: Ok(
+                                                                            IDENT@48..52 "baz" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                question_mark_token: None,
+                                                                excl_token: None,
+                                                                ty: None,
+                                                            },
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@52..54 "}" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@54..56 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@56..57 "{" [] [],
+                                                        ),
+                                                        members: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@57..58 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..59
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -1,136 +1,76 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [],
+                                    r_curly_token: R_CURLY@9..10 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@10..11 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@16..18 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@18..20 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@20..21 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsShorthandPropertyObjectMember {
+                                                name: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@21..24 "foo" [] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@9..10 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@24..25 "," [] [],
                                             ),
                                         },
-                                    ),
+                                    ],
+                                    r_curly_token: R_CURLY@25..26 "}" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@10..11 ";" [] [],
-                ),
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@16..18 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@18..20 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@20..21 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsShorthandPropertyObjectMember(
-                                                                    JsShorthandPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsReferenceIdentifierExpression {
-                                                                                name_token: Ok(
-                                                                                    IDENT@21..24 "foo" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@24..25 "," [] [],
-                                                                ),
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@25..26 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
-                    },
-                ),
-                semicolon_token: None,
-            },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -6,27 +6,25 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [],
-                                    r_curly_token: R_CURLY@9..10 "}" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@9..10 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@10..11 ";" [] [],
@@ -35,38 +33,32 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@16..18 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@16..18 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@18..20 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@20..21 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsShorthandPropertyObjectMember {
-                                                name: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@21..24 "foo" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@24..25 "," [] [],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@18..20 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@20..21 "{" [] [],
+                                members: [
+                                    JsShorthandPropertyObjectMember {
+                                        name: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@21..24 "foo" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@25..26 "}" [] [],
-                                },
+                                    }
+                                    COMMA@24..25 "," [] [],
+                                ],
+                                r_curly_token: R_CURLY@25..26 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -1,3 +1,139 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@9..10 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@10..11 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@16..18 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@18..20 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@20..21 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsShorthandPropertyObjectMember(
+                                                                    JsShorthandPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsReferenceIdentifierExpression {
+                                                                                name_token: Ok(
+                                                                                    IDENT@21..24 "foo" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@24..25 "," [] [],
+                                                                ),
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@25..26 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..27
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -6,54 +6,46 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: InitializedProp {
-                                                key: Name {
-                                                    ident_token: IDENT@10..14 "foo" [] [Whitespace(" ")],
-                                                },
-                                                eq_token: EQ@14..16 "=" [] [Whitespace(" ")],
-                                                value: JsNumberLiteralExpression {
-                                                    value_token: JS_NUMBER_LITERAL@16..17 "4" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@17..19 "," [] [Whitespace(" ")],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: [
+                                    InitializedProp {
+                                        key: Name {
+                                            ident_token: IDENT@10..14 "foo" [] [Whitespace(" ")],
                                         },
-                                        AstSeparatedElement {
-                                            node: InitializedProp {
-                                                key: Name {
-                                                    ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
-                                                },
-                                                eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
-                                                value: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@25..29 "bar" [] [Whitespace(" ")],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                                        eq_token: EQ@14..16 "=" [] [Whitespace(" ")],
+                                        value: JsNumberLiteralExpression {
+                                            value_token: JS_NUMBER_LITERAL@16..17 "4" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@29..30 "}" [] [],
-                                },
+                                    }
+                                    COMMA@17..19 "," [] [Whitespace(" ")],
+                                    InitializedProp {
+                                        key: Name {
+                                            ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
+                                        },
+                                        eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
+                                        value: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@25..29 "bar" [] [Whitespace(" ")],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@29..30 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -1,119 +1,63 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: InitializedProp {
+                                                key: Name {
+                                                    ident_token: IDENT@10..14 "foo" [] [Whitespace(" ")],
+                                                },
+                                                eq_token: EQ@14..16 "=" [] [Whitespace(" ")],
+                                                value: JsNumberLiteralExpression {
+                                                    value_token: JS_NUMBER_LITERAL@16..17 "4" [] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: InitializedProp(
-                                                                    InitializedProp {
-                                                                        key: Ok(
-                                                                            Name {
-                                                                                ident_token: Ok(
-                                                                                    IDENT@10..14 "foo" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        eq_token: Ok(
-                                                                            EQ@14..16 "=" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        value: Ok(
-                                                                            JsAnyLiteralExpression(
-                                                                                JsNumberLiteralExpression(
-                                                                                    JsNumberLiteralExpression {
-                                                                                        value_token: Ok(
-                                                                                            JS_NUMBER_LITERAL@16..17 "4" [] [],
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@17..19 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: InitializedProp(
-                                                                    InitializedProp {
-                                                                        key: Ok(
-                                                                            Name {
-                                                                                ident_token: Ok(
-                                                                                    IDENT@19..23 "foo" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        eq_token: Ok(
-                                                                            EQ@23..25 "=" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        value: Ok(
-                                                                            JsReferenceIdentifierExpression(
-                                                                                JsReferenceIdentifierExpression {
-                                                                                    name_token: Ok(
-                                                                                        IDENT@25..29 "bar" [] [Whitespace(" ")],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@29..30 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@17..19 "," [] [Whitespace(" ")],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: InitializedProp {
+                                                key: Name {
+                                                    ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
+                                                },
+                                                eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
+                                                value: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@25..29 "bar" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@29..30 "}" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_assign_prop.rast
@@ -1,3 +1,122 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: InitializedProp(
+                                                                    InitializedProp {
+                                                                        key: Ok(
+                                                                            Name {
+                                                                                ident_token: Ok(
+                                                                                    IDENT@10..14 "foo" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        eq_token: Ok(
+                                                                            EQ@14..16 "=" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        value: Ok(
+                                                                            JsAnyLiteralExpression(
+                                                                                JsNumberLiteralExpression(
+                                                                                    JsNumberLiteralExpression {
+                                                                                        value_token: Ok(
+                                                                                            JS_NUMBER_LITERAL@16..17 "4" [] [],
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@17..19 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: InitializedProp(
+                                                                    InitializedProp {
+                                                                        key: Ok(
+                                                                            Name {
+                                                                                ident_token: Ok(
+                                                                                    IDENT@19..23 "foo" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        eq_token: Ok(
+                                                                            EQ@23..25 "=" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        value: Ok(
+                                                                            JsReferenceIdentifierExpression(
+                                                                                JsReferenceIdentifierExpression {
+                                                                                    name_token: Ok(
+                                                                                        IDENT@25..29 "bar" [] [Whitespace(" ")],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@29..30 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..31
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -1,157 +1,85 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: ASYNC_KW@9..18 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@18..21 "foo" [] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@21..22 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@24..25 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@25..26 "}" [] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: Some(
-                                                                            ASYNC_KW@9..18 "async" [Whitespace("\n  ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@18..21 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@21..22 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@22..24 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@24..25 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@25..26 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@26..27 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: Some(
-                                                                            ASYNC_KW@27..36 "async" [Whitespace("\n  ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        star_token: Some(
-                                                                            STAR@36..37 "*" [] [],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@37..40 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@40..41 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@41..43 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@43..44 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@44..45 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@45..47 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@26..27 "," [] [],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: ASYNC_KW@27..36 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                star_token: STAR@36..37 "*" [] [],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@37..40 "foo" [] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@40..41 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@41..43 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@43..44 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@44..45 "}" [] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -6,76 +6,68 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: ASYNC_KW@9..18 "async" [Whitespace("\n  ")] [Whitespace(" ")],
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@18..21 "foo" [] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@21..22 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@24..25 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@25..26 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@26..27 "," [] [],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsMethodObjectMember {
+                                        async_token: ASYNC_KW@9..18 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@18..21 "foo" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: ASYNC_KW@27..36 "async" [Whitespace("\n  ")] [Whitespace(" ")],
-                                                star_token: STAR@36..37 "*" [] [],
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@37..40 "foo" [] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@40..41 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@41..43 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@43..44 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@44..45 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@21..22 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@22..24 ")" [] [Whitespace(" ")],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
-                                },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@24..25 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@25..26 "}" [] [],
+                                        },
+                                    }
+                                    COMMA@26..27 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: ASYNC_KW@27..36 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                        star_token: STAR@36..37 "*" [] [],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@37..40 "foo" [] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@40..41 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@41..43 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@43..44 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@44..45 "}" [] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -1,3 +1,160 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: Some(
+                                                                            ASYNC_KW@9..18 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@18..21 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@21..22 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@22..24 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@24..25 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@25..26 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@26..27 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: Some(
+                                                                            ASYNC_KW@27..36 "async" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        star_token: Some(
+                                                                            STAR@36..37 "*" [] [],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@37..40 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@40..41 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@41..43 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@43..44 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@44..45 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@45..47 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..48
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -1,108 +1,60 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: Some(
-                                                                            STAR@10..11 "*" [] [],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@11..14 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@14..15 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@15..17 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@17..18 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@18..20 "}" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@20..21 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: STAR@10..11 "*" [] [],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@11..14 "foo" [] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@14..15 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@15..17 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@17..18 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@18..20 "}" [] [Whitespace(" ")],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@20..21 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -6,51 +6,47 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: STAR@10..11 "*" [] [],
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@11..14 "foo" [] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@14..15 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@15..17 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@17..18 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@18..20 "}" [] [Whitespace(" ")],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: STAR@10..11 "*" [] [],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@11..14 "foo" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@20..21 "}" [] [],
-                                },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@14..15 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@15..17 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@17..18 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@18..20 "}" [] [Whitespace(" ")],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@20..21 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -1,3 +1,111 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: Some(
+                                                                            STAR@10..11 "*" [] [],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@11..14 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@14..15 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@15..17 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@17..18 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@18..20 "}" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@20..21 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..22
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
@@ -1,121 +1,63 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsGetterObjectMember(
-                                                                    JsGetterObjectMember {
-                                                                        get_token: Ok(
-                                                                            GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@15..18 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@18..19 "(" [] [],
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@19..21 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@21..22 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsReferenceIdentifierExpression(
-                                                                                                    JsReferenceIdentifierExpression {
-                                                                                                        name_token: Ok(
-                                                                                                            IDENT@33..36 "foo" [] [],
-                                                                                                        ),
-                                                                                                    },
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@36..37 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@37..40 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@40..42 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsGetterObjectMember {
+                                                get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@15..18 "foo" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@18..19 "(" [] [],
+                                                r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@21..22 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                            argument: JsReferenceIdentifierExpression {
+                                                                name_token: IDENT@33..36 "foo" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@36..37 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@40..42 "}" [Whitespace("\n")] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
@@ -1,3 +1,124 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsGetterObjectMember(
+                                                                    JsGetterObjectMember {
+                                                                        get_token: Ok(
+                                                                            GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@15..18 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@18..19 "(" [] [],
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@21..22 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsReferenceIdentifierExpression(
+                                                                                                    JsReferenceIdentifierExpression {
+                                                                                                        name_token: Ok(
+                                                                                                            IDENT@33..36 "foo" [] [],
+                                                                                                        ),
+                                                                                                    },
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@36..37 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@37..40 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@40..42 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..43
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_getter.rast
@@ -6,54 +6,50 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsGetterObjectMember {
-                                                get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@15..18 "foo" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@18..19 "(" [] [],
-                                                r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@21..22 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
-                                                            argument: JsReferenceIdentifierExpression {
-                                                                name_token: IDENT@33..36 "foo" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@36..37 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsGetterObjectMember {
+                                        get_token: GET_KW@9..15 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@15..18 "foo" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@40..42 "}" [Whitespace("\n")] [],
-                                },
+                                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                                        r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@21..22 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@22..33 "return" [Whitespace("\n   ")] [Whitespace(" ")],
+                                                    argument: JsReferenceIdentifierExpression {
+                                                        name_token: IDENT@33..36 "foo" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@36..37 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@40..42 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -1,3 +1,85 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@10..11 "a" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@11..13 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@18..19 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..20
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -6,37 +6,33 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@10..11 "a" [] [],
-                                                },
-                                                colon_token: COLON@11..13 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@10..11 "a" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@18..19 "}" [] [],
-                                },
+                                        colon_token: COLON@11..13 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@18..19 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -1,82 +1,46 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..10 "{" [] [Whitespace(" ")],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@10..11 "a" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@11..13 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@18..19 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@10..11 "a" [] [],
+                                                },
+                                                colon_token: COLON@11..13 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@18..19 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -1,3 +1,80 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsShorthandPropertyObjectMember(
+                                                                    JsShorthandPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsReferenceIdentifierExpression {
+                                                                                name_token: Ok(
+                                                                                    IDENT@9..12 "foo" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@12..13 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -1,77 +1,45 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsShorthandPropertyObjectMember(
-                                                                    JsShorthandPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsReferenceIdentifierExpression {
-                                                                                name_token: Ok(
-                                                                                    IDENT@9..12 "foo" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@12..13 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsShorthandPropertyObjectMember {
+                                                name: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@9..12 "foo" [] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@12..13 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -6,36 +6,32 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsShorthandPropertyObjectMember {
-                                                name: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@9..12 "foo" [] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsShorthandPropertyObjectMember {
+                                        name: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@9..12 "foo" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@12..13 "}" [] [],
-                                },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@12..13 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -1,3 +1,376 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@9..13 "foo" [Whitespace("\n")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@13..14 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@14..16 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@16..17 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@17..18 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@18..19 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_STRING_LITERAL@19..25 "\"bar\"" [Whitespace("\n")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@25..26 "(" [] [],
+                                                                                ),
+                                                                                parameters: [
+                                                                                    AstSeparatedElement {
+                                                                                        node: Pattern(
+                                                                                            SinglePattern(
+                                                                                                SinglePattern {
+                                                                                                    name: Ok(
+                                                                                                        Name {
+                                                                                                            ident_token: Ok(
+                                                                                                                IDENT@26..27 "a" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    question_mark_token: None,
+                                                                                                    excl_token: None,
+                                                                                                    ty: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        trailing_separator: Some(
+                                                                                            COMMA@27..29 "," [] [Whitespace(" ")],
+                                                                                        ),
+                                                                                    },
+                                                                                    AstSeparatedElement {
+                                                                                        node: Pattern(
+                                                                                            SinglePattern(
+                                                                                                SinglePattern {
+                                                                                                    name: Ok(
+                                                                                                        Name {
+                                                                                                            ident_token: Ok(
+                                                                                                                IDENT@29..30 "b" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    question_mark_token: None,
+                                                                                                    excl_token: None,
+                                                                                                    ty: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        trailing_separator: Some(
+                                                                                            COMMA@30..32 "," [] [Whitespace(" ")],
+                                                                                        ),
+                                                                                    },
+                                                                                    AstSeparatedElement {
+                                                                                        node: Pattern(
+                                                                                            SinglePattern(
+                                                                                                SinglePattern {
+                                                                                                    name: Ok(
+                                                                                                        Name {
+                                                                                                            ident_token: Ok(
+                                                                                                                IDENT@32..33 "c" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    question_mark_token: None,
+                                                                                                    excl_token: None,
+                                                                                                    ty: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        trailing_separator: None,
+                                                                                    },
+                                                                                ],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@33..35 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@35..36 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@36..37 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@37..38 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@38..40 "[" [Whitespace("\n")] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsBinaryExpression(
+                                                                                            JsBinaryExpression {
+                                                                                                left: Ok(
+                                                                                                    JsAnyLiteralExpression(
+                                                                                                        JsStringLiteralExpression(
+                                                                                                            JsStringLiteralExpression {
+                                                                                                                value_token: Ok(
+                                                                                                                    JS_STRING_LITERAL@40..46 "\"foo\"" [] [Whitespace(" ")],
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ),
+                                                                                                operator: Ok(
+                                                                                                    PLUS@46..48 "+" [] [Whitespace(" ")],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@53..54 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@54..55 "(" [] [],
+                                                                                ),
+                                                                                parameters: [
+                                                                                    AstSeparatedElement {
+                                                                                        node: Pattern(
+                                                                                            SinglePattern(
+                                                                                                SinglePattern {
+                                                                                                    name: Ok(
+                                                                                                        Name {
+                                                                                                            ident_token: Ok(
+                                                                                                                IDENT@55..56 "a" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    question_mark_token: None,
+                                                                                                    excl_token: None,
+                                                                                                    ty: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ),
+                                                                                        trailing_separator: None,
+                                                                                    },
+                                                                                ],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@58..59 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@59..60 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@60..61 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_NUMBER_LITERAL@61..63 "5" [Whitespace("\n")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@63..64 "(" [] [],
+                                                                                ),
+                                                                                parameters: [
+                                                                                    AstSeparatedElement {
+                                                                                        node: JsRestParameter(
+                                                                                            JsRestParameter {
+                                                                                                dotdotdot_token: Ok(
+                                                                                                    DOT2@64..67 "..." [] [],
+                                                                                                ),
+                                                                                                binding: Ok(
+                                                                                                    SinglePattern(
+                                                                                                        SinglePattern {
+                                                                                                            name: Ok(
+                                                                                                                Name {
+                                                                                                                    ident_token: Ok(
+                                                                                                                        IDENT@67..71 "rest" [] [],
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            question_mark_token: None,
+                                                                                                            excl_token: None,
+                                                                                                            ty: None,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                        trailing_separator: None,
+                                                                                    },
+                                                                                ],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@71..73 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@73..74 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@74..75 "}" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@75..77 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..78
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -1,373 +1,207 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@9..13 "foo" [Whitespace("\n")] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@13..14 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@14..16 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@16..17 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@17..18 "}" [] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@9..13 "foo" [Whitespace("\n")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@13..14 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@14..16 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@16..17 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@17..18 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@18..19 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_STRING_LITERAL@19..25 "\"bar\"" [Whitespace("\n")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@25..26 "(" [] [],
-                                                                                ),
-                                                                                parameters: [
-                                                                                    AstSeparatedElement {
-                                                                                        node: Pattern(
-                                                                                            SinglePattern(
-                                                                                                SinglePattern {
-                                                                                                    name: Ok(
-                                                                                                        Name {
-                                                                                                            ident_token: Ok(
-                                                                                                                IDENT@26..27 "a" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                    question_mark_token: None,
-                                                                                                    excl_token: None,
-                                                                                                    ty: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ),
-                                                                                        trailing_separator: Some(
-                                                                                            COMMA@27..29 "," [] [Whitespace(" ")],
-                                                                                        ),
-                                                                                    },
-                                                                                    AstSeparatedElement {
-                                                                                        node: Pattern(
-                                                                                            SinglePattern(
-                                                                                                SinglePattern {
-                                                                                                    name: Ok(
-                                                                                                        Name {
-                                                                                                            ident_token: Ok(
-                                                                                                                IDENT@29..30 "b" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                    question_mark_token: None,
-                                                                                                    excl_token: None,
-                                                                                                    ty: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ),
-                                                                                        trailing_separator: Some(
-                                                                                            COMMA@30..32 "," [] [Whitespace(" ")],
-                                                                                        ),
-                                                                                    },
-                                                                                    AstSeparatedElement {
-                                                                                        node: Pattern(
-                                                                                            SinglePattern(
-                                                                                                SinglePattern {
-                                                                                                    name: Ok(
-                                                                                                        Name {
-                                                                                                            ident_token: Ok(
-                                                                                                                IDENT@32..33 "c" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                    question_mark_token: None,
-                                                                                                    excl_token: None,
-                                                                                                    ty: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ),
-                                                                                        trailing_separator: None,
-                                                                                    },
-                                                                                ],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@33..35 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@35..36 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@36..37 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@37..38 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@38..40 "[" [Whitespace("\n")] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsBinaryExpression(
-                                                                                            JsBinaryExpression {
-                                                                                                left: Ok(
-                                                                                                    JsAnyLiteralExpression(
-                                                                                                        JsStringLiteralExpression(
-                                                                                                            JsStringLiteralExpression {
-                                                                                                                value_token: Ok(
-                                                                                                                    JS_STRING_LITERAL@40..46 "\"foo\"" [] [Whitespace(" ")],
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                ),
-                                                                                                operator: Ok(
-                                                                                                    PLUS@46..48 "+" [] [Whitespace(" ")],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@53..54 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@54..55 "(" [] [],
-                                                                                ),
-                                                                                parameters: [
-                                                                                    AstSeparatedElement {
-                                                                                        node: Pattern(
-                                                                                            SinglePattern(
-                                                                                                SinglePattern {
-                                                                                                    name: Ok(
-                                                                                                        Name {
-                                                                                                            ident_token: Ok(
-                                                                                                                IDENT@55..56 "a" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                    question_mark_token: None,
-                                                                                                    excl_token: None,
-                                                                                                    ty: None,
-                                                                                                },
-                                                                                            ),
-                                                                                        ),
-                                                                                        trailing_separator: None,
-                                                                                    },
-                                                                                ],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@56..58 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@58..59 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@59..60 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@60..61 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_NUMBER_LITERAL@61..63 "5" [Whitespace("\n")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@63..64 "(" [] [],
-                                                                                ),
-                                                                                parameters: [
-                                                                                    AstSeparatedElement {
-                                                                                        node: JsRestParameter(
-                                                                                            JsRestParameter {
-                                                                                                dotdotdot_token: Ok(
-                                                                                                    DOT2@64..67 "..." [] [],
-                                                                                                ),
-                                                                                                binding: Ok(
-                                                                                                    SinglePattern(
-                                                                                                        SinglePattern {
-                                                                                                            name: Ok(
-                                                                                                                Name {
-                                                                                                                    ident_token: Ok(
-                                                                                                                        IDENT@67..71 "rest" [] [],
-                                                                                                                    ),
-                                                                                                                },
-                                                                                                            ),
-                                                                                                            question_mark_token: None,
-                                                                                                            excl_token: None,
-                                                                                                            ty: None,
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                        trailing_separator: None,
-                                                                                    },
-                                                                                ],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@71..73 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@73..74 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@74..75 "}" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@75..77 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@18..19 "," [] [],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: JS_STRING_LITERAL@19..25 "\"bar\"" [Whitespace("\n")] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@25..26 "(" [] [],
+                                                    parameters: [
+                                                        AstSeparatedElement {
+                                                            node: SinglePattern {
+                                                                name: Name {
+                                                                    ident_token: IDENT@26..27 "a" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                excl_token: missing (optional),
+                                                                ty: missing (optional),
+                                                            },
+                                                            trailing_separator: Some(
+                                                                COMMA@27..29 "," [] [Whitespace(" ")],
+                                                            ),
+                                                        },
+                                                        AstSeparatedElement {
+                                                            node: SinglePattern {
+                                                                name: Name {
+                                                                    ident_token: IDENT@29..30 "b" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                excl_token: missing (optional),
+                                                                ty: missing (optional),
+                                                            },
+                                                            trailing_separator: Some(
+                                                                COMMA@30..32 "," [] [Whitespace(" ")],
+                                                            ),
+                                                        },
+                                                        AstSeparatedElement {
+                                                            node: SinglePattern {
+                                                                name: Name {
+                                                                    ident_token: IDENT@32..33 "c" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                excl_token: missing (optional),
+                                                                ty: missing (optional),
+                                                            },
+                                                            trailing_separator: None,
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@33..35 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@35..36 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@36..37 "}" [] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@37..38 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@38..40 "[" [Whitespace("\n")] [],
+                                                    expression: JsBinaryExpression {
+                                                        left: JsStringLiteralExpression {
+                                                            value_token: JS_STRING_LITERAL@40..46 "\"foo\"" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@46..48 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    r_brack_token: R_BRACK@53..54 "]" [] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@54..55 "(" [] [],
+                                                    parameters: [
+                                                        AstSeparatedElement {
+                                                            node: SinglePattern {
+                                                                name: Name {
+                                                                    ident_token: IDENT@55..56 "a" [] [],
+                                                                },
+                                                                question_mark_token: missing (optional),
+                                                                excl_token: missing (optional),
+                                                                ty: missing (optional),
+                                                            },
+                                                            trailing_separator: None,
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@58..59 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@59..60 "}" [] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@60..61 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: JS_NUMBER_LITERAL@61..63 "5" [Whitespace("\n")] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@63..64 "(" [] [],
+                                                    parameters: [
+                                                        AstSeparatedElement {
+                                                            node: JsRestParameter {
+                                                                dotdotdot_token: DOT2@64..67 "..." [] [],
+                                                                binding: SinglePattern {
+                                                                    name: Name {
+                                                                        ident_token: IDENT@67..71 "rest" [] [],
+                                                                    },
+                                                                    question_mark_token: missing (optional),
+                                                                    excl_token: missing (optional),
+                                                                    ty: missing (optional),
+                                                                },
+                                                            },
+                                                            trailing_separator: None,
+                                                        },
+                                                    ],
+                                                    r_paren_token: R_PAREN@71..73 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@73..74 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@74..75 "}" [] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@75..77 "}" [Whitespace("\n")] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -6,198 +6,168 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@9..13 "foo" [Whitespace("\n")] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@13..14 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@14..16 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@16..17 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@17..18 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@18..19 "," [] [],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@9..13 "foo" [Whitespace("\n")] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: JS_STRING_LITERAL@19..25 "\"bar\"" [Whitespace("\n")] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@25..26 "(" [] [],
-                                                    parameters: [
-                                                        AstSeparatedElement {
-                                                            node: SinglePattern {
-                                                                name: Name {
-                                                                    ident_token: IDENT@26..27 "a" [] [],
-                                                                },
-                                                                question_mark_token: missing (optional),
-                                                                excl_token: missing (optional),
-                                                                ty: missing (optional),
-                                                            },
-                                                            trailing_separator: Some(
-                                                                COMMA@27..29 "," [] [Whitespace(" ")],
-                                                            ),
-                                                        },
-                                                        AstSeparatedElement {
-                                                            node: SinglePattern {
-                                                                name: Name {
-                                                                    ident_token: IDENT@29..30 "b" [] [],
-                                                                },
-                                                                question_mark_token: missing (optional),
-                                                                excl_token: missing (optional),
-                                                                ty: missing (optional),
-                                                            },
-                                                            trailing_separator: Some(
-                                                                COMMA@30..32 "," [] [Whitespace(" ")],
-                                                            ),
-                                                        },
-                                                        AstSeparatedElement {
-                                                            node: SinglePattern {
-                                                                name: Name {
-                                                                    ident_token: IDENT@32..33 "c" [] [],
-                                                                },
-                                                                question_mark_token: missing (optional),
-                                                                excl_token: missing (optional),
-                                                                ty: missing (optional),
-                                                            },
-                                                            trailing_separator: None,
-                                                        },
-                                                    ],
-                                                    r_paren_token: R_PAREN@33..35 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@35..36 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@36..37 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@37..38 "," [] [],
-                                            ),
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@13..14 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@14..16 ")" [] [Whitespace(" ")],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@38..40 "[" [Whitespace("\n")] [],
-                                                    expression: JsBinaryExpression {
-                                                        left: JsStringLiteralExpression {
-                                                            value_token: JS_STRING_LITERAL@40..46 "\"foo\"" [] [Whitespace(" ")],
-                                                        },
-                                                        operator: PLUS@46..48 "+" [] [Whitespace(" ")],
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@16..17 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@17..18 "}" [] [],
+                                        },
+                                    }
+                                    COMMA@18..19 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: JS_STRING_LITERAL@19..25 "\"bar\"" [Whitespace("\n")] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@25..26 "(" [] [],
+                                            parameters: [
+                                                SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@26..27 "a" [] [],
                                                     },
-                                                    r_brack_token: R_BRACK@53..54 "]" [] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@54..55 "(" [] [],
-                                                    parameters: [
-                                                        AstSeparatedElement {
-                                                            node: SinglePattern {
-                                                                name: Name {
-                                                                    ident_token: IDENT@55..56 "a" [] [],
-                                                                },
-                                                                question_mark_token: missing (optional),
-                                                                excl_token: missing (optional),
-                                                                ty: missing (optional),
-                                                            },
-                                                            trailing_separator: None,
-                                                        },
-                                                    ],
-                                                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@58..59 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@59..60 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@60..61 "," [] [],
-                                            ),
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                }
+                                                COMMA@27..29 "," [] [Whitespace(" ")],
+                                                SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@29..30 "b" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                }
+                                                COMMA@30..32 "," [] [Whitespace(" ")],
+                                                SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@32..33 "c" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                }
+                                                ,
+                                            ],
+                                            r_paren_token: R_PAREN@33..35 ")" [] [Whitespace(" ")],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: JS_NUMBER_LITERAL@61..63 "5" [Whitespace("\n")] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@63..64 "(" [] [],
-                                                    parameters: [
-                                                        AstSeparatedElement {
-                                                            node: JsRestParameter {
-                                                                dotdotdot_token: DOT2@64..67 "..." [] [],
-                                                                binding: SinglePattern {
-                                                                    name: Name {
-                                                                        ident_token: IDENT@67..71 "rest" [] [],
-                                                                    },
-                                                                    question_mark_token: missing (optional),
-                                                                    excl_token: missing (optional),
-                                                                    ty: missing (optional),
-                                                                },
-                                                            },
-                                                            trailing_separator: None,
-                                                        },
-                                                    ],
-                                                    r_paren_token: R_PAREN@71..73 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@73..74 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@74..75 "}" [] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@35..36 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@36..37 "}" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@75..77 "}" [Whitespace("\n")] [],
-                                },
+                                    }
+                                    COMMA@37..38 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@38..40 "[" [Whitespace("\n")] [],
+                                            expression: JsBinaryExpression {
+                                                left: JsStringLiteralExpression {
+                                                    value_token: JS_STRING_LITERAL@40..46 "\"foo\"" [] [Whitespace(" ")],
+                                                },
+                                                operator: PLUS@46..48 "+" [] [Whitespace(" ")],
+                                            },
+                                            r_brack_token: R_BRACK@53..54 "]" [] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@54..55 "(" [] [],
+                                            parameters: [
+                                                SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@55..56 "a" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                }
+                                                ,
+                                            ],
+                                            r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@58..59 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@59..60 "}" [] [],
+                                        },
+                                    }
+                                    COMMA@60..61 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@61..63 "5" [Whitespace("\n")] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@63..64 "(" [] [],
+                                            parameters: [
+                                                JsRestParameter {
+                                                    dotdotdot_token: DOT2@64..67 "..." [] [],
+                                                    binding: SinglePattern {
+                                                        name: Name {
+                                                            ident_token: IDENT@67..71 "rest" [] [],
+                                                        },
+                                                        question_mark_token: missing (optional),
+                                                        excl_token: missing (optional),
+                                                        ty: missing (optional),
+                                                    },
+                                                }
+                                                ,
+                                            ],
+                                            r_paren_token: R_PAREN@71..73 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@73..74 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@74..75 "}" [] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@75..77 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
@@ -1,3 +1,153 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsSetterObjectMember(
+                                                                    JsSetterObjectMember {
+                                                                        set_token: Ok(
+                                                                            SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@15..16 "[" [] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsReferenceIdentifierExpression(
+                                                                                            JsReferenceIdentifierExpression {
+                                                                                                name_token: Ok(
+                                                                                                    IDENT@16..19 "foo" [] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@19..20 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@20..21 "(" [] [],
+                                                                        ),
+                                                                        parameter: Ok(
+                                                                            SinglePattern(
+                                                                                SinglePattern {
+                                                                                    name: Ok(
+                                                                                        Name {
+                                                                                            ident_token: Ok(
+                                                                                                IDENT@21..24 "bar" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    question_mark_token: None,
+                                                                                    excl_token: None,
+                                                                                    ty: None,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@26..27 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@27..39 "return" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsAnyLiteralExpression(
+                                                                                                    JsNumberLiteralExpression(
+                                                                                                        JsNumberLiteralExpression {
+                                                                                                            value_token: Ok(
+                                                                                                                JS_NUMBER_LITERAL@39..40 "5" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@40..41 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@41..44 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@44..46 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..47
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
@@ -1,150 +1,74 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "b" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsSetterObjectMember(
-                                                                    JsSetterObjectMember {
-                                                                        set_token: Ok(
-                                                                            SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@15..16 "[" [] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsReferenceIdentifierExpression(
-                                                                                            JsReferenceIdentifierExpression {
-                                                                                                name_token: Ok(
-                                                                                                    IDENT@16..19 "foo" [] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@19..20 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@20..21 "(" [] [],
-                                                                        ),
-                                                                        parameter: Ok(
-                                                                            SinglePattern(
-                                                                                SinglePattern {
-                                                                                    name: Ok(
-                                                                                        Name {
-                                                                                            ident_token: Ok(
-                                                                                                IDENT@21..24 "bar" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    question_mark_token: None,
-                                                                                    excl_token: None,
-                                                                                    ty: None,
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@24..26 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@26..27 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@27..39 "return" [Whitespace("\n    ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsAnyLiteralExpression(
-                                                                                                    JsNumberLiteralExpression(
-                                                                                                        JsNumberLiteralExpression {
-                                                                                                            value_token: Ok(
-                                                                                                                JS_NUMBER_LITERAL@39..40 "5" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@40..41 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@41..44 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@44..46 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsSetterObjectMember {
+                                                set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@15..16 "[" [] [],
+                                                    expression: JsReferenceIdentifierExpression {
+                                                        name_token: IDENT@16..19 "foo" [] [],
+                                                    },
+                                                    r_brack_token: R_BRACK@19..20 "]" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@20..21 "(" [] [],
+                                                parameter: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@21..24 "bar" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
+                                                r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@26..27 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@27..39 "return" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                            argument: JsNumberLiteralExpression {
+                                                                value_token: JS_NUMBER_LITERAL@39..40 "5" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@40..41 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@41..44 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_setter.rast
@@ -6,65 +6,61 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsSetterObjectMember {
-                                                set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@15..16 "[" [] [],
-                                                    expression: JsReferenceIdentifierExpression {
-                                                        name_token: IDENT@16..19 "foo" [] [],
-                                                    },
-                                                    r_brack_token: R_BRACK@19..20 "]" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@20..21 "(" [] [],
-                                                parameter: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@21..24 "bar" [] [],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
-                                                },
-                                                r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@26..27 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@27..39 "return" [Whitespace("\n    ")] [Whitespace(" ")],
-                                                            argument: JsNumberLiteralExpression {
-                                                                value_token: JS_NUMBER_LITERAL@39..40 "5" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@40..41 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@41..44 "}" [Whitespace("\n ")] [],
-                                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@15..16 "[" [] [],
+                                            expression: JsReferenceIdentifierExpression {
+                                                name_token: IDENT@16..19 "foo" [] [],
                                             },
-                                            trailing_separator: None,
+                                            r_brack_token: R_BRACK@19..20 "]" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
-                                },
+                                        l_paren_token: L_PAREN@20..21 "(" [] [],
+                                        parameter: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@21..24 "bar" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@26..27 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@27..39 "return" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                    argument: JsNumberLiteralExpression {
+                                                        value_token: JS_NUMBER_LITERAL@39..40 "5" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@40..41 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@41..44 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -6,37 +6,33 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsSpread {
-                                                dotdotdot_token: DOT2@9..12 "..." [] [],
-                                                argument: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@12..15 "foo" [] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsSpread {
+                                        dotdotdot_token: DOT2@9..12 "..." [] [],
+                                        argument: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@12..15 "foo" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@15..16 "}" [] [],
-                                },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@15..16 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -1,82 +1,46 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsSpread(
-                                                                    JsSpread {
-                                                                        dotdotdot_token: Ok(
-                                                                            DOT2@9..12 "..." [] [],
-                                                                        ),
-                                                                        argument: Ok(
-                                                                            JsReferenceIdentifierExpression(
-                                                                                JsReferenceIdentifierExpression {
-                                                                                    name_token: Ok(
-                                                                                        IDENT@12..15 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@15..16 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsSpread {
+                                                dotdotdot_token: DOT2@9..12 "..." [] [],
+                                                argument: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@12..15 "foo" [] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@15..16 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -1,3 +1,85 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsSpread(
+                                                                    JsSpread {
+                                                                        dotdotdot_token: Ok(
+                                                                            DOT2@9..12 "..." [] [],
+                                                                        ),
+                                                                        argument: Ok(
+                                                                            JsReferenceIdentifierExpression(
+                                                                                JsReferenceIdentifierExpression {
+                                                                                    name_token: Ok(
+                                                                                        IDENT@12..15 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@15..16 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..17
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
@@ -1,168 +1,86 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
+                                                },
+                                                colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@14..16 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@19..21 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@21..22 "[" [] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsBinaryExpression(
-                                                                                            JsBinaryExpression {
-                                                                                                left: Ok(
-                                                                                                    JsAnyLiteralExpression(
-                                                                                                        JsNumberLiteralExpression(
-                                                                                                            JsNumberLiteralExpression {
-                                                                                                                value_token: Ok(
-                                                                                                                    JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                ),
-                                                                                                operator: Ok(
-                                                                                                    PLUS@24..26 "+" [] [Whitespace(" ")],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@27..28 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@28..30 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@33..35 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@35..38 "bar" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@38..40 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@43..45 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_NUMBER_LITERAL@45..46 "7" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@46..48 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@51..52 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@19..21 "," [] [Whitespace(" ")],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@21..22 "[" [] [],
+                                                    expression: JsBinaryExpression {
+                                                        left: JsNumberLiteralExpression {
+                                                            value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    r_brack_token: R_BRACK@27..28 "]" [] [],
+                                                },
+                                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@33..35 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@35..38 "bar" [] [],
+                                                },
+                                                colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@43..45 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: JS_NUMBER_LITERAL@45..46 "7" [] [],
+                                                },
+                                                colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@51..52 "}" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
@@ -1,3 +1,171 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@14..16 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@19..21 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@21..22 "[" [] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsBinaryExpression(
+                                                                                            JsBinaryExpression {
+                                                                                                left: Ok(
+                                                                                                    JsAnyLiteralExpression(
+                                                                                                        JsNumberLiteralExpression(
+                                                                                                            JsNumberLiteralExpression {
+                                                                                                                value_token: Ok(
+                                                                                                                    JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ),
+                                                                                                operator: Ok(
+                                                                                                    PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@27..28 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@28..30 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@33..35 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@35..38 "bar" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@38..40 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@43..45 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_NUMBER_LITERAL@45..46 "7" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@46..48 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@51..52 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..53
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
@@ -6,77 +6,61 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
-                                                },
-                                                colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@19..21 "," [] [Whitespace(" ")],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@21..22 "[" [] [],
-                                                    expression: JsBinaryExpression {
-                                                        left: JsNumberLiteralExpression {
-                                                            value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
-                                                        },
-                                                        operator: PLUS@24..26 "+" [] [Whitespace(" ")],
-                                                    },
-                                                    r_brack_token: R_BRACK@27..28 "]" [] [],
+                                        colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@19..21 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@21..22 "[" [] [],
+                                            expression: JsBinaryExpression {
+                                                left: JsNumberLiteralExpression {
+                                                    value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
                                                 },
-                                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                                operator: PLUS@24..26 "+" [] [Whitespace(" ")],
                                             },
-                                            trailing_separator: Some(
-                                                COMMA@33..35 "," [] [Whitespace(" ")],
-                                            ),
+                                            r_brack_token: R_BRACK@27..28 "]" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@35..38 "bar" [] [],
-                                                },
-                                                colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@43..45 "," [] [Whitespace(" ")],
-                                            ),
+                                        colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@33..35 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@35..38 "bar" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: JS_NUMBER_LITERAL@45..46 "7" [] [],
-                                                },
-                                                colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: None,
+                                        colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@43..45 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@45..46 "7" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@51..52 "}" [] [],
-                                },
+                                        colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@51..52 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -1,168 +1,86 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
+                                                },
+                                                colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@14..16 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@19..21 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@21..22 "[" [] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsBinaryExpression(
-                                                                                            JsBinaryExpression {
-                                                                                                left: Ok(
-                                                                                                    JsAnyLiteralExpression(
-                                                                                                        JsNumberLiteralExpression(
-                                                                                                            JsNumberLiteralExpression {
-                                                                                                                value_token: Ok(
-                                                                                                                    JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                ),
-                                                                                                operator: Ok(
-                                                                                                    PLUS@24..26 "+" [] [Whitespace(" ")],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@27..28 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@28..30 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@33..35 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@35..38 "bar" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@38..40 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@43..45 "," [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsPropertyObjectMember(
-                                                                    JsPropertyObjectMember {
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_NUMBER_LITERAL@45..46 "7" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        colon_token: Ok(
-                                                                            COLON@46..48 ":" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@51..52 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@19..21 "," [] [Whitespace(" ")],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@21..22 "[" [] [],
+                                                    expression: JsBinaryExpression {
+                                                        left: JsNumberLiteralExpression {
+                                                            value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    r_brack_token: R_BRACK@27..28 "]" [] [],
+                                                },
+                                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@33..35 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@35..38 "bar" [] [],
+                                                },
+                                                colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@43..45 "," [] [Whitespace(" ")],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: JS_NUMBER_LITERAL@45..46 "7" [] [],
+                                                },
+                                                colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@51..52 "}" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -1,3 +1,171 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@14..16 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@19..21 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@21..22 "[" [] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsBinaryExpression(
+                                                                                            JsBinaryExpression {
+                                                                                                left: Ok(
+                                                                                                    JsAnyLiteralExpression(
+                                                                                                        JsNumberLiteralExpression(
+                                                                                                            JsNumberLiteralExpression {
+                                                                                                                value_token: Ok(
+                                                                                                                    JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ),
+                                                                                                operator: Ok(
+                                                                                                    PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@27..28 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@28..30 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@33..35 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@35..38 "bar" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@38..40 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@43..45 "," [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsPropertyObjectMember(
+                                                                    JsPropertyObjectMember {
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_NUMBER_LITERAL@45..46 "7" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        colon_token: Ok(
+                                                                            COLON@46..48 ":" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@51..52 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..53
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -6,77 +6,61 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
-                                                },
-                                                colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@19..21 "," [] [Whitespace(" ")],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_STRING_LITERAL@9..14 "\"foo\"" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@21..22 "[" [] [],
-                                                    expression: JsBinaryExpression {
-                                                        left: JsNumberLiteralExpression {
-                                                            value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
-                                                        },
-                                                        operator: PLUS@24..26 "+" [] [Whitespace(" ")],
-                                                    },
-                                                    r_brack_token: R_BRACK@27..28 "]" [] [],
+                                        colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@19..21 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@21..22 "[" [] [],
+                                            expression: JsBinaryExpression {
+                                                left: JsNumberLiteralExpression {
+                                                    value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
                                                 },
-                                                colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                                operator: PLUS@24..26 "+" [] [Whitespace(" ")],
                                             },
-                                            trailing_separator: Some(
-                                                COMMA@33..35 "," [] [Whitespace(" ")],
-                                            ),
+                                            r_brack_token: R_BRACK@27..28 "]" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@35..38 "bar" [] [],
-                                                },
-                                                colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@43..45 "," [] [Whitespace(" ")],
-                                            ),
+                                        colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@33..35 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@35..38 "bar" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsPropertyObjectMember {
-                                                name: JsLiteralMemberName {
-                                                    value: JS_NUMBER_LITERAL@45..46 "7" [] [],
-                                                },
-                                                colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
-                                            },
-                                            trailing_separator: None,
+                                        colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
+                                    }
+                                    COMMA@43..45 "," [] [Whitespace(" ")],
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@45..46 "7" [] [],
                                         },
-                                    ],
-                                    r_curly_token: R_CURLY@51..52 "}" [] [],
-                                },
+                                        colon_token: COLON@46..48 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@51..52 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -19,17 +19,15 @@ JsRoot {
                 parameter_list: JsParameterList {
                     l_paren_token: L_PAREN@6..8 "(" [Whitespace("\n")] [],
                     parameters: [
-                        AstSeparatedElement {
-                            node: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@8..11 "foo" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@8..11 "foo" [] [],
                             },
-                            trailing_separator: None,
-                        },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
                 },
@@ -58,50 +56,38 @@ JsRoot {
                 parameter_list: JsParameterList {
                     l_paren_token: L_PAREN@28..30 "(" [Whitespace("\n")] [],
                     parameters: [
-                        AstSeparatedElement {
-                            node: ObjectPattern {
-                                l_curly_token: L_CURLY@30..31 "{" [] [],
-                                elements: [
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@31..34 "foo" [] [],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: Some(
-                                            COMMA@34..36 "," [] [Whitespace(" ")],
-                                        ),
+                        ObjectPattern {
+                            l_curly_token: L_CURLY@30..31 "{" [] [],
+                            elements: [
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@31..34 "foo" [] [],
                                     },
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@36..39 "bar" [] [],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: Some(
-                                            COMMA@39..41 "," [] [Whitespace(" ")],
-                                        ),
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                COMMA@34..36 "," [] [Whitespace(" ")],
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@36..39 "bar" [] [],
                                     },
-                                    AstSeparatedElement {
-                                        node: KeyValuePattern {
-                                            key: Name {
-                                                ident_token: IDENT@41..42 "b" [] [],
-                                            },
-                                            colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
-                                        },
-                                        trailing_separator: None,
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                COMMA@39..41 "," [] [Whitespace(" ")],
+                                KeyValuePattern {
+                                    key: Name {
+                                        ident_token: IDENT@41..42 "b" [] [],
                                     },
-                                ],
-                                r_curly_token: R_CURLY@55..56 "}" [] [],
-                            },
-                            trailing_separator: None,
-                        },
+                                    colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@55..56 "}" [] [],
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
                 },
@@ -117,33 +103,27 @@ JsRoot {
                 parameter_list: JsParameterList {
                     l_paren_token: L_PAREN@64..66 "(" [Whitespace("\n")] [],
                     parameters: [
-                        AstSeparatedElement {
-                            node: SinglePattern {
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@66..69 "foo" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        COMMA@69..71 "," [] [Whitespace(" ")],
+                        JsRestParameter {
+                            dotdotdot_token: DOT2@71..74 "..." [] [],
+                            binding: SinglePattern {
                                 name: Name {
-                                    ident_token: IDENT@66..69 "foo" [] [],
+                                    ident_token: IDENT@74..77 "bar" [] [],
                                 },
                                 question_mark_token: missing (optional),
                                 excl_token: missing (optional),
                                 ty: missing (optional),
                             },
-                            trailing_separator: Some(
-                                COMMA@69..71 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                        AstSeparatedElement {
-                            node: JsRestParameter {
-                                dotdotdot_token: DOT2@71..74 "..." [] [],
-                                binding: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@74..77 "bar" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
-                                },
-                            },
-                            trailing_separator: None,
-                        },
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@77..79 ")" [] [Whitespace(" ")],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -1,311 +1,157 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsParenthesizedExpression(
-                        JsParenthesizedExpression {
-                            l_paren_token: Ok(
-                                L_PAREN@0..1 "(" [] [],
-                            ),
-                            expression: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@1..4 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@4..5 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@5..6 ";" [] [],
-                ),
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@0..1 "(" [] [],
+                expression: JsReferenceIdentifierExpression {
+                    name_token: IDENT@1..4 "foo" [] [],
+                },
+                r_paren_token: R_PAREN@4..5 ")" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsParameterList(
-                                    JsParameterList {
-                                        l_paren_token: Ok(
-                                            L_PAREN@6..8 "(" [Whitespace("\n")] [],
-                                        ),
-                                        parameters: [
-                                            AstSeparatedElement {
-                                                node: Pattern(
-                                                    SinglePattern(
-                                                        SinglePattern {
-                                                            name: Ok(
-                                                                Name {
-                                                                    ident_token: Ok(
-                                                                        IDENT@8..11 "foo" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            question_mark_token: None,
-                                                            excl_token: None,
-                                                            ty: None,
-                                                        },
-                                                    ),
-                                                ),
-                                                trailing_separator: None,
+            semicolon_token: SEMICOLON@5..6 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@6..8 "(" [Whitespace("\n")] [],
+                    parameters: [
+                        AstSeparatedElement {
+                            node: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@8..11 "foo" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@13..16 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: SEMICOLON@18..19 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@19..21 "(" [Whitespace("\n")] [],
+                expression: JsBinaryExpression {
+                    left: JsNumberLiteralExpression {
+                        value_token: JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")],
+                    },
+                    operator: PLUS@23..25 "+" [] [Whitespace(" ")],
+                },
+                r_paren_token: R_PAREN@26..27 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@27..28 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@28..30 "(" [Whitespace("\n")] [],
+                    parameters: [
+                        AstSeparatedElement {
+                            node: ObjectPattern {
+                                l_curly_token: L_CURLY@30..31 "{" [] [],
+                                elements: [
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@31..34 "foo" [] [],
                                             },
-                                        ],
-                                        r_paren_token: Ok(
-                                            R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        trailing_separator: Some(
+                                            COMMA@34..36 "," [] [Whitespace(" ")],
                                         ),
                                     },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@13..16 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@18..19 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsParenthesizedExpression(
-                        JsParenthesizedExpression {
-                            l_paren_token: Ok(
-                                L_PAREN@19..21 "(" [Whitespace("\n")] [],
-                            ),
-                            expression: Ok(
-                                JsBinaryExpression(
-                                    JsBinaryExpression {
-                                        left: Ok(
-                                            JsAnyLiteralExpression(
-                                                JsNumberLiteralExpression(
-                                                    JsNumberLiteralExpression {
-                                                        value_token: Ok(
-                                                            JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        ),
-                                        operator: Ok(
-                                            PLUS@23..25 "+" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@26..27 ")" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@27..28 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsParameterList(
-                                    JsParameterList {
-                                        l_paren_token: Ok(
-                                            L_PAREN@28..30 "(" [Whitespace("\n")] [],
-                                        ),
-                                        parameters: [
-                                            AstSeparatedElement {
-                                                node: Pattern(
-                                                    ObjectPattern(
-                                                        ObjectPattern {
-                                                            l_curly_token: Ok(
-                                                                L_CURLY@30..31 "{" [] [],
-                                                            ),
-                                                            elements: [
-                                                                AstSeparatedElement {
-                                                                    node: SinglePattern(
-                                                                        SinglePattern {
-                                                                            name: Ok(
-                                                                                Name {
-                                                                                    ident_token: Ok(
-                                                                                        IDENT@31..34 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            question_mark_token: None,
-                                                                            excl_token: None,
-                                                                            ty: None,
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: Some(
-                                                                        COMMA@34..36 "," [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                                AstSeparatedElement {
-                                                                    node: SinglePattern(
-                                                                        SinglePattern {
-                                                                            name: Ok(
-                                                                                Name {
-                                                                                    ident_token: Ok(
-                                                                                        IDENT@36..39 "bar" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            question_mark_token: None,
-                                                                            excl_token: None,
-                                                                            ty: None,
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: Some(
-                                                                        COMMA@39..41 "," [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                                AstSeparatedElement {
-                                                                    node: KeyValuePattern(
-                                                                        KeyValuePattern {
-                                                                            key: Ok(
-                                                                                Name(
-                                                                                    Name {
-                                                                                        ident_token: Ok(
-                                                                                            IDENT@41..42 "b" [] [],
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                            colon_token: Ok(
-                                                                                COLON@42..44 ":" [] [Whitespace(" ")],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: None,
-                                                                },
-                                                            ],
-                                                            r_curly_token: Ok(
-                                                                R_CURLY@55..56 "}" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                trailing_separator: None,
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@36..39 "bar" [] [],
                                             },
-                                        ],
-                                        r_paren_token: Ok(
-                                            R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        trailing_separator: Some(
+                                            COMMA@39..41 "," [] [Whitespace(" ")],
                                         ),
                                     },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@58..61 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@63..64 ";" [] [],
-                ),
-            },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsParameterList(
-                                    JsParameterList {
-                                        l_paren_token: Ok(
-                                            L_PAREN@64..66 "(" [Whitespace("\n")] [],
-                                        ),
-                                        parameters: [
-                                            AstSeparatedElement {
-                                                node: Pattern(
-                                                    SinglePattern(
-                                                        SinglePattern {
-                                                            name: Ok(
-                                                                Name {
-                                                                    ident_token: Ok(
-                                                                        IDENT@66..69 "foo" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            question_mark_token: None,
-                                                            excl_token: None,
-                                                            ty: None,
-                                                        },
-                                                    ),
-                                                ),
-                                                trailing_separator: Some(
-                                                    COMMA@69..71 "," [] [Whitespace(" ")],
-                                                ),
+                                    AstSeparatedElement {
+                                        node: KeyValuePattern {
+                                            key: Name {
+                                                ident_token: IDENT@41..42 "b" [] [],
                                             },
-                                            AstSeparatedElement {
-                                                node: JsRestParameter(
-                                                    JsRestParameter {
-                                                        dotdotdot_token: Ok(
-                                                            DOT2@71..74 "..." [] [],
-                                                        ),
-                                                        binding: Ok(
-                                                            SinglePattern(
-                                                                SinglePattern {
-                                                                    name: Ok(
-                                                                        Name {
-                                                                            ident_token: Ok(
-                                                                                IDENT@74..77 "bar" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    question_mark_token: None,
-                                                                    excl_token: None,
-                                                                    ty: None,
-                                                                },
-                                                            ),
-                                                        ),
-                                                    },
-                                                ),
-                                                trailing_separator: None,
-                                            },
-                                        ],
-                                        r_paren_token: Ok(
-                                            R_PAREN@77..79 ")" [] [Whitespace(" ")],
-                                        ),
+                                            colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
+                                        },
+                                        trailing_separator: None,
                                     },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@79..82 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
+                                ],
+                                r_curly_token: R_CURLY@55..56 "}" [] [],
+                            },
+                            trailing_separator: None,
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                    ],
+                    r_paren_token: R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@58..61 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
             },
-        ),
+            semicolon_token: SEMICOLON@63..64 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@64..66 "(" [Whitespace("\n")] [],
+                    parameters: [
+                        AstSeparatedElement {
+                            node: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@66..69 "foo" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            trailing_separator: Some(
+                                COMMA@69..71 "," [] [Whitespace(" ")],
+                            ),
+                        },
+                        AstSeparatedElement {
+                            node: JsRestParameter {
+                                dotdotdot_token: DOT2@71..74 "..." [] [],
+                                binding: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@74..77 "bar" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                            },
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@77..79 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@79..82 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -1,3 +1,314 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsParenthesizedExpression(
+                        JsParenthesizedExpression {
+                            l_paren_token: Ok(
+                                L_PAREN@0..1 "(" [] [],
+                            ),
+                            expression: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@1..4 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@4..5 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@5..6 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsParameterList(
+                                    JsParameterList {
+                                        l_paren_token: Ok(
+                                            L_PAREN@6..8 "(" [Whitespace("\n")] [],
+                                        ),
+                                        parameters: [
+                                            AstSeparatedElement {
+                                                node: Pattern(
+                                                    SinglePattern(
+                                                        SinglePattern {
+                                                            name: Ok(
+                                                                Name {
+                                                                    ident_token: Ok(
+                                                                        IDENT@8..11 "foo" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            question_mark_token: None,
+                                                            excl_token: None,
+                                                            ty: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                trailing_separator: None,
+                                            },
+                                        ],
+                                        r_paren_token: Ok(
+                                            R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@13..16 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@18..19 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsParenthesizedExpression(
+                        JsParenthesizedExpression {
+                            l_paren_token: Ok(
+                                L_PAREN@19..21 "(" [Whitespace("\n")] [],
+                            ),
+                            expression: Ok(
+                                JsBinaryExpression(
+                                    JsBinaryExpression {
+                                        left: Ok(
+                                            JsAnyLiteralExpression(
+                                                JsNumberLiteralExpression(
+                                                    JsNumberLiteralExpression {
+                                                        value_token: Ok(
+                                                            JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                        operator: Ok(
+                                            PLUS@23..25 "+" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@26..27 ")" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@27..28 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsParameterList(
+                                    JsParameterList {
+                                        l_paren_token: Ok(
+                                            L_PAREN@28..30 "(" [Whitespace("\n")] [],
+                                        ),
+                                        parameters: [
+                                            AstSeparatedElement {
+                                                node: Pattern(
+                                                    ObjectPattern(
+                                                        ObjectPattern {
+                                                            l_curly_token: Ok(
+                                                                L_CURLY@30..31 "{" [] [],
+                                                            ),
+                                                            elements: [
+                                                                AstSeparatedElement {
+                                                                    node: SinglePattern(
+                                                                        SinglePattern {
+                                                                            name: Ok(
+                                                                                Name {
+                                                                                    ident_token: Ok(
+                                                                                        IDENT@31..34 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            question_mark_token: None,
+                                                                            excl_token: None,
+                                                                            ty: None,
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: Some(
+                                                                        COMMA@34..36 "," [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                                AstSeparatedElement {
+                                                                    node: SinglePattern(
+                                                                        SinglePattern {
+                                                                            name: Ok(
+                                                                                Name {
+                                                                                    ident_token: Ok(
+                                                                                        IDENT@36..39 "bar" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            question_mark_token: None,
+                                                                            excl_token: None,
+                                                                            ty: None,
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: Some(
+                                                                        COMMA@39..41 "," [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                                AstSeparatedElement {
+                                                                    node: KeyValuePattern(
+                                                                        KeyValuePattern {
+                                                                            key: Ok(
+                                                                                Name(
+                                                                                    Name {
+                                                                                        ident_token: Ok(
+                                                                                            IDENT@41..42 "b" [] [],
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                            colon_token: Ok(
+                                                                                COLON@42..44 ":" [] [Whitespace(" ")],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: None,
+                                                                },
+                                                            ],
+                                                            r_curly_token: Ok(
+                                                                R_CURLY@55..56 "}" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                trailing_separator: None,
+                                            },
+                                        ],
+                                        r_paren_token: Ok(
+                                            R_PAREN@56..58 ")" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@58..61 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@63..64 ";" [] [],
+                ),
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsParameterList(
+                                    JsParameterList {
+                                        l_paren_token: Ok(
+                                            L_PAREN@64..66 "(" [Whitespace("\n")] [],
+                                        ),
+                                        parameters: [
+                                            AstSeparatedElement {
+                                                node: Pattern(
+                                                    SinglePattern(
+                                                        SinglePattern {
+                                                            name: Ok(
+                                                                Name {
+                                                                    ident_token: Ok(
+                                                                        IDENT@66..69 "foo" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            question_mark_token: None,
+                                                            excl_token: None,
+                                                            ty: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                trailing_separator: Some(
+                                                    COMMA@69..71 "," [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                            AstSeparatedElement {
+                                                node: JsRestParameter(
+                                                    JsRestParameter {
+                                                        dotdotdot_token: Ok(
+                                                            DOT2@71..74 "..." [] [],
+                                                        ),
+                                                        binding: Ok(
+                                                            SinglePattern(
+                                                                SinglePattern {
+                                                                    name: Ok(
+                                                                        Name {
+                                                                            ident_token: Ok(
+                                                                                IDENT@74..77 "bar" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    question_mark_token: None,
+                                                                    excl_token: None,
+                                                                    ty: None,
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                                trailing_separator: None,
+                                            },
+                                        ],
+                                        r_paren_token: Ok(
+                                            R_PAREN@77..79 ")" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@79..82 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..85
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -1,3 +1,56 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPostUpdateExpression(
+                        JsPostUpdateExpression {
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                PLUS2@3..5 "++" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPostUpdateExpression(
+                        JsPostUpdateExpression {
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@5..9 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                MINUS2@9..11 "--" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -1,53 +1,25 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPostUpdateExpression(
-                        JsPostUpdateExpression {
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                PLUS2@3..5 "++" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsPostUpdateExpression {
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                operator: PLUS2@3..5 "++" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPostUpdateExpression(
-                        JsPostUpdateExpression {
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@5..9 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                MINUS2@9..11 "--" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsPostUpdateExpression {
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                },
+                operator: MINUS2@9..11 "--" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
@@ -1,3 +1,56 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPostUpdateExpression(
+                        JsPostUpdateExpression {
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                PLUS2@3..5 "++" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPostUpdateExpression(
+                        JsPostUpdateExpression {
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@5..9 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                MINUS2@9..11 "--" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
@@ -1,53 +1,25 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPostUpdateExpression(
-                        JsPostUpdateExpression {
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                PLUS2@3..5 "++" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsPostUpdateExpression {
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                operator: PLUS2@3..5 "++" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPostUpdateExpression(
-                        JsPostUpdateExpression {
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@5..9 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                MINUS2@9..11 "--" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsPostUpdateExpression {
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                },
+                operator: MINUS2@9..11 "--" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -1,3 +1,56 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPreUpdateExpression(
+                        JsPreUpdateExpression {
+                            operator: Ok(
+                                PLUS2@0..2 "++" [] [],
+                            ),
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@2..5 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsPreUpdateExpression(
+                        JsPreUpdateExpression {
+                            operator: Ok(
+                                MINUS2@5..8 "--" [Whitespace("\n")] [],
+                            ),
+                            operand: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@8..11 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -1,53 +1,25 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPreUpdateExpression(
-                        JsPreUpdateExpression {
-                            operator: Ok(
-                                PLUS2@0..2 "++" [] [],
-                            ),
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@2..5 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsPreUpdateExpression {
+                operator: PLUS2@0..2 "++" [] [],
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@2..5 "foo" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsPreUpdateExpression(
-                        JsPreUpdateExpression {
-                            operator: Ok(
-                                MINUS2@5..8 "--" [Whitespace("\n")] [],
-                            ),
-                            operand: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@8..11 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsPreUpdateExpression {
+                operator: MINUS2@5..8 "--" [Whitespace("\n")] [],
+                operand: JsReferenceIdentifierExpression {
+                    name_token: IDENT@8..11 "foo" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
@@ -1,410 +1,218 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@11..21 "property" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@21..30 "declare" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: Some(
-                                SEMICOLON@30..31 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@31..53 "initializedProperty" [Whitespace("\n\t")] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: Some(
-                                JsEqualValueClause {
-                                    eq_token: Ok(
-                                        EQ@53..55 "=" [] [Whitespace(" ")],
-                                    ),
-                                    expression: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsStringLiteralExpression(
-                                                JsStringLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_STRING_LITERAL@55..58 "\"a\"" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                },
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_STRING_LITERAL@58..64 "\"a\"" [Whitespace("\n\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: Some(
-                                SEMICOLON@64..65 ";" [] [],
-                            ),
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_NUMBER_LITERAL@65..68 "5" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsComputedMemberName(
-                                    JsComputedMemberName {
-                                        l_brack_token: Ok(
-                                            L_BRACK@68..71 "[" [Whitespace("\n\t")] [],
-                                        ),
-                                        expression: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@71..75 "\"a\"" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@75..77 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@80..81 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@81..91 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@91..105 "staticProperty" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@105..114 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@114..140 "staticInitializedProperty" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: Some(
-                                JsEqualValueClause {
-                                    eq_token: Ok(
-                                        EQ@140..142 "=" [] [Whitespace(" ")],
-                                    ),
-                                    expression: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsNumberLiteralExpression(
-                                                JsNumberLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_NUMBER_LITERAL@142..143 "1" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                },
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@143..147 "#" [Whitespace("\n\n\t")] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@147..154 "private" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@154..157 "#" [Whitespace("\n\t")] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@157..176 "privateInitialized" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: Some(
-                                JsEqualValueClause {
-                                    eq_token: Ok(
-                                        EQ@176..178 "=" [] [Whitespace(" ")],
-                                    ),
-                                    expression: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsStringLiteralExpression(
-                                                JsStringLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_STRING_LITERAL@178..181 "\"a\"" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                },
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@181..191 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@191..192 "#" [] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@192..205 "staticPrivate" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@205..214 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@214..215 "#" [] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@215..248 "staticPrivateInitializedProperty" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: Some(
-                                JsEqualValueClause {
-                                    eq_token: Ok(
-                                        EQ@248..250 "=" [] [Whitespace(" ")],
-                                    ),
-                                    expression: Ok(
-                                        JsAnyLiteralExpression(
-                                            JsNumberLiteralExpression(
-                                                JsNumberLiteralExpression {
-                                                    value_token: Ok(
-                                                        JS_NUMBER_LITERAL@250..251 "1" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                },
-                            ),
-                            semicolon_token: None,
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@251..253 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@11..21 "property" [Whitespace("\n\t")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@21..30 "declare" [Whitespace("\n\t")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@30..31 ";" [] [],
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@31..53 "initializedProperty" [Whitespace("\n\t")] [Whitespace(" ")],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: JsEqualValueClause {
+                        eq_token: EQ@53..55 "=" [] [Whitespace(" ")],
+                        expression: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@55..58 "\"a\"" [] [],
+                        },
+                    },
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@58..64 "\"a\"" [Whitespace("\n\n\t")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@64..65 ";" [] [],
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@65..68 "5" [Whitespace("\n\t")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@68..71 "[" [Whitespace("\n\t")] [],
+                        expression: JsBinaryExpression {
+                            left: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@71..75 "\"a\"" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@75..77 "+" [] [Whitespace(" ")],
+                        },
+                        r_brack_token: R_BRACK@80..81 "]" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@81..91 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@91..105 "staticProperty" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@105..114 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@114..140 "staticInitializedProperty" [] [Whitespace(" ")],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: JsEqualValueClause {
+                        eq_token: EQ@140..142 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@142..143 "1" [] [],
+                        },
+                    },
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@143..147 "#" [Whitespace("\n\n\t")] [],
+                        id_token: IDENT@147..154 "private" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@154..157 "#" [Whitespace("\n\t")] [],
+                        id_token: IDENT@157..176 "privateInitialized" [] [Whitespace(" ")],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: JsEqualValueClause {
+                        eq_token: EQ@176..178 "=" [] [Whitespace(" ")],
+                        expression: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@178..181 "\"a\"" [] [],
+                        },
+                    },
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@181..191 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@191..192 "#" [] [],
+                        id_token: IDENT@192..205 "staticPrivate" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@205..214 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@214..215 "#" [] [],
+                        id_token: IDENT@215..248 "staticPrivateInitializedProperty" [] [Whitespace(" ")],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: JsEqualValueClause {
+                        eq_token: EQ@248..250 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@250..251 "1" [] [],
+                        },
+                    },
+                    semicolon_token: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@251..253 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
@@ -1,3 +1,413 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@11..21 "property" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@21..30 "declare" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: Some(
+                                SEMICOLON@30..31 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@31..53 "initializedProperty" [Whitespace("\n\t")] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: Some(
+                                JsEqualValueClause {
+                                    eq_token: Ok(
+                                        EQ@53..55 "=" [] [Whitespace(" ")],
+                                    ),
+                                    expression: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsStringLiteralExpression(
+                                                JsStringLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_STRING_LITERAL@55..58 "\"a\"" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                },
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_STRING_LITERAL@58..64 "\"a\"" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: Some(
+                                SEMICOLON@64..65 ";" [] [],
+                            ),
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_NUMBER_LITERAL@65..68 "5" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsComputedMemberName(
+                                    JsComputedMemberName {
+                                        l_brack_token: Ok(
+                                            L_BRACK@68..71 "[" [Whitespace("\n\t")] [],
+                                        ),
+                                        expression: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@71..75 "\"a\"" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@75..77 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@80..81 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@81..91 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@91..105 "staticProperty" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@105..114 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@114..140 "staticInitializedProperty" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: Some(
+                                JsEqualValueClause {
+                                    eq_token: Ok(
+                                        EQ@140..142 "=" [] [Whitespace(" ")],
+                                    ),
+                                    expression: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsNumberLiteralExpression(
+                                                JsNumberLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_NUMBER_LITERAL@142..143 "1" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                },
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@143..147 "#" [Whitespace("\n\n\t")] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@147..154 "private" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@154..157 "#" [Whitespace("\n\t")] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@157..176 "privateInitialized" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: Some(
+                                JsEqualValueClause {
+                                    eq_token: Ok(
+                                        EQ@176..178 "=" [] [Whitespace(" ")],
+                                    ),
+                                    expression: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsStringLiteralExpression(
+                                                JsStringLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_STRING_LITERAL@178..181 "\"a\"" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                },
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@181..191 "static" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@191..192 "#" [] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@192..205 "staticPrivate" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@205..214 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@214..215 "#" [] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@215..248 "staticPrivateInitializedProperty" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: Some(
+                                JsEqualValueClause {
+                                    eq_token: Ok(
+                                        EQ@248..250 "=" [] [Whitespace(" ")],
+                                    ),
+                                    expression: Ok(
+                                        JsAnyLiteralExpression(
+                                            JsNumberLiteralExpression(
+                                                JsNumberLiteralExpression {
+                                                    value_token: Ok(
+                                                        JS_NUMBER_LITERAL@250..251 "1" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                },
+                            ),
+                            semicolon_token: None,
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@251..253 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..255
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -1,3 +1,40 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsArrowFunctionExpression(
+                        JsArrowFunctionExpression {
+                            async_token: None,
+                            type_parameters: None,
+                            parameter_list: Some(
+                                JsParameterList(
+                                    JsParameterList {
+                                        l_paren_token: Ok(
+                                            L_PAREN@0..1 "(" [] [],
+                                        ),
+                                        parameters: [],
+                                        r_paren_token: Ok(
+                                            R_PAREN@1..3 ")" [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            fat_arrow_token: Ok(
+                                FAT_ARROW@3..6 "=>" [] [Whitespace(" ")],
+                            ),
+                            return_type: None,
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..43
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -1,37 +1,21 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsArrowFunctionExpression(
-                        JsArrowFunctionExpression {
-                            async_token: None,
-                            type_parameters: None,
-                            parameter_list: Some(
-                                JsParameterList(
-                                    JsParameterList {
-                                        l_paren_token: Ok(
-                                            L_PAREN@0..1 "(" [] [],
-                                        ),
-                                        parameters: [],
-                                        r_paren_token: Ok(
-                                            R_PAREN@1..3 ")" [] [Whitespace(" ")],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            fat_arrow_token: Ok(
-                                FAT_ARROW@3..6 "=>" [] [Whitespace(" ")],
-                            ),
-                            return_type: None,
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@0..1 "(" [] [],
+                    parameters: [],
+                    r_paren_token: R_PAREN@1..3 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@3..6 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -1,284 +1,156 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..8 "foo" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@8..10 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsReferenceIdentifierExpression(
-                                                    JsReferenceIdentifierExpression {
-                                                        name_token: Ok(
-                                                            IDENT@10..13 "bar" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@13..14 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@19..23 "foo" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@23..25 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsReferenceIdentifierExpression(
-                                                    JsReferenceIdentifierExpression {
-                                                        name_token: Ok(
-                                                            IDENT@25..26 "b" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@8..10 "=" [] [Whitespace(" ")],
+                                expression: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@10..13 "bar" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@26..27 ";" [] [],
-                ),
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@32..35 "foo" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: None,
+            semicolon_token: SEMICOLON@13..14 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@35..36 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@41..44 "foo" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: None,
+                            init: JsEqualValueClause {
+                                eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
+                                expression: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@25..26 "b" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@49..52 "foo" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: None,
+            semicolon_token: SEMICOLON@26..27 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@32..35 "foo" [] [],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: missing (optional),
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@62..65 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@65..66 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@66..68 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@68..70 "{" [] [Whitespace(" ")],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsReturnStatement(
-                                JsReturnStatement {
-                                    return_token: Ok(
-                                        RETURN_KW@70..77 "return" [] [Whitespace(" ")],
-                                    ),
-                                    argument: Some(
-                                        JsAnyLiteralExpression(
-                                            JsBooleanLiteralExpression(
-                                                JsBooleanLiteralExpression {
-                                                    value_token: Ok(
-                                                        TRUE_KW@77..82 "true" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                    ),
-                                    semicolon_token: None,
+            semicolon_token: SEMICOLON@35..36 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@41..44 "foo" [] [],
                                 },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@82..83 "}" [] [],
-                        ),
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: missing (optional),
+                        },
+                        trailing_separator: None,
                     },
-                ),
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@49..52 "foo" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: missing (optional),
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@62..65 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@65..66 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@66..68 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@68..70 "{" [] [Whitespace(" ")],
+                directives: [],
+                statements: [
+                    JsReturnStatement {
+                        return_token: RETURN_KW@70..77 "return" [] [Whitespace(" ")],
+                        argument: JsBooleanLiteralExpression {
+                            value_token: TRUE_KW@77..82 "true" [] [Whitespace(" ")],
+                        },
+                        semicolon_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@82..83 "}" [] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -6,25 +6,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@8..10 "=" [] [Whitespace(" ")],
-                                expression: JsReferenceIdentifierExpression {
-                                    name_token: IDENT@10..13 "bar" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@8..10 "=" [] [Whitespace(" ")],
+                            expression: JsReferenceIdentifierExpression {
+                                name_token: IDENT@10..13 "bar" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@13..14 ";" [] [],
@@ -33,25 +31,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
-                                expression: JsReferenceIdentifierExpression {
-                                    name_token: IDENT@25..26 "b" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@23..25 "=" [] [Whitespace(" ")],
+                            expression: JsReferenceIdentifierExpression {
+                                name_token: IDENT@25..26 "b" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@26..27 ";" [] [],
@@ -60,20 +56,18 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@32..35 "foo" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@32..35 "foo" [] [],
                             },
-                            init: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
                         },
-                        trailing_separator: None,
-                    },
+                        init: missing (optional),
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@35..36 ";" [] [],
@@ -82,20 +76,18 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@41..44 "foo" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@41..44 "foo" [] [],
                             },
-                            init: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
                         },
-                        trailing_separator: None,
-                    },
+                        init: missing (optional),
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),
@@ -104,20 +96,18 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@49..52 "foo" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@49..52 "foo" [] [],
                             },
-                            init: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
                         },
-                        trailing_separator: None,
-                    },
+                        init: missing (optional),
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -1,3 +1,287 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..8 "foo" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@8..10 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsReferenceIdentifierExpression(
+                                                    JsReferenceIdentifierExpression {
+                                                        name_token: Ok(
+                                                            IDENT@10..13 "bar" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@13..14 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@19..23 "foo" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@23..25 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsReferenceIdentifierExpression(
+                                                    JsReferenceIdentifierExpression {
+                                                        name_token: Ok(
+                                                            IDENT@25..26 "b" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@26..27 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@32..35 "foo" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: None,
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@35..36 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@41..44 "foo" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: None,
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@49..52 "foo" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: None,
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@62..65 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@65..66 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@68..70 "{" [] [Whitespace(" ")],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsReturnStatement(
+                                JsReturnStatement {
+                                    return_token: Ok(
+                                        RETURN_KW@70..77 "return" [] [Whitespace(" ")],
+                                    ),
+                                    argument: Some(
+                                        JsAnyLiteralExpression(
+                                            JsBooleanLiteralExpression(
+                                                JsBooleanLiteralExpression {
+                                                    value_token: Ok(
+                                                        TRUE_KW@77..82 "true" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                    ),
+                                    semicolon_token: None,
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@82..83 "}" [] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..84
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -1,3 +1,35 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsSequenceExpression(
+                        JsSequenceExpression {
+                            left: Ok(
+                                JsAnyLiteralExpression(
+                                    JsNumberLiteralExpression(
+                                        JsNumberLiteralExpression {
+                                            value_token: Ok(
+                                                JS_NUMBER_LITERAL@0..1 "1" [] [],
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ),
+                            comma_token: Ok(
+                                COMMA@1..3 "," [] [Whitespace(" ")],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -1,32 +1,16 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsSequenceExpression(
-                        JsSequenceExpression {
-                            left: Ok(
-                                JsAnyLiteralExpression(
-                                    JsNumberLiteralExpression(
-                                        JsNumberLiteralExpression {
-                                            value_token: Ok(
-                                                JS_NUMBER_LITERAL@0..1 "1" [] [],
-                                            ),
-                                        },
-                                    ),
-                                ),
-                            ),
-                            comma_token: Ok(
-                                COMMA@1..3 "," [] [Whitespace(" ")],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsSequenceExpression {
+                left: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@0..1 "1" [] [],
+                },
+                comma_token: COMMA@1..3 "," [] [Whitespace(" ")],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
@@ -219,17 +219,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@174..175 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@175..176 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@175..176 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@176..178 ")" [] [Whitespace(" ")],
                     },
@@ -254,17 +252,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@191..192 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@192..193 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@192..193 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@193..195 ")" [] [Whitespace(" ")],
                     },
@@ -289,17 +285,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@209..210 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@210..211 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@210..211 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@211..213 ")" [] [Whitespace(" ")],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
@@ -1,647 +1,319 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..14 "Setters" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@14..15 "{" [] [],
-                ),
-                members: [
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@21..24 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@24..25 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@25..26 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@26..28 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@28..29 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@29..30 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@36..42 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@42..43 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@43..44 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@44..46 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@46..47 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@47..48 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            set_token: Ok(
-                                SET_KW@57..61 "set" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@61..64 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@64..65 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@65..66 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@66..68 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@68..69 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@69..70 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@70..77 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_STRING_LITERAL@77..82 "\"baz\"" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@82..83 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@83..84 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@84..86 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@86..87 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@87..88 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@88..95 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsComputedMemberName(
-                                    JsComputedMemberName {
-                                        l_brack_token: Ok(
-                                            L_BRACK@95..96 "[" [] [],
-                                        ),
-                                        expression: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@96..100 "\"a\"" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@100..102 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@105..106 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@106..107 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@107..108 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@108..110 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@110..111 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@111..112 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@112..119 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_NUMBER_LITERAL@119..120 "5" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@120..121 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@121..122 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@122..124 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@124..125 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@125..126 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@126..133 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@133..134 "#" [] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@134..141 "private" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@141..142 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@142..143 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@143..145 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@145..146 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@146..147 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@147..149 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..14 "Setters" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@149..157 "class" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@157..168 "NotSetters" [] [Whitespace(" ")],
-                        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@14..15 "{" [] [],
+            members: [
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@21..24 "foo" [] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@168..169 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@169..174 "set" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@174..175 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@175..176 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@176..178 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@178..179 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@179..180 "}" [] [],
-                                    ),
-                                },
-                            ),
+                    l_paren_token: L_PAREN@24..25 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@25..26 "a" [] [],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@180..188 "async" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@188..191 "set" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@191..192 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@192..193 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@193..195 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@195..196 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@196..197 "}" [] [],
-                                    ),
-                                },
-                            ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@28..29 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@29..30 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@36..42 "static" [] [],
+                    },
+                    l_paren_token: L_PAREN@42..43 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@43..44 "a" [] [],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@197..206 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@206..209 "set" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@209..210 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@210..211 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@211..213 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@213..214 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@214..215 "}" [] [],
-                                    ),
-                                },
-                            ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@44..46 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@46..47 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@47..48 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    set_token: SET_KW@57..61 "set" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@61..64 "bar" [] [],
+                    },
+                    l_paren_token: L_PAREN@64..65 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@65..66 "a" [] [],
                         },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@215..217 "}" [Whitespace("\n")] [],
-                ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@68..69 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@69..70 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@70..77 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@77..82 "\"baz\"" [] [],
+                    },
+                    l_paren_token: L_PAREN@82..83 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@83..84 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@84..86 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@86..87 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@87..88 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@88..95 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@95..96 "[" [] [],
+                        expression: JsBinaryExpression {
+                            left: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@96..100 "\"a\"" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@100..102 "+" [] [Whitespace(" ")],
+                        },
+                        r_brack_token: R_BRACK@105..106 "]" [] [],
+                    },
+                    l_paren_token: L_PAREN@106..107 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@107..108 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@108..110 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@110..111 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@111..112 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@112..119 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@119..120 "5" [] [],
+                    },
+                    l_paren_token: L_PAREN@120..121 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@121..122 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@122..124 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@124..125 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@125..126 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@126..133 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@133..134 "#" [] [],
+                        id_token: IDENT@134..141 "private" [] [],
+                    },
+                    l_paren_token: L_PAREN@141..142 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@142..143 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@143..145 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@145..146 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@146..147 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@147..149 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@149..157 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@157..168 "NotSetters" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@168..169 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@169..174 "set" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@174..175 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@175..176 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@176..178 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@178..179 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@179..180 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@180..188 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@188..191 "set" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@191..192 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@192..193 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@193..195 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@195..196 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@196..197 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@197..206 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@206..209 "set" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@209..210 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@210..211 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@211..213 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@213..214 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@214..215 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@215..217 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
@@ -1,3 +1,650 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..14 "Setters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@14..15 "{" [] [],
+                ),
+                members: [
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@21..24 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@24..25 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@25..26 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@28..29 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@29..30 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@36..42 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@42..43 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@43..44 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@44..46 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@46..47 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@47..48 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            set_token: Ok(
+                                SET_KW@57..61 "set" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@61..64 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@64..65 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@65..66 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@68..69 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@69..70 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@70..77 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_STRING_LITERAL@77..82 "\"baz\"" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@82..83 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@83..84 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@84..86 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@86..87 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@87..88 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@88..95 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsComputedMemberName(
+                                    JsComputedMemberName {
+                                        l_brack_token: Ok(
+                                            L_BRACK@95..96 "[" [] [],
+                                        ),
+                                        expression: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@96..100 "\"a\"" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@100..102 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@105..106 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@106..107 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@107..108 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@108..110 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@110..111 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@111..112 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@112..119 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_NUMBER_LITERAL@119..120 "5" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@120..121 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@121..122 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@122..124 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@124..125 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@125..126 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@126..133 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@133..134 "#" [] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@134..141 "private" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@141..142 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@142..143 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@143..145 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@145..146 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@146..147 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@147..149 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@149..157 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@157..168 "NotSetters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@168..169 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@169..174 "set" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@174..175 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@175..176 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@176..178 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@178..179 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@179..180 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@180..188 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@188..191 "set" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@191..192 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@192..193 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@193..195 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@195..196 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@196..197 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@197..206 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@206..209 "set" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@209..210 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@210..211 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@211..213 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@213..214 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@214..215 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@215..217 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..219
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
@@ -1,647 +1,319 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..14 "Setters" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@14..15 "{" [] [],
-                ),
-                members: [
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@21..24 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@24..25 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@25..26 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@26..28 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@28..29 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@29..30 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@36..42 "static" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@42..43 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@43..44 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@44..46 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@46..47 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@47..48 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: Some(
-                                STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            set_token: Ok(
-                                SET_KW@57..61 "set" [] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@61..64 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@64..65 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@65..66 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@66..68 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@68..69 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@69..70 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@70..76 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_STRING_LITERAL@76..81 "\"baz\"" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@81..82 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@82..83 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@83..85 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@85..86 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@86..87 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@87..93 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsComputedMemberName(
-                                    JsComputedMemberName {
-                                        l_brack_token: Ok(
-                                            L_BRACK@93..94 "[" [] [],
-                                        ),
-                                        expression: Ok(
-                                            JsBinaryExpression(
-                                                JsBinaryExpression {
-                                                    left: Ok(
-                                                        JsAnyLiteralExpression(
-                                                            JsStringLiteralExpression(
-                                                                JsStringLiteralExpression {
-                                                                    value_token: Ok(
-                                                                        JS_STRING_LITERAL@94..98 "\"a\"" [] [Whitespace(" ")],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ),
-                                                    ),
-                                                    operator: Ok(
-                                                        PLUS@98..100 "+" [] [Whitespace(" ")],
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        r_brack_token: Ok(
-                                            R_BRACK@103..104 "]" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@104..105 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@105..106 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@106..108 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@108..109 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@109..110 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@110..116 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            JS_NUMBER_LITERAL@116..117 "5" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@117..118 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@118..119 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@119..121 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@121..122 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@122..123 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsSetterClassMember(
-                        JsSetterClassMember {
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            set_token: Ok(
-                                SET_KW@123..129 "set" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@129..130 "#" [] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@130..137 "private" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            l_paren_token: Ok(
-                                L_PAREN@137..138 "(" [] [],
-                            ),
-                            parameter: Ok(
-                                SinglePattern(
-                                    SinglePattern {
-                                        name: Ok(
-                                            Name {
-                                                ident_token: Ok(
-                                                    IDENT@138..139 "a" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        question_mark_token: None,
-                                        excl_token: None,
-                                        ty: None,
-                                    },
-                                ),
-                            ),
-                            r_paren_token: Ok(
-                                R_PAREN@139..141 ")" [] [Whitespace(" ")],
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@141..142 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@142..143 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@143..145 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..14 "Setters" [] [Whitespace(" ")],
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@145..152 "class" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@152..163 "NotSetters" [] [Whitespace(" ")],
-                        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@14..15 "{" [] [],
+            members: [
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@21..24 "foo" [] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@163..164 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@164..169 "set" [Whitespace("\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@169..170 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@170..171 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@171..173 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@173..174 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@174..175 "}" [] [],
-                                    ),
-                                },
-                            ),
+                    l_paren_token: L_PAREN@24..25 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@25..26 "a" [] [],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@175..183 "async" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@183..186 "set" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@186..187 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@187..188 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@188..190 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@190..191 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@191..192 "}" [] [],
-                                    ),
-                                },
-                            ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@28..29 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@29..30 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@36..42 "static" [] [],
+                    },
+                    l_paren_token: L_PAREN@42..43 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@43..44 "a" [] [],
                         },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@192..201 "static" [Whitespace("\n\t")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@201..204 "set" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@204..205 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@205..206 "a" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@206..208 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@208..209 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@209..210 "}" [] [],
-                                    ),
-                                },
-                            ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@44..46 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@46..47 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@47..48 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    set_token: SET_KW@57..61 "set" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@61..64 "bar" [] [],
+                    },
+                    l_paren_token: L_PAREN@64..65 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@65..66 "a" [] [],
                         },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@210..212 "}" [Whitespace("\n")] [],
-                ),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@68..69 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@69..70 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@70..76 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_STRING_LITERAL@76..81 "\"baz\"" [] [],
+                    },
+                    l_paren_token: L_PAREN@81..82 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@82..83 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@83..85 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@85..86 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@86..87 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@87..93 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@93..94 "[" [] [],
+                        expression: JsBinaryExpression {
+                            left: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@94..98 "\"a\"" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@98..100 "+" [] [Whitespace(" ")],
+                        },
+                        r_brack_token: R_BRACK@103..104 "]" [] [],
+                    },
+                    l_paren_token: L_PAREN@104..105 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@105..106 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@106..108 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@108..109 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@109..110 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@110..116 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: JS_NUMBER_LITERAL@116..117 "5" [] [],
+                    },
+                    l_paren_token: L_PAREN@117..118 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@118..119 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@119..121 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@121..122 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@122..123 "}" [] [],
+                    },
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@123..129 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@129..130 "#" [] [],
+                        id_token: IDENT@130..137 "private" [] [],
+                    },
+                    l_paren_token: L_PAREN@137..138 "(" [] [],
+                    parameter: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@138..139 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@139..141 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@141..142 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@142..143 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@143..145 "}" [Whitespace("\n")] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@145..152 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@152..163 "NotSetters" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@163..164 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@164..169 "set" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@169..170 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@170..171 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@171..173 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@173..174 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@174..175 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@175..183 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@183..186 "set" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@186..187 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@187..188 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@188..190 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@190..191 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@191..192 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@192..201 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@201..204 "set" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@204..205 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@205..206 "a" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@206..208 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@208..209 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@209..210 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@210..212 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
@@ -219,17 +219,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@169..170 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@170..171 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@170..171 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@171..173 ")" [] [Whitespace(" ")],
                     },
@@ -254,17 +252,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@186..187 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@187..188 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@187..188 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@188..190 ")" [] [Whitespace(" ")],
                     },
@@ -289,17 +285,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@204..205 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@205..206 "a" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@205..206 "a" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@206..208 ")" [] [Whitespace(" ")],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_number.rast
@@ -1,3 +1,650 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..14 "Setters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@14..15 "{" [] [],
+                ),
+                members: [
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@15..21 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@21..24 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@24..25 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@25..26 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@28..29 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@29..30 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@30..36 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@36..42 "static" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@42..43 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@43..44 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@44..46 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@46..47 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@47..48 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: Some(
+                                STATIC_KW@48..57 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            set_token: Ok(
+                                SET_KW@57..61 "set" [] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@61..64 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@64..65 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@65..66 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@66..68 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@68..69 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@69..70 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@70..76 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_STRING_LITERAL@76..81 "\"baz\"" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@81..82 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@82..83 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@83..85 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@85..86 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@86..87 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@87..93 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsComputedMemberName(
+                                    JsComputedMemberName {
+                                        l_brack_token: Ok(
+                                            L_BRACK@93..94 "[" [] [],
+                                        ),
+                                        expression: Ok(
+                                            JsBinaryExpression(
+                                                JsBinaryExpression {
+                                                    left: Ok(
+                                                        JsAnyLiteralExpression(
+                                                            JsStringLiteralExpression(
+                                                                JsStringLiteralExpression {
+                                                                    value_token: Ok(
+                                                                        JS_STRING_LITERAL@94..98 "\"a\"" [] [Whitespace(" ")],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    ),
+                                                    operator: Ok(
+                                                        PLUS@98..100 "+" [] [Whitespace(" ")],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        r_brack_token: Ok(
+                                            R_BRACK@103..104 "]" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@104..105 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@105..106 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@106..108 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@108..109 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@109..110 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@110..116 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            JS_NUMBER_LITERAL@116..117 "5" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@117..118 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@118..119 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@119..121 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@121..122 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@122..123 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsSetterClassMember(
+                        JsSetterClassMember {
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            set_token: Ok(
+                                SET_KW@123..129 "set" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@129..130 "#" [] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@130..137 "private" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            l_paren_token: Ok(
+                                L_PAREN@137..138 "(" [] [],
+                            ),
+                            parameter: Ok(
+                                SinglePattern(
+                                    SinglePattern {
+                                        name: Ok(
+                                            Name {
+                                                ident_token: Ok(
+                                                    IDENT@138..139 "a" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        question_mark_token: None,
+                                        excl_token: None,
+                                        ty: None,
+                                    },
+                                ),
+                            ),
+                            r_paren_token: Ok(
+                                R_PAREN@139..141 ")" [] [Whitespace(" ")],
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@141..142 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@142..143 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@143..145 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@145..152 "class" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@152..163 "NotSetters" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@163..164 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@164..169 "set" [Whitespace("\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@169..170 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@170..171 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@171..173 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@173..174 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@174..175 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@175..183 "async" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@183..186 "set" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@186..187 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@187..188 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@188..190 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@190..191 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@191..192 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@192..201 "static" [Whitespace("\n\t")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@201..204 "set" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@204..205 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@205..206 "a" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@206..208 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@208..209 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@209..210 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@210..212 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..213
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
@@ -1,3 +1,374 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@8..9 "{" [] [],
+                                                        ),
+                                                        members: [
+                                                            AstSeparatedElement {
+                                                                node: JsSetterObjectMember(
+                                                                    JsSetterObjectMember {
+                                                                        set_token: Ok(
+                                                                            SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@15..18 "foo" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@18..19 "(" [] [],
+                                                                        ),
+                                                                        parameter: Ok(
+                                                                            SinglePattern(
+                                                                                SinglePattern {
+                                                                                    name: Ok(
+                                                                                        Name {
+                                                                                            ident_token: Ok(
+                                                                                                IDENT@19..24 "value" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    question_mark_token: None,
+                                                                                    excl_token: None,
+                                                                                    ty: None,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@26..27 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@27..30 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@30..31 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsSetterObjectMember(
+                                                                    JsSetterObjectMember {
+                                                                        set_token: Ok(
+                                                                            SET_KW@31..38 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_STRING_LITERAL@38..43 "\"bar\"" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@43..44 "(" [] [],
+                                                                        ),
+                                                                        parameter: Ok(
+                                                                            SinglePattern(
+                                                                                SinglePattern {
+                                                                                    name: Ok(
+                                                                                        Name {
+                                                                                            ident_token: Ok(
+                                                                                                IDENT@44..49 "value" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    question_mark_token: None,
+                                                                                    excl_token: None,
+                                                                                    ty: None,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@49..51 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@51..52 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@52..55 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@55..56 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsSetterObjectMember(
+                                                                    JsSetterObjectMember {
+                                                                        set_token: Ok(
+                                                                            SET_KW@56..63 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsComputedMemberName(
+                                                                                JsComputedMemberName {
+                                                                                    l_brack_token: Ok(
+                                                                                        L_BRACK@63..64 "[" [] [],
+                                                                                    ),
+                                                                                    expression: Ok(
+                                                                                        JsBinaryExpression(
+                                                                                            JsBinaryExpression {
+                                                                                                left: Ok(
+                                                                                                    JsAnyLiteralExpression(
+                                                                                                        JsStringLiteralExpression(
+                                                                                                            JsStringLiteralExpression {
+                                                                                                                value_token: Ok(
+                                                                                                                    JS_STRING_LITERAL@64..68 "\"a\"" [] [Whitespace(" ")],
+                                                                                                                ),
+                                                                                                            },
+                                                                                                        ),
+                                                                                                    ),
+                                                                                                ),
+                                                                                                operator: Ok(
+                                                                                                    PLUS@68..70 "+" [] [Whitespace(" ")],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    r_brack_token: Ok(
+                                                                                        R_BRACK@73..74 "]" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@74..75 "(" [] [],
+                                                                        ),
+                                                                        parameter: Ok(
+                                                                            SinglePattern(
+                                                                                SinglePattern {
+                                                                                    name: Ok(
+                                                                                        Name {
+                                                                                            ident_token: Ok(
+                                                                                                IDENT@75..80 "value" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    question_mark_token: None,
+                                                                                    excl_token: None,
+                                                                                    ty: None,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@80..82 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@82..83 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@83..86 "}" [Whitespace("\n ")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@86..87 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsSetterObjectMember(
+                                                                    JsSetterObjectMember {
+                                                                        set_token: Ok(
+                                                                            SET_KW@87..94 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                                        ),
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        JS_NUMBER_LITERAL@94..95 "5" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@95..96 "(" [] [],
+                                                                        ),
+                                                                        parameter: Ok(
+                                                                            SinglePattern(
+                                                                                SinglePattern {
+                                                                                    name: Ok(
+                                                                                        Name {
+                                                                                            ident_token: Ok(
+                                                                                                IDENT@96..101 "value" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    question_mark_token: None,
+                                                                                    excl_token: None,
+                                                                                    ty: None,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@101..103 ")" [] [Whitespace(" ")],
+                                                                        ),
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@103..104 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@104..107 "}" [Whitespace("\n\t")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: Some(
+                                                                    COMMA@107..108 "," [] [],
+                                                                ),
+                                                            },
+                                                            AstSeparatedElement {
+                                                                node: JsMethodObjectMember(
+                                                                    JsMethodObjectMember {
+                                                                        async_token: None,
+                                                                        star_token: None,
+                                                                        name: Ok(
+                                                                            JsLiteralMemberName(
+                                                                                JsLiteralMemberName {
+                                                                                    value: Ok(
+                                                                                        IDENT@108..114 "set" [Whitespace("\n\n\t")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        type_params: None,
+                                                                        parameter_list: Ok(
+                                                                            JsParameterList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@114..115 "(" [] [],
+                                                                                ),
+                                                                                parameters: [],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@115..117 ")" [] [Whitespace(" ")],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        return_type: None,
+                                                                        body: Ok(
+                                                                            JsFunctionBody {
+                                                                                l_curly_token: Ok(
+                                                                                    L_CURLY@117..118 "{" [] [],
+                                                                                ),
+                                                                                directives: [],
+                                                                                statements: [
+                                                                                    JsReturnStatement(
+                                                                                        JsReturnStatement {
+                                                                                            return_token: Ok(
+                                                                                                RETURN_KW@118..128 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                                                            ),
+                                                                                            argument: Some(
+                                                                                                JsAnyLiteralExpression(
+                                                                                                    JsStringLiteralExpression(
+                                                                                                        JsStringLiteralExpression {
+                                                                                                            value_token: Ok(
+                                                                                                                JS_STRING_LITERAL@128..163 "\"This is a method and not a setter\"" [] [],
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ),
+                                                                                            ),
+                                                                                            semicolon_token: Some(
+                                                                                                SEMICOLON@163..164 ";" [] [],
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                r_curly_token: Ok(
+                                                                                    R_CURLY@164..167 "}" [Whitespace("\n\t")] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                trailing_separator: None,
+                                                            },
+                                                        ],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@167..169 "}" [Whitespace("\n")] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..170
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
@@ -6,174 +6,154 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@8..9 "{" [] [],
-                                    members: [
-                                        AstSeparatedElement {
-                                            node: JsSetterObjectMember {
-                                                set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@15..18 "foo" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@18..19 "(" [] [],
-                                                parameter: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@19..24 "value" [] [],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
-                                                },
-                                                r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@26..27 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@27..30 "}" [Whitespace("\n ")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@30..31 "," [] [],
-                                            ),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@15..18 "foo" [] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsSetterObjectMember {
-                                                set_token: SET_KW@31..38 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: JS_STRING_LITERAL@38..43 "\"bar\"" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@43..44 "(" [] [],
-                                                parameter: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@44..49 "value" [] [],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
-                                                },
-                                                r_paren_token: R_PAREN@49..51 ")" [] [Whitespace(" ")],
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@51..52 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@52..55 "}" [Whitespace("\n ")] [],
-                                                },
+                                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                                        parameter: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@19..24 "value" [] [],
                                             },
-                                            trailing_separator: Some(
-                                                COMMA@55..56 "," [] [],
-                                            ),
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
                                         },
-                                        AstSeparatedElement {
-                                            node: JsSetterObjectMember {
-                                                set_token: SET_KW@56..63 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                name: JsComputedMemberName {
-                                                    l_brack_token: L_BRACK@63..64 "[" [] [],
-                                                    expression: JsBinaryExpression {
-                                                        left: JsStringLiteralExpression {
-                                                            value_token: JS_STRING_LITERAL@64..68 "\"a\"" [] [Whitespace(" ")],
-                                                        },
-                                                        operator: PLUS@68..70 "+" [] [Whitespace(" ")],
-                                                    },
-                                                    r_brack_token: R_BRACK@73..74 "]" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@74..75 "(" [] [],
-                                                parameter: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@75..80 "value" [] [],
-                                                    },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
-                                                },
-                                                r_paren_token: R_PAREN@80..82 ")" [] [Whitespace(" ")],
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@82..83 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@83..86 "}" [Whitespace("\n ")] [],
-                                                },
+                                        r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@26..27 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@27..30 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    COMMA@30..31 "," [] [],
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@31..38 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: JS_STRING_LITERAL@38..43 "\"bar\"" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@43..44 "(" [] [],
+                                        parameter: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@44..49 "value" [] [],
                                             },
-                                            trailing_separator: Some(
-                                                COMMA@86..87 "," [] [],
-                                            ),
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
                                         },
-                                        AstSeparatedElement {
-                                            node: JsSetterObjectMember {
-                                                set_token: SET_KW@87..94 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                name: JsLiteralMemberName {
-                                                    value: JS_NUMBER_LITERAL@94..95 "5" [] [],
+                                        r_paren_token: R_PAREN@49..51 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@51..52 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@52..55 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    COMMA@55..56 "," [] [],
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@56..63 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                        name: JsComputedMemberName {
+                                            l_brack_token: L_BRACK@63..64 "[" [] [],
+                                            expression: JsBinaryExpression {
+                                                left: JsStringLiteralExpression {
+                                                    value_token: JS_STRING_LITERAL@64..68 "\"a\"" [] [Whitespace(" ")],
                                                 },
-                                                l_paren_token: L_PAREN@95..96 "(" [] [],
-                                                parameter: SinglePattern {
-                                                    name: Name {
-                                                        ident_token: IDENT@96..101 "value" [] [],
+                                                operator: PLUS@68..70 "+" [] [Whitespace(" ")],
+                                            },
+                                            r_brack_token: R_BRACK@73..74 "]" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@74..75 "(" [] [],
+                                        parameter: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@75..80 "value" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        r_paren_token: R_PAREN@80..82 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@82..83 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@83..86 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    COMMA@86..87 "," [] [],
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@87..94 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@94..95 "5" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@95..96 "(" [] [],
+                                        parameter: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@96..101 "value" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        r_paren_token: R_PAREN@101..103 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@103..104 "{" [] [],
+                                            directives: [],
+                                            statements: [],
+                                            r_curly_token: R_CURLY@104..107 "}" [Whitespace("\n\t")] [],
+                                        },
+                                    }
+                                    COMMA@107..108 "," [] [],
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@108..114 "set" [Whitespace("\n\n\t")] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameter_list: JsParameterList {
+                                            l_paren_token: L_PAREN@114..115 "(" [] [],
+                                            parameters: [],
+                                            r_paren_token: R_PAREN@115..117 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@117..118 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@118..128 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                    argument: JsStringLiteralExpression {
+                                                        value_token: JS_STRING_LITERAL@128..163 "\"This is a method and not a setter\"" [] [],
                                                     },
-                                                    question_mark_token: missing (optional),
-                                                    excl_token: missing (optional),
-                                                    ty: missing (optional),
+                                                    semicolon_token: SEMICOLON@163..164 ";" [] [],
                                                 },
-                                                r_paren_token: R_PAREN@101..103 ")" [] [Whitespace(" ")],
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@103..104 "{" [] [],
-                                                    directives: [],
-                                                    statements: [],
-                                                    r_curly_token: R_CURLY@104..107 "}" [Whitespace("\n\t")] [],
-                                                },
-                                            },
-                                            trailing_separator: Some(
-                                                COMMA@107..108 "," [] [],
-                                            ),
+                                            ],
+                                            r_curly_token: R_CURLY@164..167 "}" [Whitespace("\n\t")] [],
                                         },
-                                        AstSeparatedElement {
-                                            node: JsMethodObjectMember {
-                                                async_token: missing (optional),
-                                                star_token: missing (optional),
-                                                name: JsLiteralMemberName {
-                                                    value: IDENT@108..114 "set" [Whitespace("\n\n\t")] [],
-                                                },
-                                                type_params: missing (optional),
-                                                parameter_list: JsParameterList {
-                                                    l_paren_token: L_PAREN@114..115 "(" [] [],
-                                                    parameters: [],
-                                                    r_paren_token: R_PAREN@115..117 ")" [] [Whitespace(" ")],
-                                                },
-                                                return_type: missing (optional),
-                                                body: JsFunctionBody {
-                                                    l_curly_token: L_CURLY@117..118 "{" [] [],
-                                                    directives: [],
-                                                    statements: [
-                                                        JsReturnStatement {
-                                                            return_token: RETURN_KW@118..128 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                            argument: JsStringLiteralExpression {
-                                                                value_token: JS_STRING_LITERAL@128..163 "\"This is a method and not a setter\"" [] [],
-                                                            },
-                                                            semicolon_token: SEMICOLON@163..164 ";" [] [],
-                                                        },
-                                                    ],
-                                                    r_curly_token: R_CURLY@164..167 "}" [Whitespace("\n\t")] [],
-                                                },
-                                            },
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_curly_token: R_CURLY@167..169 "}" [Whitespace("\n")] [],
-                                },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@167..169 "}" [Whitespace("\n")] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
@@ -1,371 +1,183 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@8..9 "{" [] [],
+                                    members: [
+                                        AstSeparatedElement {
+                                            node: JsSetterObjectMember {
+                                                set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@15..18 "foo" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@18..19 "(" [] [],
+                                                parameter: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@19..24 "value" [] [],
                                                     },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
+                                                r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@26..27 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@27..30 "}" [Whitespace("\n ")] [],
+                                                },
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@8..9 "{" [] [],
-                                                        ),
-                                                        members: [
-                                                            AstSeparatedElement {
-                                                                node: JsSetterObjectMember(
-                                                                    JsSetterObjectMember {
-                                                                        set_token: Ok(
-                                                                            SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@15..18 "foo" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@18..19 "(" [] [],
-                                                                        ),
-                                                                        parameter: Ok(
-                                                                            SinglePattern(
-                                                                                SinglePattern {
-                                                                                    name: Ok(
-                                                                                        Name {
-                                                                                            ident_token: Ok(
-                                                                                                IDENT@19..24 "value" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    question_mark_token: None,
-                                                                                    excl_token: None,
-                                                                                    ty: None,
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@24..26 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@26..27 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@27..30 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@30..31 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsSetterObjectMember(
-                                                                    JsSetterObjectMember {
-                                                                        set_token: Ok(
-                                                                            SET_KW@31..38 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_STRING_LITERAL@38..43 "\"bar\"" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@43..44 "(" [] [],
-                                                                        ),
-                                                                        parameter: Ok(
-                                                                            SinglePattern(
-                                                                                SinglePattern {
-                                                                                    name: Ok(
-                                                                                        Name {
-                                                                                            ident_token: Ok(
-                                                                                                IDENT@44..49 "value" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    question_mark_token: None,
-                                                                                    excl_token: None,
-                                                                                    ty: None,
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@49..51 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@51..52 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@52..55 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@55..56 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsSetterObjectMember(
-                                                                    JsSetterObjectMember {
-                                                                        set_token: Ok(
-                                                                            SET_KW@56..63 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsComputedMemberName(
-                                                                                JsComputedMemberName {
-                                                                                    l_brack_token: Ok(
-                                                                                        L_BRACK@63..64 "[" [] [],
-                                                                                    ),
-                                                                                    expression: Ok(
-                                                                                        JsBinaryExpression(
-                                                                                            JsBinaryExpression {
-                                                                                                left: Ok(
-                                                                                                    JsAnyLiteralExpression(
-                                                                                                        JsStringLiteralExpression(
-                                                                                                            JsStringLiteralExpression {
-                                                                                                                value_token: Ok(
-                                                                                                                    JS_STRING_LITERAL@64..68 "\"a\"" [] [Whitespace(" ")],
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ),
-                                                                                                ),
-                                                                                                operator: Ok(
-                                                                                                    PLUS@68..70 "+" [] [Whitespace(" ")],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    r_brack_token: Ok(
-                                                                                        R_BRACK@73..74 "]" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@74..75 "(" [] [],
-                                                                        ),
-                                                                        parameter: Ok(
-                                                                            SinglePattern(
-                                                                                SinglePattern {
-                                                                                    name: Ok(
-                                                                                        Name {
-                                                                                            ident_token: Ok(
-                                                                                                IDENT@75..80 "value" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    question_mark_token: None,
-                                                                                    excl_token: None,
-                                                                                    ty: None,
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@80..82 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@82..83 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@83..86 "}" [Whitespace("\n ")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@86..87 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsSetterObjectMember(
-                                                                    JsSetterObjectMember {
-                                                                        set_token: Ok(
-                                                                            SET_KW@87..94 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
-                                                                        ),
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        JS_NUMBER_LITERAL@94..95 "5" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@95..96 "(" [] [],
-                                                                        ),
-                                                                        parameter: Ok(
-                                                                            SinglePattern(
-                                                                                SinglePattern {
-                                                                                    name: Ok(
-                                                                                        Name {
-                                                                                            ident_token: Ok(
-                                                                                                IDENT@96..101 "value" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                    question_mark_token: None,
-                                                                                    excl_token: None,
-                                                                                    ty: None,
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@101..103 ")" [] [Whitespace(" ")],
-                                                                        ),
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@103..104 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@104..107 "}" [Whitespace("\n\t")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: Some(
-                                                                    COMMA@107..108 "," [] [],
-                                                                ),
-                                                            },
-                                                            AstSeparatedElement {
-                                                                node: JsMethodObjectMember(
-                                                                    JsMethodObjectMember {
-                                                                        async_token: None,
-                                                                        star_token: None,
-                                                                        name: Ok(
-                                                                            JsLiteralMemberName(
-                                                                                JsLiteralMemberName {
-                                                                                    value: Ok(
-                                                                                        IDENT@108..114 "set" [Whitespace("\n\n\t")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        type_params: None,
-                                                                        parameter_list: Ok(
-                                                                            JsParameterList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@114..115 "(" [] [],
-                                                                                ),
-                                                                                parameters: [],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@115..117 ")" [] [Whitespace(" ")],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                        return_type: None,
-                                                                        body: Ok(
-                                                                            JsFunctionBody {
-                                                                                l_curly_token: Ok(
-                                                                                    L_CURLY@117..118 "{" [] [],
-                                                                                ),
-                                                                                directives: [],
-                                                                                statements: [
-                                                                                    JsReturnStatement(
-                                                                                        JsReturnStatement {
-                                                                                            return_token: Ok(
-                                                                                                RETURN_KW@118..128 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
-                                                                                            ),
-                                                                                            argument: Some(
-                                                                                                JsAnyLiteralExpression(
-                                                                                                    JsStringLiteralExpression(
-                                                                                                        JsStringLiteralExpression {
-                                                                                                            value_token: Ok(
-                                                                                                                JS_STRING_LITERAL@128..163 "\"This is a method and not a setter\"" [] [],
-                                                                                                            ),
-                                                                                                        },
-                                                                                                    ),
-                                                                                                ),
-                                                                                            ),
-                                                                                            semicolon_token: Some(
-                                                                                                SEMICOLON@163..164 ";" [] [],
-                                                                                            ),
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                r_curly_token: Ok(
-                                                                                    R_CURLY@164..167 "}" [Whitespace("\n\t")] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                trailing_separator: None,
-                                                            },
-                                                        ],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@167..169 "}" [Whitespace("\n")] [],
-                                                        ),
-                                                    },
-                                                ),
+                                            trailing_separator: Some(
+                                                COMMA@30..31 "," [] [],
                                             ),
                                         },
-                                    ),
+                                        AstSeparatedElement {
+                                            node: JsSetterObjectMember {
+                                                set_token: SET_KW@31..38 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: JS_STRING_LITERAL@38..43 "\"bar\"" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@43..44 "(" [] [],
+                                                parameter: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@44..49 "value" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
+                                                r_paren_token: R_PAREN@49..51 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@51..52 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@52..55 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@55..56 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsSetterObjectMember {
+                                                set_token: SET_KW@56..63 "set" [Whitespace("\n\n ")] [Whitespace(" ")],
+                                                name: JsComputedMemberName {
+                                                    l_brack_token: L_BRACK@63..64 "[" [] [],
+                                                    expression: JsBinaryExpression {
+                                                        left: JsStringLiteralExpression {
+                                                            value_token: JS_STRING_LITERAL@64..68 "\"a\"" [] [Whitespace(" ")],
+                                                        },
+                                                        operator: PLUS@68..70 "+" [] [Whitespace(" ")],
+                                                    },
+                                                    r_brack_token: R_BRACK@73..74 "]" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@74..75 "(" [] [],
+                                                parameter: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@75..80 "value" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
+                                                r_paren_token: R_PAREN@80..82 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@82..83 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@83..86 "}" [Whitespace("\n ")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@86..87 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsSetterObjectMember {
+                                                set_token: SET_KW@87..94 "set" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: JS_NUMBER_LITERAL@94..95 "5" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@95..96 "(" [] [],
+                                                parameter: SinglePattern {
+                                                    name: Name {
+                                                        ident_token: IDENT@96..101 "value" [] [],
+                                                    },
+                                                    question_mark_token: missing (optional),
+                                                    excl_token: missing (optional),
+                                                    ty: missing (optional),
+                                                },
+                                                r_paren_token: R_PAREN@101..103 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@103..104 "{" [] [],
+                                                    directives: [],
+                                                    statements: [],
+                                                    r_curly_token: R_CURLY@104..107 "}" [Whitespace("\n\t")] [],
+                                                },
+                                            },
+                                            trailing_separator: Some(
+                                                COMMA@107..108 "," [] [],
+                                            ),
+                                        },
+                                        AstSeparatedElement {
+                                            node: JsMethodObjectMember {
+                                                async_token: missing (optional),
+                                                star_token: missing (optional),
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@108..114 "set" [Whitespace("\n\n\t")] [],
+                                                },
+                                                type_params: missing (optional),
+                                                parameter_list: JsParameterList {
+                                                    l_paren_token: L_PAREN@114..115 "(" [] [],
+                                                    parameters: [],
+                                                    r_paren_token: R_PAREN@115..117 ")" [] [Whitespace(" ")],
+                                                },
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@117..118 "{" [] [],
+                                                    directives: [],
+                                                    statements: [
+                                                        JsReturnStatement {
+                                                            return_token: RETURN_KW@118..128 "return" [Whitespace("\n\t ")] [Whitespace(" ")],
+                                                            argument: JsStringLiteralExpression {
+                                                                value_token: JS_STRING_LITERAL@128..163 "\"This is a method and not a setter\"" [] [],
+                                                            },
+                                                            semicolon_token: SEMICOLON@163..164 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@164..167 "}" [Whitespace("\n\t")] [],
+                                                },
+                                            },
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@167..169 "}" [Whitespace("\n")] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: None,
+                ],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
@@ -1,3 +1,463 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@0..3 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@3..4 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@4..7 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@7..11 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@11..12 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@12..17 "await" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@17..21 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@21..22 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@22..27 "yield" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@27..31 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@31..32 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@32..35 "for" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@35..39 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTIONDOT@39..41 "?." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@41..44 "for" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                QUESTIONDOT@48..50 "?." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@50..53 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@53..61 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@61..66 "Test" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@66..67 "{" [] [],
+                ),
+                members: [
+                    JsPropertyClassMember(
+                        JsPropertyClassMember {
+                            declare_token: None,
+                            access_modifier: None,
+                            abstract_token: None,
+                            static_token: None,
+                            name: Ok(
+                                JsPrivateClassMemberName(
+                                    JsPrivateClassMemberName {
+                                        hash_token: Ok(
+                                            HASH@67..70 "#" [Whitespace("\n\t")] [],
+                                        ),
+                                        id_token: Ok(
+                                            IDENT@70..73 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            question_mark_token: None,
+                            excl_token: None,
+                            ty: None,
+                            value: None,
+                            semicolon_token: None,
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@73..80 "test" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@80..81 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@81..86 "other" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@86..88 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@88..89 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    JsStaticMemberExpression(
+                                                        JsStaticMemberExpression {
+                                                            object: Ok(
+                                                                JsThisExpression(
+                                                                    JsThisExpression {
+                                                                        this_token: Ok(
+                                                                            THIS_KW@89..96 "this" [Whitespace("\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            operator: Ok(
+                                                                DOT@96..97 "." [] [],
+                                                            ),
+                                                            member: Ok(
+                                                                JsReferencePrivateMember(
+                                                                    JsReferencePrivateMember {
+                                                                        hash_token: Ok(
+                                                                            HASH@97..98 "#" [] [],
+                                                                        ),
+                                                                        name_token: Ok(
+                                                                            IDENT@98..101 "bar" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@101..102 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    JsStaticMemberExpression(
+                                                        JsStaticMemberExpression {
+                                                            object: Ok(
+                                                                JsThisExpression(
+                                                                    JsThisExpression {
+                                                                        this_token: Ok(
+                                                                            THIS_KW@102..109 "this" [Whitespace("\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            operator: Ok(
+                                                                QUESTIONDOT@109..111 "?." [] [],
+                                                            ),
+                                                            member: Ok(
+                                                                JsReferencePrivateMember(
+                                                                    JsReferencePrivateMember {
+                                                                        hash_token: Ok(
+                                                                            HASH@111..112 "#" [] [],
+                                                                        ),
+                                                                        name_token: Ok(
+                                                                            IDENT@112..115 "bar" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@115..116 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    JsStaticMemberExpression(
+                                                        JsStaticMemberExpression {
+                                                            object: Ok(
+                                                                JsReferenceIdentifierExpression(
+                                                                    JsReferenceIdentifierExpression {
+                                                                        name_token: Ok(
+                                                                            IDENT@116..125 "other" [Whitespace("\n\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            operator: Ok(
+                                                                DOT@125..126 "." [] [],
+                                                            ),
+                                                            member: Ok(
+                                                                JsReferencePrivateMember(
+                                                                    JsReferencePrivateMember {
+                                                                        hash_token: Ok(
+                                                                            HASH@126..127 "#" [] [],
+                                                                        ),
+                                                                        name_token: Ok(
+                                                                            IDENT@127..130 "bar" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@130..131 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    JsStaticMemberExpression(
+                                                        JsStaticMemberExpression {
+                                                            object: Ok(
+                                                                JsReferenceIdentifierExpression(
+                                                                    JsReferenceIdentifierExpression {
+                                                                        name_token: Ok(
+                                                                            IDENT@131..139 "other" [Whitespace("\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            operator: Ok(
+                                                                QUESTIONDOT@139..141 "?." [] [],
+                                                            ),
+                                                            member: Ok(
+                                                                JsReferencePrivateMember(
+                                                                    JsReferencePrivateMember {
+                                                                        hash_token: Ok(
+                                                                            HASH@141..142 "#" [] [],
+                                                                        ),
+                                                                        name_token: Ok(
+                                                                            IDENT@142..145 "bar" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@145..146 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    r_curly_token: Ok(
+                                        R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@149..151 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..152
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
@@ -111,17 +111,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@80..81 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@81..86 "other" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@81..86 "other" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@86..88 ")" [] [Whitespace(" ")],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
@@ -1,460 +1,194 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@0..3 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@3..4 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@4..7 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                operator: DOT@3..4 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@4..7 "bar" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@7..11 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@11..12 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@12..17 "await" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@7..11 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@11..12 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@12..17 "await" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@17..21 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@21..22 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@22..27 "yield" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@17..21 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@21..22 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@22..27 "yield" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@27..31 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@31..32 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@32..35 "for" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@27..31 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@31..32 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@32..35 "for" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@35..39 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTIONDOT@39..41 "?." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@41..44 "for" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@35..39 "foo" [Whitespace("\n")] [],
+                },
+                operator: QUESTIONDOT@39..41 "?." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@41..44 "for" [] [],
+                },
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@44..48 "foo" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                QUESTIONDOT@48..50 "?." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@50..53 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                },
+                operator: QUESTIONDOT@48..50 "?." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@50..53 "bar" [] [],
+                },
             },
-        ),
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@53..61 "class" [Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@61..66 "Test" [] [Whitespace(" ")],
-                        ),
+            semicolon_token: missing (optional),
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@53..61 "class" [Whitespace("\n\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@61..66 "Test" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@66..67 "{" [] [],
+            members: [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@67..70 "#" [Whitespace("\n\t")] [],
+                        id_token: IDENT@70..73 "bar" [] [],
                     },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@66..67 "{" [] [],
-                ),
-                members: [
-                    JsPropertyClassMember(
-                        JsPropertyClassMember {
-                            declare_token: None,
-                            access_modifier: None,
-                            abstract_token: None,
-                            static_token: None,
-                            name: Ok(
-                                JsPrivateClassMemberName(
-                                    JsPrivateClassMemberName {
-                                        hash_token: Ok(
-                                            HASH@67..70 "#" [Whitespace("\n\t")] [],
-                                        ),
-                                        id_token: Ok(
-                                            IDENT@70..73 "bar" [] [],
-                                        ),
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@73..80 "test" [Whitespace("\n\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@80..81 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@81..86 "other" [] [],
                                     },
-                                ),
-                            ),
-                            question_mark_token: None,
-                            excl_token: None,
-                            ty: None,
-                            value: None,
-                            semicolon_token: None,
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@73..80 "test" [Whitespace("\n\n\t")] [],
-                                        ),
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@86..88 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@88..89 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: JsStaticMemberExpression {
+                                    object: JsThisExpression {
+                                        this_token: THIS_KW@89..96 "this" [Whitespace("\n\t\t")] [],
                                     },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@80..81 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@81..86 "other" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@86..88 ")" [] [Whitespace(" ")],
-                                    ),
+                                    operator: DOT@96..97 "." [] [],
+                                    member: JsReferencePrivateMember {
+                                        hash_token: HASH@97..98 "#" [] [],
+                                        name_token: IDENT@98..101 "bar" [] [],
+                                    },
                                 },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@88..89 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    JsStaticMemberExpression(
-                                                        JsStaticMemberExpression {
-                                                            object: Ok(
-                                                                JsThisExpression(
-                                                                    JsThisExpression {
-                                                                        this_token: Ok(
-                                                                            THIS_KW@89..96 "this" [Whitespace("\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            operator: Ok(
-                                                                DOT@96..97 "." [] [],
-                                                            ),
-                                                            member: Ok(
-                                                                JsReferencePrivateMember(
-                                                                    JsReferencePrivateMember {
-                                                                        hash_token: Ok(
-                                                                            HASH@97..98 "#" [] [],
-                                                                        ),
-                                                                        name_token: Ok(
-                                                                            IDENT@98..101 "bar" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@101..102 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    JsStaticMemberExpression(
-                                                        JsStaticMemberExpression {
-                                                            object: Ok(
-                                                                JsThisExpression(
-                                                                    JsThisExpression {
-                                                                        this_token: Ok(
-                                                                            THIS_KW@102..109 "this" [Whitespace("\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            operator: Ok(
-                                                                QUESTIONDOT@109..111 "?." [] [],
-                                                            ),
-                                                            member: Ok(
-                                                                JsReferencePrivateMember(
-                                                                    JsReferencePrivateMember {
-                                                                        hash_token: Ok(
-                                                                            HASH@111..112 "#" [] [],
-                                                                        ),
-                                                                        name_token: Ok(
-                                                                            IDENT@112..115 "bar" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@115..116 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    JsStaticMemberExpression(
-                                                        JsStaticMemberExpression {
-                                                            object: Ok(
-                                                                JsReferenceIdentifierExpression(
-                                                                    JsReferenceIdentifierExpression {
-                                                                        name_token: Ok(
-                                                                            IDENT@116..125 "other" [Whitespace("\n\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            operator: Ok(
-                                                                DOT@125..126 "." [] [],
-                                                            ),
-                                                            member: Ok(
-                                                                JsReferencePrivateMember(
-                                                                    JsReferencePrivateMember {
-                                                                        hash_token: Ok(
-                                                                            HASH@126..127 "#" [] [],
-                                                                        ),
-                                                                        name_token: Ok(
-                                                                            IDENT@127..130 "bar" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@130..131 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    JsStaticMemberExpression(
-                                                        JsStaticMemberExpression {
-                                                            object: Ok(
-                                                                JsReferenceIdentifierExpression(
-                                                                    JsReferenceIdentifierExpression {
-                                                                        name_token: Ok(
-                                                                            IDENT@131..139 "other" [Whitespace("\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            operator: Ok(
-                                                                QUESTIONDOT@139..141 "?." [] [],
-                                                            ),
-                                                            member: Ok(
-                                                                JsReferencePrivateMember(
-                                                                    JsReferencePrivateMember {
-                                                                        hash_token: Ok(
-                                                                            HASH@141..142 "#" [] [],
-                                                                        ),
-                                                                        name_token: Ok(
-                                                                            IDENT@142..145 "bar" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@145..146 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    r_curly_token: Ok(
-                                        R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
-                                    ),
+                                semicolon_token: SEMICOLON@101..102 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsStaticMemberExpression {
+                                    object: JsThisExpression {
+                                        this_token: THIS_KW@102..109 "this" [Whitespace("\n\t\t")] [],
+                                    },
+                                    operator: QUESTIONDOT@109..111 "?." [] [],
+                                    member: JsReferencePrivateMember {
+                                        hash_token: HASH@111..112 "#" [] [],
+                                        name_token: IDENT@112..115 "bar" [] [],
+                                    },
                                 },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@149..151 "}" [Whitespace("\n")] [],
-                ),
-            },
-        ),
+                                semicolon_token: SEMICOLON@115..116 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsStaticMemberExpression {
+                                    object: JsReferenceIdentifierExpression {
+                                        name_token: IDENT@116..125 "other" [Whitespace("\n\n\t\t")] [],
+                                    },
+                                    operator: DOT@125..126 "." [] [],
+                                    member: JsReferencePrivateMember {
+                                        hash_token: HASH@126..127 "#" [] [],
+                                        name_token: IDENT@127..130 "bar" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@130..131 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsStaticMemberExpression {
+                                    object: JsReferenceIdentifierExpression {
+                                        name_token: IDENT@131..139 "other" [Whitespace("\n\t\t")] [],
+                                    },
+                                    operator: QUESTIONDOT@139..141 "?." [] [],
+                                    member: JsReferencePrivateMember {
+                                        hash_token: HASH@141..142 "#" [] [],
+                                        name_token: IDENT@142..145 "bar" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@145..146 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@146..149 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@149..151 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -1,3 +1,242 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..10 "foo" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: None,
+                l_curly_token: Ok(
+                    L_CURLY@10..11 "{" [] [],
+                ),
+                members: [
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@11..20 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@20..23 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@23..24 "(" [] [],
+                                    ),
+                                    parameters: [
+                                        AstSeparatedElement {
+                                            node: Pattern(
+                                                SinglePattern(
+                                                    SinglePattern {
+                                                        name: Ok(
+                                                            Name {
+                                                                ident_token: Ok(
+                                                                    IDENT@24..27 "bar" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        question_mark_token: None,
+                                                        excl_token: None,
+                                                        ty: None,
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@29..30 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@30..31 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@31..40 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: Some(
+                                STAR@40..41 "*" [] [],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@41..44 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@44..45 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@45..47 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@47..48 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@48..49 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@49..58 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@58..64 "async" [] [Whitespace(" ")],
+                            ),
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@64..67 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@67..68 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@68..70 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@70..71 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@71..72 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: Some(
+                                STATIC_KW@72..81 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            abstract_token: None,
+                            async_token: Some(
+                                ASYNC_KW@81..87 "async" [] [Whitespace(" ")],
+                            ),
+                            star_token: Some(
+                                STAR@87..88 "*" [] [],
+                            ),
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@88..91 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@91..92 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@92..94 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@94..95 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [],
+                                    r_curly_token: Ok(
+                                        R_CURLY@95..96 "}" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@96..98 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..99
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -24,17 +24,15 @@ JsRoot {
                     parameter_list: JsParameterList {
                         l_paren_token: L_PAREN@23..24 "(" [] [],
                         parameters: [
-                            AstSeparatedElement {
-                                node: SinglePattern {
-                                    name: Name {
-                                        ident_token: IDENT@24..27 "bar" [] [],
-                                    },
-                                    question_mark_token: missing (optional),
-                                    excl_token: missing (optional),
-                                    ty: missing (optional),
+                            SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@24..27 "bar" [] [],
                                 },
-                                trailing_separator: None,
-                            },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -1,239 +1,123 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..10 "foo" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: None,
-                l_curly_token: Ok(
-                    L_CURLY@10..11 "{" [] [],
-                ),
-                members: [
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@11..20 "static" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@20..23 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@23..24 "(" [] [],
-                                    ),
-                                    parameters: [
-                                        AstSeparatedElement {
-                                            node: Pattern(
-                                                SinglePattern(
-                                                    SinglePattern {
-                                                        name: Ok(
-                                                            Name {
-                                                                ident_token: Ok(
-                                                                    IDENT@24..27 "bar" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        question_mark_token: None,
-                                                        excl_token: None,
-                                                        ty: None,
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@27..29 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@29..30 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@30..31 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@31..40 "static" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: Some(
-                                STAR@40..41 "*" [] [],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@41..44 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@44..45 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@45..47 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@47..48 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@48..49 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@49..58 "static" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@58..64 "async" [] [Whitespace(" ")],
-                            ),
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@64..67 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@67..68 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@68..70 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@70..71 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@71..72 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: Some(
-                                STATIC_KW@72..81 "static" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            abstract_token: None,
-                            async_token: Some(
-                                ASYNC_KW@81..87 "async" [] [Whitespace(" ")],
-                            ),
-                            star_token: Some(
-                                STAR@87..88 "*" [] [],
-                            ),
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@88..91 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@91..92 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@92..94 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@94..95 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [],
-                                    r_curly_token: Ok(
-                                        R_CURLY@95..96 "}" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@96..98 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@11..20 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@20..23 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@23..24 "(" [] [],
+                        parameters: [
+                            AstSeparatedElement {
+                                node: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@24..27 "bar" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@29..30 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@30..31 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@31..40 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@40..41 "*" [] [],
+                    name: JsLiteralMemberName {
+                        value: IDENT@41..44 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@44..45 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@45..47 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@47..48 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@48..49 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@49..58 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@58..64 "async" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@64..67 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@67..68 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@68..70 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@70..71 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@71..72 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@72..81 "static" [Whitespace("\n ")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@81..87 "async" [] [Whitespace(" ")],
+                    star_token: STAR@87..88 "*" [] [],
+                    name: JsLiteralMemberName {
+                        value: IDENT@88..91 "foo" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@91..92 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@92..94 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@94..95 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@95..96 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@96..98 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -22,12 +22,10 @@ JsRoot {
                             arguments: ArgList {
                                 l_paren_token: L_PAREN@12..13 "(" [] [],
                                 args: [
-                                    AstSeparatedElement {
-                                        node: JsReferenceIdentifierExpression {
-                                            name_token: IDENT@13..16 "bar" [] [],
-                                        },
-                                        trailing_separator: None,
-                                    },
+                                    JsReferenceIdentifierExpression {
+                                        name_token: IDENT@13..16 "bar" [] [],
+                                    }
+                                    ,
                                 ],
                                 r_paren_token: R_PAREN@16..17 ")" [] [],
                             },
@@ -35,12 +33,10 @@ JsRoot {
                         arguments: ArgList {
                             l_paren_token: L_PAREN@17..18 "(" [] [],
                             args: [
-                                AstSeparatedElement {
-                                    node: JsReferenceIdentifierExpression {
-                                        name_token: IDENT@18..21 "baz" [] [],
-                                    },
-                                    trailing_separator: None,
-                                },
+                                JsReferenceIdentifierExpression {
+                                    name_token: IDENT@18..21 "baz" [] [],
+                                }
+                                ,
                             ],
                             r_paren_token: R_PAREN@21..22 ")" [] [],
                         },
@@ -48,12 +44,10 @@ JsRoot {
                     arguments: ArgList {
                         l_paren_token: L_PAREN@22..23 "(" [] [],
                         args: [
-                            AstSeparatedElement {
-                                node: JsReferenceIdentifierExpression {
-                                    name_token: IDENT@23..26 "baz" [] [],
-                                },
-                                trailing_separator: None,
-                            },
+                            JsReferenceIdentifierExpression {
+                                name_token: IDENT@23..26 "baz" [] [],
+                            }
+                            ,
                         ],
                         r_paren_token: R_PAREN@26..27 ")" [] [],
                     },

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -1,135 +1,69 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    Template(
-                        Template {
-                            backtick_token: Ok(
-                                BACKTICK@3..4 "`" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: Template {
+                backtick_token: BACKTICK@3..4 "`" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsComputedMemberExpression(
-                        JsComputedMemberExpression {
-                            object: Ok(
-                                CallExpr(
-                                    CallExpr {
-                                        type_args: None,
-                                        callee: Ok(
-                                            CallExpr(
-                                                CallExpr {
-                                                    type_args: None,
-                                                    callee: Ok(
-                                                        CallExpr(
-                                                            CallExpr {
-                                                                type_args: None,
-                                                                callee: Ok(
-                                                                    JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@8..12 "foo" [Whitespace("\n")] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                arguments: Ok(
-                                                                    ArgList {
-                                                                        l_paren_token: Ok(
-                                                                            L_PAREN@12..13 "(" [] [],
-                                                                        ),
-                                                                        args: [
-                                                                            AstSeparatedElement {
-                                                                                node: JsReferenceIdentifierExpression(
-                                                                                    JsReferenceIdentifierExpression {
-                                                                                        name_token: Ok(
-                                                                                            IDENT@13..16 "bar" [] [],
-                                                                                        ),
-                                                                                    },
-                                                                                ),
-                                                                                trailing_separator: None,
-                                                                            },
-                                                                        ],
-                                                                        r_paren_token: Ok(
-                                                                            R_PAREN@16..17 ")" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ),
-                                                    arguments: Ok(
-                                                        ArgList {
-                                                            l_paren_token: Ok(
-                                                                L_PAREN@17..18 "(" [] [],
-                                                            ),
-                                                            args: [
-                                                                AstSeparatedElement {
-                                                                    node: JsReferenceIdentifierExpression(
-                                                                        JsReferenceIdentifierExpression {
-                                                                            name_token: Ok(
-                                                                                IDENT@18..21 "baz" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    trailing_separator: None,
-                                                                },
-                                                            ],
-                                                            r_paren_token: Ok(
-                                                                R_PAREN@21..22 ")" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        ),
-                                        arguments: Ok(
-                                            ArgList {
-                                                l_paren_token: Ok(
-                                                    L_PAREN@22..23 "(" [] [],
-                                                ),
-                                                args: [
-                                                    AstSeparatedElement {
-                                                        node: JsReferenceIdentifierExpression(
-                                                            JsReferenceIdentifierExpression {
-                                                                name_token: Ok(
-                                                                    IDENT@23..26 "baz" [] [],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_paren_token: Ok(
-                                                    R_PAREN@26..27 ")" [] [],
-                                                ),
-                                            },
-                                        ),
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: CallExpr {
+                    type_args: missing (optional),
+                    callee: CallExpr {
+                        type_args: missing (optional),
+                        callee: CallExpr {
+                            type_args: missing (optional),
+                            callee: JsReferenceIdentifierExpression {
+                                name_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                            },
+                            arguments: ArgList {
+                                l_paren_token: L_PAREN@12..13 "(" [] [],
+                                args: [
+                                    AstSeparatedElement {
+                                        node: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@13..16 "bar" [] [],
+                                        },
+                                        trailing_separator: None,
                                     },
-                                ),
-                            ),
-                            optional_chain_token_token: None,
-                            l_brack_token: Ok(
-                                L_BRACK@27..28 "[" [] [],
-                            ),
-                            r_brack_token: Ok(
-                                R_BRACK@31..32 "]" [] [],
-                            ),
+                                ],
+                                r_paren_token: R_PAREN@16..17 ")" [] [],
+                            },
                         },
-                    ),
-                ),
-                semicolon_token: None,
+                        arguments: ArgList {
+                            l_paren_token: L_PAREN@17..18 "(" [] [],
+                            args: [
+                                AstSeparatedElement {
+                                    node: JsReferenceIdentifierExpression {
+                                        name_token: IDENT@18..21 "baz" [] [],
+                                    },
+                                    trailing_separator: None,
+                                },
+                            ],
+                            r_paren_token: R_PAREN@21..22 ")" [] [],
+                        },
+                    },
+                    arguments: ArgList {
+                        l_paren_token: L_PAREN@22..23 "(" [] [],
+                        args: [
+                            AstSeparatedElement {
+                                node: JsReferenceIdentifierExpression {
+                                    name_token: IDENT@23..26 "baz" [] [],
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: R_PAREN@26..27 ")" [] [],
+                    },
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@27..28 "[" [] [],
+                r_brack_token: R_BRACK@31..32 "]" [] [],
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -1,3 +1,138 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    Template(
+                        Template {
+                            backtick_token: Ok(
+                                BACKTICK@3..4 "`" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsComputedMemberExpression(
+                        JsComputedMemberExpression {
+                            object: Ok(
+                                CallExpr(
+                                    CallExpr {
+                                        type_args: None,
+                                        callee: Ok(
+                                            CallExpr(
+                                                CallExpr {
+                                                    type_args: None,
+                                                    callee: Ok(
+                                                        CallExpr(
+                                                            CallExpr {
+                                                                type_args: None,
+                                                                callee: Ok(
+                                                                    JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@8..12 "foo" [Whitespace("\n")] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                arguments: Ok(
+                                                                    ArgList {
+                                                                        l_paren_token: Ok(
+                                                                            L_PAREN@12..13 "(" [] [],
+                                                                        ),
+                                                                        args: [
+                                                                            AstSeparatedElement {
+                                                                                node: JsReferenceIdentifierExpression(
+                                                                                    JsReferenceIdentifierExpression {
+                                                                                        name_token: Ok(
+                                                                                            IDENT@13..16 "bar" [] [],
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                trailing_separator: None,
+                                                                            },
+                                                                        ],
+                                                                        r_paren_token: Ok(
+                                                                            R_PAREN@16..17 ")" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                    arguments: Ok(
+                                                        ArgList {
+                                                            l_paren_token: Ok(
+                                                                L_PAREN@17..18 "(" [] [],
+                                                            ),
+                                                            args: [
+                                                                AstSeparatedElement {
+                                                                    node: JsReferenceIdentifierExpression(
+                                                                        JsReferenceIdentifierExpression {
+                                                                            name_token: Ok(
+                                                                                IDENT@18..21 "baz" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    trailing_separator: None,
+                                                                },
+                                                            ],
+                                                            r_paren_token: Ok(
+                                                                R_PAREN@21..22 ")" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        arguments: Ok(
+                                            ArgList {
+                                                l_paren_token: Ok(
+                                                    L_PAREN@22..23 "(" [] [],
+                                                ),
+                                                args: [
+                                                    AstSeparatedElement {
+                                                        node: JsReferenceIdentifierExpression(
+                                                            JsReferenceIdentifierExpression {
+                                                                name_token: Ok(
+                                                                    IDENT@23..26 "baz" [] [],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_paren_token: Ok(
+                                                    R_PAREN@26..27 ")" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                            optional_chain_token_token: None,
+                            l_brack_token: Ok(
+                                L_BRACK@27..28 "[" [] [],
+                            ),
+                            r_brack_token: Ok(
+                                R_BRACK@31..32 "]" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..33
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -1,264 +1,126 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsClassDeclaration(
-            JsClassDeclaration {
-                class_token: Ok(
-                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@6..11 "Test" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                implements_clause: None,
-                extends_clause: Some(
-                    JsExtendsClause {
-                        extends_token: Ok(
-                            EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")],
-                        ),
-                        super_class: Ok(
-                            JsReferenceIdentifierExpression(
-                                JsReferenceIdentifierExpression {
-                                    name_token: Ok(
-                                        IDENT@19..21 "B" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                        ),
-                    },
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@21..22 "{" [] [],
-                ),
-                members: [
-                    JsConstructorClassMember(
-                        JsConstructorClassMember {
-                            access_modifier: None,
-                            name: Ok(
-                                JsLiteralMemberName {
-                                    value: Ok(
-                                        IDENT@22..35 "constructor" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                            parameter_list: Ok(
-                                JsConstructorParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@35..36 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@36..38 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@38..39 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    CallExpr(
-                                                        CallExpr {
-                                                            type_args: None,
-                                                            callee: Ok(
-                                                                JsSuperExpression(
-                                                                    JsSuperExpression {
-                                                                        super_token: Ok(
-                                                                            SUPER_KW@39..47 "super" [Whitespace("\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            arguments: Ok(
-                                                                ArgList {
-                                                                    l_paren_token: Ok(
-                                                                        L_PAREN@47..48 "(" [] [],
-                                                                    ),
-                                                                    args: [],
-                                                                    r_paren_token: Ok(
-                                                                        R_PAREN@48..49 ")" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@49..50 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    r_curly_token: Ok(
-                                        R_CURLY@50..53 "}" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                    JsMethodClassMember(
-                        JsMethodClassMember {
-                            access_modifier: None,
-                            static_token: None,
-                            abstract_token: None,
-                            async_token: None,
-                            star_token: None,
-                            name: Ok(
-                                JsLiteralMemberName(
-                                    JsLiteralMemberName {
-                                        value: Ok(
-                                            IDENT@53..60 "test" [Whitespace("\n\n\t")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            type_parameters: None,
-                            parameter_list: Ok(
-                                JsParameterList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@60..61 "(" [] [],
-                                    ),
-                                    parameters: [],
-                                    r_paren_token: Ok(
-                                        R_PAREN@61..63 ")" [] [Whitespace(" ")],
-                                    ),
-                                },
-                            ),
-                            return_type: None,
-                            body: Ok(
-                                JsFunctionBody {
-                                    l_curly_token: Ok(
-                                        L_CURLY@63..64 "{" [] [],
-                                    ),
-                                    directives: [],
-                                    statements: [
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    CallExpr(
-                                                        CallExpr {
-                                                            type_args: None,
-                                                            callee: Ok(
-                                                                JsStaticMemberExpression(
-                                                                    JsStaticMemberExpression {
-                                                                        object: Ok(
-                                                                            JsSuperExpression(
-                                                                                JsSuperExpression {
-                                                                                    super_token: Ok(
-                                                                                        SUPER_KW@64..72 "super" [Whitespace("\n\t\t")] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        operator: Ok(
-                                                                            DOT@72..73 "." [] [],
-                                                                        ),
-                                                                        member: Ok(
-                                                                            JsReferenceIdentifierMember(
-                                                                                JsReferenceIdentifierMember {
-                                                                                    name_token: Ok(
-                                                                                        IDENT@73..77 "test" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            arguments: Ok(
-                                                                ArgList {
-                                                                    l_paren_token: Ok(
-                                                                        L_PAREN@77..78 "(" [] [],
-                                                                    ),
-                                                                    args: [
-                                                                        AstSeparatedElement {
-                                                                            node: JsReferenceIdentifierExpression(
-                                                                                JsReferenceIdentifierExpression {
-                                                                                    name_token: Ok(
-                                                                                        IDENT@78..79 "a" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            trailing_separator: Some(
-                                                                                COMMA@79..81 "," [] [Whitespace(" ")],
-                                                                            ),
-                                                                        },
-                                                                        AstSeparatedElement {
-                                                                            node: JsReferenceIdentifierExpression(
-                                                                                JsReferenceIdentifierExpression {
-                                                                                    name_token: Ok(
-                                                                                        IDENT@81..82 "b" [] [],
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                            trailing_separator: None,
-                                                                        },
-                                                                    ],
-                                                                    r_paren_token: Ok(
-                                                                        R_PAREN@82..83 ")" [] [],
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@83..84 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                        JsExpressionStatement(
-                                            JsExpressionStatement {
-                                                expression: Ok(
-                                                    JsComputedMemberExpression(
-                                                        JsComputedMemberExpression {
-                                                            object: Ok(
-                                                                JsSuperExpression(
-                                                                    JsSuperExpression {
-                                                                        super_token: Ok(
-                                                                            SUPER_KW@84..92 "super" [Whitespace("\n\t\t")] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            optional_chain_token_token: None,
-                                                            l_brack_token: Ok(
-                                                                L_BRACK@92..93 "[" [] [],
-                                                            ),
-                                                            r_brack_token: Ok(
-                                                                R_BRACK@94..95 "]" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                                semicolon_token: Some(
-                                                    SEMICOLON@95..96 ";" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    r_curly_token: Ok(
-                                        R_CURLY@96..99 "}" [Whitespace("\n\t")] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@99..101 "}" [Whitespace("\n")] [],
-                ),
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..11 "Test" [] [Whitespace(" ")],
             },
-        ),
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@19..21 "B" [] [Whitespace(" ")],
+                },
+            },
+            l_curly_token: L_CURLY@21..22 "{" [] [],
+            members: [
+                JsConstructorClassMember {
+                    access_modifier: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@22..35 "constructor" [Whitespace("\n\t")] [],
+                    },
+                    parameter_list: JsConstructorParameterList {
+                        l_paren_token: L_PAREN@35..36 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@36..38 ")" [] [Whitespace(" ")],
+                    },
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@38..39 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: CallExpr {
+                                    type_args: missing (optional),
+                                    callee: JsSuperExpression {
+                                        super_token: SUPER_KW@39..47 "super" [Whitespace("\n\t\t")] [],
+                                    },
+                                    arguments: ArgList {
+                                        l_paren_token: L_PAREN@47..48 "(" [] [],
+                                        args: [],
+                                        r_paren_token: R_PAREN@48..49 ")" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@49..50 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@50..53 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@53..60 "test" [Whitespace("\n\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@60..61 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@61..63 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@63..64 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: CallExpr {
+                                    type_args: missing (optional),
+                                    callee: JsStaticMemberExpression {
+                                        object: JsSuperExpression {
+                                            super_token: SUPER_KW@64..72 "super" [Whitespace("\n\t\t")] [],
+                                        },
+                                        operator: DOT@72..73 "." [] [],
+                                        member: JsReferenceIdentifierMember {
+                                            name_token: IDENT@73..77 "test" [] [],
+                                        },
+                                    },
+                                    arguments: ArgList {
+                                        l_paren_token: L_PAREN@77..78 "(" [] [],
+                                        args: [
+                                            AstSeparatedElement {
+                                                node: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@78..79 "a" [] [],
+                                                },
+                                                trailing_separator: Some(
+                                                    COMMA@79..81 "," [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                            AstSeparatedElement {
+                                                node: JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@81..82 "b" [] [],
+                                                },
+                                                trailing_separator: None,
+                                            },
+                                        ],
+                                        r_paren_token: R_PAREN@82..83 ")" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@83..84 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsComputedMemberExpression {
+                                    object: JsSuperExpression {
+                                        super_token: SUPER_KW@84..92 "super" [Whitespace("\n\t\t")] [],
+                                    },
+                                    optional_chain_token_token: missing (optional),
+                                    l_brack_token: L_BRACK@92..93 "[" [] [],
+                                    r_brack_token: R_BRACK@94..95 "]" [] [],
+                                },
+                                semicolon_token: SEMICOLON@95..96 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@96..99 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@99..101 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -83,20 +83,14 @@ JsRoot {
                                     arguments: ArgList {
                                         l_paren_token: L_PAREN@77..78 "(" [] [],
                                         args: [
-                                            AstSeparatedElement {
-                                                node: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@78..79 "a" [] [],
-                                                },
-                                                trailing_separator: Some(
-                                                    COMMA@79..81 "," [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                            AstSeparatedElement {
-                                                node: JsReferenceIdentifierExpression {
-                                                    name_token: IDENT@81..82 "b" [] [],
-                                                },
-                                                trailing_separator: None,
-                                            },
+                                            JsReferenceIdentifierExpression {
+                                                name_token: IDENT@78..79 "a" [] [],
+                                            }
+                                            COMMA@79..81 "," [] [Whitespace(" ")],
+                                            JsReferenceIdentifierExpression {
+                                                name_token: IDENT@81..82 "b" [] [],
+                                            }
+                                            ,
                                         ],
                                         r_paren_token: R_PAREN@82..83 ")" [] [],
                                     },

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -1,3 +1,267 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsClassDeclaration(
+            JsClassDeclaration {
+                class_token: Ok(
+                    CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@6..11 "Test" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                implements_clause: None,
+                extends_clause: Some(
+                    JsExtendsClause {
+                        extends_token: Ok(
+                            EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")],
+                        ),
+                        super_class: Ok(
+                            JsReferenceIdentifierExpression(
+                                JsReferenceIdentifierExpression {
+                                    name_token: Ok(
+                                        IDENT@19..21 "B" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@21..22 "{" [] [],
+                ),
+                members: [
+                    JsConstructorClassMember(
+                        JsConstructorClassMember {
+                            access_modifier: None,
+                            name: Ok(
+                                JsLiteralMemberName {
+                                    value: Ok(
+                                        IDENT@22..35 "constructor" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                            parameter_list: Ok(
+                                JsConstructorParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@35..36 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@36..38 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@38..39 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    CallExpr(
+                                                        CallExpr {
+                                                            type_args: None,
+                                                            callee: Ok(
+                                                                JsSuperExpression(
+                                                                    JsSuperExpression {
+                                                                        super_token: Ok(
+                                                                            SUPER_KW@39..47 "super" [Whitespace("\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            arguments: Ok(
+                                                                ArgList {
+                                                                    l_paren_token: Ok(
+                                                                        L_PAREN@47..48 "(" [] [],
+                                                                    ),
+                                                                    args: [],
+                                                                    r_paren_token: Ok(
+                                                                        R_PAREN@48..49 ")" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@49..50 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    r_curly_token: Ok(
+                                        R_CURLY@50..53 "}" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    JsMethodClassMember(
+                        JsMethodClassMember {
+                            access_modifier: None,
+                            static_token: None,
+                            abstract_token: None,
+                            async_token: None,
+                            star_token: None,
+                            name: Ok(
+                                JsLiteralMemberName(
+                                    JsLiteralMemberName {
+                                        value: Ok(
+                                            IDENT@53..60 "test" [Whitespace("\n\n\t")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            type_parameters: None,
+                            parameter_list: Ok(
+                                JsParameterList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@60..61 "(" [] [],
+                                    ),
+                                    parameters: [],
+                                    r_paren_token: Ok(
+                                        R_PAREN@61..63 ")" [] [Whitespace(" ")],
+                                    ),
+                                },
+                            ),
+                            return_type: None,
+                            body: Ok(
+                                JsFunctionBody {
+                                    l_curly_token: Ok(
+                                        L_CURLY@63..64 "{" [] [],
+                                    ),
+                                    directives: [],
+                                    statements: [
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    CallExpr(
+                                                        CallExpr {
+                                                            type_args: None,
+                                                            callee: Ok(
+                                                                JsStaticMemberExpression(
+                                                                    JsStaticMemberExpression {
+                                                                        object: Ok(
+                                                                            JsSuperExpression(
+                                                                                JsSuperExpression {
+                                                                                    super_token: Ok(
+                                                                                        SUPER_KW@64..72 "super" [Whitespace("\n\t\t")] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        operator: Ok(
+                                                                            DOT@72..73 "." [] [],
+                                                                        ),
+                                                                        member: Ok(
+                                                                            JsReferenceIdentifierMember(
+                                                                                JsReferenceIdentifierMember {
+                                                                                    name_token: Ok(
+                                                                                        IDENT@73..77 "test" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            arguments: Ok(
+                                                                ArgList {
+                                                                    l_paren_token: Ok(
+                                                                        L_PAREN@77..78 "(" [] [],
+                                                                    ),
+                                                                    args: [
+                                                                        AstSeparatedElement {
+                                                                            node: JsReferenceIdentifierExpression(
+                                                                                JsReferenceIdentifierExpression {
+                                                                                    name_token: Ok(
+                                                                                        IDENT@78..79 "a" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            trailing_separator: Some(
+                                                                                COMMA@79..81 "," [] [Whitespace(" ")],
+                                                                            ),
+                                                                        },
+                                                                        AstSeparatedElement {
+                                                                            node: JsReferenceIdentifierExpression(
+                                                                                JsReferenceIdentifierExpression {
+                                                                                    name_token: Ok(
+                                                                                        IDENT@81..82 "b" [] [],
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            trailing_separator: None,
+                                                                        },
+                                                                    ],
+                                                                    r_paren_token: Ok(
+                                                                        R_PAREN@82..83 ")" [] [],
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@83..84 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                        JsExpressionStatement(
+                                            JsExpressionStatement {
+                                                expression: Ok(
+                                                    JsComputedMemberExpression(
+                                                        JsComputedMemberExpression {
+                                                            object: Ok(
+                                                                JsSuperExpression(
+                                                                    JsSuperExpression {
+                                                                        super_token: Ok(
+                                                                            SUPER_KW@84..92 "super" [Whitespace("\n\t\t")] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            optional_chain_token_token: None,
+                                                            l_brack_token: Ok(
+                                                                L_BRACK@92..93 "[" [] [],
+                                                            ),
+                                                            r_brack_token: Ok(
+                                                                R_BRACK@94..95 "]" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                                semicolon_token: Some(
+                                                    SEMICOLON@95..96 ";" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                    r_curly_token: Ok(
+                                        R_CURLY@96..99 "}" [Whitespace("\n\t")] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@99..101 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..102
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -1,3 +1,71 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsSwitchStatement(
+            JsSwitchStatement {
+                switch_token: Ok(
+                    SWITCH_KW@0..7 "switch" [] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@7..8 "(" [] [],
+                ),
+                discriminant: Ok(
+                    JsReferenceIdentifierExpression(
+                        JsReferenceIdentifierExpression {
+                            name_token: Ok(
+                                IDENT@8..11 "foo" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                ),
+                l_curly_token: Ok(
+                    L_CURLY@13..14 "{" [] [],
+                ),
+                cases: [
+                    JsCaseClause(
+                        JsCaseClause {
+                            case_token: Ok(
+                                CASE_KW@14..21 "case" [Whitespace("\n ")] [Whitespace(" ")],
+                            ),
+                            test: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@21..24 "bar" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            colon_token: Ok(
+                                COLON@24..25 ":" [] [],
+                            ),
+                            consequent: [],
+                        },
+                    ),
+                    JsDefaultClause(
+                        JsDefaultClause {
+                            default_token: Ok(
+                                DEFAULT_KW@25..34 "default" [Whitespace("\n ")] [],
+                            ),
+                            colon_token: Ok(
+                                COLON@34..35 ":" [] [],
+                            ),
+                            consequent: [],
+                        },
+                    ),
+                ],
+                r_curly_token: Ok(
+                    R_CURLY@35..37 "}" [Whitespace("\n")] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..38
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -1,68 +1,32 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsSwitchStatement(
-            JsSwitchStatement {
-                switch_token: Ok(
-                    SWITCH_KW@0..7 "switch" [] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@7..8 "(" [] [],
-                ),
-                discriminant: Ok(
-                    JsReferenceIdentifierExpression(
-                        JsReferenceIdentifierExpression {
-                            name_token: Ok(
-                                IDENT@8..11 "foo" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@11..13 ")" [] [Whitespace(" ")],
-                ),
-                l_curly_token: Ok(
-                    L_CURLY@13..14 "{" [] [],
-                ),
-                cases: [
-                    JsCaseClause(
-                        JsCaseClause {
-                            case_token: Ok(
-                                CASE_KW@14..21 "case" [Whitespace("\n ")] [Whitespace(" ")],
-                            ),
-                            test: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@21..24 "bar" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            colon_token: Ok(
-                                COLON@24..25 ":" [] [],
-                            ),
-                            consequent: [],
-                        },
-                    ),
-                    JsDefaultClause(
-                        JsDefaultClause {
-                            default_token: Ok(
-                                DEFAULT_KW@25..34 "default" [Whitespace("\n ")] [],
-                            ),
-                            colon_token: Ok(
-                                COLON@34..35 ":" [] [],
-                            ),
-                            consequent: [],
-                        },
-                    ),
-                ],
-                r_curly_token: Ok(
-                    R_CURLY@35..37 "}" [Whitespace("\n")] [],
-                ),
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@0..7 "switch" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@7..8 "(" [] [],
+            discriminant: JsReferenceIdentifierExpression {
+                name_token: IDENT@8..11 "foo" [] [],
             },
-        ),
+            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+            l_curly_token: L_CURLY@13..14 "{" [] [],
+            cases: [
+                JsCaseClause {
+                    case_token: CASE_KW@14..21 "case" [Whitespace("\n ")] [Whitespace(" ")],
+                    test: JsReferenceIdentifierExpression {
+                        name_token: IDENT@21..24 "bar" [] [],
+                    },
+                    colon_token: COLON@24..25 ":" [] [],
+                    consequent: [],
+                },
+                JsDefaultClause {
+                    default_token: DEFAULT_KW@25..34 "default" [Whitespace("\n ")] [],
+                    colon_token: COLON@34..35 ":" [] [],
+                    consequent: [],
+                },
+            ],
+            r_curly_token: R_CURLY@35..37 "}" [Whitespace("\n")] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -6,25 +6,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: Template {
-                                    backtick_token: BACKTICK@8..9 "`" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: Template {
+                                backtick_token: BACKTICK@8..9 "`" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@20..21 ";" [] [],
@@ -33,25 +31,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
-                                expression: Template {
-                                    backtick_token: BACKTICK@30..31 "`" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                            expression: Template {
+                                backtick_token: BACKTICK@30..31 "`" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@32..33 ";" [] [],
@@ -60,25 +56,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@38..40 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@38..40 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@40..42 "=" [] [Whitespace(" ")],
-                                expression: Template {
-                                    backtick_token: BACKTICK@42..43 "`" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@40..42 "=" [] [Whitespace(" ")],
+                            expression: Template {
+                                backtick_token: BACKTICK@42..43 "`" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@50..51 ";" [] [],
@@ -87,25 +81,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@56..58 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@56..58 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@58..60 "=" [] [Whitespace(" ")],
-                                expression: Template {
-                                    backtick_token: BACKTICK@60..61 "`" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@58..60 "=" [] [Whitespace(" ")],
+                            expression: Template {
+                                backtick_token: BACKTICK@60..61 "`" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@65..66 ";" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -1,3 +1,222 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@0..4 "let" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                Template(
+                                                    Template {
+                                                        backtick_token: Ok(
+                                                            BACKTICK@8..9 "`" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@20..21 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@26..28 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@28..30 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                Template(
+                                                    Template {
+                                                        backtick_token: Ok(
+                                                            BACKTICK@30..31 "`" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@32..33 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@38..40 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@40..42 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                Template(
+                                                    Template {
+                                                        backtick_token: Ok(
+                                                            BACKTICK@42..43 "`" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@50..51 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@56..58 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@58..60 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                Template(
+                                                    Template {
+                                                        backtick_token: Ok(
+                                                            BACKTICK@60..61 "`" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@65..66 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..67
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -1,219 +1,115 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@0..4 "let" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                Template(
-                                                    Template {
-                                                        backtick_token: Ok(
-                                                            BACKTICK@8..9 "`" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@20..21 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@26..28 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@28..30 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                Template(
-                                                    Template {
-                                                        backtick_token: Ok(
-                                                            BACKTICK@30..31 "`" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: Template {
+                                    backtick_token: BACKTICK@8..9 "`" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@32..33 ";" [] [],
-                ),
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@38..40 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@40..42 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                Template(
-                                                    Template {
-                                                        backtick_token: Ok(
-                                                            BACKTICK@42..43 "`" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+            semicolon_token: SEMICOLON@20..21 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@26..28 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
-                    },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@50..51 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@56..58 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@58..60 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                Template(
-                                                    Template {
-                                                        backtick_token: Ok(
-                                                            BACKTICK@60..61 "`" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                            init: JsEqualValueClause {
+                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                                expression: Template {
+                                    backtick_token: BACKTICK@30..31 "`" [] [],
                                 },
-                                trailing_separator: None,
                             },
-                        ],
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@65..66 ";" [] [],
-                ),
+                ],
             },
-        ),
+            semicolon_token: SEMICOLON@32..33 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@38..40 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@40..42 "=" [] [Whitespace(" ")],
+                                expression: Template {
+                                    backtick_token: BACKTICK@42..43 "`" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@50..51 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@56..58 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@58..60 "=" [] [Whitespace(" ")],
+                                expression: Template {
+                                    backtick_token: BACKTICK@60..61 "`" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@65..66 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -1,3 +1,56 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsThisExpression(
+                        JsThisExpression {
+                            this_token: Ok(
+                                THIS_KW@0..4 "this" [] [],
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+        JsExpressionStatement(
+            JsExpressionStatement {
+                expression: Ok(
+                    JsStaticMemberExpression(
+                        JsStaticMemberExpression {
+                            object: Ok(
+                                JsThisExpression(
+                                    JsThisExpression {
+                                        this_token: Ok(
+                                            THIS_KW@4..9 "this" [Whitespace("\n")] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            operator: Ok(
+                                DOT@9..10 "." [] [],
+                            ),
+                            member: Ok(
+                                JsReferenceIdentifierMember(
+                                    JsReferenceIdentifierMember {
+                                        name_token: Ok(
+                                            IDENT@10..13 "foo" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..14
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -1,53 +1,25 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsThisExpression(
-                        JsThisExpression {
-                            this_token: Ok(
-                                THIS_KW@0..4 "this" [] [],
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+        JsExpressionStatement {
+            expression: JsThisExpression {
+                this_token: THIS_KW@0..4 "this" [] [],
             },
-        ),
-        JsExpressionStatement(
-            JsExpressionStatement {
-                expression: Ok(
-                    JsStaticMemberExpression(
-                        JsStaticMemberExpression {
-                            object: Ok(
-                                JsThisExpression(
-                                    JsThisExpression {
-                                        this_token: Ok(
-                                            THIS_KW@4..9 "this" [Whitespace("\n")] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            operator: Ok(
-                                DOT@9..10 "." [] [],
-                            ),
-                            member: Ok(
-                                JsReferenceIdentifierMember(
-                                    JsReferenceIdentifierMember {
-                                        name_token: Ok(
-                                            IDENT@10..13 "foo" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: None,
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsThisExpression {
+                    this_token: THIS_KW@4..9 "this" [Whitespace("\n")] [],
+                },
+                operator: DOT@9..10 "." [] [],
+                member: JsReferenceIdentifierMember {
+                    name_token: IDENT@10..13 "foo" [] [],
+                },
             },
-        ),
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -1,3 +1,82 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsThrowStatement(
+            JsThrowStatement {
+                throw_token: Ok(
+                    THROW_KW@0..6 "throw" [] [Whitespace(" ")],
+                ),
+                argument: Ok(
+                    NewExpr(
+                        NewExpr {
+                            new_token: Ok(
+                                NEW_KW@6..10 "new" [] [Whitespace(" ")],
+                            ),
+                            type_args: None,
+                            object: Ok(
+                                JsReferenceIdentifierExpression(
+                                    JsReferenceIdentifierExpression {
+                                        name_token: Ok(
+                                            IDENT@10..15 "Error" [] [],
+                                        ),
+                                    },
+                                ),
+                            ),
+                            arguments: Ok(
+                                ArgList {
+                                    l_paren_token: Ok(
+                                        L_PAREN@15..16 "(" [] [],
+                                    ),
+                                    args: [
+                                        AstSeparatedElement {
+                                            node: JsAnyLiteralExpression(
+                                                JsStringLiteralExpression(
+                                                    JsStringLiteralExpression {
+                                                        value_token: Ok(
+                                                            JS_STRING_LITERAL@16..21 "\"foo\"" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                            trailing_separator: None,
+                                        },
+                                    ],
+                                    r_paren_token: Ok(
+                                        R_PAREN@21..22 ")" [] [],
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@22..23 ";" [] [],
+                ),
+            },
+        ),
+        JsThrowStatement(
+            JsThrowStatement {
+                throw_token: Ok(
+                    THROW_KW@23..30 "throw" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                argument: Ok(
+                    JsAnyLiteralExpression(
+                        JsStringLiteralExpression(
+                            JsStringLiteralExpression {
+                                value_token: Ok(
+                                    JS_STRING_LITERAL@30..35 "\"foo\"" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                semicolon_token: None,
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..36
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -1,79 +1,37 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsThrowStatement(
-            JsThrowStatement {
-                throw_token: Ok(
-                    THROW_KW@0..6 "throw" [] [Whitespace(" ")],
-                ),
-                argument: Ok(
-                    NewExpr(
-                        NewExpr {
-                            new_token: Ok(
-                                NEW_KW@6..10 "new" [] [Whitespace(" ")],
-                            ),
-                            type_args: None,
-                            object: Ok(
-                                JsReferenceIdentifierExpression(
-                                    JsReferenceIdentifierExpression {
-                                        name_token: Ok(
-                                            IDENT@10..15 "Error" [] [],
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arguments: Ok(
-                                ArgList {
-                                    l_paren_token: Ok(
-                                        L_PAREN@15..16 "(" [] [],
-                                    ),
-                                    args: [
-                                        AstSeparatedElement {
-                                            node: JsAnyLiteralExpression(
-                                                JsStringLiteralExpression(
-                                                    JsStringLiteralExpression {
-                                                        value_token: Ok(
-                                                            JS_STRING_LITERAL@16..21 "\"foo\"" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                            trailing_separator: None,
-                                        },
-                                    ],
-                                    r_paren_token: Ok(
-                                        R_PAREN@21..22 ")" [] [],
-                                    ),
-                                },
-                            ),
-                        },
-                    ),
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@22..23 ";" [] [],
-                ),
-            },
-        ),
-        JsThrowStatement(
-            JsThrowStatement {
-                throw_token: Ok(
-                    THROW_KW@23..30 "throw" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                argument: Ok(
-                    JsAnyLiteralExpression(
-                        JsStringLiteralExpression(
-                            JsStringLiteralExpression {
-                                value_token: Ok(
-                                    JS_STRING_LITERAL@30..35 "\"foo\"" [] [],
-                                ),
+        JsThrowStatement {
+            throw_token: THROW_KW@0..6 "throw" [] [Whitespace(" ")],
+            argument: NewExpr {
+                new_token: NEW_KW@6..10 "new" [] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@10..15 "Error" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@15..16 "(" [] [],
+                    args: [
+                        AstSeparatedElement {
+                            node: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@16..21 "\"foo\"" [] [],
                             },
-                        ),
-                    ),
-                ),
-                semicolon_token: None,
+                            trailing_separator: None,
+                        },
+                    ],
+                    r_paren_token: R_PAREN@21..22 ")" [] [],
+                },
             },
-        ),
+            semicolon_token: SEMICOLON@22..23 ";" [] [],
+        },
+        JsThrowStatement {
+            throw_token: THROW_KW@23..30 "throw" [Whitespace("\n")] [Whitespace(" ")],
+            argument: JsStringLiteralExpression {
+                value_token: JS_STRING_LITERAL@30..35 "\"foo\"" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -13,12 +13,10 @@ JsRoot {
                 arguments: ArgList {
                     l_paren_token: L_PAREN@15..16 "(" [] [],
                     args: [
-                        AstSeparatedElement {
-                            node: JsStringLiteralExpression {
-                                value_token: JS_STRING_LITERAL@16..21 "\"foo\"" [] [],
-                            },
-                            trailing_separator: None,
-                        },
+                        JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@16..21 "\"foo\"" [] [],
+                        }
+                        ,
                     ],
                     r_paren_token: R_PAREN@21..22 ")" [] [],
                 },

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -1,278 +1,130 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsTryStatement(
-            JsTryStatement {
-                try_token: Ok(
-                    TRY_KW@0..4 "try" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement {
-                        l_curly_token: Ok(
-                            L_CURLY@4..5 "{" [] [],
-                        ),
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@5..7 "}" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                catch_clause: Ok(
-                    JsCatchClause {
-                        catch_token: Ok(
-                            CATCH_KW@7..13 "catch" [] [Whitespace(" ")],
-                        ),
-                        declaration: None,
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@13..14 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@14..15 "}" [] [],
-                                ),
-                            },
-                        ),
-                    },
-                ),
+        JsTryStatement {
+            try_token: TRY_KW@0..4 "try" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@4..5 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@5..7 "}" [] [Whitespace(" ")],
             },
-        ),
-        JsTryStatement(
-            JsTryStatement {
-                try_token: Ok(
-                    TRY_KW@15..20 "try" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement {
-                        l_curly_token: Ok(
-                            L_CURLY@20..21 "{" [] [],
-                        ),
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@21..23 "}" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                catch_clause: Ok(
-                    JsCatchClause {
-                        catch_token: Ok(
-                            CATCH_KW@23..29 "catch" [] [Whitespace(" ")],
-                        ),
-                        declaration: Some(
-                            JsCatchDeclaration {
-                                l_paren_token: Ok(
-                                    L_PAREN@29..30 "(" [] [],
-                                ),
-                                binding: Ok(
-                                    SinglePattern(
-                                        SinglePattern {
-                                            name: Ok(
-                                                Name {
-                                                    ident_token: Ok(
-                                                        IDENT@30..31 "e" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            question_mark_token: None,
-                                            excl_token: None,
-                                            ty: None,
-                                        },
-                                    ),
-                                ),
-                                r_paren_token: Ok(
-                                    R_PAREN@31..33 ")" [] [Whitespace(" ")],
-                                ),
-                            },
-                        ),
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@33..34 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@34..35 "}" [] [],
-                                ),
-                            },
-                        ),
-                    },
-                ),
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@7..13 "catch" [] [Whitespace(" ")],
+                declaration: missing (optional),
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@13..14 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@14..15 "}" [] [],
+                },
             },
-        ),
-        JsTryFinallyStatement(
-            JsTryFinallyStatement {
-                try_token: Ok(
-                    TRY_KW@35..40 "try" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement {
-                        l_curly_token: Ok(
-                            L_CURLY@40..41 "{" [] [],
-                        ),
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@41..43 "}" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                catch_clause: Some(
-                    JsCatchClause {
-                        catch_token: Ok(
-                            CATCH_KW@43..49 "catch" [] [Whitespace(" ")],
-                        ),
-                        declaration: None,
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@49..50 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@50..52 "}" [] [Whitespace(" ")],
-                                ),
-                            },
-                        ),
-                    },
-                ),
-                finally_clause: Ok(
-                    JsFinallyClause {
-                        finally_token: Ok(
-                            FINALLY_KW@52..60 "finally" [] [Whitespace(" ")],
-                        ),
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@60..61 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@61..62 "}" [] [],
-                                ),
-                            },
-                        ),
-                    },
-                ),
+        },
+        JsTryStatement {
+            try_token: TRY_KW@15..20 "try" [Whitespace("\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@20..21 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@21..23 "}" [] [Whitespace(" ")],
             },
-        ),
-        JsTryFinallyStatement(
-            JsTryFinallyStatement {
-                try_token: Ok(
-                    TRY_KW@62..67 "try" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement {
-                        l_curly_token: Ok(
-                            L_CURLY@67..68 "{" [] [],
-                        ),
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@68..70 "}" [] [Whitespace(" ")],
-                        ),
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@23..29 "catch" [] [Whitespace(" ")],
+                declaration: JsCatchDeclaration {
+                    l_paren_token: L_PAREN@29..30 "(" [] [],
+                    binding: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@30..31 "e" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
                     },
-                ),
-                catch_clause: Some(
-                    JsCatchClause {
-                        catch_token: Ok(
-                            CATCH_KW@70..76 "catch" [] [Whitespace(" ")],
-                        ),
-                        declaration: Some(
-                            JsCatchDeclaration {
-                                l_paren_token: Ok(
-                                    L_PAREN@76..77 "(" [] [],
-                                ),
-                                binding: Ok(
-                                    SinglePattern(
-                                        SinglePattern {
-                                            name: Ok(
-                                                Name {
-                                                    ident_token: Ok(
-                                                        IDENT@77..78 "e" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            question_mark_token: None,
-                                            excl_token: None,
-                                            ty: None,
-                                        },
-                                    ),
-                                ),
-                                r_paren_token: Ok(
-                                    R_PAREN@78..80 ")" [] [Whitespace(" ")],
-                                ),
-                            },
-                        ),
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@80..81 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@81..83 "}" [] [Whitespace(" ")],
-                                ),
-                            },
-                        ),
-                    },
-                ),
-                finally_clause: Ok(
-                    JsFinallyClause {
-                        finally_token: Ok(
-                            FINALLY_KW@83..91 "finally" [] [Whitespace(" ")],
-                        ),
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@91..92 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@92..93 "}" [] [],
-                                ),
-                            },
-                        ),
-                    },
-                ),
+                    r_paren_token: R_PAREN@31..33 ")" [] [Whitespace(" ")],
+                },
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@33..34 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@34..35 "}" [] [],
+                },
             },
-        ),
-        JsTryFinallyStatement(
-            JsTryFinallyStatement {
-                try_token: Ok(
-                    TRY_KW@93..98 "try" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement {
-                        l_curly_token: Ok(
-                            L_CURLY@98..99 "{" [] [],
-                        ),
-                        statements: [],
-                        r_curly_token: Ok(
-                            R_CURLY@99..101 "}" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                catch_clause: None,
-                finally_clause: Ok(
-                    JsFinallyClause {
-                        finally_token: Ok(
-                            FINALLY_KW@101..109 "finally" [] [Whitespace(" ")],
-                        ),
-                        body: Ok(
-                            JsBlockStatement {
-                                l_curly_token: Ok(
-                                    L_CURLY@109..110 "{" [] [],
-                                ),
-                                statements: [],
-                                r_curly_token: Ok(
-                                    R_CURLY@110..111 "}" [] [],
-                                ),
-                            },
-                        ),
-                    },
-                ),
+        },
+        JsTryFinallyStatement {
+            try_token: TRY_KW@35..40 "try" [Whitespace("\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@40..41 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@41..43 "}" [] [Whitespace(" ")],
             },
-        ),
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@43..49 "catch" [] [Whitespace(" ")],
+                declaration: missing (optional),
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@49..50 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@50..52 "}" [] [Whitespace(" ")],
+                },
+            },
+            finally_clause: JsFinallyClause {
+                finally_token: FINALLY_KW@52..60 "finally" [] [Whitespace(" ")],
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@60..61 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@61..62 "}" [] [],
+                },
+            },
+        },
+        JsTryFinallyStatement {
+            try_token: TRY_KW@62..67 "try" [Whitespace("\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@67..68 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@68..70 "}" [] [Whitespace(" ")],
+            },
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@70..76 "catch" [] [Whitespace(" ")],
+                declaration: JsCatchDeclaration {
+                    l_paren_token: L_PAREN@76..77 "(" [] [],
+                    binding: SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@77..78 "e" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    },
+                    r_paren_token: R_PAREN@78..80 ")" [] [Whitespace(" ")],
+                },
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@80..81 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@81..83 "}" [] [Whitespace(" ")],
+                },
+            },
+            finally_clause: JsFinallyClause {
+                finally_token: FINALLY_KW@83..91 "finally" [] [Whitespace(" ")],
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@91..92 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@92..93 "}" [] [],
+                },
+            },
+        },
+        JsTryFinallyStatement {
+            try_token: TRY_KW@93..98 "try" [Whitespace("\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@98..99 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@99..101 "}" [] [Whitespace(" ")],
+            },
+            catch_clause: missing (optional),
+            finally_clause: JsFinallyClause {
+                finally_token: FINALLY_KW@101..109 "finally" [] [Whitespace(" ")],
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@109..110 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@110..111 "}" [] [],
+                },
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -1,3 +1,281 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsTryStatement(
+            JsTryStatement {
+                try_token: Ok(
+                    TRY_KW@0..4 "try" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement {
+                        l_curly_token: Ok(
+                            L_CURLY@4..5 "{" [] [],
+                        ),
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@5..7 "}" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                catch_clause: Ok(
+                    JsCatchClause {
+                        catch_token: Ok(
+                            CATCH_KW@7..13 "catch" [] [Whitespace(" ")],
+                        ),
+                        declaration: None,
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@13..14 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@14..15 "}" [] [],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsTryStatement(
+            JsTryStatement {
+                try_token: Ok(
+                    TRY_KW@15..20 "try" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement {
+                        l_curly_token: Ok(
+                            L_CURLY@20..21 "{" [] [],
+                        ),
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@21..23 "}" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                catch_clause: Ok(
+                    JsCatchClause {
+                        catch_token: Ok(
+                            CATCH_KW@23..29 "catch" [] [Whitespace(" ")],
+                        ),
+                        declaration: Some(
+                            JsCatchDeclaration {
+                                l_paren_token: Ok(
+                                    L_PAREN@29..30 "(" [] [],
+                                ),
+                                binding: Ok(
+                                    SinglePattern(
+                                        SinglePattern {
+                                            name: Ok(
+                                                Name {
+                                                    ident_token: Ok(
+                                                        IDENT@30..31 "e" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            question_mark_token: None,
+                                            excl_token: None,
+                                            ty: None,
+                                        },
+                                    ),
+                                ),
+                                r_paren_token: Ok(
+                                    R_PAREN@31..33 ")" [] [Whitespace(" ")],
+                                ),
+                            },
+                        ),
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@33..34 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@34..35 "}" [] [],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsTryFinallyStatement(
+            JsTryFinallyStatement {
+                try_token: Ok(
+                    TRY_KW@35..40 "try" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement {
+                        l_curly_token: Ok(
+                            L_CURLY@40..41 "{" [] [],
+                        ),
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@41..43 "}" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                catch_clause: Some(
+                    JsCatchClause {
+                        catch_token: Ok(
+                            CATCH_KW@43..49 "catch" [] [Whitespace(" ")],
+                        ),
+                        declaration: None,
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@49..50 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@50..52 "}" [] [Whitespace(" ")],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+                finally_clause: Ok(
+                    JsFinallyClause {
+                        finally_token: Ok(
+                            FINALLY_KW@52..60 "finally" [] [Whitespace(" ")],
+                        ),
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@60..61 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@61..62 "}" [] [],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsTryFinallyStatement(
+            JsTryFinallyStatement {
+                try_token: Ok(
+                    TRY_KW@62..67 "try" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement {
+                        l_curly_token: Ok(
+                            L_CURLY@67..68 "{" [] [],
+                        ),
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@68..70 "}" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                catch_clause: Some(
+                    JsCatchClause {
+                        catch_token: Ok(
+                            CATCH_KW@70..76 "catch" [] [Whitespace(" ")],
+                        ),
+                        declaration: Some(
+                            JsCatchDeclaration {
+                                l_paren_token: Ok(
+                                    L_PAREN@76..77 "(" [] [],
+                                ),
+                                binding: Ok(
+                                    SinglePattern(
+                                        SinglePattern {
+                                            name: Ok(
+                                                Name {
+                                                    ident_token: Ok(
+                                                        IDENT@77..78 "e" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            question_mark_token: None,
+                                            excl_token: None,
+                                            ty: None,
+                                        },
+                                    ),
+                                ),
+                                r_paren_token: Ok(
+                                    R_PAREN@78..80 ")" [] [Whitespace(" ")],
+                                ),
+                            },
+                        ),
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@80..81 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@81..83 "}" [] [Whitespace(" ")],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+                finally_clause: Ok(
+                    JsFinallyClause {
+                        finally_token: Ok(
+                            FINALLY_KW@83..91 "finally" [] [Whitespace(" ")],
+                        ),
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@91..92 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@92..93 "}" [] [],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+        JsTryFinallyStatement(
+            JsTryFinallyStatement {
+                try_token: Ok(
+                    TRY_KW@93..98 "try" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement {
+                        l_curly_token: Ok(
+                            L_CURLY@98..99 "{" [] [],
+                        ),
+                        statements: [],
+                        r_curly_token: Ok(
+                            R_CURLY@99..101 "}" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                catch_clause: None,
+                finally_clause: Ok(
+                    JsFinallyClause {
+                        finally_token: Ok(
+                            FINALLY_KW@101..109 "finally" [] [Whitespace(" ")],
+                        ),
+                        body: Ok(
+                            JsBlockStatement {
+                                l_curly_token: Ok(
+                                    L_CURLY@109..110 "{" [] [],
+                                ),
+                                statements: [],
+                                r_curly_token: Ok(
+                                    R_CURLY@110..111 "}" [] [],
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..112
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -1,3 +1,542 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            VAR_KW@0..4 "var" [] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@6..8 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@8..9 "5" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@9..10 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        ObjectPattern(
+                                            ObjectPattern {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                                                ),
+                                                elements: [
+                                                    AstSeparatedElement {
+                                                        node: SinglePattern(
+                                                            SinglePattern {
+                                                                name: Ok(
+                                                                    Name {
+                                                                        ident_token: Ok(
+                                                                            IDENT@17..20 "foo" [] [],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                question_mark_token: None,
+                                                                excl_token: None,
+                                                                ty: None,
+                                                            },
+                                                        ),
+                                                        trailing_separator: Some(
+                                                            COMMA@20..22 "," [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                    AstSeparatedElement {
+                                                        node: SinglePattern(
+                                                            SinglePattern {
+                                                                name: Ok(
+                                                                    Name {
+                                                                        ident_token: Ok(
+                                                                            IDENT@22..26 "bar" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                question_mark_token: None,
+                                                                excl_token: None,
+                                                                ty: None,
+                                                            },
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@26..28 "}" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@28..30 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@30..31 "5" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@31..32 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@37..40 "bar" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: None,
+                                },
+                                trailing_separator: Some(
+                                    COMMA@40..42 "," [] [Whitespace(" ")],
+                                ),
+                            },
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@42..45 "foo" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: None,
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@45..46 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@53..55 "a" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@55..57 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@57..58 "5" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@58..59 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        ObjectPattern(
+                                            ObjectPattern {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@66..68 "{" [] [Whitespace(" ")],
+                                                ),
+                                                elements: [
+                                                    AstSeparatedElement {
+                                                        node: KeyValuePattern(
+                                                            KeyValuePattern {
+                                                                key: Ok(
+                                                                    Name(
+                                                                        Name {
+                                                                            ident_token: Ok(
+                                                                                IDENT@68..71 "foo" [] [],
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                                colon_token: Ok(
+                                                                    COLON@71..73 ":" [] [Whitespace(" ")],
+                                                                ),
+                                                            },
+                                                        ),
+                                                        trailing_separator: Some(
+                                                            COMMA@78..80 "," [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                    AstSeparatedElement {
+                                                        node: SinglePattern(
+                                                            SinglePattern {
+                                                                name: Ok(
+                                                                    Name {
+                                                                        ident_token: Ok(
+                                                                            IDENT@80..84 "baz" [] [Whitespace(" ")],
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                question_mark_token: None,
+                                                                excl_token: None,
+                                                                ty: None,
+                                                            },
+                                                        ),
+                                                        trailing_separator: None,
+                                                    },
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@84..86 "}" [] [Whitespace(" ")],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@86..88 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsObjectExpression(
+                                                    JsObjectExpression {
+                                                        l_curly_token: Ok(
+                                                            L_CURLY@88..89 "{" [] [],
+                                                        ),
+                                                        members: [],
+                                                        r_curly_token: Ok(
+                                                            R_CURLY@89..90 "}" [] [],
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@90..91 ";" [] [],
+                ),
+            },
+        ),
+        JsVariableDeclarationStatement(
+            JsVariableDeclarationStatement {
+                declaration: Ok(
+                    JsVariableDeclaration {
+                        kind_token: Ok(
+                            LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")],
+                        ),
+                        declarators: [
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@96..100 "foo" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@100..102 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsStringLiteralExpression(
+                                                        JsStringLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_STRING_LITERAL@102..109 "\"lorem\"" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: Some(
+                                    COMMA@109..111 "," [] [Whitespace(" ")],
+                                ),
+                            },
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@111..115 "bar" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@115..117 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsStringLiteralExpression(
+                                                        JsStringLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_STRING_LITERAL@117..124 "\"ipsum\"" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: Some(
+                                    COMMA@124..126 "," [] [Whitespace(" ")],
+                                ),
+                            },
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@126..132 "third" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@132..134 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsStringLiteralExpression(
+                                                        JsStringLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_STRING_LITERAL@134..141 "\"value\"" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: Some(
+                                    COMMA@141..143 "," [] [Whitespace(" ")],
+                                ),
+                            },
+                            AstSeparatedElement {
+                                node: JsVariableDeclarator {
+                                    id: Ok(
+                                        SinglePattern(
+                                            SinglePattern {
+                                                name: Ok(
+                                                    Name {
+                                                        ident_token: Ok(
+                                                            IDENT@143..150 "fourth" [] [Whitespace(" ")],
+                                                        ),
+                                                    },
+                                                ),
+                                                question_mark_token: None,
+                                                excl_token: None,
+                                                ty: None,
+                                            },
+                                        ),
+                                    ),
+                                    init: Some(
+                                        JsEqualValueClause {
+                                            eq_token: Ok(
+                                                EQ@150..152 "=" [] [Whitespace(" ")],
+                                            ),
+                                            expression: Ok(
+                                                JsAnyLiteralExpression(
+                                                    JsNumberLiteralExpression(
+                                                        JsNumberLiteralExpression {
+                                                            value_token: Ok(
+                                                                JS_NUMBER_LITERAL@152..153 "6" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                trailing_separator: None,
+                            },
+                        ],
+                    },
+                ),
+                semicolon_token: Some(
+                    SEMICOLON@153..154 ";" [] [],
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..155
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -6,25 +6,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: VAR_KW@0..4 "var" [] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@8..9 "5" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@8..9 "5" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@9..10 ";" [] [],
@@ -33,47 +31,39 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: ObjectPattern {
-                                l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
-                                elements: [
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@17..20 "foo" [] [],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: Some(
-                                            COMMA@20..22 "," [] [Whitespace(" ")],
-                                        ),
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                            elements: [
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@17..20 "foo" [] [],
                                     },
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@22..26 "bar" [] [Whitespace(" ")],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: None,
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                COMMA@20..22 "," [] [Whitespace(" ")],
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@22..26 "bar" [] [Whitespace(" ")],
                                     },
-                                ],
-                                r_curly_token: R_CURLY@26..28 "}" [] [Whitespace(" ")],
-                            },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@30..31 "5" [] [],
-                                },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@26..28 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@30..31 "5" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@31..32 ";" [] [],
@@ -82,36 +72,30 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@37..40 "bar" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@37..40 "bar" [] [],
                             },
-                            init: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
                         },
-                        trailing_separator: Some(
-                            COMMA@40..42 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@42..45 "foo" [] [],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                        init: missing (optional),
+                    }
+                    COMMA@40..42 "," [] [Whitespace(" ")],
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@42..45 "foo" [] [],
                             },
-                            init: missing (optional),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
                         },
-                        trailing_separator: None,
-                    },
+                        init: missing (optional),
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@45..46 ";" [] [],
@@ -120,25 +104,23 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@53..55 "a" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@53..55 "a" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@55..57 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@57..58 "5" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@55..57 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@57..58 "5" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@58..59 ";" [] [],
@@ -147,47 +129,39 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: ObjectPattern {
-                                l_curly_token: L_CURLY@66..68 "{" [] [Whitespace(" ")],
-                                elements: [
-                                    AstSeparatedElement {
-                                        node: KeyValuePattern {
-                                            key: Name {
-                                                ident_token: IDENT@68..71 "foo" [] [],
-                                            },
-                                            colon_token: COLON@71..73 ":" [] [Whitespace(" ")],
-                                        },
-                                        trailing_separator: Some(
-                                            COMMA@78..80 "," [] [Whitespace(" ")],
-                                        ),
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@66..68 "{" [] [Whitespace(" ")],
+                            elements: [
+                                KeyValuePattern {
+                                    key: Name {
+                                        ident_token: IDENT@68..71 "foo" [] [],
                                     },
-                                    AstSeparatedElement {
-                                        node: SinglePattern {
-                                            name: Name {
-                                                ident_token: IDENT@80..84 "baz" [] [Whitespace(" ")],
-                                            },
-                                            question_mark_token: missing (optional),
-                                            excl_token: missing (optional),
-                                            ty: missing (optional),
-                                        },
-                                        trailing_separator: None,
+                                    colon_token: COLON@71..73 ":" [] [Whitespace(" ")],
+                                }
+                                COMMA@78..80 "," [] [Whitespace(" ")],
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@80..84 "baz" [] [Whitespace(" ")],
                                     },
-                                ],
-                                r_curly_token: R_CURLY@84..86 "}" [] [Whitespace(" ")],
-                            },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
-                                expression: JsObjectExpression {
-                                    l_curly_token: L_CURLY@88..89 "{" [] [],
-                                    members: [],
-                                    r_curly_token: R_CURLY@89..90 "}" [] [],
-                                },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@84..86 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@88..89 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@89..90 "}" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@90..91 ";" [] [],
@@ -196,88 +170,74 @@ JsRoot {
             declaration: JsVariableDeclaration {
                 kind_token: LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")],
                 declarators: [
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@96..100 "foo" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@96..100 "foo" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@100..102 "=" [] [Whitespace(" ")],
-                                expression: JsStringLiteralExpression {
-                                    value_token: JS_STRING_LITERAL@102..109 "\"lorem\"" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@100..102 "=" [] [Whitespace(" ")],
+                            expression: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@102..109 "\"lorem\"" [] [],
                             },
                         },
-                        trailing_separator: Some(
-                            COMMA@109..111 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@111..115 "bar" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    }
+                    COMMA@109..111 "," [] [Whitespace(" ")],
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@111..115 "bar" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@115..117 "=" [] [Whitespace(" ")],
-                                expression: JsStringLiteralExpression {
-                                    value_token: JS_STRING_LITERAL@117..124 "\"ipsum\"" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@115..117 "=" [] [Whitespace(" ")],
+                            expression: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@117..124 "\"ipsum\"" [] [],
                             },
                         },
-                        trailing_separator: Some(
-                            COMMA@124..126 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@126..132 "third" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    }
+                    COMMA@124..126 "," [] [Whitespace(" ")],
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@126..132 "third" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@132..134 "=" [] [Whitespace(" ")],
-                                expression: JsStringLiteralExpression {
-                                    value_token: JS_STRING_LITERAL@134..141 "\"value\"" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@132..134 "=" [] [Whitespace(" ")],
+                            expression: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@134..141 "\"value\"" [] [],
                             },
                         },
-                        trailing_separator: Some(
-                            COMMA@141..143 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: JsVariableDeclarator {
-                            id: SinglePattern {
-                                name: Name {
-                                    ident_token: IDENT@143..150 "fourth" [] [Whitespace(" ")],
-                                },
-                                question_mark_token: missing (optional),
-                                excl_token: missing (optional),
-                                ty: missing (optional),
+                    }
+                    COMMA@141..143 "," [] [Whitespace(" ")],
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@143..150 "fourth" [] [Whitespace(" ")],
                             },
-                            init: JsEqualValueClause {
-                                eq_token: EQ@150..152 "=" [] [Whitespace(" ")],
-                                expression: JsNumberLiteralExpression {
-                                    value_token: JS_NUMBER_LITERAL@152..153 "6" [] [],
-                                },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@150..152 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@152..153 "6" [] [],
                             },
                         },
-                        trailing_separator: None,
-                    },
+                    }
+                    ,
                 ],
             },
             semicolon_token: SEMICOLON@153..154 ";" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -1,539 +1,287 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            VAR_KW@0..4 "var" [] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@4..6 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@6..8 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@8..9 "5" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: VAR_KW@0..4 "var" [] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
                                 },
-                                trailing_separator: None,
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@8..9 "5" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@9..10 ";" [] [],
-                ),
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")],
-                        ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        ObjectPattern(
-                                            ObjectPattern {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@15..17 "{" [] [Whitespace(" ")],
-                                                ),
-                                                elements: [
-                                                    AstSeparatedElement {
-                                                        node: SinglePattern(
-                                                            SinglePattern {
-                                                                name: Ok(
-                                                                    Name {
-                                                                        ident_token: Ok(
-                                                                            IDENT@17..20 "foo" [] [],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                question_mark_token: None,
-                                                                excl_token: None,
-                                                                ty: None,
-                                                            },
-                                                        ),
-                                                        trailing_separator: Some(
-                                                            COMMA@20..22 "," [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                    AstSeparatedElement {
-                                                        node: SinglePattern(
-                                                            SinglePattern {
-                                                                name: Ok(
-                                                                    Name {
-                                                                        ident_token: Ok(
-                                                                            IDENT@22..26 "bar" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                question_mark_token: None,
-                                                                excl_token: None,
-                                                                ty: None,
-                                                            },
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@26..28 "}" [] [Whitespace(" ")],
-                                                ),
+            semicolon_token: SEMICOLON@9..10 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: ObjectPattern {
+                                l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                                elements: [
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@17..20 "foo" [] [],
                                             },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@28..30 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@30..31 "5" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
                                         },
-                                    ),
-                                },
-                                trailing_separator: None,
+                                        trailing_separator: Some(
+                                            COMMA@20..22 "," [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@22..26 "bar" [] [Whitespace(" ")],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        trailing_separator: None,
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@26..28 "}" [] [Whitespace(" ")],
                             },
-                        ],
+                            init: JsEqualValueClause {
+                                eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@30..31 "5" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@31..32 ";" [] [],
-                ),
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")],
+            semicolon_token: SEMICOLON@31..32 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@37..40 "bar" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: missing (optional),
+                        },
+                        trailing_separator: Some(
+                            COMMA@40..42 "," [] [Whitespace(" ")],
                         ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@37..40 "bar" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: None,
-                                },
-                                trailing_separator: Some(
-                                    COMMA@40..42 "," [] [Whitespace(" ")],
-                                ),
-                            },
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@42..45 "foo" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: None,
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@45..46 ";" [] [],
-                ),
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@42..45 "foo" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: missing (optional),
+                        },
+                        trailing_separator: None,
+                    },
+                ],
             },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")],
+            semicolon_token: SEMICOLON@45..46 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@53..55 "a" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@55..57 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@57..58 "5" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@58..59 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: ObjectPattern {
+                                l_curly_token: L_CURLY@66..68 "{" [] [Whitespace(" ")],
+                                elements: [
+                                    AstSeparatedElement {
+                                        node: KeyValuePattern {
+                                            key: Name {
+                                                ident_token: IDENT@68..71 "foo" [] [],
+                                            },
+                                            colon_token: COLON@71..73 ":" [] [Whitespace(" ")],
+                                        },
+                                        trailing_separator: Some(
+                                            COMMA@78..80 "," [] [Whitespace(" ")],
+                                        ),
+                                    },
+                                    AstSeparatedElement {
+                                        node: SinglePattern {
+                                            name: Name {
+                                                ident_token: IDENT@80..84 "baz" [] [Whitespace(" ")],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            excl_token: missing (optional),
+                                            ty: missing (optional),
+                                        },
+                                        trailing_separator: None,
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@84..86 "}" [] [Whitespace(" ")],
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
+                                expression: JsObjectExpression {
+                                    l_curly_token: L_CURLY@88..89 "{" [] [],
+                                    members: [],
+                                    r_curly_token: R_CURLY@89..90 "}" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@90..91 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@96..100 "foo" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@100..102 "=" [] [Whitespace(" ")],
+                                expression: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@102..109 "\"lorem\"" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: Some(
+                            COMMA@109..111 "," [] [Whitespace(" ")],
                         ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@53..55 "a" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@55..57 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@57..58 "5" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@58..59 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")],
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@111..115 "bar" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@115..117 "=" [] [Whitespace(" ")],
+                                expression: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@117..124 "\"ipsum\"" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: Some(
+                            COMMA@124..126 "," [] [Whitespace(" ")],
                         ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        ObjectPattern(
-                                            ObjectPattern {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@66..68 "{" [] [Whitespace(" ")],
-                                                ),
-                                                elements: [
-                                                    AstSeparatedElement {
-                                                        node: KeyValuePattern(
-                                                            KeyValuePattern {
-                                                                key: Ok(
-                                                                    Name(
-                                                                        Name {
-                                                                            ident_token: Ok(
-                                                                                IDENT@68..71 "foo" [] [],
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ),
-                                                                colon_token: Ok(
-                                                                    COLON@71..73 ":" [] [Whitespace(" ")],
-                                                                ),
-                                                            },
-                                                        ),
-                                                        trailing_separator: Some(
-                                                            COMMA@78..80 "," [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                    AstSeparatedElement {
-                                                        node: SinglePattern(
-                                                            SinglePattern {
-                                                                name: Ok(
-                                                                    Name {
-                                                                        ident_token: Ok(
-                                                                            IDENT@80..84 "baz" [] [Whitespace(" ")],
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                question_mark_token: None,
-                                                                excl_token: None,
-                                                                ty: None,
-                                                            },
-                                                        ),
-                                                        trailing_separator: None,
-                                                    },
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@84..86 "}" [] [Whitespace(" ")],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@86..88 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsObjectExpression(
-                                                    JsObjectExpression {
-                                                        l_curly_token: Ok(
-                                                            L_CURLY@88..89 "{" [] [],
-                                                        ),
-                                                        members: [],
-                                                        r_curly_token: Ok(
-                                                            R_CURLY@89..90 "}" [] [],
-                                                        ),
-                                                    },
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@90..91 ";" [] [],
-                ),
-            },
-        ),
-        JsVariableDeclarationStatement(
-            JsVariableDeclarationStatement {
-                declaration: Ok(
-                    JsVariableDeclaration {
-                        kind_token: Ok(
-                            LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")],
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@126..132 "third" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@132..134 "=" [] [Whitespace(" ")],
+                                expression: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@134..141 "\"value\"" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: Some(
+                            COMMA@141..143 "," [] [Whitespace(" ")],
                         ),
-                        declarators: [
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@96..100 "foo" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@100..102 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsStringLiteralExpression(
-                                                        JsStringLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_STRING_LITERAL@102..109 "\"lorem\"" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: Some(
-                                    COMMA@109..111 "," [] [Whitespace(" ")],
-                                ),
-                            },
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@111..115 "bar" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@115..117 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsStringLiteralExpression(
-                                                        JsStringLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_STRING_LITERAL@117..124 "\"ipsum\"" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: Some(
-                                    COMMA@124..126 "," [] [Whitespace(" ")],
-                                ),
-                            },
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@126..132 "third" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@132..134 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsStringLiteralExpression(
-                                                        JsStringLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_STRING_LITERAL@134..141 "\"value\"" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: Some(
-                                    COMMA@141..143 "," [] [Whitespace(" ")],
-                                ),
-                            },
-                            AstSeparatedElement {
-                                node: JsVariableDeclarator {
-                                    id: Ok(
-                                        SinglePattern(
-                                            SinglePattern {
-                                                name: Ok(
-                                                    Name {
-                                                        ident_token: Ok(
-                                                            IDENT@143..150 "fourth" [] [Whitespace(" ")],
-                                                        ),
-                                                    },
-                                                ),
-                                                question_mark_token: None,
-                                                excl_token: None,
-                                                ty: None,
-                                            },
-                                        ),
-                                    ),
-                                    init: Some(
-                                        JsEqualValueClause {
-                                            eq_token: Ok(
-                                                EQ@150..152 "=" [] [Whitespace(" ")],
-                                            ),
-                                            expression: Ok(
-                                                JsAnyLiteralExpression(
-                                                    JsNumberLiteralExpression(
-                                                        JsNumberLiteralExpression {
-                                                            value_token: Ok(
-                                                                JS_NUMBER_LITERAL@152..153 "6" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            ),
-                                        },
-                                    ),
-                                },
-                                trailing_separator: None,
-                            },
-                        ],
                     },
-                ),
-                semicolon_token: Some(
-                    SEMICOLON@153..154 ";" [] [],
-                ),
+                    AstSeparatedElement {
+                        node: JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@143..150 "fourth" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@150..152 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@152..153 "6" [] [],
+                                },
+                            },
+                        },
+                        trailing_separator: None,
+                    },
+                ],
             },
-        ),
+            semicolon_token: SEMICOLON@153..154 ";" [] [],
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -1,3 +1,84 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsWhileStatement(
+            JsWhileStatement {
+                while_token: Ok(
+                    WHILE_KW@0..6 "while" [] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@6..7 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsBooleanLiteralExpression(
+                            JsBooleanLiteralExpression {
+                                value_token: Ok(
+                                    TRUE_KW@7..11 "true" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@13..14 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@14..15 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+        JsWhileStatement(
+            JsWhileStatement {
+                while_token: Ok(
+                    WHILE_KW@15..22 "while" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                l_paren_token: Ok(
+                    L_PAREN@22..23 "(" [] [],
+                ),
+                test: Ok(
+                    JsAnyLiteralExpression(
+                        JsNumberLiteralExpression(
+                            JsNumberLiteralExpression {
+                                value_token: Ok(
+                                    JS_NUMBER_LITERAL@23..24 "5" [] [],
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                r_paren_token: Ok(
+                    R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                ),
+                body: Ok(
+                    JsBlockStatement(
+                        JsBlockStatement {
+                            l_curly_token: Ok(
+                                L_CURLY@26..27 "{" [] [],
+                            ),
+                            statements: [],
+                            r_curly_token: Ok(
+                                R_CURLY@27..28 "}" [] [],
+                            ),
+                        },
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..29
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -1,81 +1,33 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsWhileStatement(
-            JsWhileStatement {
-                while_token: Ok(
-                    WHILE_KW@0..6 "while" [] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@6..7 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsBooleanLiteralExpression(
-                            JsBooleanLiteralExpression {
-                                value_token: Ok(
-                                    TRUE_KW@7..11 "true" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@11..13 ")" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@13..14 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@14..15 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+        JsWhileStatement {
+            while_token: WHILE_KW@0..6 "while" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@6..7 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@7..11 "true" [] [],
             },
-        ),
-        JsWhileStatement(
-            JsWhileStatement {
-                while_token: Ok(
-                    WHILE_KW@15..22 "while" [Whitespace("\n")] [Whitespace(" ")],
-                ),
-                l_paren_token: Ok(
-                    L_PAREN@22..23 "(" [] [],
-                ),
-                test: Ok(
-                    JsAnyLiteralExpression(
-                        JsNumberLiteralExpression(
-                            JsNumberLiteralExpression {
-                                value_token: Ok(
-                                    JS_NUMBER_LITERAL@23..24 "5" [] [],
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                r_paren_token: Ok(
-                    R_PAREN@24..26 ")" [] [Whitespace(" ")],
-                ),
-                body: Ok(
-                    JsBlockStatement(
-                        JsBlockStatement {
-                            l_curly_token: Ok(
-                                L_CURLY@26..27 "{" [] [],
-                            ),
-                            statements: [],
-                            r_curly_token: Ok(
-                                R_CURLY@27..28 "}" [] [],
-                            ),
-                        },
-                    ),
-                ),
+            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@13..14 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@14..15 "}" [] [],
             },
-        ),
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@15..22 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@22..23 "(" [] [],
+            test: JsNumberLiteralExpression {
+                value_token: JS_NUMBER_LITERAL@23..24 "5" [] [],
+            },
+            r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@26..27 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@27..28 "}" [] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -1,3 +1,192 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")],
+                ),
+                star_token: None,
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@20..21 "f" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@21..22 "(" [] [],
+                        ),
+                        parameters: [
+                            AstSeparatedElement {
+                                node: Pattern(
+                                    SinglePattern(
+                                        SinglePattern {
+                                            name: Ok(
+                                                Name {
+                                                    ident_token: Ok(
+                                                        IDENT@22..23 "x" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            question_mark_token: None,
+                                            excl_token: None,
+                                            ty: None,
+                                        },
+                                    ),
+                                ),
+                                trailing_separator: Some(
+                                    COMMA@23..25 "," [] [Whitespace(" ")],
+                                ),
+                            },
+                            AstSeparatedElement {
+                                node: Pattern(
+                                    SinglePattern(
+                                        SinglePattern {
+                                            name: Ok(
+                                                Name {
+                                                    ident_token: Ok(
+                                                        IDENT@25..26 "o" [] [],
+                                                    ),
+                                                },
+                                            ),
+                                            question_mark_token: None,
+                                            excl_token: None,
+                                            ty: None,
+                                        },
+                                    ),
+                                ),
+                                trailing_separator: None,
+                            },
+                        ],
+                        r_paren_token: Ok(
+                            R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@28..29 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsWithStatement(
+                                JsWithStatement {
+                                    with_token: Ok(
+                                        WITH_KW@29..36 "with" [Whitespace("\n\t")] [Whitespace(" ")],
+                                    ),
+                                    l_paren_token: Ok(
+                                        L_PAREN@36..37 "(" [] [],
+                                    ),
+                                    object: Ok(
+                                        JsReferenceIdentifierExpression(
+                                            JsReferenceIdentifierExpression {
+                                                name_token: Ok(
+                                                    IDENT@37..38 "o" [] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    r_paren_token: Ok(
+                                        R_PAREN@38..40 ")" [] [Whitespace(" ")],
+                                    ),
+                                    body: Ok(
+                                        JsBlockStatement(
+                                            JsBlockStatement {
+                                                l_curly_token: Ok(
+                                                    L_CURLY@40..41 "{" [] [],
+                                                ),
+                                                statements: [
+                                                    JsExpressionStatement(
+                                                        JsExpressionStatement {
+                                                            expression: Ok(
+                                                                CallExpr(
+                                                                    CallExpr {
+                                                                        type_args: None,
+                                                                        callee: Ok(
+                                                                            JsStaticMemberExpression(
+                                                                                JsStaticMemberExpression {
+                                                                                    object: Ok(
+                                                                                        JsReferenceIdentifierExpression(
+                                                                                            JsReferenceIdentifierExpression {
+                                                                                                name_token: Ok(
+                                                                                                    IDENT@41..51 "console" [Whitespace("\n\t\t")] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                    operator: Ok(
+                                                                                        DOT@51..52 "." [] [],
+                                                                                    ),
+                                                                                    member: Ok(
+                                                                                        JsReferenceIdentifierMember(
+                                                                                            JsReferenceIdentifierMember {
+                                                                                                name_token: Ok(
+                                                                                                    IDENT@52..55 "log" [] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        arguments: Ok(
+                                                                            ArgList {
+                                                                                l_paren_token: Ok(
+                                                                                    L_PAREN@55..56 "(" [] [],
+                                                                                ),
+                                                                                args: [
+                                                                                    AstSeparatedElement {
+                                                                                        node: JsReferenceIdentifierExpression(
+                                                                                            JsReferenceIdentifierExpression {
+                                                                                                name_token: Ok(
+                                                                                                    IDENT@56..57 "x" [] [],
+                                                                                                ),
+                                                                                            },
+                                                                                        ),
+                                                                                        trailing_separator: None,
+                                                                                    },
+                                                                                ],
+                                                                                r_paren_token: Ok(
+                                                                                    R_PAREN@57..58 ")" [] [],
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            semicolon_token: Some(
+                                                                SEMICOLON@58..59 ";" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                                r_curly_token: Ok(
+                                                    R_CURLY@59..62 "}" [Whitespace("\n\t")] [],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@62..64 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..65
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -13,30 +13,24 @@ JsRoot {
             parameter_list: JsParameterList {
                 l_paren_token: L_PAREN@21..22 "(" [] [],
                 parameters: [
-                    AstSeparatedElement {
-                        node: SinglePattern {
-                            name: Name {
-                                ident_token: IDENT@22..23 "x" [] [],
-                            },
-                            question_mark_token: missing (optional),
-                            excl_token: missing (optional),
-                            ty: missing (optional),
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@22..23 "x" [] [],
                         },
-                        trailing_separator: Some(
-                            COMMA@23..25 "," [] [Whitespace(" ")],
-                        ),
-                    },
-                    AstSeparatedElement {
-                        node: SinglePattern {
-                            name: Name {
-                                ident_token: IDENT@25..26 "o" [] [],
-                            },
-                            question_mark_token: missing (optional),
-                            excl_token: missing (optional),
-                            ty: missing (optional),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    COMMA@23..25 "," [] [Whitespace(" ")],
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@25..26 "o" [] [],
                         },
-                        trailing_separator: None,
-                    },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
                 ],
                 r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
             },
@@ -70,12 +64,10 @@ JsRoot {
                                         arguments: ArgList {
                                             l_paren_token: L_PAREN@55..56 "(" [] [],
                                             args: [
-                                                AstSeparatedElement {
-                                                    node: JsReferenceIdentifierExpression {
-                                                        name_token: IDENT@56..57 "x" [] [],
-                                                    },
-                                                    trailing_separator: None,
-                                                },
+                                                JsReferenceIdentifierExpression {
+                                                    name_token: IDENT@56..57 "x" [] [],
+                                                }
+                                                ,
                                             ],
                                             r_paren_token: R_PAREN@57..58 ")" [] [],
                                         },

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -1,189 +1,95 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")],
-                ),
-                star_token: None,
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@20..21 "f" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@21..22 "(" [] [],
-                        ),
-                        parameters: [
-                            AstSeparatedElement {
-                                node: Pattern(
-                                    SinglePattern(
-                                        SinglePattern {
-                                            name: Ok(
-                                                Name {
-                                                    ident_token: Ok(
-                                                        IDENT@22..23 "x" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            question_mark_token: None,
-                                            excl_token: None,
-                                            ty: None,
-                                        },
-                                    ),
-                                ),
-                                trailing_separator: Some(
-                                    COMMA@23..25 "," [] [Whitespace(" ")],
-                                ),
-                            },
-                            AstSeparatedElement {
-                                node: Pattern(
-                                    SinglePattern(
-                                        SinglePattern {
-                                            name: Ok(
-                                                Name {
-                                                    ident_token: Ok(
-                                                        IDENT@25..26 "o" [] [],
-                                                    ),
-                                                },
-                                            ),
-                                            question_mark_token: None,
-                                            excl_token: None,
-                                            ty: None,
-                                        },
-                                    ),
-                                ),
-                                trailing_separator: None,
-                            },
-                        ],
-                        r_paren_token: Ok(
-                            R_PAREN@26..28 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@28..29 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsWithStatement(
-                                JsWithStatement {
-                                    with_token: Ok(
-                                        WITH_KW@29..36 "with" [Whitespace("\n\t")] [Whitespace(" ")],
-                                    ),
-                                    l_paren_token: Ok(
-                                        L_PAREN@36..37 "(" [] [],
-                                    ),
-                                    object: Ok(
-                                        JsReferenceIdentifierExpression(
-                                            JsReferenceIdentifierExpression {
-                                                name_token: Ok(
-                                                    IDENT@37..38 "o" [] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    r_paren_token: Ok(
-                                        R_PAREN@38..40 ")" [] [Whitespace(" ")],
-                                    ),
-                                    body: Ok(
-                                        JsBlockStatement(
-                                            JsBlockStatement {
-                                                l_curly_token: Ok(
-                                                    L_CURLY@40..41 "{" [] [],
-                                                ),
-                                                statements: [
-                                                    JsExpressionStatement(
-                                                        JsExpressionStatement {
-                                                            expression: Ok(
-                                                                CallExpr(
-                                                                    CallExpr {
-                                                                        type_args: None,
-                                                                        callee: Ok(
-                                                                            JsStaticMemberExpression(
-                                                                                JsStaticMemberExpression {
-                                                                                    object: Ok(
-                                                                                        JsReferenceIdentifierExpression(
-                                                                                            JsReferenceIdentifierExpression {
-                                                                                                name_token: Ok(
-                                                                                                    IDENT@41..51 "console" [Whitespace("\n\t\t")] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                    operator: Ok(
-                                                                                        DOT@51..52 "." [] [],
-                                                                                    ),
-                                                                                    member: Ok(
-                                                                                        JsReferenceIdentifierMember(
-                                                                                            JsReferenceIdentifierMember {
-                                                                                                name_token: Ok(
-                                                                                                    IDENT@52..55 "log" [] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                    ),
-                                                                                },
-                                                                            ),
-                                                                        ),
-                                                                        arguments: Ok(
-                                                                            ArgList {
-                                                                                l_paren_token: Ok(
-                                                                                    L_PAREN@55..56 "(" [] [],
-                                                                                ),
-                                                                                args: [
-                                                                                    AstSeparatedElement {
-                                                                                        node: JsReferenceIdentifierExpression(
-                                                                                            JsReferenceIdentifierExpression {
-                                                                                                name_token: Ok(
-                                                                                                    IDENT@56..57 "x" [] [],
-                                                                                                ),
-                                                                                            },
-                                                                                        ),
-                                                                                        trailing_separator: None,
-                                                                                    },
-                                                                                ],
-                                                                                r_paren_token: Ok(
-                                                                                    R_PAREN@57..58 ")" [] [],
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            semicolon_token: Some(
-                                                                SEMICOLON@58..59 ";" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ],
-                                                r_curly_token: Ok(
-                                                    R_CURLY@59..62 "}" [Whitespace("\n\t")] [],
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@62..64 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..21 "f" [] [],
             },
-        ),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@21..22 "(" [] [],
+                parameters: [
+                    AstSeparatedElement {
+                        node: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@22..23 "x" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        trailing_separator: Some(
+                            COMMA@23..25 "," [] [Whitespace(" ")],
+                        ),
+                    },
+                    AstSeparatedElement {
+                        node: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@25..26 "o" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        trailing_separator: None,
+                    },
+                ],
+                r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@28..29 "{" [] [],
+                directives: [],
+                statements: [
+                    JsWithStatement {
+                        with_token: WITH_KW@29..36 "with" [Whitespace("\n\t")] [Whitespace(" ")],
+                        l_paren_token: L_PAREN@36..37 "(" [] [],
+                        object: JsReferenceIdentifierExpression {
+                            name_token: IDENT@37..38 "o" [] [],
+                        },
+                        r_paren_token: R_PAREN@38..40 ")" [] [Whitespace(" ")],
+                        body: JsBlockStatement {
+                            l_curly_token: L_CURLY@40..41 "{" [] [],
+                            statements: [
+                                JsExpressionStatement {
+                                    expression: CallExpr {
+                                        type_args: missing (optional),
+                                        callee: JsStaticMemberExpression {
+                                            object: JsReferenceIdentifierExpression {
+                                                name_token: IDENT@41..51 "console" [Whitespace("\n\t\t")] [],
+                                            },
+                                            operator: DOT@51..52 "." [] [],
+                                            member: JsReferenceIdentifierMember {
+                                                name_token: IDENT@52..55 "log" [] [],
+                                            },
+                                        },
+                                        arguments: ArgList {
+                                            l_paren_token: L_PAREN@55..56 "(" [] [],
+                                            args: [
+                                                AstSeparatedElement {
+                                                    node: JsReferenceIdentifierExpression {
+                                                        name_token: IDENT@56..57 "x" [] [],
+                                                    },
+                                                    trailing_separator: None,
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@57..58 ")" [] [],
+                                        },
+                                    },
+                                    semicolon_token: SEMICOLON@58..59 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@59..62 "}" [Whitespace("\n\t")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@62..64 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -1,123 +1,57 @@
 JsRoot {
-    interpreter_token: None,
+    interpreter_token: missing (optional),
     directives: [],
     statements: [
-        JsFunctionDeclaration(
-            JsFunctionDeclaration {
-                async_token: None,
-                function_token: Ok(
-                    FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
-                ),
-                star_token: Some(
-                    STAR@9..10 "*" [] [],
-                ),
-                id: Ok(
-                    JsIdentifierBinding {
-                        name_token: Ok(
-                            IDENT@10..13 "foo" [] [],
-                        ),
-                    },
-                ),
-                type_parameters: None,
-                parameter_list: Ok(
-                    JsParameterList {
-                        l_paren_token: Ok(
-                            L_PAREN@13..14 "(" [] [],
-                        ),
-                        parameters: [],
-                        r_paren_token: Ok(
-                            R_PAREN@14..16 ")" [] [Whitespace(" ")],
-                        ),
-                    },
-                ),
-                return_type: None,
-                body: Ok(
-                    JsFunctionBody {
-                        l_curly_token: Ok(
-                            L_CURLY@16..17 "{" [] [],
-                        ),
-                        directives: [],
-                        statements: [
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsYieldExpression(
-                                            JsYieldExpression {
-                                                yield_token: Ok(
-                                                    YIELD_KW@17..25 "yield" [Whitespace("\n ")] [Whitespace(" ")],
-                                                ),
-                                                star_token: None,
-                                                argument: Some(
-                                                    JsReferenceIdentifierExpression(
-                                                        JsReferenceIdentifierExpression {
-                                                            name_token: Ok(
-                                                                IDENT@25..28 "foo" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@28..29 ";" [] [],
-                                    ),
-                                },
-                            ),
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsYieldExpression(
-                                            JsYieldExpression {
-                                                yield_token: Ok(
-                                                    YIELD_KW@29..36 "yield" [Whitespace("\n ")] [],
-                                                ),
-                                                star_token: Some(
-                                                    STAR@36..38 "*" [] [Whitespace(" ")],
-                                                ),
-                                                argument: Some(
-                                                    JsReferenceIdentifierExpression(
-                                                        JsReferenceIdentifierExpression {
-                                                            name_token: Ok(
-                                                                IDENT@38..41 "foo" [] [],
-                                                            ),
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@41..42 ";" [] [],
-                                    ),
-                                },
-                            ),
-                            JsExpressionStatement(
-                                JsExpressionStatement {
-                                    expression: Ok(
-                                        JsYieldExpression(
-                                            JsYieldExpression {
-                                                yield_token: Ok(
-                                                    YIELD_KW@42..49 "yield" [Whitespace("\n ")] [],
-                                                ),
-                                                star_token: None,
-                                                argument: None,
-                                            },
-                                        ),
-                                    ),
-                                    semicolon_token: Some(
-                                        SEMICOLON@49..50 ";" [] [],
-                                    ),
-                                },
-                            ),
-                        ],
-                        r_curly_token: Ok(
-                            R_CURLY@50..52 "}" [Whitespace("\n")] [],
-                        ),
-                    },
-                ),
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: STAR@9..10 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@10..13 "foo" [] [],
             },
-        ),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@13..14 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@14..16 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@16..17 "{" [] [],
+                directives: [],
+                statements: [
+                    JsExpressionStatement {
+                        expression: JsYieldExpression {
+                            yield_token: YIELD_KW@17..25 "yield" [Whitespace("\n ")] [Whitespace(" ")],
+                            star_token: missing (optional),
+                            argument: JsReferenceIdentifierExpression {
+                                name_token: IDENT@25..28 "foo" [] [],
+                            },
+                        },
+                        semicolon_token: SEMICOLON@28..29 ";" [] [],
+                    },
+                    JsExpressionStatement {
+                        expression: JsYieldExpression {
+                            yield_token: YIELD_KW@29..36 "yield" [Whitespace("\n ")] [],
+                            star_token: STAR@36..38 "*" [] [Whitespace(" ")],
+                            argument: JsReferenceIdentifierExpression {
+                                name_token: IDENT@38..41 "foo" [] [],
+                            },
+                        },
+                        semicolon_token: SEMICOLON@41..42 ";" [] [],
+                    },
+                    JsExpressionStatement {
+                        expression: JsYieldExpression {
+                            yield_token: YIELD_KW@42..49 "yield" [Whitespace("\n ")] [],
+                            star_token: missing (optional),
+                            argument: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@49..50 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@50..52 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -1,3 +1,126 @@
+JsRoot {
+    interpreter_token: None,
+    directives: [],
+    statements: [
+        JsFunctionDeclaration(
+            JsFunctionDeclaration {
+                async_token: None,
+                function_token: Ok(
+                    FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+                ),
+                star_token: Some(
+                    STAR@9..10 "*" [] [],
+                ),
+                id: Ok(
+                    JsIdentifierBinding {
+                        name_token: Ok(
+                            IDENT@10..13 "foo" [] [],
+                        ),
+                    },
+                ),
+                type_parameters: None,
+                parameter_list: Ok(
+                    JsParameterList {
+                        l_paren_token: Ok(
+                            L_PAREN@13..14 "(" [] [],
+                        ),
+                        parameters: [],
+                        r_paren_token: Ok(
+                            R_PAREN@14..16 ")" [] [Whitespace(" ")],
+                        ),
+                    },
+                ),
+                return_type: None,
+                body: Ok(
+                    JsFunctionBody {
+                        l_curly_token: Ok(
+                            L_CURLY@16..17 "{" [] [],
+                        ),
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsYieldExpression(
+                                            JsYieldExpression {
+                                                yield_token: Ok(
+                                                    YIELD_KW@17..25 "yield" [Whitespace("\n ")] [Whitespace(" ")],
+                                                ),
+                                                star_token: None,
+                                                argument: Some(
+                                                    JsReferenceIdentifierExpression(
+                                                        JsReferenceIdentifierExpression {
+                                                            name_token: Ok(
+                                                                IDENT@25..28 "foo" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@28..29 ";" [] [],
+                                    ),
+                                },
+                            ),
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsYieldExpression(
+                                            JsYieldExpression {
+                                                yield_token: Ok(
+                                                    YIELD_KW@29..36 "yield" [Whitespace("\n ")] [],
+                                                ),
+                                                star_token: Some(
+                                                    STAR@36..38 "*" [] [Whitespace(" ")],
+                                                ),
+                                                argument: Some(
+                                                    JsReferenceIdentifierExpression(
+                                                        JsReferenceIdentifierExpression {
+                                                            name_token: Ok(
+                                                                IDENT@38..41 "foo" [] [],
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@41..42 ";" [] [],
+                                    ),
+                                },
+                            ),
+                            JsExpressionStatement(
+                                JsExpressionStatement {
+                                    expression: Ok(
+                                        JsYieldExpression(
+                                            JsYieldExpression {
+                                                yield_token: Ok(
+                                                    YIELD_KW@42..49 "yield" [Whitespace("\n ")] [],
+                                                ),
+                                                star_token: None,
+                                                argument: None,
+                                            },
+                                        ),
+                                    ),
+                                    semicolon_token: Some(
+                                        SEMICOLON@49..50 ";" [] [],
+                                    ),
+                                },
+                            ),
+                        ],
+                        r_curly_token: Ok(
+                            R_CURLY@50..52 "}" [Whitespace("\n")] [],
+                        ),
+                    },
+                ),
+            },
+        ),
+    ],
+}
+
 0: JS_ROOT@0..53
   0: (empty)
   1: LIST@0..0

--- a/xtask/js.ungram
+++ b/xtask/js.ungram
@@ -865,7 +865,7 @@ JsReferencePrivateMember =
 
 JsParameterList =
 	'('
-	parameters: (Pattern (',' Pattern)* ','?)
+	parameters: (JsAnyParameter (',' JsAnyParameter)* ','?)
 	')'
 
 JsAnyParameter = Pattern | JsRestParameter

--- a/xtask/src/codegen/generate_nodes.rs
+++ b/xtask/src/codegen/generate_nodes.rs
@@ -9,25 +9,25 @@ use crate::{
 use quote::{format_ident, quote};
 
 // these node won't generate any code
-const BUILT_IN_TYPE: &str = "SyntaxElement";
+const SYNTAX_ELEMENT_TYPE: &str = "SyntaxElement";
 
 pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
 	let filtered_enums: Vec<_> = ast
 		.enums
 		.iter()
-		.filter(|e| e.name.as_str() != BUILT_IN_TYPE)
+		.filter(|e| e.name.as_str() != SYNTAX_ELEMENT_TYPE)
 		.collect();
 
 	let filtered_nodes: Vec<_> = ast
 		.nodes
 		.iter()
-		.filter(|e| e.name.as_str() != BUILT_IN_TYPE)
+		.filter(|e| e.name.as_str() != SYNTAX_ELEMENT_TYPE)
 		.collect();
 
 	let (node_defs, node_boilerplate_impls): (Vec<_>, Vec<_>) = filtered_nodes
 		.iter()
 		.filter_map(|node| {
-			if node.name.as_str() == BUILT_IN_TYPE {
+			if node.name.as_str() == SYNTAX_ELEMENT_TYPE {
 				return None;
 			}
 
@@ -85,16 +85,16 @@ pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
 					separated,
 					..
 				} => {
-					let is_built_in_tpe = &ty.eq(BUILT_IN_TYPE);
+					let is_syntax_type = &ty.eq(SYNTAX_ELEMENT_TYPE);
 					let ty = format_ident!("{}", &ty);
 
 					let method_name = field.method_name();
 					// this is when we encounter a node that has "Unknown" in its name
 					// it will return tokens a and nodes regardless because there's an error
 					// inside the code
-					if *is_built_in_tpe {
+					if *is_syntax_type {
 						quote! {
-							pub fn #method_name(&self) -> SyntaxElementChildren {
+							pub fn items(&self) -> SyntaxElementChildren {
 								support::elements(&self.syntax)
 							}
 						}
@@ -138,6 +138,7 @@ pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
 						kind: TokenKind::Many(_),
 						..
 					} => format_ident!("{}", name),
+					Field::Node { ty, .. } if ty == SYNTAX_ELEMENT_TYPE => format_ident!("items"),
 					_ => field.method_name(),
 				};
 

--- a/xtask/src/codegen/kinds_src.rs
+++ b/xtask/src/codegen/kinds_src.rs
@@ -426,9 +426,8 @@ pub struct AstEnumSrc {
 }
 
 impl Field {
-	#[allow(dead_code)]
 	pub fn is_many(&self) -> bool {
-		matches!(self, Field::Node { .. })
+		matches!(self, Field::Node { has_many: true, .. })
 	}
 
 	pub fn method_name(&self) -> proc_macro2::Ident {


### PR DESCRIPTION
## Summary

We test our parser by comparing the expected syntax tree with the actual tree produced by the parser. This works well but doesn't give us any guarantee that what the parser produces matches the AST structure. 

This PR removes the derived `Debug` implementation for `AstNode` and replaces it with a generated implementation that prints the children of a node:

```rust
impl std::fmt::Debug for JsConstructorClassMember {
	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
		f.debug_struct("JsConstructorClassMember")
			.field(
				"access_modifier",
				&support::DebugOptionalNode(self.access_modifier()),
			)
			.field("name", &support::DebugSyntaxResult(self.name()))
			.field(
				"parameter_list",
				&support::DebugSyntaxResult(self.parameter_list()),
			)
			.field("body", &support::DebugSyntaxResult(self.body()))
			.finish()
	}
}
```

and adds the AST output to the parser's `ok` integration tests. 

This helps us 

* The format is easier to read than the syntax node output because it labels children
* It allows us to spot structural mismatches: New children will always be "missing" until the necessary parser changes are made. Mismatching field types also show up as `missing` (see included fix for class members named "static")
* Simplifies debugging for pass-authors that may be less familiar with our internal syntax level representation. 


Should we print the syntax and the ast tree: I think yes because:
* The syntax tree can be useful when debugging
* Changes that are only reflected in one may point out structural mismatches 

The PR doesn't add the AST assertions for failing tree tests yet because some tests are panicking because of `AstSeparatedList` children that have missing separators/elements. We'll ned to rework the `AstSeparatedList` to allow for empty elements and missing separators to be able to recover from `fn(a b)` (missing separator) or `fn(,a)` because we don't want to insert non existing tokens into the parse tree (fixing missing separators) nor empty elements (fixing missing elements). I plan to follow up on this in a new PR.

I also tried to wrap the printing with `std::panic::catch_unwind` but `Cell`s are not `UnwindSafe`. 

## Test Plan

I verified some of the AST tree outputs by hand.
