### PR TITLE
Allow missing tokens/nodes in AstSeparatedList

### DIFF
--- a/crates/rome_formatter/src/format_json.rs
+++ b/crates/rome_formatter/src/format_json.rs
@@ -72,6 +72,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatElement {
 			let properties_list: Vec<FormatElement> = object
 				.members()
 				.iter()
+				.flatten()
 				.map(|prop| match prop {
 					JsAnyObjectMember::JsPropertyObjectMember(prop) => {
 						format_elements![tokenize_node(prop.syntax().clone())]
@@ -98,6 +99,7 @@ fn tokenize_node(node: SyntaxNode) -> FormatElement {
 				array
 					.elements()
 					.iter()
+					.flatten()
 					.map(|element| tokenize_node(element.syntax().clone())),
 			);
 

--- a/crates/rome_formatter/src/ts/arg_list.rs
+++ b/crates/rome_formatter/src/ts/arg_list.rs
@@ -1,5 +1,5 @@
 use crate::{
-	format_elements, group_elements, join_elements, token, FormatElement, FormatResult, Formatter,
+	concat_elements, format_elements, group_elements, FormatElement, FormatResult, Formatter,
 	ToFormatElement,
 };
 use rslint_parser::ast::ArgList;
@@ -7,13 +7,9 @@ use rslint_parser::ast::ArgList;
 impl ToFormatElement for ArgList {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
 		let l_bracket = formatter.format_token(&self.l_paren_token()?)?;
-		let args = formatter.format_nodes(self.args())?;
+		let args = concat_elements(formatter.format_separated(self.args())?);
 		let r_bracket = formatter.format_token(&self.r_paren_token()?)?;
 
-		Ok(group_elements(format_elements![
-			l_bracket,
-			join_elements(token(", "), args),
-			r_bracket
-		]))
+		Ok(group_elements(format_elements![l_bracket, args, r_bracket]))
 	}
 }

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -1,5 +1,5 @@
 use crate::{
-	format_elements, group_elements, join_elements, soft_line_break_or_space, space_token, token,
+	format_elements, group_elements, join_elements, soft_line_break_or_space, space_token,
 	FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{
@@ -20,15 +20,12 @@ impl ToFormatElement for JsConstructorClassMember {
 impl ToFormatElement for JsConstructorParameterList {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
 		let l_bracket = formatter.format_token(&self.l_paren_token()?)?;
-		let params = formatter.format_nodes(self.parameters())?;
+		let params = formatter.format_separated(self.parameters())?;
 		let r_bracket = formatter.format_token(&self.r_paren_token()?)?;
 
 		Ok(format_elements![group_elements(format_elements![
 			l_bracket,
-			join_elements(
-				format_elements![token(","), soft_line_break_or_space()],
-				params
-			),
+			join_elements(soft_line_break_or_space(), params),
 			r_bracket
 		])])
 	}

--- a/crates/rome_formatter/src/ts/declarators/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/declarators/variable_declaration_statement.rs
@@ -17,16 +17,12 @@ impl ToFormatElement for JsVariableDeclarationStatement {
 
 impl ToFormatElement for JsVariableDeclaration {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-		let mut declarators = Vec::with_capacity(self.declarators().len());
-
-		for declarator in self.declarators().iter() {
-			declarators.push(formatter.format_node(declarator)?);
-		}
+		let declarators = formatter.format_separated(self.declarators())?;
 
 		Ok(format_elements![
 			formatter.format_token(&self.kind_token()?)?,
 			space_token(),
-			join_elements(format_elements![token(","), space_token()], declarators),
+			join_elements(space_token(), declarators),
 		])
 	}
 }

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -6,14 +6,11 @@ use rslint_parser::ast::{JsArrayExpression, JsArrayHole};
 
 impl ToFormatElement for JsArrayExpression {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-		let elements = formatter.format_nodes(self.elements())?;
+		let elements = formatter.format_separated(self.elements())?;
 
 		Ok(group_elements(format_elements!(
 			formatter.format_token(&self.l_brack_token()?)?,
-			soft_indent(join_elements(
-				format_elements!(token(","), soft_line_break_or_space()),
-				elements
-			)),
+			soft_indent(join_elements(soft_line_break_or_space(), elements)),
 			if_group_breaks(token(",")),
 			formatter.format_token(&self.r_brack_token()?)?,
 		)))

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -6,12 +6,11 @@ use rslint_parser::ast::JsObjectExpression;
 
 impl ToFormatElement for JsObjectExpression {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-		let separator = format_elements!(token(","), soft_line_break_or_space());
-		let props = formatter.format_nodes(self.members())?;
+		let props = formatter.format_separated(self.members())?;
 
 		Ok(group_elements(format_elements!(
 			formatter.format_token(&self.l_curly_token()?)?,
-			soft_indent(join_elements(separator, props)),
+			soft_indent(join_elements(soft_line_break_or_space(), props)),
 			if_group_breaks(token(",")),
 			formatter.format_token(&self.r_curly_token()?)?,
 		)))

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -1,19 +1,16 @@
 use crate::{
-	format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
+	format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space,
 	FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{JsAnyParameter, JsParameterList};
 
 impl ToFormatElement for JsParameterList {
 	fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-		let param_tokens = formatter.format_nodes(self.parameters())?;
+		let param_tokens = formatter.format_separated(self.parameters())?;
 
 		Ok(group_elements(format_elements![
 			formatter.format_token(&self.l_paren_token()?)?,
-			soft_indent(join_elements(
-				format_elements![token(","), soft_line_break_or_space()],
-				param_tokens,
-			),),
+			soft_indent(join_elements(soft_line_break_or_space(), param_tokens,),),
 			formatter.format_token(&self.r_paren_token()?)?
 		]))
 	}

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -622,6 +622,7 @@ impl<L: Language> SyntaxNode<L> {
 		}
 	}
 
+	/// Returns an iterator over all the slots of this syntax node.
 	pub fn slots(&self) -> SyntaxSlots<L> {
 		SyntaxSlots {
 			raw: Some(self.raw.slots()),
@@ -1112,10 +1113,16 @@ impl<L: Language> From<SyntaxElement<L>> for cursor::SyntaxElement {
 	}
 }
 
+/// Each node has a slot for each of its children regardless if the child is present or not.
+/// A child that isn't present either because it's optional or because of a syntax error
+/// is stored in an [SyntaxSlot::Empty] to preserve the index of each child.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SyntaxSlot<L: Language> {
+	/// Slot that stores a node child
 	Node(SyntaxNode<L>),
+	/// Slot that stores a token child
 	Token(SyntaxToken<L>),
+	/// Slot that marks that the child in this position isn't present in the source code.
 	Empty,
 }
 
@@ -1146,6 +1153,7 @@ impl<L: Language> From<cursor::SyntaxSlot> for SyntaxSlot<L> {
 	}
 }
 
+/// Iterator over the slots of a node.
 #[derive(Debug, Clone)]
 pub struct SyntaxSlots<L> {
 	raw: Option<cursor::SyntaxSlots>,

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -5,7 +5,7 @@ mod token;
 
 pub(crate) use self::{
 	element::{GreenElement, GreenElementRef},
-	node::{Child, Children, GreenNode, GreenNodeData, Slot, Slots},
+	node::{Child, Children, GreenNode, GreenNodeData, Slot},
 	token::{GreenToken, GreenTokenData},
 };
 

--- a/crates/rome_rowan/src/lib.rs
+++ b/crates/rome_rowan/src/lib.rs
@@ -31,7 +31,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 pub use crate::{
 	api::{
 		Language, SyntaxElement, SyntaxElementChildren, SyntaxList, SyntaxNode, SyntaxNodeChildren,
-		SyntaxToken, TriviaPiece,
+		SyntaxSlot, SyntaxSlots, SyntaxToken, TriviaPiece,
 	},
 	green::SyntaxKind,
 	syntax_text::SyntaxText,

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -12,54 +12,42 @@ pub struct JsUnknownStatement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownPattern {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownMember {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownBinding {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownAssignmentTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownAssignmentTarget {
-	pub fn items(&self) -> SyntaxElementChildren {
-		support::elements(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
@@ -93,9 +81,7 @@ impl JsDirective {
 	pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBlockStatement {
@@ -129,9 +115,7 @@ impl JsExpressionStatement {
 	pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsIfStatement {
@@ -144,18 +128,14 @@ impl JsIfStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 	pub fn consequent(&self) -> SyntaxResult<JsAnyStatement> {
 		support::required_node(&self.syntax)
 	}
-	pub fn else_clause(&self) -> Option<JsElseClause> {
-		support::node(&self.syntax)
-	}
+	pub fn else_clause(&self) -> Option<JsElseClause> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDoWhileStatement {
@@ -165,24 +145,18 @@ impl JsDoWhileStatement {
 	pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![do])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![while])
 	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWhileStatement {
@@ -195,15 +169,11 @@ impl JsWhileStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmt {
@@ -216,21 +186,13 @@ impl ForStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn init(&self) -> Option<ForStmtInit> {
-		support::node(&self.syntax)
-	}
-	pub fn test(&self) -> Option<ForStmtTest> {
-		support::node(&self.syntax)
-	}
-	pub fn update(&self) -> Option<ForStmtUpdate> {
-		support::node(&self.syntax)
-	}
+	pub fn init(&self) -> Option<ForStmtInit> { support::node(&self.syntax) }
+	pub fn test(&self) -> Option<ForStmtTest> { support::node(&self.syntax) }
+	pub fn update(&self) -> Option<ForStmtUpdate> { support::node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForInStmt {
@@ -243,21 +205,15 @@ impl ForInStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
 	pub fn in_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![in])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForOfStmt {
@@ -270,21 +226,15 @@ impl ForOfStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
 	pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![of])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsContinueStatement {
@@ -294,12 +244,8 @@ impl JsContinueStatement {
 	pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![continue])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![ident])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBreakStatement {
@@ -309,12 +255,8 @@ impl JsBreakStatement {
 	pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![break])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![ident])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReturnStatement {
@@ -324,12 +266,8 @@ impl JsReturnStatement {
 	pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![return])
 	}
-	pub fn argument(&self) -> Option<JsAnyExpression> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWithStatement {
@@ -342,15 +280,11 @@ impl JsWithStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLabeledStatement {
@@ -363,9 +297,7 @@ impl JsLabeledStatement {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSwitchStatement {
@@ -402,12 +334,8 @@ impl JsThrowStatement {
 	pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![throw])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsTryStatement {
@@ -417,9 +345,7 @@ impl JsTryStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 	pub fn catch_clause(&self) -> SyntaxResult<JsCatchClause> {
 		support::required_node(&self.syntax)
 	}
@@ -432,12 +358,8 @@ impl JsTryFinallyStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
-	pub fn catch_clause(&self) -> Option<JsCatchClause> {
-		support::node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn catch_clause(&self) -> Option<JsCatchClause> { support::node(&self.syntax) }
 	pub fn finally_clause(&self) -> SyntaxResult<JsFinallyClause> {
 		support::required_node(&self.syntax)
 	}
@@ -450,39 +372,25 @@ impl JsDebuggerStatement {
 	pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![debugger])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionDeclaration {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsClassDeclaration {
@@ -492,15 +400,9 @@ impl JsClassDeclaration {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
-		support::required_node(&self.syntax)
-	}
-	pub fn implements_clause(&self) -> Option<TsImplementsClause> {
-		support::node(&self.syntax)
-	}
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
+	pub fn implements_clause(&self) -> Option<TsImplementsClause> { support::node(&self.syntax) }
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -519,30 +421,22 @@ impl JsVariableDeclarationStatement {
 	pub fn declaration(&self) -> SyntaxResult<JsVariableDeclaration> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnum {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
-	pub fn const_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![const])
-	}
+	pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
 	pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![enum])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsEnumMember> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -555,15 +449,11 @@ impl TsTypeAliasDecl {
 	pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![type])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceDecl {
@@ -573,15 +463,9 @@ impl TsNamespaceDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleDecl {
@@ -591,48 +475,30 @@ impl TsModuleDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn global_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![global])
-	}
+	pub fn global_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![global]) }
 	pub fn module_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![module])
 	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsInterfaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInterfaceDecl {
-	pub fn declare_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![declare])
-	}
+	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
 	pub fn interface_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![interface])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
-	pub fn extends_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![extends])
-	}
-	pub fn extends(&self) -> Option<TsExprWithTypeArgs> {
-		support::node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn extends_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![extends]) }
+	pub fn extends(&self) -> Option<TsExprWithTypeArgs> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> SyntaxResult<TsTypeElement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn members(&self) -> SyntaxResult<TsTypeElement> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -645,12 +511,8 @@ impl ImportDecl {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn imports(&self) -> AstNodeList<ImportClause> {
-		support::node_list(&self.syntax, 0usize)
-	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax, 0usize) }
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -660,12 +522,8 @@ impl ImportDecl {
 	pub fn asserted_object(&self) -> SyntaxResult<JsObjectExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn assert_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![assert])
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn assert_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![assert]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportNamed {
@@ -675,12 +533,8 @@ impl ExportNamed {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn from_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![from])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn from_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![from]) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -699,15 +553,9 @@ impl ExportDefaultDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn default_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![default])
-	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn decl(&self) -> SyntaxResult<DefaultDecl> {
-		support::required_node(&self.syntax)
-	}
+	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn decl(&self) -> SyntaxResult<DefaultDecl> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDefaultExpr {
@@ -717,15 +565,9 @@ impl ExportDefaultExpr {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
-	pub fn default_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![default])
-	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportWildcard {
@@ -735,18 +577,12 @@ impl ExportWildcard {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![as])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
+	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -762,9 +598,7 @@ impl ExportDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![type])
-	}
+	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
 	pub fn decl(&self) -> SyntaxResult<JsAnyExportDeclaration> {
 		support::required_node(&self.syntax)
 	}
@@ -780,18 +614,12 @@ impl TsImportEqualsDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn module(&self) -> SyntaxResult<TsModuleRef> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn module(&self) -> SyntaxResult<TsModuleRef> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExportAssignment {
@@ -804,12 +632,8 @@ impl TsExportAssignment {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceExportDecl {
@@ -825,12 +649,8 @@ impl TsNamespaceExportDecl {
 	pub fn namespace_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![namespace])
 	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsElseClause {
@@ -840,18 +660,14 @@ impl JsElseClause {
 	pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![else])
 	}
-	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtInit {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtInit {
-	pub fn inner(&self) -> SyntaxResult<ForHead> {
-		support::required_node(&self.syntax)
-	}
+	pub fn inner(&self) -> SyntaxResult<ForHead> { support::required_node(&self.syntax) }
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -861,9 +677,7 @@ pub struct ForStmtTest {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtTest {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -873,9 +687,7 @@ pub struct ForStmtUpdate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtUpdate {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclaration {
@@ -897,9 +709,7 @@ impl JsCaseClause {
 	pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![case])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -930,12 +740,8 @@ impl JsCatchClause {
 	pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![catch])
 	}
-	pub fn declaration(&self) -> Option<JsCatchDeclaration> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn declaration(&self) -> Option<JsCatchDeclaration> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFinallyClause {
@@ -945,9 +751,7 @@ impl JsFinallyClause {
 	pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![finally])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCatchDeclaration {
@@ -957,9 +761,7 @@ impl JsCatchDeclaration {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -984,21 +786,15 @@ pub struct JsArrowFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsArrowFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> Option<JsAnyArrowFunctionParameters> {
 		support::node(&self.syntax)
 	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAwaitExpression {
@@ -1008,18 +804,14 @@ impl JsAwaitExpression {
 	pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![await])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBinaryExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsBinaryExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(
 			&self.syntax,
@@ -1058,12 +850,8 @@ impl JsClassExpression {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> {
-		support::node(&self.syntax)
-	}
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -1079,9 +867,7 @@ pub struct JsConditionalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConditionalExpression {
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
@@ -1094,9 +880,7 @@ pub struct JsComputedMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn optional_chain_token_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?.])
 	}
@@ -1112,30 +896,18 @@ pub struct JsFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> {
-		support::node(&self.syntax)
-	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportCallExpression {
@@ -1148,9 +920,7 @@ impl JsImportCallExpression {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -1160,9 +930,7 @@ pub struct JsLogicalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsLogicalExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [??], T ! [||], T ! [&&]])
 	}
@@ -1211,9 +979,7 @@ pub struct JsSequenceExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSequenceExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn comma_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [,])
 	}
@@ -1223,9 +989,7 @@ pub struct JsStaticMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [.], T ! [?.]])
 	}
@@ -1270,9 +1034,7 @@ impl JsUnaryExpression {
 			],
 		)
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPreUpdateExpression {
@@ -1282,18 +1044,14 @@ impl JsPreUpdateExpression {
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPostUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPostUpdateExpression {
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
@@ -1306,12 +1064,8 @@ impl JsYieldExpression {
 	pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![yield])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
-	pub fn argument(&self) -> Option<JsAnyExpression> {
-		support::node(&self.syntax)
-	}
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Template {
@@ -1330,30 +1084,18 @@ impl NewExpr {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_args(&self) -> Option<TsTypeArgs> {
-		support::node(&self.syntax)
-	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn arguments(&self) -> SyntaxResult<ArgList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CallExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CallExpr {
-	pub fn type_args(&self) -> Option<TsTypeArgs> {
-		support::node(&self.syntax)
-	}
-	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn arguments(&self) -> SyntaxResult<ArgList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
+	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignExpr {
@@ -1415,9 +1157,7 @@ pub struct TsNonNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
@@ -1427,18 +1167,12 @@ pub struct TsAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1448,12 +1182,8 @@ pub struct TsConstAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
@@ -1472,9 +1202,7 @@ impl TsTypeArgs {
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn args(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn args(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1508,15 +1236,9 @@ pub struct TsTypeParams {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParams {
-	pub fn l_angle_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [<])
-	}
-	pub fn params(&self) -> SyntaxResult<TsTypeParam> {
-		support::required_node(&self.syntax)
-	}
-	pub fn r_angle_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [>])
-	}
+	pub fn l_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [<]) }
+	pub fn params(&self) -> SyntaxResult<TsTypeParam> { support::required_node(&self.syntax) }
+	pub fn r_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [>]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsParameterList {
@@ -1541,9 +1263,7 @@ impl TsTypeAnnotation {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionBody {
@@ -1571,9 +1291,7 @@ impl SpreadElement {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn element(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn element(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrayHole {
@@ -1624,27 +1342,17 @@ pub struct JsMethodObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodObjectMember {
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_params(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn type_params(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterObjectMember {
@@ -1663,12 +1371,8 @@ impl JsGetterObjectMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterObjectMember {
@@ -1684,30 +1388,22 @@ impl JsSetterObjectMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct InitializedProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl InitializedProp {
-	pub fn key(&self) -> SyntaxResult<Name> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsShorthandPropertyObjectMember {
@@ -1726,9 +1422,7 @@ impl JsSpread {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsStringLiteralExpression {
@@ -1786,12 +1480,8 @@ pub struct TsExprWithTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
-	pub fn item(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
+	pub fn item(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPrivateClassMemberName {
@@ -1810,105 +1500,67 @@ pub struct JsConstructorClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
-	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> { support::required_node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsConstructorParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPropertyClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyClassMember {
-	pub fn declare_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![declare])
-	}
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![!])
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn value(&self) -> Option<JsEqualValueClause> {
-		support::node(&self.syntax)
-	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn value(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsMethodClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn async_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![async])
-	}
-	pub fn star_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [*])
-	}
+	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> {
-		support::node(&self.syntax)
-	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![get])
 	}
@@ -1921,27 +1573,19 @@ impl JsGetterClassMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> {
-		support::node(&self.syntax)
-	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![static])
-	}
+	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
 	pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![set])
 	}
@@ -1951,15 +1595,11 @@ impl JsSetterClassMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-		support::required_node(&self.syntax)
-	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEmptyClassMember {
@@ -1981,15 +1621,11 @@ impl TsIndexSignature {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn pat(&self) -> SyntaxResult<SinglePattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<SinglePattern> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2029,9 +1665,7 @@ impl TsConstructorParam {
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![readonly])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEqualValueClause {
@@ -2086,18 +1720,12 @@ pub struct SinglePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SinglePattern {
-	pub fn name(&self) -> SyntaxResult<Name> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![!])
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RestPattern {
@@ -2107,27 +1735,19 @@ impl RestPattern {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignPattern {
-	pub fn key(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ObjectPattern {
@@ -2152,36 +1772,28 @@ impl ArrayPattern {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<Pattern> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> {
-		support::node(&self.syntax)
-	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExprPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprPattern {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyValuePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl KeyValuePattern {
-	pub fn key(&self) -> SyntaxResult<PropName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<PropName> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -2191,12 +1803,8 @@ pub struct JsVariableDeclarator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclarator {
-	pub fn id(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
-	pub fn init(&self) -> Option<JsEqualValueClause> {
-		support::node(&self.syntax)
-	}
+	pub fn id(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn init(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct WildcardImport {
@@ -2206,12 +1814,8 @@ impl WildcardImport {
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![as])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
+	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamedImports {
@@ -2242,9 +1846,7 @@ pub struct Specifier {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Specifier {
-	pub fn name(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferenceIdentifierMember {
@@ -2275,9 +1877,7 @@ impl JsRestParameter {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> {
-		support::required_node(&self.syntax)
-	}
+	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExternalModuleRef {
@@ -2320,54 +1920,42 @@ pub struct TsNumber {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNumber {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObject {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObject {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBoolean {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBoolean {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBigint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBigint {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsString {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsString {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsSymbol {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbol {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsVoid {
@@ -2419,21 +2007,15 @@ pub struct TsLiteral {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsLiteral {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPredicate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPredicate {
-	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> {
-		support::required_node(&self.syntax)
-	}
-	pub fn rhs(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> { support::required_node(&self.syntax) }
+	pub fn rhs(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTuple {
@@ -2443,9 +2025,7 @@ impl TsTuple {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> SyntaxResult<TsTupleElement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn elements(&self) -> SyntaxResult<TsTupleElement> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2458,9 +2038,7 @@ impl TsParen {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2470,12 +2048,8 @@ pub struct TsTypeRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeRef {
-	pub fn name(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
+	pub fn name(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplate {
@@ -2494,33 +2068,21 @@ impl TsMappedType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> {
-		support::node(&self.syntax)
-	}
-	pub fn minus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [-])
-	}
-	pub fn plus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [+])
-	}
+	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> { support::node(&self.syntax) }
+	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
+	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> {
-		support::required_node(&self.syntax)
-	}
+	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [;])
-	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImport {
@@ -2530,18 +2092,12 @@ impl TsImport {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
-		support::required_node(&self.syntax)
-	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [.])
-	}
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2554,9 +2110,7 @@ impl TsArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2569,9 +2123,7 @@ impl TsIndexedArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2581,42 +2133,32 @@ pub struct TsTypeOperator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperator {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIntersection {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersection {
-	pub fn types(&self) -> AstNodeList<TsType> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUnion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnion {
-	pub fn types(&self) -> AstNodeList<TsType> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsFnType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsFnType {
-	pub fn params(&self) -> SyntaxResult<JsParameterList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsType> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructorType {
@@ -2626,33 +2168,25 @@ impl TsConstructorType {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn params(&self) -> SyntaxResult<JsParameterList> {
-		support::required_node(&self.syntax)
-	}
+	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> Option<TsType> {
-		support::node(&self.syntax)
-	}
+	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConditionalType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn extends(&self) -> SyntaxResult<TsExtends> {
-		support::required_node(&self.syntax)
-	}
+	pub fn extends(&self) -> SyntaxResult<TsExtends> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObjectType {
@@ -2662,9 +2196,7 @@ impl TsObjectType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsTypeElement> {
-		support::node_list(&self.syntax, 0usize)
-	}
+	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax, 0usize) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2677,54 +2209,40 @@ impl TsInfer {
 	pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![infer])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTupleElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleElement {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
-	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [...])
-	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [...]) }
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnumMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplateElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2734,12 +2252,8 @@ pub struct TsMappedTypeReadonly {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonly {
-	pub fn minus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [-])
-	}
-	pub fn plus_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [+])
-	}
+	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
+	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
@@ -2749,30 +2263,18 @@ pub struct TsMappedTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeParam {
-	pub fn l_brack_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T!['['])
-	}
-	pub fn name(&self) -> Option<TsTypeName> {
-		support::node(&self.syntax)
-	}
-	pub fn r_brack_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T![']'])
-	}
-	pub fn ident(&self) -> Option<Ident> {
-		support::node(&self.syntax)
-	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
+	pub fn name(&self) -> Option<TsTypeName> { support::node(&self.syntax) }
+	pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
+	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeName {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExtends {
@@ -2782,9 +2284,7 @@ impl TsExtends {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleBlock {
@@ -2794,9 +2294,7 @@ impl TsModuleBlock {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn items(&self) -> SyntaxResult<JsAnyStatement> {
-		support::required_node(&self.syntax)
-	}
+	pub fn items(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2806,15 +2304,9 @@ pub struct TsTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParam {
-	pub fn ident(&self) -> SyntaxResult<Ident> {
-		support::required_node(&self.syntax)
-	}
-	pub fn constraint(&self) -> SyntaxResult<TsConstraint> {
-		support::required_node(&self.syntax)
-	}
-	pub fn default(&self) -> SyntaxResult<TsDefault> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn constraint(&self) -> SyntaxResult<TsConstraint> { support::required_node(&self.syntax) }
+	pub fn default(&self) -> SyntaxResult<TsDefault> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstraint {
@@ -2824,9 +2316,7 @@ impl TsConstraint {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsDefault {
@@ -2836,27 +2326,21 @@ impl TsDefault {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsCallSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureDecl {
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructSignatureDecl {
@@ -2866,18 +2350,12 @@ impl TsConstructSignatureDecl {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn colon_token(&self) -> Option<SyntaxToken> {
-		support::token(&self.syntax, T ! [:])
-	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [:]) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPropertySignature {
@@ -2887,18 +2365,14 @@ impl TsPropertySignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
+	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMethodSignature {
@@ -2908,12 +2382,8 @@ impl TsMethodSignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn key(&self) -> SyntaxResult<JsAnyExpression> {
-		support::required_node(&self.syntax)
-	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
-		support::required_node(&self.syntax)
-	}
+	pub fn key(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
@@ -2923,24 +2393,18 @@ impl TsMethodSignature {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> {
-		support::required_node(&self.syntax)
-	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsQualifiedPath {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedPath {
-	pub fn lhs(&self) -> SyntaxResult<TsEntityName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn lhs(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [.])
 	}
-	pub fn rhs(&self) -> SyntaxResult<TsTypeName> {
-		support::required_node(&self.syntax)
-	}
+	pub fn rhs(&self) -> SyntaxResult<TsTypeName> { support::required_node(&self.syntax) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyStatement {
@@ -3218,9 +2682,7 @@ pub enum TsNamespaceBody {
 	TsNamespaceDecl(TsNamespaceDecl),
 }
 impl AstNode for JsUnknownStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3228,9 +2690,7 @@ impl AstNode for JsUnknownStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3240,9 +2700,7 @@ impl std::fmt::Debug for JsUnknownStatement {
 	}
 }
 impl AstNode for JsUnknownExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3250,9 +2708,7 @@ impl AstNode for JsUnknownExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3262,9 +2718,7 @@ impl std::fmt::Debug for JsUnknownExpression {
 	}
 }
 impl AstNode for JsUnknownPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3272,9 +2726,7 @@ impl AstNode for JsUnknownPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3284,9 +2736,7 @@ impl std::fmt::Debug for JsUnknownPattern {
 	}
 }
 impl AstNode for JsUnknownMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3294,9 +2744,7 @@ impl AstNode for JsUnknownMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3306,9 +2754,7 @@ impl std::fmt::Debug for JsUnknownMember {
 	}
 }
 impl AstNode for JsUnknownBinding {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_BINDING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3316,9 +2762,7 @@ impl AstNode for JsUnknownBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3328,9 +2772,7 @@ impl std::fmt::Debug for JsUnknownBinding {
 	}
 }
 impl AstNode for JsUnknownAssignmentTarget {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNKNOWN_ASSIGNMENT_TARGET
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT_TARGET }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3338,9 +2780,7 @@ impl AstNode for JsUnknownAssignmentTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3350,9 +2790,7 @@ impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	}
 }
 impl AstNode for Ident {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IDENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IDENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3360,9 +2798,7 @@ impl AstNode for Ident {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Ident {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3375,9 +2811,7 @@ impl std::fmt::Debug for Ident {
 	}
 }
 impl AstNode for JsRoot {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ROOT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ROOT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3385,9 +2819,7 @@ impl AstNode for JsRoot {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRoot {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3402,9 +2834,7 @@ impl std::fmt::Debug for JsRoot {
 	}
 }
 impl AstNode for JsDirective {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DIRECTIVE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3412,9 +2842,7 @@ impl AstNode for JsDirective {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDirective {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3431,9 +2859,7 @@ impl std::fmt::Debug for JsDirective {
 	}
 }
 impl AstNode for JsBlockStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BLOCK_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3441,9 +2867,7 @@ impl AstNode for JsBlockStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBlockStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3461,9 +2885,7 @@ impl std::fmt::Debug for JsBlockStatement {
 	}
 }
 impl AstNode for JsEmptyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EMPTY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3471,9 +2893,7 @@ impl AstNode for JsEmptyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEmptyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3486,9 +2906,7 @@ impl std::fmt::Debug for JsEmptyStatement {
 	}
 }
 impl AstNode for JsExpressionStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EXPRESSION_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3496,9 +2914,7 @@ impl AstNode for JsExpressionStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsExpressionStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3512,9 +2928,7 @@ impl std::fmt::Debug for JsExpressionStatement {
 	}
 }
 impl AstNode for JsIfStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IF_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3522,9 +2936,7 @@ impl AstNode for JsIfStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsIfStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3548,9 +2960,7 @@ impl std::fmt::Debug for JsIfStatement {
 	}
 }
 impl AstNode for JsDoWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DO_WHILE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3558,9 +2968,7 @@ impl AstNode for JsDoWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDoWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3588,9 +2996,7 @@ impl std::fmt::Debug for JsDoWhileStatement {
 	}
 }
 impl AstNode for JsWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_WHILE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3598,9 +3004,7 @@ impl AstNode for JsWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3623,9 +3027,7 @@ impl std::fmt::Debug for JsWhileStatement {
 	}
 }
 impl AstNode for ForStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3633,9 +3035,7 @@ impl AstNode for ForStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3657,9 +3057,7 @@ impl std::fmt::Debug for ForStmt {
 	}
 }
 impl AstNode for ForInStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_IN_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_IN_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3667,9 +3065,7 @@ impl AstNode for ForInStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForInStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3691,9 +3087,7 @@ impl std::fmt::Debug for ForInStmt {
 	}
 }
 impl AstNode for ForOfStmt {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_OF_STMT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_OF_STMT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3701,9 +3095,7 @@ impl AstNode for ForOfStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForOfStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3725,9 +3117,7 @@ impl std::fmt::Debug for ForOfStmt {
 	}
 }
 impl AstNode for JsContinueStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONTINUE_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3735,9 +3125,7 @@ impl AstNode for JsContinueStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsContinueStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3758,9 +3146,7 @@ impl std::fmt::Debug for JsContinueStatement {
 	}
 }
 impl AstNode for JsBreakStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BREAK_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3768,9 +3154,7 @@ impl AstNode for JsBreakStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBreakStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3791,9 +3175,7 @@ impl std::fmt::Debug for JsBreakStatement {
 	}
 }
 impl AstNode for JsReturnStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_RETURN_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3801,9 +3183,7 @@ impl AstNode for JsReturnStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReturnStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3821,9 +3201,7 @@ impl std::fmt::Debug for JsReturnStatement {
 	}
 }
 impl AstNode for JsWithStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_WITH_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3831,9 +3209,7 @@ impl AstNode for JsWithStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsWithStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3853,9 +3229,7 @@ impl std::fmt::Debug for JsWithStatement {
 	}
 }
 impl AstNode for JsLabeledStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LABELED_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3863,9 +3237,7 @@ impl AstNode for JsLabeledStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLabeledStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3883,9 +3255,7 @@ impl std::fmt::Debug for JsLabeledStatement {
 	}
 }
 impl AstNode for JsSwitchStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SWITCH_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3893,9 +3263,7 @@ impl AstNode for JsSwitchStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSwitchStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3929,9 +3297,7 @@ impl std::fmt::Debug for JsSwitchStatement {
 	}
 }
 impl AstNode for JsThrowStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_THROW_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3939,9 +3305,7 @@ impl AstNode for JsThrowStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsThrowStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3959,9 +3323,7 @@ impl std::fmt::Debug for JsThrowStatement {
 	}
 }
 impl AstNode for JsTryStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_TRY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3969,9 +3331,7 @@ impl AstNode for JsTryStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsTryStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3986,9 +3346,7 @@ impl std::fmt::Debug for JsTryStatement {
 	}
 }
 impl AstNode for JsTryFinallyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_TRY_FINALLY_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3996,9 +3354,7 @@ impl AstNode for JsTryFinallyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsTryFinallyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4017,9 +3373,7 @@ impl std::fmt::Debug for JsTryFinallyStatement {
 	}
 }
 impl AstNode for JsDebuggerStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DEBUGGER_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4027,9 +3381,7 @@ impl AstNode for JsDebuggerStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDebuggerStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4046,9 +3398,7 @@ impl std::fmt::Debug for JsDebuggerStatement {
 	}
 }
 impl AstNode for JsFunctionDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4056,9 +3406,7 @@ impl AstNode for JsFunctionDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4090,9 +3438,7 @@ impl std::fmt::Debug for JsFunctionDeclaration {
 	}
 }
 impl AstNode for JsClassDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CLASS_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4100,9 +3446,7 @@ impl AstNode for JsClassDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsClassDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4133,9 +3477,7 @@ impl std::fmt::Debug for JsClassDeclaration {
 	}
 }
 impl AstNode for JsVariableDeclarationStatement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATION_STATEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_STATEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4143,9 +3485,7 @@ impl AstNode for JsVariableDeclarationStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclarationStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4162,9 +3502,7 @@ impl std::fmt::Debug for JsVariableDeclarationStatement {
 	}
 }
 impl AstNode for TsEnum {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ENUM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4172,9 +3510,7 @@ impl AstNode for TsEnum {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsEnum {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4198,9 +3534,7 @@ impl std::fmt::Debug for TsEnum {
 	}
 }
 impl AstNode for TsTypeAliasDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ALIAS_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4208,9 +3542,7 @@ impl AstNode for TsTypeAliasDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeAliasDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4226,9 +3558,7 @@ impl std::fmt::Debug for TsTypeAliasDecl {
 	}
 }
 impl AstNode for TsNamespaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NAMESPACE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4236,9 +3566,7 @@ impl AstNode for TsNamespaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNamespaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4254,9 +3582,7 @@ impl std::fmt::Debug for TsNamespaceDecl {
 	}
 }
 impl AstNode for TsModuleDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MODULE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4264,9 +3590,7 @@ impl AstNode for TsModuleDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsModuleDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4290,9 +3614,7 @@ impl std::fmt::Debug for TsModuleDecl {
 	}
 }
 impl AstNode for TsInterfaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INTERFACE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4300,9 +3622,7 @@ impl AstNode for TsInterfaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsInterfaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4337,9 +3657,7 @@ impl std::fmt::Debug for TsInterfaceDecl {
 	}
 }
 impl AstNode for ImportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4347,9 +3665,7 @@ impl AstNode for ImportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4381,9 +3697,7 @@ impl std::fmt::Debug for ImportDecl {
 	}
 }
 impl AstNode for ExportNamed {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_NAMED
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_NAMED }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4391,9 +3705,7 @@ impl AstNode for ExportNamed {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportNamed {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4417,9 +3729,7 @@ impl std::fmt::Debug for ExportNamed {
 	}
 }
 impl AstNode for ExportDefaultDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DEFAULT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4427,9 +3737,7 @@ impl AstNode for ExportDefaultDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDefaultDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4448,9 +3756,7 @@ impl std::fmt::Debug for ExportDefaultDecl {
 	}
 }
 impl AstNode for ExportDefaultExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DEFAULT_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4458,9 +3764,7 @@ impl AstNode for ExportDefaultExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDefaultExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4479,9 +3783,7 @@ impl std::fmt::Debug for ExportDefaultExpr {
 	}
 }
 impl AstNode for ExportWildcard {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_WILDCARD
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_WILDCARD }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4489,9 +3791,7 @@ impl AstNode for ExportWildcard {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportWildcard {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4513,9 +3813,7 @@ impl std::fmt::Debug for ExportWildcard {
 	}
 }
 impl AstNode for ExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4523,9 +3821,7 @@ impl AstNode for ExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4540,9 +3836,7 @@ impl std::fmt::Debug for ExportDecl {
 	}
 }
 impl AstNode for TsImportEqualsDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPORT_EQUALS_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4550,9 +3844,7 @@ impl AstNode for TsImportEqualsDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImportEqualsDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4576,9 +3868,7 @@ impl std::fmt::Debug for TsImportEqualsDecl {
 	}
 }
 impl AstNode for TsExportAssignment {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXPORT_ASSIGNMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4586,9 +3876,7 @@ impl AstNode for TsExportAssignment {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExportAssignment {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4607,9 +3895,7 @@ impl std::fmt::Debug for TsExportAssignment {
 	}
 }
 impl AstNode for TsNamespaceExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NAMESPACE_EXPORT_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_EXPORT_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4617,9 +3903,7 @@ impl AstNode for TsNamespaceExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNamespaceExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4642,9 +3926,7 @@ impl std::fmt::Debug for TsNamespaceExportDecl {
 	}
 }
 impl AstNode for JsElseClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ELSE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4652,9 +3934,7 @@ impl AstNode for JsElseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsElseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4665,9 +3945,7 @@ impl std::fmt::Debug for JsElseClause {
 	}
 }
 impl AstNode for ForStmtInit {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_INIT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_INIT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4675,9 +3953,7 @@ impl AstNode for ForStmtInit {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtInit {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4691,9 +3967,7 @@ impl std::fmt::Debug for ForStmtInit {
 	}
 }
 impl AstNode for ForStmtTest {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_TEST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_TEST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4701,9 +3975,7 @@ impl AstNode for ForStmtTest {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtTest {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4717,9 +3989,7 @@ impl std::fmt::Debug for ForStmtTest {
 	}
 }
 impl AstNode for ForStmtUpdate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == FOR_STMT_UPDATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_UPDATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4727,9 +3997,7 @@ impl AstNode for ForStmtUpdate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ForStmtUpdate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4739,9 +4007,7 @@ impl std::fmt::Debug for ForStmtUpdate {
 	}
 }
 impl AstNode for JsVariableDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4749,9 +4015,7 @@ impl AstNode for JsVariableDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4762,9 +4026,7 @@ impl std::fmt::Debug for JsVariableDeclaration {
 	}
 }
 impl AstNode for JsCaseClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CASE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4772,9 +4034,7 @@ impl AstNode for JsCaseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCaseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4790,9 +4050,7 @@ impl std::fmt::Debug for JsCaseClause {
 	}
 }
 impl AstNode for JsDefaultClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_DEFAULT_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4800,9 +4058,7 @@ impl AstNode for JsDefaultClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsDefaultClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4820,9 +4076,7 @@ impl std::fmt::Debug for JsDefaultClause {
 	}
 }
 impl AstNode for JsCatchClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CATCH_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4830,9 +4084,7 @@ impl AstNode for JsCatchClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCatchClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4850,9 +4102,7 @@ impl std::fmt::Debug for JsCatchClause {
 	}
 }
 impl AstNode for JsFinallyClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FINALLY_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4860,9 +4110,7 @@ impl AstNode for JsFinallyClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFinallyClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4876,9 +4124,7 @@ impl std::fmt::Debug for JsFinallyClause {
 	}
 }
 impl AstNode for JsCatchDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CATCH_DECLARATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4886,9 +4132,7 @@ impl AstNode for JsCatchDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsCatchDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4906,9 +4150,7 @@ impl std::fmt::Debug for JsCatchDeclaration {
 	}
 }
 impl AstNode for JsArrayExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARRAY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4916,9 +4158,7 @@ impl AstNode for JsArrayExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrayExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4936,9 +4176,7 @@ impl std::fmt::Debug for JsArrayExpression {
 	}
 }
 impl AstNode for JsArrowFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARROW_FUNCTION_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4946,9 +4184,7 @@ impl AstNode for JsArrowFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrowFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4977,9 +4213,7 @@ impl std::fmt::Debug for JsArrowFunctionExpression {
 	}
 }
 impl AstNode for JsAwaitExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_AWAIT_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4987,9 +4221,7 @@ impl AstNode for JsAwaitExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsAwaitExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5003,9 +4235,7 @@ impl std::fmt::Debug for JsAwaitExpression {
 	}
 }
 impl AstNode for JsBinaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BINARY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5013,9 +4243,7 @@ impl AstNode for JsBinaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBinaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5026,9 +4254,7 @@ impl std::fmt::Debug for JsBinaryExpression {
 	}
 }
 impl AstNode for JsClassExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CLASS_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5036,9 +4262,7 @@ impl AstNode for JsClassExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsClassExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5065,9 +4289,7 @@ impl std::fmt::Debug for JsClassExpression {
 	}
 }
 impl AstNode for JsConditionalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONDITIONAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5075,9 +4297,7 @@ impl AstNode for JsConditionalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConditionalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5095,9 +4315,7 @@ impl std::fmt::Debug for JsConditionalExpression {
 	}
 }
 impl AstNode for JsComputedMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_COMPUTED_MEMBER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5105,9 +4323,7 @@ impl AstNode for JsComputedMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsComputedMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5129,9 +4345,7 @@ impl std::fmt::Debug for JsComputedMemberExpression {
 	}
 }
 impl AstNode for JsFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5139,9 +4353,7 @@ impl AstNode for JsFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5170,9 +4382,7 @@ impl std::fmt::Debug for JsFunctionExpression {
 	}
 }
 impl AstNode for JsImportCallExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IMPORT_CALL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5180,9 +4390,7 @@ impl AstNode for JsImportCallExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsImportCallExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5204,9 +4412,7 @@ impl std::fmt::Debug for JsImportCallExpression {
 	}
 }
 impl AstNode for JsLogicalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LOGICAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5214,9 +4420,7 @@ impl AstNode for JsLogicalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLogicalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5227,9 +4431,7 @@ impl std::fmt::Debug for JsLogicalExpression {
 	}
 }
 impl AstNode for JsObjectExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_OBJECT_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5237,9 +4439,7 @@ impl AstNode for JsObjectExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsObjectExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5257,9 +4457,7 @@ impl std::fmt::Debug for JsObjectExpression {
 	}
 }
 impl AstNode for JsParenthesizedExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PARENTHESIZED_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5267,9 +4465,7 @@ impl AstNode for JsParenthesizedExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsParenthesizedExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5287,9 +4483,7 @@ impl std::fmt::Debug for JsParenthesizedExpression {
 	}
 }
 impl AstNode for JsReferenceIdentifierExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_IDENTIFIER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5297,9 +4491,7 @@ impl AstNode for JsReferenceIdentifierExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferenceIdentifierExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5309,9 +4501,7 @@ impl std::fmt::Debug for JsReferenceIdentifierExpression {
 	}
 }
 impl AstNode for JsSequenceExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SEQUENCE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5319,9 +4509,7 @@ impl AstNode for JsSequenceExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSequenceExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5335,9 +4523,7 @@ impl std::fmt::Debug for JsSequenceExpression {
 	}
 }
 impl AstNode for JsStaticMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_STATIC_MEMBER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5345,9 +4531,7 @@ impl AstNode for JsStaticMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsStaticMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5359,9 +4543,7 @@ impl std::fmt::Debug for JsStaticMemberExpression {
 	}
 }
 impl AstNode for JsSuperExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SUPER_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5369,9 +4551,7 @@ impl AstNode for JsSuperExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSuperExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5384,9 +4564,7 @@ impl std::fmt::Debug for JsSuperExpression {
 	}
 }
 impl AstNode for JsThisExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_THIS_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5394,9 +4572,7 @@ impl AstNode for JsThisExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsThisExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5406,9 +4582,7 @@ impl std::fmt::Debug for JsThisExpression {
 	}
 }
 impl AstNode for JsUnaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_UNARY_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5416,9 +4590,7 @@ impl AstNode for JsUnaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsUnaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5429,9 +4601,7 @@ impl std::fmt::Debug for JsUnaryExpression {
 	}
 }
 impl AstNode for JsPreUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PRE_UPDATE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5439,9 +4609,7 @@ impl AstNode for JsPreUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPreUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5452,9 +4620,7 @@ impl std::fmt::Debug for JsPreUpdateExpression {
 	}
 }
 impl AstNode for JsPostUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_POST_UPDATE_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5462,9 +4628,7 @@ impl AstNode for JsPostUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPostUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5475,9 +4639,7 @@ impl std::fmt::Debug for JsPostUpdateExpression {
 	}
 }
 impl AstNode for JsYieldExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_YIELD_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5485,9 +4647,7 @@ impl AstNode for JsYieldExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsYieldExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5502,9 +4662,7 @@ impl std::fmt::Debug for JsYieldExpression {
 	}
 }
 impl AstNode for Template {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TEMPLATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TEMPLATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5512,9 +4670,7 @@ impl AstNode for Template {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Template {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5527,9 +4683,7 @@ impl std::fmt::Debug for Template {
 	}
 }
 impl AstNode for NewExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NEW_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5537,9 +4691,7 @@ impl AstNode for NewExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NewExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5552,9 +4704,7 @@ impl std::fmt::Debug for NewExpr {
 	}
 }
 impl AstNode for CallExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == CALL_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == CALL_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5562,9 +4712,7 @@ impl AstNode for CallExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for CallExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5576,9 +4724,7 @@ impl std::fmt::Debug for CallExpr {
 	}
 }
 impl AstNode for AssignExpr {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ASSIGN_EXPR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_EXPR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5586,9 +4732,7 @@ impl AstNode for AssignExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for AssignExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5598,9 +4742,7 @@ impl std::fmt::Debug for AssignExpr {
 	}
 }
 impl AstNode for NewTarget {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NEW_TARGET
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5608,9 +4750,7 @@ impl AstNode for NewTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NewTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5625,9 +4765,7 @@ impl std::fmt::Debug for NewTarget {
 	}
 }
 impl AstNode for ImportMeta {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_META
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5635,9 +4773,7 @@ impl AstNode for ImportMeta {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportMeta {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5651,9 +4787,7 @@ impl std::fmt::Debug for ImportMeta {
 	}
 }
 impl AstNode for TsNonNull {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NON_NULL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5661,9 +4795,7 @@ impl AstNode for TsNonNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNonNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5674,9 +4806,7 @@ impl std::fmt::Debug for TsNonNull {
 	}
 }
 impl AstNode for TsAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ASSERTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5684,9 +4814,7 @@ impl AstNode for TsAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5706,9 +4834,7 @@ impl std::fmt::Debug for TsAssertion {
 	}
 }
 impl AstNode for TsConstAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONST_ASSERTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONST_ASSERTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5716,9 +4842,7 @@ impl AstNode for TsConstAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5741,9 +4865,7 @@ impl std::fmt::Debug for TsConstAssertion {
 	}
 }
 impl AstNode for TsTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ARGS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5751,9 +4873,7 @@ impl AstNode for TsTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5771,9 +4891,7 @@ impl std::fmt::Debug for TsTypeArgs {
 	}
 }
 impl AstNode for ArgList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ARG_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ARG_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5781,9 +4899,7 @@ impl AstNode for ArgList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ArgList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5801,9 +4917,7 @@ impl std::fmt::Debug for ArgList {
 	}
 }
 impl AstNode for JsIdentifierBinding {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_IDENTIFIER_BINDING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5811,9 +4925,7 @@ impl AstNode for JsIdentifierBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsIdentifierBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5823,9 +4935,7 @@ impl std::fmt::Debug for JsIdentifierBinding {
 	}
 }
 impl AstNode for TsTypeParams {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_PARAMS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5833,9 +4943,7 @@ impl AstNode for TsTypeParams {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeParams {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5853,9 +4961,7 @@ impl std::fmt::Debug for TsTypeParams {
 	}
 }
 impl AstNode for JsParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PARAMETER_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5863,9 +4969,7 @@ impl AstNode for JsParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5883,9 +4987,7 @@ impl std::fmt::Debug for JsParameterList {
 	}
 }
 impl AstNode for TsTypeAnnotation {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_ANNOTATION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5893,9 +4995,7 @@ impl AstNode for TsTypeAnnotation {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeAnnotation {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5909,9 +5009,7 @@ impl std::fmt::Debug for TsTypeAnnotation {
 	}
 }
 impl AstNode for JsFunctionBody {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_FUNCTION_BODY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5919,9 +5017,7 @@ impl AstNode for JsFunctionBody {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsFunctionBody {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5940,9 +5036,7 @@ impl std::fmt::Debug for JsFunctionBody {
 	}
 }
 impl AstNode for SpreadElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SPREAD_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SPREAD_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5950,9 +5044,7 @@ impl AstNode for SpreadElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for SpreadElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5966,9 +5058,7 @@ impl std::fmt::Debug for SpreadElement {
 	}
 }
 impl AstNode for JsArrayHole {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_ARRAY_HOLE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5976,9 +5066,7 @@ impl AstNode for JsArrayHole {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsArrayHole {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5986,9 +5074,7 @@ impl std::fmt::Debug for JsArrayHole {
 	}
 }
 impl AstNode for JsLiteralMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_LITERAL_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5996,9 +5082,7 @@ impl AstNode for JsLiteralMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsLiteralMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6008,9 +5092,7 @@ impl std::fmt::Debug for JsLiteralMemberName {
 	}
 }
 impl AstNode for JsComputedMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_COMPUTED_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6018,9 +5100,7 @@ impl AstNode for JsComputedMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsComputedMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6038,9 +5118,7 @@ impl std::fmt::Debug for JsComputedMemberName {
 	}
 }
 impl AstNode for JsPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PROPERTY_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6048,9 +5126,7 @@ impl AstNode for JsPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6064,9 +5140,7 @@ impl std::fmt::Debug for JsPropertyObjectMember {
 	}
 }
 impl AstNode for JsMethodObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_METHOD_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6074,9 +5148,7 @@ impl AstNode for JsMethodObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsMethodObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6104,9 +5176,7 @@ impl std::fmt::Debug for JsMethodObjectMember {
 	}
 }
 impl AstNode for JsGetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_GETTER_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6114,9 +5184,7 @@ impl AstNode for JsGetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsGetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6140,9 +5208,7 @@ impl std::fmt::Debug for JsGetterObjectMember {
 	}
 }
 impl AstNode for JsSetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SETTER_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6150,9 +5216,7 @@ impl AstNode for JsSetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6173,9 +5237,7 @@ impl std::fmt::Debug for JsSetterObjectMember {
 	}
 }
 impl AstNode for InitializedProp {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == INITIALIZED_PROP
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == INITIALIZED_PROP }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6183,9 +5245,7 @@ impl AstNode for InitializedProp {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for InitializedProp {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6197,9 +5257,7 @@ impl std::fmt::Debug for InitializedProp {
 	}
 }
 impl AstNode for JsShorthandPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6207,9 +5265,7 @@ impl AstNode for JsShorthandPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsShorthandPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6219,9 +5275,7 @@ impl std::fmt::Debug for JsShorthandPropertyObjectMember {
 	}
 }
 impl AstNode for JsSpread {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SPREAD
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6229,9 +5283,7 @@ impl AstNode for JsSpread {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSpread {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6245,9 +5297,7 @@ impl std::fmt::Debug for JsSpread {
 	}
 }
 impl AstNode for JsStringLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_STRING_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6255,9 +5305,7 @@ impl AstNode for JsStringLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsStringLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6270,9 +5318,7 @@ impl std::fmt::Debug for JsStringLiteralExpression {
 	}
 }
 impl AstNode for JsNumberLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_NUMBER_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6280,9 +5326,7 @@ impl AstNode for JsNumberLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsNumberLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6295,9 +5339,7 @@ impl std::fmt::Debug for JsNumberLiteralExpression {
 	}
 }
 impl AstNode for Name {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6305,9 +5347,7 @@ impl AstNode for Name {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Name {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6320,9 +5360,7 @@ impl std::fmt::Debug for Name {
 	}
 }
 impl AstNode for TsImplementsClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPLEMENTS_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6330,9 +5368,7 @@ impl AstNode for TsImplementsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImplementsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6346,9 +5382,7 @@ impl std::fmt::Debug for TsImplementsClause {
 	}
 }
 impl AstNode for JsExtendsClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EXTENDS_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6356,9 +5390,7 @@ impl AstNode for JsExtendsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsExtendsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6375,9 +5407,7 @@ impl std::fmt::Debug for JsExtendsClause {
 	}
 }
 impl AstNode for TsExprWithTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXPR_WITH_TYPE_ARGS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPR_WITH_TYPE_ARGS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6385,9 +5415,7 @@ impl AstNode for TsExprWithTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExprWithTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6401,9 +5429,7 @@ impl std::fmt::Debug for TsExprWithTypeArgs {
 	}
 }
 impl AstNode for JsPrivateClassMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PRIVATE_CLASS_MEMBER_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6411,9 +5437,7 @@ impl AstNode for JsPrivateClassMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPrivateClassMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6424,9 +5448,7 @@ impl std::fmt::Debug for JsPrivateClassMemberName {
 	}
 }
 impl AstNode for JsConstructorClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONSTRUCTOR_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6434,9 +5456,7 @@ impl AstNode for JsConstructorClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConstructorClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6455,9 +5475,7 @@ impl std::fmt::Debug for JsConstructorClassMember {
 	}
 }
 impl AstNode for JsPropertyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_PROPERTY_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6465,9 +5483,7 @@ impl AstNode for JsPropertyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsPropertyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6504,9 +5520,7 @@ impl std::fmt::Debug for JsPropertyClassMember {
 	}
 }
 impl AstNode for JsMethodClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_METHOD_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6514,9 +5528,7 @@ impl AstNode for JsMethodClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsMethodClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6556,9 +5568,7 @@ impl std::fmt::Debug for JsMethodClassMember {
 	}
 }
 impl AstNode for JsGetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_GETTER_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6566,9 +5576,7 @@ impl AstNode for JsGetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsGetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6604,9 +5612,7 @@ impl std::fmt::Debug for JsGetterClassMember {
 	}
 }
 impl AstNode for JsSetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_SETTER_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6614,9 +5620,7 @@ impl AstNode for JsSetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsSetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6649,9 +5653,7 @@ impl std::fmt::Debug for JsSetterClassMember {
 	}
 }
 impl AstNode for JsEmptyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EMPTY_CLASS_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6659,9 +5661,7 @@ impl AstNode for JsEmptyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEmptyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6674,9 +5674,7 @@ impl std::fmt::Debug for JsEmptyClassMember {
 	}
 }
 impl AstNode for TsIndexSignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INDEX_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6684,9 +5682,7 @@ impl AstNode for TsIndexSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIndexSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6713,9 +5709,7 @@ impl std::fmt::Debug for TsIndexSignature {
 	}
 }
 impl AstNode for TsAccessibility {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ACCESSIBILITY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6723,9 +5717,7 @@ impl AstNode for TsAccessibility {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAccessibility {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6742,9 +5734,7 @@ impl std::fmt::Debug for TsAccessibility {
 	}
 }
 impl AstNode for JsConstructorParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_CONSTRUCTOR_PARAMETER_LIST
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6752,9 +5742,7 @@ impl AstNode for JsConstructorParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsConstructorParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6772,9 +5760,7 @@ impl std::fmt::Debug for JsConstructorParameterList {
 	}
 }
 impl AstNode for TsConstructorParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCTOR_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6782,9 +5768,7 @@ impl AstNode for TsConstructorParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructorParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6798,9 +5782,7 @@ impl std::fmt::Debug for TsConstructorParam {
 	}
 }
 impl AstNode for JsEqualValueClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_EQUAL_VALUE_CLAUSE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EQUAL_VALUE_CLAUSE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6808,9 +5790,7 @@ impl AstNode for JsEqualValueClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsEqualValueClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6821,9 +5801,7 @@ impl std::fmt::Debug for JsEqualValueClause {
 	}
 }
 impl AstNode for JsBigIntLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BIG_INT_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6831,9 +5809,7 @@ impl AstNode for JsBigIntLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBigIntLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6846,9 +5822,7 @@ impl std::fmt::Debug for JsBigIntLiteralExpression {
 	}
 }
 impl AstNode for JsBooleanLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_BOOLEAN_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6856,9 +5830,7 @@ impl AstNode for JsBooleanLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsBooleanLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6871,9 +5843,7 @@ impl std::fmt::Debug for JsBooleanLiteralExpression {
 	}
 }
 impl AstNode for JsNullLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_NULL_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6881,9 +5851,7 @@ impl AstNode for JsNullLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsNullLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6896,9 +5864,7 @@ impl std::fmt::Debug for JsNullLiteralExpression {
 	}
 }
 impl AstNode for JsRegexLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REGEX_LITERAL_EXPRESSION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6906,9 +5872,7 @@ impl AstNode for JsRegexLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRegexLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6921,9 +5885,7 @@ impl std::fmt::Debug for JsRegexLiteralExpression {
 	}
 }
 impl AstNode for SinglePattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SINGLE_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SINGLE_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6931,9 +5893,7 @@ impl AstNode for SinglePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for SinglePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6949,9 +5909,7 @@ impl std::fmt::Debug for SinglePattern {
 	}
 }
 impl AstNode for RestPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == REST_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == REST_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6959,9 +5917,7 @@ impl AstNode for RestPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for RestPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6975,9 +5931,7 @@ impl std::fmt::Debug for RestPattern {
 	}
 }
 impl AstNode for AssignPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ASSIGN_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6985,9 +5939,7 @@ impl AstNode for AssignPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for AssignPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7000,9 +5952,7 @@ impl std::fmt::Debug for AssignPattern {
 	}
 }
 impl AstNode for ObjectPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == OBJECT_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7010,9 +5960,7 @@ impl AstNode for ObjectPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ObjectPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7030,9 +5978,7 @@ impl std::fmt::Debug for ObjectPattern {
 	}
 }
 impl AstNode for ArrayPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == ARRAY_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == ARRAY_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7040,9 +5986,7 @@ impl AstNode for ArrayPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ArrayPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7062,9 +6006,7 @@ impl std::fmt::Debug for ArrayPattern {
 	}
 }
 impl AstNode for ExprPattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == EXPR_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPR_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7072,9 +6014,7 @@ impl AstNode for ExprPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ExprPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7084,9 +6024,7 @@ impl std::fmt::Debug for ExprPattern {
 	}
 }
 impl AstNode for KeyValuePattern {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == KEY_VALUE_PATTERN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == KEY_VALUE_PATTERN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7094,9 +6032,7 @@ impl AstNode for KeyValuePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for KeyValuePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7110,9 +6046,7 @@ impl std::fmt::Debug for KeyValuePattern {
 	}
 }
 impl AstNode for JsVariableDeclarator {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_VARIABLE_DECLARATOR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7120,9 +6054,7 @@ impl AstNode for JsVariableDeclarator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsVariableDeclarator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7133,9 +6065,7 @@ impl std::fmt::Debug for JsVariableDeclarator {
 	}
 }
 impl AstNode for WildcardImport {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == WILDCARD_IMPORT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == WILDCARD_IMPORT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7143,9 +6073,7 @@ impl AstNode for WildcardImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for WildcardImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7157,9 +6085,7 @@ impl std::fmt::Debug for WildcardImport {
 	}
 }
 impl AstNode for NamedImports {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == NAMED_IMPORTS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == NAMED_IMPORTS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7167,9 +6093,7 @@ impl AstNode for NamedImports {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for NamedImports {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7187,9 +6111,7 @@ impl std::fmt::Debug for NamedImports {
 	}
 }
 impl AstNode for ImportStringSpecifier {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == IMPORT_STRING_SPECIFIER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_STRING_SPECIFIER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7197,9 +6119,7 @@ impl AstNode for ImportStringSpecifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for ImportStringSpecifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7212,9 +6132,7 @@ impl std::fmt::Debug for ImportStringSpecifier {
 	}
 }
 impl AstNode for Specifier {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == SPECIFIER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == SPECIFIER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7222,9 +6140,7 @@ impl AstNode for Specifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for Specifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7234,9 +6150,7 @@ impl std::fmt::Debug for Specifier {
 	}
 }
 impl AstNode for JsReferenceIdentifierMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_IDENTIFIER_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7244,9 +6158,7 @@ impl AstNode for JsReferenceIdentifierMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferenceIdentifierMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7256,9 +6168,7 @@ impl std::fmt::Debug for JsReferenceIdentifierMember {
 	}
 }
 impl AstNode for JsReferencePrivateMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REFERENCE_PRIVATE_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_PRIVATE_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7266,9 +6176,7 @@ impl AstNode for JsReferencePrivateMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsReferencePrivateMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7279,9 +6187,7 @@ impl std::fmt::Debug for JsReferencePrivateMember {
 	}
 }
 impl AstNode for JsRestParameter {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == JS_REST_PARAMETER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7289,9 +6195,7 @@ impl AstNode for JsRestParameter {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for JsRestParameter {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7305,9 +6209,7 @@ impl std::fmt::Debug for JsRestParameter {
 	}
 }
 impl AstNode for TsExternalModuleRef {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXTERNAL_MODULE_REF
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REF }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7315,9 +6217,7 @@ impl AstNode for TsExternalModuleRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExternalModuleRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7342,9 +6242,7 @@ impl std::fmt::Debug for TsExternalModuleRef {
 	}
 }
 impl AstNode for TsAny {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ANY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7352,9 +6250,7 @@ impl AstNode for TsAny {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsAny {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7364,9 +6260,7 @@ impl std::fmt::Debug for TsAny {
 	}
 }
 impl AstNode for TsUnknown {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNKNOWN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7374,9 +6268,7 @@ impl AstNode for TsUnknown {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUnknown {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7389,9 +6281,7 @@ impl std::fmt::Debug for TsUnknown {
 	}
 }
 impl AstNode for TsNumber {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NUMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7399,9 +6289,7 @@ impl AstNode for TsNumber {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNumber {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7411,9 +6299,7 @@ impl std::fmt::Debug for TsNumber {
 	}
 }
 impl AstNode for TsObject {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_OBJECT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7421,9 +6307,7 @@ impl AstNode for TsObject {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsObject {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7433,9 +6317,7 @@ impl std::fmt::Debug for TsObject {
 	}
 }
 impl AstNode for TsBoolean {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_BOOLEAN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7443,9 +6325,7 @@ impl AstNode for TsBoolean {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsBoolean {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7455,9 +6335,7 @@ impl std::fmt::Debug for TsBoolean {
 	}
 }
 impl AstNode for TsBigint {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_BIGINT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7465,9 +6343,7 @@ impl AstNode for TsBigint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsBigint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7477,9 +6353,7 @@ impl std::fmt::Debug for TsBigint {
 	}
 }
 impl AstNode for TsString {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_STRING
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7487,9 +6361,7 @@ impl AstNode for TsString {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsString {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7499,9 +6371,7 @@ impl std::fmt::Debug for TsString {
 	}
 }
 impl AstNode for TsSymbol {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_SYMBOL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7509,9 +6379,7 @@ impl AstNode for TsSymbol {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsSymbol {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7521,9 +6389,7 @@ impl std::fmt::Debug for TsSymbol {
 	}
 }
 impl AstNode for TsVoid {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_VOID
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7531,9 +6397,7 @@ impl AstNode for TsVoid {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsVoid {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7543,9 +6407,7 @@ impl std::fmt::Debug for TsVoid {
 	}
 }
 impl AstNode for TsUndefined {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNDEFINED
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7553,9 +6415,7 @@ impl AstNode for TsUndefined {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUndefined {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7568,9 +6428,7 @@ impl std::fmt::Debug for TsUndefined {
 	}
 }
 impl AstNode for TsNull {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NULL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7578,9 +6436,7 @@ impl AstNode for TsNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7590,9 +6446,7 @@ impl std::fmt::Debug for TsNull {
 	}
 }
 impl AstNode for TsNever {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_NEVER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7600,9 +6454,7 @@ impl AstNode for TsNever {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsNever {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7615,9 +6467,7 @@ impl std::fmt::Debug for TsNever {
 	}
 }
 impl AstNode for TsThis {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_THIS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7625,9 +6475,7 @@ impl AstNode for TsThis {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsThis {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7637,9 +6485,7 @@ impl std::fmt::Debug for TsThis {
 	}
 }
 impl AstNode for TsLiteral {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_LITERAL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_LITERAL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7647,9 +6493,7 @@ impl AstNode for TsLiteral {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsLiteral {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7659,9 +6503,7 @@ impl std::fmt::Debug for TsLiteral {
 	}
 }
 impl AstNode for TsPredicate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PREDICATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7669,9 +6511,7 @@ impl AstNode for TsPredicate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsPredicate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7682,9 +6522,7 @@ impl std::fmt::Debug for TsPredicate {
 	}
 }
 impl AstNode for TsTuple {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TUPLE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7692,9 +6530,7 @@ impl AstNode for TsTuple {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTuple {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7712,9 +6548,7 @@ impl std::fmt::Debug for TsTuple {
 	}
 }
 impl AstNode for TsParen {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PAREN
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PAREN }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7722,9 +6556,7 @@ impl AstNode for TsParen {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsParen {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7742,9 +6574,7 @@ impl std::fmt::Debug for TsParen {
 	}
 }
 impl AstNode for TsTypeRef {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_REF
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_REF }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7752,9 +6582,7 @@ impl AstNode for TsTypeRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7765,9 +6593,7 @@ impl std::fmt::Debug for TsTypeRef {
 	}
 }
 impl AstNode for TsTemplate {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TEMPLATE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7775,9 +6601,7 @@ impl AstNode for TsTemplate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTemplate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7787,9 +6611,7 @@ impl std::fmt::Debug for TsTemplate {
 	}
 }
 impl AstNode for TsMappedType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7797,9 +6619,7 @@ impl AstNode for TsMappedType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7839,9 +6659,7 @@ impl std::fmt::Debug for TsMappedType {
 	}
 }
 impl AstNode for TsImport {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_IMPORT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7849,9 +6667,7 @@ impl AstNode for TsImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7875,9 +6691,7 @@ impl std::fmt::Debug for TsImport {
 	}
 }
 impl AstNode for TsArray {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ARRAY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7885,9 +6699,7 @@ impl AstNode for TsArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7905,9 +6717,7 @@ impl std::fmt::Debug for TsArray {
 	}
 }
 impl AstNode for TsIndexedArray {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INDEXED_ARRAY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ARRAY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7915,9 +6725,7 @@ impl AstNode for TsIndexedArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIndexedArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7935,9 +6743,7 @@ impl std::fmt::Debug for TsIndexedArray {
 	}
 }
 impl AstNode for TsTypeOperator {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_OPERATOR
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7945,9 +6751,7 @@ impl AstNode for TsTypeOperator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeOperator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7957,9 +6761,7 @@ impl std::fmt::Debug for TsTypeOperator {
 	}
 }
 impl AstNode for TsIntersection {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INTERSECTION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7967,9 +6769,7 @@ impl AstNode for TsIntersection {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsIntersection {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7979,9 +6779,7 @@ impl std::fmt::Debug for TsIntersection {
 	}
 }
 impl AstNode for TsUnion {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_UNION
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7989,9 +6787,7 @@ impl AstNode for TsUnion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsUnion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8001,9 +6797,7 @@ impl std::fmt::Debug for TsUnion {
 	}
 }
 impl AstNode for TsFnType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_FN_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FN_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8011,9 +6805,7 @@ impl AstNode for TsFnType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsFnType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8031,9 +6823,7 @@ impl std::fmt::Debug for TsFnType {
 	}
 }
 impl AstNode for TsConstructorType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCTOR_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8041,9 +6831,7 @@ impl AstNode for TsConstructorType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructorType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8062,9 +6850,7 @@ impl std::fmt::Debug for TsConstructorType {
 	}
 }
 impl AstNode for TsConditionalType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONDITIONAL_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8072,9 +6858,7 @@ impl AstNode for TsConditionalType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConditionalType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8093,9 +6877,7 @@ impl std::fmt::Debug for TsConditionalType {
 	}
 }
 impl AstNode for TsObjectType {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_OBJECT_TYPE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8103,9 +6885,7 @@ impl AstNode for TsObjectType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsObjectType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8123,9 +6903,7 @@ impl std::fmt::Debug for TsObjectType {
 	}
 }
 impl AstNode for TsInfer {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_INFER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8133,9 +6911,7 @@ impl AstNode for TsInfer {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsInfer {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8149,9 +6925,7 @@ impl std::fmt::Debug for TsInfer {
 	}
 }
 impl AstNode for TsTupleElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TUPLE_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8159,9 +6933,7 @@ impl AstNode for TsTupleElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTupleElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8184,9 +6956,7 @@ impl std::fmt::Debug for TsTupleElement {
 	}
 }
 impl AstNode for TsEnumMember {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_ENUM_MEMBER
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8194,9 +6964,7 @@ impl AstNode for TsEnumMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsEnumMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8208,9 +6976,7 @@ impl std::fmt::Debug for TsEnumMember {
 	}
 }
 impl AstNode for TsTemplateElement {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TEMPLATE_ELEMENT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8218,9 +6984,7 @@ impl AstNode for TsTemplateElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTemplateElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8234,9 +6998,7 @@ impl std::fmt::Debug for TsTemplateElement {
 	}
 }
 impl AstNode for TsMappedTypeReadonly {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE_READONLY
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8244,9 +7006,7 @@ impl AstNode for TsMappedTypeReadonly {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedTypeReadonly {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8264,9 +7024,7 @@ impl std::fmt::Debug for TsMappedTypeReadonly {
 	}
 }
 impl AstNode for TsMappedTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MAPPED_TYPE_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8274,9 +7032,7 @@ impl AstNode for TsMappedTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMappedTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8296,9 +7052,7 @@ impl std::fmt::Debug for TsMappedTypeParam {
 	}
 }
 impl AstNode for TsTypeName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_NAME
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_NAME }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8306,9 +7060,7 @@ impl AstNode for TsTypeName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8318,9 +7070,7 @@ impl std::fmt::Debug for TsTypeName {
 	}
 }
 impl AstNode for TsExtends {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_EXTENDS
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8328,9 +7078,7 @@ impl AstNode for TsExtends {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsExtends {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8344,9 +7092,7 @@ impl std::fmt::Debug for TsExtends {
 	}
 }
 impl AstNode for TsModuleBlock {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_MODULE_BLOCK
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8354,9 +7100,7 @@ impl AstNode for TsModuleBlock {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsModuleBlock {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8374,9 +7118,7 @@ impl std::fmt::Debug for TsModuleBlock {
 	}
 }
 impl AstNode for TsTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_TYPE_PARAM
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAM }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8384,9 +7126,7 @@ impl AstNode for TsTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8398,9 +7138,7 @@ impl std::fmt::Debug for TsTypeParam {
 	}
 }
 impl AstNode for TsConstraint {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRAINT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRAINT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8408,9 +7146,7 @@ impl AstNode for TsConstraint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstraint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8424,9 +7160,7 @@ impl std::fmt::Debug for TsConstraint {
 	}
 }
 impl AstNode for TsDefault {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_DEFAULT
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8434,9 +7168,7 @@ impl AstNode for TsDefault {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsDefault {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8447,9 +7179,7 @@ impl std::fmt::Debug for TsDefault {
 	}
 }
 impl AstNode for TsCallSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CALL_SIGNATURE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8457,9 +7187,7 @@ impl AstNode for TsCallSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsCallSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8481,9 +7209,7 @@ impl std::fmt::Debug for TsCallSignatureDecl {
 	}
 }
 impl AstNode for TsConstructSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_CONSTRUCT_SIGNATURE_DECL
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_DECL }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8491,9 +7217,7 @@ impl AstNode for TsConstructSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsConstructSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8516,9 +7240,7 @@ impl std::fmt::Debug for TsConstructSignatureDecl {
 	}
 }
 impl AstNode for TsPropertySignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_PROPERTY_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8526,9 +7248,7 @@ impl AstNode for TsPropertySignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsPropertySignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8551,9 +7271,7 @@ impl std::fmt::Debug for TsPropertySignature {
 	}
 }
 impl AstNode for TsMethodSignature {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_METHOD_SIGNATURE
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8561,9 +7279,7 @@ impl AstNode for TsMethodSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsMethodSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8594,9 +7310,7 @@ impl std::fmt::Debug for TsMethodSignature {
 	}
 }
 impl AstNode for TsQualifiedPath {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		kind == TS_QUALIFIED_PATH
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_PATH }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -8604,9 +7318,7 @@ impl AstNode for TsQualifiedPath {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode {
-		&self.syntax
-	}
+	fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl std::fmt::Debug for TsQualifiedPath {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -8618,14 +7330,10 @@ impl std::fmt::Debug for TsQualifiedPath {
 	}
 }
 impl From<JsBlockStatement> for JsAnyStatement {
-	fn from(node: JsBlockStatement) -> JsAnyStatement {
-		JsAnyStatement::JsBlockStatement(node)
-	}
+	fn from(node: JsBlockStatement) -> JsAnyStatement { JsAnyStatement::JsBlockStatement(node) }
 }
 impl From<JsEmptyStatement> for JsAnyStatement {
-	fn from(node: JsEmptyStatement) -> JsAnyStatement {
-		JsAnyStatement::JsEmptyStatement(node)
-	}
+	fn from(node: JsEmptyStatement) -> JsAnyStatement { JsAnyStatement::JsEmptyStatement(node) }
 }
 impl From<JsExpressionStatement> for JsAnyStatement {
 	fn from(node: JsExpressionStatement) -> JsAnyStatement {
@@ -8633,34 +7341,22 @@ impl From<JsExpressionStatement> for JsAnyStatement {
 	}
 }
 impl From<JsIfStatement> for JsAnyStatement {
-	fn from(node: JsIfStatement) -> JsAnyStatement {
-		JsAnyStatement::JsIfStatement(node)
-	}
+	fn from(node: JsIfStatement) -> JsAnyStatement { JsAnyStatement::JsIfStatement(node) }
 }
 impl From<JsDoWhileStatement> for JsAnyStatement {
-	fn from(node: JsDoWhileStatement) -> JsAnyStatement {
-		JsAnyStatement::JsDoWhileStatement(node)
-	}
+	fn from(node: JsDoWhileStatement) -> JsAnyStatement { JsAnyStatement::JsDoWhileStatement(node) }
 }
 impl From<JsWhileStatement> for JsAnyStatement {
-	fn from(node: JsWhileStatement) -> JsAnyStatement {
-		JsAnyStatement::JsWhileStatement(node)
-	}
+	fn from(node: JsWhileStatement) -> JsAnyStatement { JsAnyStatement::JsWhileStatement(node) }
 }
 impl From<ForStmt> for JsAnyStatement {
-	fn from(node: ForStmt) -> JsAnyStatement {
-		JsAnyStatement::ForStmt(node)
-	}
+	fn from(node: ForStmt) -> JsAnyStatement { JsAnyStatement::ForStmt(node) }
 }
 impl From<ForInStmt> for JsAnyStatement {
-	fn from(node: ForInStmt) -> JsAnyStatement {
-		JsAnyStatement::ForInStmt(node)
-	}
+	fn from(node: ForInStmt) -> JsAnyStatement { JsAnyStatement::ForInStmt(node) }
 }
 impl From<ForOfStmt> for JsAnyStatement {
-	fn from(node: ForOfStmt) -> JsAnyStatement {
-		JsAnyStatement::ForOfStmt(node)
-	}
+	fn from(node: ForOfStmt) -> JsAnyStatement { JsAnyStatement::ForOfStmt(node) }
 }
 impl From<JsContinueStatement> for JsAnyStatement {
 	fn from(node: JsContinueStatement) -> JsAnyStatement {
@@ -8668,39 +7364,25 @@ impl From<JsContinueStatement> for JsAnyStatement {
 	}
 }
 impl From<JsBreakStatement> for JsAnyStatement {
-	fn from(node: JsBreakStatement) -> JsAnyStatement {
-		JsAnyStatement::JsBreakStatement(node)
-	}
+	fn from(node: JsBreakStatement) -> JsAnyStatement { JsAnyStatement::JsBreakStatement(node) }
 }
 impl From<JsReturnStatement> for JsAnyStatement {
-	fn from(node: JsReturnStatement) -> JsAnyStatement {
-		JsAnyStatement::JsReturnStatement(node)
-	}
+	fn from(node: JsReturnStatement) -> JsAnyStatement { JsAnyStatement::JsReturnStatement(node) }
 }
 impl From<JsWithStatement> for JsAnyStatement {
-	fn from(node: JsWithStatement) -> JsAnyStatement {
-		JsAnyStatement::JsWithStatement(node)
-	}
+	fn from(node: JsWithStatement) -> JsAnyStatement { JsAnyStatement::JsWithStatement(node) }
 }
 impl From<JsLabeledStatement> for JsAnyStatement {
-	fn from(node: JsLabeledStatement) -> JsAnyStatement {
-		JsAnyStatement::JsLabeledStatement(node)
-	}
+	fn from(node: JsLabeledStatement) -> JsAnyStatement { JsAnyStatement::JsLabeledStatement(node) }
 }
 impl From<JsSwitchStatement> for JsAnyStatement {
-	fn from(node: JsSwitchStatement) -> JsAnyStatement {
-		JsAnyStatement::JsSwitchStatement(node)
-	}
+	fn from(node: JsSwitchStatement) -> JsAnyStatement { JsAnyStatement::JsSwitchStatement(node) }
 }
 impl From<JsThrowStatement> for JsAnyStatement {
-	fn from(node: JsThrowStatement) -> JsAnyStatement {
-		JsAnyStatement::JsThrowStatement(node)
-	}
+	fn from(node: JsThrowStatement) -> JsAnyStatement { JsAnyStatement::JsThrowStatement(node) }
 }
 impl From<JsTryStatement> for JsAnyStatement {
-	fn from(node: JsTryStatement) -> JsAnyStatement {
-		JsAnyStatement::JsTryStatement(node)
-	}
+	fn from(node: JsTryStatement) -> JsAnyStatement { JsAnyStatement::JsTryStatement(node) }
 }
 impl From<JsTryFinallyStatement> for JsAnyStatement {
 	fn from(node: JsTryFinallyStatement) -> JsAnyStatement {
@@ -8718,9 +7400,7 @@ impl From<JsFunctionDeclaration> for JsAnyStatement {
 	}
 }
 impl From<JsClassDeclaration> for JsAnyStatement {
-	fn from(node: JsClassDeclaration) -> JsAnyStatement {
-		JsAnyStatement::JsClassDeclaration(node)
-	}
+	fn from(node: JsClassDeclaration) -> JsAnyStatement { JsAnyStatement::JsClassDeclaration(node) }
 }
 impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	fn from(node: JsVariableDeclarationStatement) -> JsAnyStatement {
@@ -8728,69 +7408,43 @@ impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	}
 }
 impl From<TsEnum> for JsAnyStatement {
-	fn from(node: TsEnum) -> JsAnyStatement {
-		JsAnyStatement::TsEnum(node)
-	}
+	fn from(node: TsEnum) -> JsAnyStatement { JsAnyStatement::TsEnum(node) }
 }
 impl From<TsTypeAliasDecl> for JsAnyStatement {
-	fn from(node: TsTypeAliasDecl) -> JsAnyStatement {
-		JsAnyStatement::TsTypeAliasDecl(node)
-	}
+	fn from(node: TsTypeAliasDecl) -> JsAnyStatement { JsAnyStatement::TsTypeAliasDecl(node) }
 }
 impl From<TsNamespaceDecl> for JsAnyStatement {
-	fn from(node: TsNamespaceDecl) -> JsAnyStatement {
-		JsAnyStatement::TsNamespaceDecl(node)
-	}
+	fn from(node: TsNamespaceDecl) -> JsAnyStatement { JsAnyStatement::TsNamespaceDecl(node) }
 }
 impl From<TsModuleDecl> for JsAnyStatement {
-	fn from(node: TsModuleDecl) -> JsAnyStatement {
-		JsAnyStatement::TsModuleDecl(node)
-	}
+	fn from(node: TsModuleDecl) -> JsAnyStatement { JsAnyStatement::TsModuleDecl(node) }
 }
 impl From<TsInterfaceDecl> for JsAnyStatement {
-	fn from(node: TsInterfaceDecl) -> JsAnyStatement {
-		JsAnyStatement::TsInterfaceDecl(node)
-	}
+	fn from(node: TsInterfaceDecl) -> JsAnyStatement { JsAnyStatement::TsInterfaceDecl(node) }
 }
 impl From<ImportDecl> for JsAnyStatement {
-	fn from(node: ImportDecl) -> JsAnyStatement {
-		JsAnyStatement::ImportDecl(node)
-	}
+	fn from(node: ImportDecl) -> JsAnyStatement { JsAnyStatement::ImportDecl(node) }
 }
 impl From<ExportNamed> for JsAnyStatement {
-	fn from(node: ExportNamed) -> JsAnyStatement {
-		JsAnyStatement::ExportNamed(node)
-	}
+	fn from(node: ExportNamed) -> JsAnyStatement { JsAnyStatement::ExportNamed(node) }
 }
 impl From<ExportDefaultDecl> for JsAnyStatement {
-	fn from(node: ExportDefaultDecl) -> JsAnyStatement {
-		JsAnyStatement::ExportDefaultDecl(node)
-	}
+	fn from(node: ExportDefaultDecl) -> JsAnyStatement { JsAnyStatement::ExportDefaultDecl(node) }
 }
 impl From<ExportDefaultExpr> for JsAnyStatement {
-	fn from(node: ExportDefaultExpr) -> JsAnyStatement {
-		JsAnyStatement::ExportDefaultExpr(node)
-	}
+	fn from(node: ExportDefaultExpr) -> JsAnyStatement { JsAnyStatement::ExportDefaultExpr(node) }
 }
 impl From<ExportWildcard> for JsAnyStatement {
-	fn from(node: ExportWildcard) -> JsAnyStatement {
-		JsAnyStatement::ExportWildcard(node)
-	}
+	fn from(node: ExportWildcard) -> JsAnyStatement { JsAnyStatement::ExportWildcard(node) }
 }
 impl From<ExportDecl> for JsAnyStatement {
-	fn from(node: ExportDecl) -> JsAnyStatement {
-		JsAnyStatement::ExportDecl(node)
-	}
+	fn from(node: ExportDecl) -> JsAnyStatement { JsAnyStatement::ExportDecl(node) }
 }
 impl From<TsImportEqualsDecl> for JsAnyStatement {
-	fn from(node: TsImportEqualsDecl) -> JsAnyStatement {
-		JsAnyStatement::TsImportEqualsDecl(node)
-	}
+	fn from(node: TsImportEqualsDecl) -> JsAnyStatement { JsAnyStatement::TsImportEqualsDecl(node) }
 }
 impl From<TsExportAssignment> for JsAnyStatement {
-	fn from(node: TsExportAssignment) -> JsAnyStatement {
-		JsAnyStatement::TsExportAssignment(node)
-	}
+	fn from(node: TsExportAssignment) -> JsAnyStatement { JsAnyStatement::TsExportAssignment(node) }
 }
 impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	fn from(node: TsNamespaceExportDecl) -> JsAnyStatement {
@@ -8798,9 +7452,7 @@ impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	}
 }
 impl From<JsUnknownStatement> for JsAnyStatement {
-	fn from(node: JsUnknownStatement) -> JsAnyStatement {
-		JsAnyStatement::JsUnknownStatement(node)
-	}
+	fn from(node: JsUnknownStatement) -> JsAnyStatement { JsAnyStatement::JsUnknownStatement(node) }
 }
 impl AstNode for JsAnyStatement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8996,9 +7648,7 @@ impl std::fmt::Debug for JsAnyStatement {
 	}
 }
 impl From<JsArrayExpression> for JsAnyExpression {
-	fn from(node: JsArrayExpression) -> JsAnyExpression {
-		JsAnyExpression::JsArrayExpression(node)
-	}
+	fn from(node: JsArrayExpression) -> JsAnyExpression { JsAnyExpression::JsArrayExpression(node) }
 }
 impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	fn from(node: JsArrowFunctionExpression) -> JsAnyExpression {
@@ -9006,9 +7656,7 @@ impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	}
 }
 impl From<JsAwaitExpression> for JsAnyExpression {
-	fn from(node: JsAwaitExpression) -> JsAnyExpression {
-		JsAnyExpression::JsAwaitExpression(node)
-	}
+	fn from(node: JsAwaitExpression) -> JsAnyExpression { JsAnyExpression::JsAwaitExpression(node) }
 }
 impl From<JsBinaryExpression> for JsAnyExpression {
 	fn from(node: JsBinaryExpression) -> JsAnyExpression {
@@ -9016,9 +7664,7 @@ impl From<JsBinaryExpression> for JsAnyExpression {
 	}
 }
 impl From<JsClassExpression> for JsAnyExpression {
-	fn from(node: JsClassExpression) -> JsAnyExpression {
-		JsAnyExpression::JsClassExpression(node)
-	}
+	fn from(node: JsClassExpression) -> JsAnyExpression { JsAnyExpression::JsClassExpression(node) }
 }
 impl From<JsConditionalExpression> for JsAnyExpression {
 	fn from(node: JsConditionalExpression) -> JsAnyExpression {
@@ -9071,19 +7717,13 @@ impl From<JsStaticMemberExpression> for JsAnyExpression {
 	}
 }
 impl From<JsSuperExpression> for JsAnyExpression {
-	fn from(node: JsSuperExpression) -> JsAnyExpression {
-		JsAnyExpression::JsSuperExpression(node)
-	}
+	fn from(node: JsSuperExpression) -> JsAnyExpression { JsAnyExpression::JsSuperExpression(node) }
 }
 impl From<JsThisExpression> for JsAnyExpression {
-	fn from(node: JsThisExpression) -> JsAnyExpression {
-		JsAnyExpression::JsThisExpression(node)
-	}
+	fn from(node: JsThisExpression) -> JsAnyExpression { JsAnyExpression::JsThisExpression(node) }
 }
 impl From<JsUnaryExpression> for JsAnyExpression {
-	fn from(node: JsUnaryExpression) -> JsAnyExpression {
-		JsAnyExpression::JsUnaryExpression(node)
-	}
+	fn from(node: JsUnaryExpression) -> JsAnyExpression { JsAnyExpression::JsUnaryExpression(node) }
 }
 impl From<JsPreUpdateExpression> for JsAnyExpression {
 	fn from(node: JsPreUpdateExpression) -> JsAnyExpression {
@@ -9096,54 +7736,34 @@ impl From<JsPostUpdateExpression> for JsAnyExpression {
 	}
 }
 impl From<JsYieldExpression> for JsAnyExpression {
-	fn from(node: JsYieldExpression) -> JsAnyExpression {
-		JsAnyExpression::JsYieldExpression(node)
-	}
+	fn from(node: JsYieldExpression) -> JsAnyExpression { JsAnyExpression::JsYieldExpression(node) }
 }
 impl From<Template> for JsAnyExpression {
-	fn from(node: Template) -> JsAnyExpression {
-		JsAnyExpression::Template(node)
-	}
+	fn from(node: Template) -> JsAnyExpression { JsAnyExpression::Template(node) }
 }
 impl From<NewExpr> for JsAnyExpression {
-	fn from(node: NewExpr) -> JsAnyExpression {
-		JsAnyExpression::NewExpr(node)
-	}
+	fn from(node: NewExpr) -> JsAnyExpression { JsAnyExpression::NewExpr(node) }
 }
 impl From<CallExpr> for JsAnyExpression {
-	fn from(node: CallExpr) -> JsAnyExpression {
-		JsAnyExpression::CallExpr(node)
-	}
+	fn from(node: CallExpr) -> JsAnyExpression { JsAnyExpression::CallExpr(node) }
 }
 impl From<AssignExpr> for JsAnyExpression {
-	fn from(node: AssignExpr) -> JsAnyExpression {
-		JsAnyExpression::AssignExpr(node)
-	}
+	fn from(node: AssignExpr) -> JsAnyExpression { JsAnyExpression::AssignExpr(node) }
 }
 impl From<NewTarget> for JsAnyExpression {
-	fn from(node: NewTarget) -> JsAnyExpression {
-		JsAnyExpression::NewTarget(node)
-	}
+	fn from(node: NewTarget) -> JsAnyExpression { JsAnyExpression::NewTarget(node) }
 }
 impl From<ImportMeta> for JsAnyExpression {
-	fn from(node: ImportMeta) -> JsAnyExpression {
-		JsAnyExpression::ImportMeta(node)
-	}
+	fn from(node: ImportMeta) -> JsAnyExpression { JsAnyExpression::ImportMeta(node) }
 }
 impl From<TsNonNull> for JsAnyExpression {
-	fn from(node: TsNonNull) -> JsAnyExpression {
-		JsAnyExpression::TsNonNull(node)
-	}
+	fn from(node: TsNonNull) -> JsAnyExpression { JsAnyExpression::TsNonNull(node) }
 }
 impl From<TsAssertion> for JsAnyExpression {
-	fn from(node: TsAssertion) -> JsAnyExpression {
-		JsAnyExpression::TsAssertion(node)
-	}
+	fn from(node: TsAssertion) -> JsAnyExpression { JsAnyExpression::TsAssertion(node) }
 }
 impl From<TsConstAssertion> for JsAnyExpression {
-	fn from(node: TsConstAssertion) -> JsAnyExpression {
-		JsAnyExpression::TsConstAssertion(node)
-	}
+	fn from(node: TsConstAssertion) -> JsAnyExpression { JsAnyExpression::TsConstAssertion(node) }
 }
 impl From<JsUnknownExpression> for JsAnyExpression {
 	fn from(node: JsUnknownExpression) -> JsAnyExpression {
@@ -9340,9 +7960,7 @@ impl std::fmt::Debug for JsAnyExpression {
 	}
 }
 impl From<JsVariableDeclaration> for ForHead {
-	fn from(node: JsVariableDeclaration) -> ForHead {
-		ForHead::JsVariableDeclaration(node)
-	}
+	fn from(node: JsVariableDeclaration) -> ForHead { ForHead::JsVariableDeclaration(node) }
 }
 impl AstNode for ForHead {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9382,19 +8000,13 @@ impl std::fmt::Debug for ForHead {
 	}
 }
 impl From<JsCaseClause> for JsAnySwitchClause {
-	fn from(node: JsCaseClause) -> JsAnySwitchClause {
-		JsAnySwitchClause::JsCaseClause(node)
-	}
+	fn from(node: JsCaseClause) -> JsAnySwitchClause { JsAnySwitchClause::JsCaseClause(node) }
 }
 impl From<JsDefaultClause> for JsAnySwitchClause {
-	fn from(node: JsDefaultClause) -> JsAnySwitchClause {
-		JsAnySwitchClause::JsDefaultClause(node)
-	}
+	fn from(node: JsDefaultClause) -> JsAnySwitchClause { JsAnySwitchClause::JsDefaultClause(node) }
 }
 impl AstNode for JsAnySwitchClause {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			JS_CASE_CLAUSE => JsAnySwitchClause::JsCaseClause(JsCaseClause { syntax }),
@@ -9419,39 +8031,25 @@ impl std::fmt::Debug for JsAnySwitchClause {
 	}
 }
 impl From<SinglePattern> for Pattern {
-	fn from(node: SinglePattern) -> Pattern {
-		Pattern::SinglePattern(node)
-	}
+	fn from(node: SinglePattern) -> Pattern { Pattern::SinglePattern(node) }
 }
 impl From<RestPattern> for Pattern {
-	fn from(node: RestPattern) -> Pattern {
-		Pattern::RestPattern(node)
-	}
+	fn from(node: RestPattern) -> Pattern { Pattern::RestPattern(node) }
 }
 impl From<AssignPattern> for Pattern {
-	fn from(node: AssignPattern) -> Pattern {
-		Pattern::AssignPattern(node)
-	}
+	fn from(node: AssignPattern) -> Pattern { Pattern::AssignPattern(node) }
 }
 impl From<ObjectPattern> for Pattern {
-	fn from(node: ObjectPattern) -> Pattern {
-		Pattern::ObjectPattern(node)
-	}
+	fn from(node: ObjectPattern) -> Pattern { Pattern::ObjectPattern(node) }
 }
 impl From<ArrayPattern> for Pattern {
-	fn from(node: ArrayPattern) -> Pattern {
-		Pattern::ArrayPattern(node)
-	}
+	fn from(node: ArrayPattern) -> Pattern { Pattern::ArrayPattern(node) }
 }
 impl From<ExprPattern> for Pattern {
-	fn from(node: ExprPattern) -> Pattern {
-		Pattern::ExprPattern(node)
-	}
+	fn from(node: ExprPattern) -> Pattern { Pattern::ExprPattern(node) }
 }
 impl From<JsUnknownPattern> for Pattern {
-	fn from(node: JsUnknownPattern) -> Pattern {
-		Pattern::JsUnknownPattern(node)
-	}
+	fn from(node: JsUnknownPattern) -> Pattern { Pattern::JsUnknownPattern(node) }
 }
 impl AstNode for Pattern {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9682,14 +8280,10 @@ impl std::fmt::Debug for JsAnyArrowFunctionBody {
 	}
 }
 impl From<SpreadElement> for JsAnyArrayElement {
-	fn from(node: SpreadElement) -> JsAnyArrayElement {
-		JsAnyArrayElement::SpreadElement(node)
-	}
+	fn from(node: SpreadElement) -> JsAnyArrayElement { JsAnyArrayElement::SpreadElement(node) }
 }
 impl From<JsArrayHole> for JsAnyArrayElement {
-	fn from(node: JsArrayHole) -> JsAnyArrayElement {
-		JsAnyArrayElement::JsArrayHole(node)
-	}
+	fn from(node: JsArrayHole) -> JsAnyArrayElement { JsAnyArrayElement::JsArrayHole(node) }
 }
 impl AstNode for JsAnyArrayElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9869,9 +8463,7 @@ impl From<JsSetterObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<InitializedProp> for JsAnyObjectMember {
-	fn from(node: InitializedProp) -> JsAnyObjectMember {
-		JsAnyObjectMember::InitializedProp(node)
-	}
+	fn from(node: InitializedProp) -> JsAnyObjectMember { JsAnyObjectMember::InitializedProp(node) }
 }
 impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	fn from(node: JsShorthandPropertyObjectMember) -> JsAnyObjectMember {
@@ -9879,14 +8471,10 @@ impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<JsSpread> for JsAnyObjectMember {
-	fn from(node: JsSpread) -> JsAnyObjectMember {
-		JsAnyObjectMember::JsSpread(node)
-	}
+	fn from(node: JsSpread) -> JsAnyObjectMember { JsAnyObjectMember::JsSpread(node) }
 }
 impl From<JsUnknownMember> for JsAnyObjectMember {
-	fn from(node: JsUnknownMember) -> JsAnyObjectMember {
-		JsAnyObjectMember::JsUnknownMember(node)
-	}
+	fn from(node: JsUnknownMember) -> JsAnyObjectMember { JsAnyObjectMember::JsUnknownMember(node) }
 }
 impl AstNode for JsAnyObjectMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9955,9 +8543,7 @@ impl std::fmt::Debug for JsAnyObjectMember {
 	}
 }
 impl From<JsComputedMemberName> for PropName {
-	fn from(node: JsComputedMemberName) -> PropName {
-		PropName::JsComputedMemberName(node)
-	}
+	fn from(node: JsComputedMemberName) -> PropName { PropName::JsComputedMemberName(node) }
 }
 impl From<JsStringLiteralExpression> for PropName {
 	fn from(node: JsStringLiteralExpression) -> PropName {
@@ -9970,19 +8556,13 @@ impl From<JsNumberLiteralExpression> for PropName {
 	}
 }
 impl From<Ident> for PropName {
-	fn from(node: Ident) -> PropName {
-		PropName::Ident(node)
-	}
+	fn from(node: Ident) -> PropName { PropName::Ident(node) }
 }
 impl From<Name> for PropName {
-	fn from(node: Name) -> PropName {
-		PropName::Name(node)
-	}
+	fn from(node: Name) -> PropName { PropName::Name(node) }
 }
 impl From<JsUnknownBinding> for PropName {
-	fn from(node: JsUnknownBinding) -> PropName {
-		PropName::JsUnknownBinding(node)
-	}
+	fn from(node: JsUnknownBinding) -> PropName { PropName::JsUnknownBinding(node) }
 }
 impl AstNode for PropName {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10066,14 +8646,10 @@ impl From<JsEmptyClassMember> for JsAnyClassMember {
 	}
 }
 impl From<TsIndexSignature> for JsAnyClassMember {
-	fn from(node: TsIndexSignature) -> JsAnyClassMember {
-		JsAnyClassMember::TsIndexSignature(node)
-	}
+	fn from(node: TsIndexSignature) -> JsAnyClassMember { JsAnyClassMember::TsIndexSignature(node) }
 }
 impl From<JsUnknownMember> for JsAnyClassMember {
-	fn from(node: JsUnknownMember) -> JsAnyClassMember {
-		JsAnyClassMember::JsUnknownMember(node)
-	}
+	fn from(node: JsUnknownMember) -> JsAnyClassMember { JsAnyClassMember::JsUnknownMember(node) }
 }
 impl AstNode for JsAnyClassMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10239,24 +8815,16 @@ impl std::fmt::Debug for JsAnyConstructorParameter {
 	}
 }
 impl From<AssignPattern> for ObjectPatternProp {
-	fn from(node: AssignPattern) -> ObjectPatternProp {
-		ObjectPatternProp::AssignPattern(node)
-	}
+	fn from(node: AssignPattern) -> ObjectPatternProp { ObjectPatternProp::AssignPattern(node) }
 }
 impl From<KeyValuePattern> for ObjectPatternProp {
-	fn from(node: KeyValuePattern) -> ObjectPatternProp {
-		ObjectPatternProp::KeyValuePattern(node)
-	}
+	fn from(node: KeyValuePattern) -> ObjectPatternProp { ObjectPatternProp::KeyValuePattern(node) }
 }
 impl From<RestPattern> for ObjectPatternProp {
-	fn from(node: RestPattern) -> ObjectPatternProp {
-		ObjectPatternProp::RestPattern(node)
-	}
+	fn from(node: RestPattern) -> ObjectPatternProp { ObjectPatternProp::RestPattern(node) }
 }
 impl From<SinglePattern> for ObjectPatternProp {
-	fn from(node: SinglePattern) -> ObjectPatternProp {
-		ObjectPatternProp::SinglePattern(node)
-	}
+	fn from(node: SinglePattern) -> ObjectPatternProp { ObjectPatternProp::SinglePattern(node) }
 }
 impl From<JsUnknownPattern> for ObjectPatternProp {
 	fn from(node: JsUnknownPattern) -> ObjectPatternProp {
@@ -10303,159 +8871,97 @@ impl std::fmt::Debug for ObjectPatternProp {
 	}
 }
 impl From<TsAny> for TsType {
-	fn from(node: TsAny) -> TsType {
-		TsType::TsAny(node)
-	}
+	fn from(node: TsAny) -> TsType { TsType::TsAny(node) }
 }
 impl From<TsUnknown> for TsType {
-	fn from(node: TsUnknown) -> TsType {
-		TsType::TsUnknown(node)
-	}
+	fn from(node: TsUnknown) -> TsType { TsType::TsUnknown(node) }
 }
 impl From<TsNumber> for TsType {
-	fn from(node: TsNumber) -> TsType {
-		TsType::TsNumber(node)
-	}
+	fn from(node: TsNumber) -> TsType { TsType::TsNumber(node) }
 }
 impl From<TsObject> for TsType {
-	fn from(node: TsObject) -> TsType {
-		TsType::TsObject(node)
-	}
+	fn from(node: TsObject) -> TsType { TsType::TsObject(node) }
 }
 impl From<TsBoolean> for TsType {
-	fn from(node: TsBoolean) -> TsType {
-		TsType::TsBoolean(node)
-	}
+	fn from(node: TsBoolean) -> TsType { TsType::TsBoolean(node) }
 }
 impl From<TsBigint> for TsType {
-	fn from(node: TsBigint) -> TsType {
-		TsType::TsBigint(node)
-	}
+	fn from(node: TsBigint) -> TsType { TsType::TsBigint(node) }
 }
 impl From<TsString> for TsType {
-	fn from(node: TsString) -> TsType {
-		TsType::TsString(node)
-	}
+	fn from(node: TsString) -> TsType { TsType::TsString(node) }
 }
 impl From<TsSymbol> for TsType {
-	fn from(node: TsSymbol) -> TsType {
-		TsType::TsSymbol(node)
-	}
+	fn from(node: TsSymbol) -> TsType { TsType::TsSymbol(node) }
 }
 impl From<TsVoid> for TsType {
-	fn from(node: TsVoid) -> TsType {
-		TsType::TsVoid(node)
-	}
+	fn from(node: TsVoid) -> TsType { TsType::TsVoid(node) }
 }
 impl From<TsUndefined> for TsType {
-	fn from(node: TsUndefined) -> TsType {
-		TsType::TsUndefined(node)
-	}
+	fn from(node: TsUndefined) -> TsType { TsType::TsUndefined(node) }
 }
 impl From<TsNull> for TsType {
-	fn from(node: TsNull) -> TsType {
-		TsType::TsNull(node)
-	}
+	fn from(node: TsNull) -> TsType { TsType::TsNull(node) }
 }
 impl From<TsNever> for TsType {
-	fn from(node: TsNever) -> TsType {
-		TsType::TsNever(node)
-	}
+	fn from(node: TsNever) -> TsType { TsType::TsNever(node) }
 }
 impl From<TsThis> for TsType {
-	fn from(node: TsThis) -> TsType {
-		TsType::TsThis(node)
-	}
+	fn from(node: TsThis) -> TsType { TsType::TsThis(node) }
 }
 impl From<TsLiteral> for TsType {
-	fn from(node: TsLiteral) -> TsType {
-		TsType::TsLiteral(node)
-	}
+	fn from(node: TsLiteral) -> TsType { TsType::TsLiteral(node) }
 }
 impl From<TsPredicate> for TsType {
-	fn from(node: TsPredicate) -> TsType {
-		TsType::TsPredicate(node)
-	}
+	fn from(node: TsPredicate) -> TsType { TsType::TsPredicate(node) }
 }
 impl From<TsTuple> for TsType {
-	fn from(node: TsTuple) -> TsType {
-		TsType::TsTuple(node)
-	}
+	fn from(node: TsTuple) -> TsType { TsType::TsTuple(node) }
 }
 impl From<TsParen> for TsType {
-	fn from(node: TsParen) -> TsType {
-		TsType::TsParen(node)
-	}
+	fn from(node: TsParen) -> TsType { TsType::TsParen(node) }
 }
 impl From<TsTypeRef> for TsType {
-	fn from(node: TsTypeRef) -> TsType {
-		TsType::TsTypeRef(node)
-	}
+	fn from(node: TsTypeRef) -> TsType { TsType::TsTypeRef(node) }
 }
 impl From<TsTemplate> for TsType {
-	fn from(node: TsTemplate) -> TsType {
-		TsType::TsTemplate(node)
-	}
+	fn from(node: TsTemplate) -> TsType { TsType::TsTemplate(node) }
 }
 impl From<TsMappedType> for TsType {
-	fn from(node: TsMappedType) -> TsType {
-		TsType::TsMappedType(node)
-	}
+	fn from(node: TsMappedType) -> TsType { TsType::TsMappedType(node) }
 }
 impl From<TsImport> for TsType {
-	fn from(node: TsImport) -> TsType {
-		TsType::TsImport(node)
-	}
+	fn from(node: TsImport) -> TsType { TsType::TsImport(node) }
 }
 impl From<TsArray> for TsType {
-	fn from(node: TsArray) -> TsType {
-		TsType::TsArray(node)
-	}
+	fn from(node: TsArray) -> TsType { TsType::TsArray(node) }
 }
 impl From<TsIndexedArray> for TsType {
-	fn from(node: TsIndexedArray) -> TsType {
-		TsType::TsIndexedArray(node)
-	}
+	fn from(node: TsIndexedArray) -> TsType { TsType::TsIndexedArray(node) }
 }
 impl From<TsTypeOperator> for TsType {
-	fn from(node: TsTypeOperator) -> TsType {
-		TsType::TsTypeOperator(node)
-	}
+	fn from(node: TsTypeOperator) -> TsType { TsType::TsTypeOperator(node) }
 }
 impl From<TsIntersection> for TsType {
-	fn from(node: TsIntersection) -> TsType {
-		TsType::TsIntersection(node)
-	}
+	fn from(node: TsIntersection) -> TsType { TsType::TsIntersection(node) }
 }
 impl From<TsUnion> for TsType {
-	fn from(node: TsUnion) -> TsType {
-		TsType::TsUnion(node)
-	}
+	fn from(node: TsUnion) -> TsType { TsType::TsUnion(node) }
 }
 impl From<TsFnType> for TsType {
-	fn from(node: TsFnType) -> TsType {
-		TsType::TsFnType(node)
-	}
+	fn from(node: TsFnType) -> TsType { TsType::TsFnType(node) }
 }
 impl From<TsConstructorType> for TsType {
-	fn from(node: TsConstructorType) -> TsType {
-		TsType::TsConstructorType(node)
-	}
+	fn from(node: TsConstructorType) -> TsType { TsType::TsConstructorType(node) }
 }
 impl From<TsConditionalType> for TsType {
-	fn from(node: TsConditionalType) -> TsType {
-		TsType::TsConditionalType(node)
-	}
+	fn from(node: TsConditionalType) -> TsType { TsType::TsConditionalType(node) }
 }
 impl From<TsObjectType> for TsType {
-	fn from(node: TsObjectType) -> TsType {
-		TsType::TsObjectType(node)
-	}
+	fn from(node: TsObjectType) -> TsType { TsType::TsObjectType(node) }
 }
 impl From<TsInfer> for TsType {
-	fn from(node: TsInfer) -> TsType {
-		TsType::TsInfer(node)
-	}
+	fn from(node: TsInfer) -> TsType { TsType::TsInfer(node) }
 }
 impl AstNode for TsType {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10592,19 +9098,13 @@ impl std::fmt::Debug for TsType {
 	}
 }
 impl From<WildcardImport> for ImportClause {
-	fn from(node: WildcardImport) -> ImportClause {
-		ImportClause::WildcardImport(node)
-	}
+	fn from(node: WildcardImport) -> ImportClause { ImportClause::WildcardImport(node) }
 }
 impl From<NamedImports> for ImportClause {
-	fn from(node: NamedImports) -> ImportClause {
-		ImportClause::NamedImports(node)
-	}
+	fn from(node: NamedImports) -> ImportClause { ImportClause::NamedImports(node) }
 }
 impl From<Name> for ImportClause {
-	fn from(node: Name) -> ImportClause {
-		ImportClause::Name(node)
-	}
+	fn from(node: Name) -> ImportClause { ImportClause::Name(node) }
 }
 impl From<ImportStringSpecifier> for ImportClause {
 	fn from(node: ImportStringSpecifier) -> ImportClause {
@@ -10650,14 +9150,10 @@ impl std::fmt::Debug for ImportClause {
 	}
 }
 impl From<JsFunctionDeclaration> for DefaultDecl {
-	fn from(node: JsFunctionDeclaration) -> DefaultDecl {
-		DefaultDecl::JsFunctionDeclaration(node)
-	}
+	fn from(node: JsFunctionDeclaration) -> DefaultDecl { DefaultDecl::JsFunctionDeclaration(node) }
 }
 impl From<JsClassDeclaration> for DefaultDecl {
-	fn from(node: JsClassDeclaration) -> DefaultDecl {
-		DefaultDecl::JsClassDeclaration(node)
-	}
+	fn from(node: JsClassDeclaration) -> DefaultDecl { DefaultDecl::JsClassDeclaration(node) }
 }
 impl AstNode for DefaultDecl {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10704,9 +9200,7 @@ impl From<JsVariableDeclarationStatement> for JsAnyExportDeclaration {
 	}
 }
 impl From<TsEnum> for JsAnyExportDeclaration {
-	fn from(node: TsEnum) -> JsAnyExportDeclaration {
-		JsAnyExportDeclaration::TsEnum(node)
-	}
+	fn from(node: TsEnum) -> JsAnyExportDeclaration { JsAnyExportDeclaration::TsEnum(node) }
 }
 impl From<TsTypeAliasDecl> for JsAnyExportDeclaration {
 	fn from(node: TsTypeAliasDecl) -> JsAnyExportDeclaration {
@@ -10798,9 +9292,7 @@ impl std::fmt::Debug for JsAnyExportDeclaration {
 	}
 }
 impl From<JsRestParameter> for JsAnyParameter {
-	fn from(node: JsRestParameter) -> JsAnyParameter {
-		JsAnyParameter::JsRestParameter(node)
-	}
+	fn from(node: JsRestParameter) -> JsAnyParameter { JsAnyParameter::JsRestParameter(node) }
 }
 impl AstNode for JsAnyParameter {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10838,9 +9330,7 @@ impl std::fmt::Debug for JsAnyParameter {
 	}
 }
 impl From<TsExternalModuleRef> for TsModuleRef {
-	fn from(node: TsExternalModuleRef) -> TsModuleRef {
-		TsModuleRef::TsExternalModuleRef(node)
-	}
+	fn from(node: TsExternalModuleRef) -> TsModuleRef { TsModuleRef::TsExternalModuleRef(node) }
 }
 impl AstNode for TsModuleRef {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -10880,19 +9370,13 @@ impl std::fmt::Debug for TsModuleRef {
 	}
 }
 impl From<TsTypeName> for TsEntityName {
-	fn from(node: TsTypeName) -> TsEntityName {
-		TsEntityName::TsTypeName(node)
-	}
+	fn from(node: TsTypeName) -> TsEntityName { TsEntityName::TsTypeName(node) }
 }
 impl From<TsQualifiedPath> for TsEntityName {
-	fn from(node: TsQualifiedPath) -> TsEntityName {
-		TsEntityName::TsQualifiedPath(node)
-	}
+	fn from(node: TsQualifiedPath) -> TsEntityName { TsEntityName::TsQualifiedPath(node) }
 }
 impl AstNode for TsEntityName {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_TYPE_NAME => TsEntityName::TsTypeName(TsTypeName { syntax }),
@@ -10917,19 +9401,13 @@ impl std::fmt::Debug for TsEntityName {
 	}
 }
 impl From<TsThis> for TsThisOrMore {
-	fn from(node: TsThis) -> TsThisOrMore {
-		TsThisOrMore::TsThis(node)
-	}
+	fn from(node: TsThis) -> TsThisOrMore { TsThisOrMore::TsThis(node) }
 }
 impl From<TsTypeName> for TsThisOrMore {
-	fn from(node: TsTypeName) -> TsThisOrMore {
-		TsThisOrMore::TsTypeName(node)
-	}
+	fn from(node: TsTypeName) -> TsThisOrMore { TsThisOrMore::TsTypeName(node) }
 }
 impl AstNode for TsThisOrMore {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_THIS | TS_TYPE_NAME)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_THIS | TS_TYPE_NAME) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_THIS => TsThisOrMore::TsThis(TsThis { syntax }),
@@ -10954,9 +9432,7 @@ impl std::fmt::Debug for TsThisOrMore {
 	}
 }
 impl From<TsCallSignatureDecl> for TsTypeElement {
-	fn from(node: TsCallSignatureDecl) -> TsTypeElement {
-		TsTypeElement::TsCallSignatureDecl(node)
-	}
+	fn from(node: TsCallSignatureDecl) -> TsTypeElement { TsTypeElement::TsCallSignatureDecl(node) }
 }
 impl From<TsConstructSignatureDecl> for TsTypeElement {
 	fn from(node: TsConstructSignatureDecl) -> TsTypeElement {
@@ -10964,19 +9440,13 @@ impl From<TsConstructSignatureDecl> for TsTypeElement {
 	}
 }
 impl From<TsPropertySignature> for TsTypeElement {
-	fn from(node: TsPropertySignature) -> TsTypeElement {
-		TsTypeElement::TsPropertySignature(node)
-	}
+	fn from(node: TsPropertySignature) -> TsTypeElement { TsTypeElement::TsPropertySignature(node) }
 }
 impl From<TsMethodSignature> for TsTypeElement {
-	fn from(node: TsMethodSignature) -> TsTypeElement {
-		TsTypeElement::TsMethodSignature(node)
-	}
+	fn from(node: TsMethodSignature) -> TsTypeElement { TsTypeElement::TsMethodSignature(node) }
 }
 impl From<TsIndexSignature> for TsTypeElement {
-	fn from(node: TsIndexSignature) -> TsTypeElement {
-		TsTypeElement::TsIndexSignature(node)
-	}
+	fn from(node: TsIndexSignature) -> TsTypeElement { TsTypeElement::TsIndexSignature(node) }
 }
 impl AstNode for TsTypeElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -11028,19 +9498,13 @@ impl std::fmt::Debug for TsTypeElement {
 	}
 }
 impl From<TsModuleBlock> for TsNamespaceBody {
-	fn from(node: TsModuleBlock) -> TsNamespaceBody {
-		TsNamespaceBody::TsModuleBlock(node)
-	}
+	fn from(node: TsModuleBlock) -> TsNamespaceBody { TsNamespaceBody::TsModuleBlock(node) }
 }
 impl From<TsNamespaceDecl> for TsNamespaceBody {
-	fn from(node: TsNamespaceDecl) -> TsNamespaceBody {
-		TsNamespaceBody::TsNamespaceDecl(node)
-	}
+	fn from(node: TsNamespaceDecl) -> TsNamespaceBody { TsNamespaceBody::TsNamespaceDecl(node) }
 }
 impl AstNode for TsNamespaceBody {
-	fn can_cast(kind: SyntaxKind) -> bool {
-		matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL)
-	}
+	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL) }
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_MODULE_BLOCK => TsNamespaceBody::TsModuleBlock(TsModuleBlock { syntax }),

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -12,42 +12,54 @@ pub struct JsUnknownStatement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownPattern {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownMember {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownBinding {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsUnknownAssignmentTarget {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsUnknownAssignmentTarget {
-	pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
+	pub fn items(&self) -> SyntaxElementChildren {
+		support::elements(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
@@ -81,7 +93,9 @@ impl JsDirective {
 	pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![js_string_literal])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBlockStatement {
@@ -115,7 +129,9 @@ impl JsExpressionStatement {
 	pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsIfStatement {
@@ -128,14 +144,18 @@ impl JsIfStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
 	pub fn consequent(&self) -> SyntaxResult<JsAnyStatement> {
 		support::required_node(&self.syntax)
 	}
-	pub fn else_clause(&self) -> Option<JsElseClause> { support::node(&self.syntax) }
+	pub fn else_clause(&self) -> Option<JsElseClause> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsDoWhileStatement {
@@ -145,18 +165,24 @@ impl JsDoWhileStatement {
 	pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![do])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![while])
 	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWhileStatement {
@@ -169,11 +195,15 @@ impl JsWhileStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmt {
@@ -186,13 +216,21 @@ impl ForStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn init(&self) -> Option<ForStmtInit> { support::node(&self.syntax) }
-	pub fn test(&self) -> Option<ForStmtTest> { support::node(&self.syntax) }
-	pub fn update(&self) -> Option<ForStmtUpdate> { support::node(&self.syntax) }
+	pub fn init(&self) -> Option<ForStmtInit> {
+		support::node(&self.syntax)
+	}
+	pub fn test(&self) -> Option<ForStmtTest> {
+		support::node(&self.syntax)
+	}
+	pub fn update(&self) -> Option<ForStmtUpdate> {
+		support::node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForInStmt {
@@ -205,15 +243,21 @@ impl ForInStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
+		support::required_node(&self.syntax)
+	}
 	pub fn in_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![in])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForOfStmt {
@@ -226,15 +270,21 @@ impl ForOfStmt {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn left(&self) -> SyntaxResult<ForStmtInit> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<ForStmtInit> {
+		support::required_node(&self.syntax)
+	}
 	pub fn of_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![of])
 	}
-	pub fn right(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn cons(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsContinueStatement {
@@ -244,8 +294,12 @@ impl JsContinueStatement {
 	pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![continue])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn label_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![ident])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBreakStatement {
@@ -255,8 +309,12 @@ impl JsBreakStatement {
 	pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![break])
 	}
-	pub fn label_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![ident]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn label_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![ident])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReturnStatement {
@@ -266,8 +324,12 @@ impl JsReturnStatement {
 	pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![return])
 	}
-	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn argument(&self) -> Option<JsAnyExpression> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsWithStatement {
@@ -280,11 +342,15 @@ impl JsWithStatement {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsLabeledStatement {
@@ -297,7 +363,9 @@ impl JsLabeledStatement {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn body(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSwitchStatement {
@@ -334,8 +402,12 @@ impl JsThrowStatement {
 	pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![throw])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsTryStatement {
@@ -345,7 +417,9 @@ impl JsTryStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn catch_clause(&self) -> SyntaxResult<JsCatchClause> {
 		support::required_node(&self.syntax)
 	}
@@ -358,8 +432,12 @@ impl JsTryFinallyStatement {
 	pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![try])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
-	pub fn catch_clause(&self) -> Option<JsCatchClause> { support::node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
+	pub fn catch_clause(&self) -> Option<JsCatchClause> {
+		support::node(&self.syntax)
+	}
 	pub fn finally_clause(&self) -> SyntaxResult<JsFinallyClause> {
 		support::required_node(&self.syntax)
 	}
@@ -372,25 +450,39 @@ impl JsDebuggerStatement {
 	pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![debugger])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionDeclaration {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionDeclaration {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsClassDeclaration {
@@ -400,9 +492,15 @@ impl JsClassDeclaration {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> { support::required_node(&self.syntax) }
-	pub fn implements_clause(&self) -> Option<TsImplementsClause> { support::node(&self.syntax) }
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> SyntaxResult<JsIdentifierBinding> {
+		support::required_node(&self.syntax)
+	}
+	pub fn implements_clause(&self) -> Option<TsImplementsClause> {
+		support::node(&self.syntax)
+	}
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -421,22 +519,30 @@ impl JsVariableDeclarationStatement {
 	pub fn declaration(&self) -> SyntaxResult<JsVariableDeclaration> {
 		support::required_node(&self.syntax)
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnum {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
-	pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
+	pub fn const_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![const])
+	}
 	pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![enum])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsEnumMember> { support::node_list(&self.syntax, 0usize) }
+	pub fn members(&self) -> AstNodeList<TsEnumMember> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -449,11 +555,15 @@ impl TsTypeAliasDecl {
 	pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![type])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceDecl {
@@ -463,9 +573,15 @@ impl TsNamespaceDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleDecl {
@@ -475,30 +591,48 @@ impl TsModuleDecl {
 	pub fn declare_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![declare])
 	}
-	pub fn global_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![global]) }
+	pub fn global_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![global])
+	}
 	pub fn module_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![module])
 	}
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> { support::required_node(&self.syntax) }
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<TsNamespaceBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsInterfaceDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsInterfaceDecl {
-	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
+	pub fn declare_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![declare])
+	}
 	pub fn interface_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![interface])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
-	pub fn extends_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![extends]) }
-	pub fn extends(&self) -> Option<TsExprWithTypeArgs> { support::node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
+	pub fn extends_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![extends])
+	}
+	pub fn extends(&self) -> Option<TsExprWithTypeArgs> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> SyntaxResult<TsTypeElement> { support::required_node(&self.syntax) }
+	pub fn members(&self) -> SyntaxResult<TsTypeElement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -511,8 +645,12 @@ impl ImportDecl {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn imports(&self) -> AstNodeList<ImportClause> { support::node_list(&self.syntax, 0usize) }
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn imports(&self) -> AstNodeList<ImportClause> {
+		support::node_list(&self.syntax, 0usize)
+	}
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -522,8 +660,12 @@ impl ImportDecl {
 	pub fn asserted_object(&self) -> SyntaxResult<JsObjectExpression> {
 		support::required_node(&self.syntax)
 	}
-	pub fn assert_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![assert]) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn assert_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![assert])
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportNamed {
@@ -533,8 +675,12 @@ impl ExportNamed {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn from_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![from]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn from_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![from])
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -553,9 +699,15 @@ impl ExportDefaultDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn decl(&self) -> SyntaxResult<DefaultDecl> { support::required_node(&self.syntax) }
+	pub fn default_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![default])
+	}
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn decl(&self) -> SyntaxResult<DefaultDecl> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportDefaultExpr {
@@ -565,9 +717,15 @@ impl ExportDefaultExpr {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
-	pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
+	pub fn default_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![default])
+	}
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExportWildcard {
@@ -577,12 +735,18 @@ impl ExportWildcard {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn as_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![as])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
 	pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![from])
 	}
@@ -598,7 +762,9 @@ impl ExportDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
+	pub fn type_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![type])
+	}
 	pub fn decl(&self) -> SyntaxResult<JsAnyExportDeclaration> {
 		support::required_node(&self.syntax)
 	}
@@ -614,12 +780,18 @@ impl TsImportEqualsDecl {
 	pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![export])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn module(&self) -> SyntaxResult<TsModuleRef> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn module(&self) -> SyntaxResult<TsModuleRef> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExportAssignment {
@@ -632,8 +804,12 @@ impl TsExportAssignment {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsNamespaceExportDecl {
@@ -649,8 +825,12 @@ impl TsNamespaceExportDecl {
 	pub fn namespace_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![namespace])
 	}
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsElseClause {
@@ -660,14 +840,18 @@ impl JsElseClause {
 	pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![else])
 	}
-	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn alternate(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ForStmtInit {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtInit {
-	pub fn inner(&self) -> SyntaxResult<ForHead> { support::required_node(&self.syntax) }
+	pub fn inner(&self) -> SyntaxResult<ForHead> {
+		support::required_node(&self.syntax)
+	}
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -677,7 +861,9 @@ pub struct ForStmtTest {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtTest {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [;])
 	}
@@ -687,7 +873,9 @@ pub struct ForStmtUpdate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ForStmtUpdate {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsVariableDeclaration {
@@ -709,7 +897,9 @@ impl JsCaseClause {
 	pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![case])
 	}
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -740,8 +930,12 @@ impl JsCatchClause {
 	pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![catch])
 	}
-	pub fn declaration(&self) -> Option<JsCatchDeclaration> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn declaration(&self) -> Option<JsCatchDeclaration> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFinallyClause {
@@ -751,7 +945,9 @@ impl JsFinallyClause {
 	pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![finally])
 	}
-	pub fn body(&self) -> SyntaxResult<JsBlockStatement> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsBlockStatement> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsCatchDeclaration {
@@ -761,7 +957,9 @@ impl JsCatchDeclaration {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn binding(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -786,15 +984,21 @@ pub struct JsArrowFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsArrowFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> Option<JsAnyArrowFunctionParameters> {
 		support::node(&self.syntax)
 	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAwaitExpression {
@@ -804,14 +1008,18 @@ impl JsAwaitExpression {
 	pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![await])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsBinaryExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsBinaryExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(
 			&self.syntax,
@@ -850,8 +1058,12 @@ impl JsClassExpression {
 	pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![class])
 	}
-	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
-	pub fn extends_clause(&self) -> Option<JsExtendsClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> Option<JsIdentifierBinding> {
+		support::node(&self.syntax)
+	}
+	pub fn extends_clause(&self) -> Option<JsExtendsClause> {
+		support::node(&self.syntax)
+	}
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
@@ -867,7 +1079,9 @@ pub struct JsConditionalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConditionalExpression {
-	pub fn test(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
@@ -880,7 +1094,9 @@ pub struct JsComputedMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn optional_chain_token_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?.])
 	}
@@ -896,18 +1112,30 @@ pub struct JsFunctionExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionExpression {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
 	pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![function])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn id(&self) -> Option<JsIdentifierBinding> { support::node(&self.syntax) }
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn id(&self) -> Option<JsIdentifierBinding> {
+		support::node(&self.syntax)
+	}
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportCallExpression {
@@ -920,7 +1148,9 @@ impl JsImportCallExpression {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -930,7 +1160,9 @@ pub struct JsLogicalExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsLogicalExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [??], T ! [||], T ! [&&]])
 	}
@@ -979,7 +1211,9 @@ pub struct JsSequenceExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSequenceExpression {
-	pub fn left(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn comma_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [,])
 	}
@@ -989,7 +1223,9 @@ pub struct JsStaticMemberExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberExpression {
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [.], T ! [?.]])
 	}
@@ -1034,7 +1270,9 @@ impl JsUnaryExpression {
 			],
 		)
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPreUpdateExpression {
@@ -1044,14 +1282,18 @@ impl JsPreUpdateExpression {
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPostUpdateExpression {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPostUpdateExpression {
-	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn operand(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
 		support::find_required_token(&self.syntax, &[T ! [++], T ! [--]])
 	}
@@ -1064,8 +1306,12 @@ impl JsYieldExpression {
 	pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![yield])
 	}
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
-	pub fn argument(&self) -> Option<JsAnyExpression> { support::node(&self.syntax) }
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
+	pub fn argument(&self) -> Option<JsAnyExpression> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Template {
@@ -1084,18 +1330,30 @@ impl NewExpr {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
-	pub fn object(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> Option<TsTypeArgs> {
+		support::node(&self.syntax)
+	}
+	pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn arguments(&self) -> SyntaxResult<ArgList> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CallExpr {
 	pub(crate) syntax: SyntaxNode,
 }
 impl CallExpr {
-	pub fn type_args(&self) -> Option<TsTypeArgs> { support::node(&self.syntax) }
-	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn arguments(&self) -> SyntaxResult<ArgList> { support::required_node(&self.syntax) }
+	pub fn type_args(&self) -> Option<TsTypeArgs> {
+		support::node(&self.syntax)
+	}
+	pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn arguments(&self) -> SyntaxResult<ArgList> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignExpr {
@@ -1157,7 +1415,9 @@ pub struct TsNonNull {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
@@ -1167,12 +1427,18 @@ pub struct TsAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1182,8 +1448,12 @@ pub struct TsConstAssertion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConstAssertion {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
@@ -1202,7 +1472,9 @@ impl TsTypeArgs {
 	pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [<])
 	}
-	pub fn args(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn args(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_angle_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [>])
 	}
@@ -1236,9 +1508,15 @@ pub struct TsTypeParams {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParams {
-	pub fn l_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [<]) }
-	pub fn params(&self) -> SyntaxResult<TsTypeParam> { support::required_node(&self.syntax) }
-	pub fn r_angle_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [>]) }
+	pub fn l_angle_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [<])
+	}
+	pub fn params(&self) -> SyntaxResult<TsTypeParam> {
+		support::required_node(&self.syntax)
+	}
+	pub fn r_angle_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [>])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsParameterList {
@@ -1263,7 +1541,9 @@ impl TsTypeAnnotation {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsFunctionBody {
@@ -1291,7 +1571,9 @@ impl SpreadElement {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn element(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn element(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrayHole {
@@ -1342,17 +1624,27 @@ pub struct JsMethodObjectMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodObjectMember {
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_params(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn type_params(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterObjectMember {
@@ -1371,8 +1663,12 @@ impl JsGetterObjectMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterObjectMember {
@@ -1388,22 +1684,30 @@ impl JsSetterObjectMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn parameter(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct InitializedProp {
 	pub(crate) syntax: SyntaxNode,
 }
 impl InitializedProp {
-	pub fn key(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<Name> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsShorthandPropertyObjectMember {
@@ -1422,7 +1726,9 @@ impl JsSpread {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsStringLiteralExpression {
@@ -1480,8 +1786,12 @@ pub struct TsExprWithTypeArgs {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
-	pub fn item(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
-	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn item(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPrivateClassMemberName {
@@ -1500,67 +1810,105 @@ pub struct JsConstructorClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
-	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> { support::required_node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
+	pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsConstructorParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPropertyClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyClassMember {
-	pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![declare]) }
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn declare_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![declare])
+	}
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn value(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn excl_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![!])
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn value(&self) -> Option<JsEqualValueClause> {
+		support::node(&self.syntax)
+	}
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsMethodClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
-	pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [*]) }
+	pub fn async_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![async])
+	}
+	pub fn star_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [*])
+	}
 	pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
 		support::required_node(&self.syntax)
 	}
-	pub fn type_parameters(&self) -> Option<TsTypeParams> { support::node(&self.syntax) }
+	pub fn type_parameters(&self) -> Option<TsTypeParams> {
+		support::node(&self.syntax)
+	}
 	pub fn parameter_list(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsGetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![get])
 	}
@@ -1573,19 +1921,27 @@ impl JsGetterClassMember {
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn return_type(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsSetterClassMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterClassMember {
-	pub fn access_modifier(&self) -> Option<TsAccessibility> { support::node(&self.syntax) }
+	pub fn access_modifier(&self) -> Option<TsAccessibility> {
+		support::node(&self.syntax)
+	}
 	pub fn abstract_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![abstract])
 	}
-	pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
+	pub fn static_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![static])
+	}
 	pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![set])
 	}
@@ -1595,11 +1951,15 @@ impl JsSetterClassMember {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn parameter(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn parameter(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
-	pub fn body(&self) -> SyntaxResult<JsFunctionBody> { support::required_node(&self.syntax) }
+	pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEmptyClassMember {
@@ -1621,11 +1981,15 @@ impl TsIndexSignature {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn pat(&self) -> SyntaxResult<SinglePattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<SinglePattern> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -1665,7 +2029,9 @@ impl TsConstructorParam {
 	pub fn readonly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![readonly])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsEqualValueClause {
@@ -1720,12 +2086,18 @@ pub struct SinglePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl SinglePattern {
-	pub fn name(&self) -> SyntaxResult<Name> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<Name> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn excl_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![!])
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RestPattern {
@@ -1735,19 +2107,27 @@ impl RestPattern {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn pat(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn pat(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AssignPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl AssignPattern {
-	pub fn key(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ObjectPattern {
@@ -1772,28 +2152,36 @@ impl ArrayPattern {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> AstNodeList<Pattern> { support::node_list(&self.syntax, 0usize) }
+	pub fn elements(&self) -> AstNodeList<Pattern> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
 	pub fn excl_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![!])
 	}
-	pub fn ty(&self) -> Option<TsTypeAnnotation> { support::node(&self.syntax) }
+	pub fn ty(&self) -> Option<TsTypeAnnotation> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ExprPattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl ExprPattern {
-	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyValuePattern {
 	pub(crate) syntax: SyntaxNode,
 }
 impl KeyValuePattern {
-	pub fn key(&self) -> SyntaxResult<PropName> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<PropName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
@@ -1803,8 +2191,12 @@ pub struct JsVariableDeclarator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclarator {
-	pub fn id(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
-	pub fn init(&self) -> Option<JsEqualValueClause> { support::node(&self.syntax) }
+	pub fn id(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
+	pub fn init(&self) -> Option<JsEqualValueClause> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct WildcardImport {
@@ -1814,8 +2206,12 @@ impl WildcardImport {
 	pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [*])
 	}
-	pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
+	pub fn as_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![as])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamedImports {
@@ -1846,7 +2242,9 @@ pub struct Specifier {
 	pub(crate) syntax: SyntaxNode,
 }
 impl Specifier {
-	pub fn name(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsReferenceIdentifierMember {
@@ -1877,7 +2275,9 @@ impl JsRestParameter {
 	pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [...])
 	}
-	pub fn binding(&self) -> SyntaxResult<Pattern> { support::required_node(&self.syntax) }
+	pub fn binding(&self) -> SyntaxResult<Pattern> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExternalModuleRef {
@@ -1920,42 +2320,54 @@ pub struct TsNumber {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsNumber {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObject {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsObject {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBoolean {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBoolean {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsBigint {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsBigint {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsString {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsString {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsSymbol {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbol {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsVoid {
@@ -2007,15 +2419,21 @@ pub struct TsLiteral {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsLiteral {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPredicate {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsPredicate {
-	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> { support::required_node(&self.syntax) }
-	pub fn rhs(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn lhs(&self) -> SyntaxResult<TsThisOrMore> {
+		support::required_node(&self.syntax)
+	}
+	pub fn rhs(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTuple {
@@ -2025,7 +2443,9 @@ impl TsTuple {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn elements(&self) -> SyntaxResult<TsTupleElement> { support::required_node(&self.syntax) }
+	pub fn elements(&self) -> SyntaxResult<TsTupleElement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2038,7 +2458,9 @@ impl TsParen {
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2048,8 +2470,12 @@ pub struct TsTypeRef {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeRef {
-	pub fn name(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
+	pub fn name(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplate {
@@ -2068,21 +2494,33 @@ impl TsMappedType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> { support::node(&self.syntax) }
-	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
-	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
+	pub fn readonly_modifier(&self) -> Option<TsMappedTypeReadonly> {
+		support::node(&self.syntax)
+	}
+	pub fn minus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [-])
+	}
+	pub fn plus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [+])
+	}
 	pub fn question_mark_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T ! [?])
 	}
-	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> { support::required_node(&self.syntax) }
+	pub fn param(&self) -> SyntaxResult<TsMappedTypeParam> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
-	pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [;]) }
+	pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [;])
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsImport {
@@ -2092,12 +2530,18 @@ impl TsImport {
 	pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![import])
 	}
-	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> { support::required_node(&self.syntax) }
-	pub fn dot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [.]) }
+	pub fn type_args(&self) -> SyntaxResult<TsTypeArgs> {
+		support::required_node(&self.syntax)
+	}
+	pub fn dot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [.])
+	}
 	pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['('])
 	}
-	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn qualifier(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![')'])
 	}
@@ -2110,7 +2554,9 @@ impl TsArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2123,7 +2569,9 @@ impl TsIndexedArray {
 	pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['['])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_brack_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![']'])
 	}
@@ -2133,32 +2581,42 @@ pub struct TsTypeOperator {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperator {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsIntersection {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersection {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	pub fn types(&self) -> AstNodeList<TsType> {
+		support::node_list(&self.syntax, 0usize)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsUnion {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsUnion {
-	pub fn types(&self) -> AstNodeList<TsType> { support::node_list(&self.syntax, 0usize) }
+	pub fn types(&self) -> AstNodeList<TsType> {
+		support::node_list(&self.syntax, 0usize)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsFnType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsFnType {
-	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
+	pub fn params(&self) -> SyntaxResult<JsParameterList> {
+		support::required_node(&self.syntax)
+	}
 	pub fn fat_arrow_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=>])
 	}
-	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsType> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructorType {
@@ -2168,25 +2626,33 @@ impl TsConstructorType {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn params(&self) -> SyntaxResult<JsParameterList> { support::required_node(&self.syntax) }
+	pub fn params(&self) -> SyntaxResult<JsParameterList> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> Option<TsType> { support::node(&self.syntax) }
+	pub fn return_type(&self) -> Option<TsType> {
+		support::node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConditionalType {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn extends(&self) -> SyntaxResult<TsExtends> { support::required_node(&self.syntax) }
+	pub fn extends(&self) -> SyntaxResult<TsExtends> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsObjectType {
@@ -2196,7 +2662,9 @@ impl TsObjectType {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn members(&self) -> AstNodeList<TsTypeElement> { support::node_list(&self.syntax, 0usize) }
+	pub fn members(&self) -> AstNodeList<TsTypeElement> {
+		support::node_list(&self.syntax, 0usize)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2209,40 +2677,54 @@ impl TsInfer {
 	pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![infer])
 	}
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTupleElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleElement {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
-	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [...]) }
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [...])
+	}
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsEnumMember {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn value(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn value(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTemplateElement {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2252,8 +2734,12 @@ pub struct TsMappedTypeReadonly {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonly {
-	pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [-]) }
-	pub fn plus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [+]) }
+	pub fn minus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [-])
+	}
+	pub fn plus_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [+])
+	}
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
@@ -2263,18 +2749,30 @@ pub struct TsMappedTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeParam {
-	pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
-	pub fn name(&self) -> Option<TsTypeName> { support::node(&self.syntax) }
-	pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
-	pub fn ident(&self) -> Option<Ident> { support::node(&self.syntax) }
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn l_brack_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T!['['])
+	}
+	pub fn name(&self) -> Option<TsTypeName> {
+		support::node(&self.syntax)
+	}
+	pub fn r_brack_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T![']'])
+	}
+	pub fn ident(&self) -> Option<Ident> {
+		support::node(&self.syntax)
+	}
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsTypeName {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeName {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsExtends {
@@ -2284,7 +2782,9 @@ impl TsExtends {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsModuleBlock {
@@ -2294,7 +2794,9 @@ impl TsModuleBlock {
 	pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['{'])
 	}
-	pub fn items(&self) -> SyntaxResult<JsAnyStatement> { support::required_node(&self.syntax) }
+	pub fn items(&self) -> SyntaxResult<JsAnyStatement> {
+		support::required_node(&self.syntax)
+	}
 	pub fn r_curly_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T!['}'])
 	}
@@ -2304,9 +2806,15 @@ pub struct TsTypeParam {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParam {
-	pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax) }
-	pub fn constraint(&self) -> SyntaxResult<TsConstraint> { support::required_node(&self.syntax) }
-	pub fn default(&self) -> SyntaxResult<TsDefault> { support::required_node(&self.syntax) }
+	pub fn ident(&self) -> SyntaxResult<Ident> {
+		support::required_node(&self.syntax)
+	}
+	pub fn constraint(&self) -> SyntaxResult<TsConstraint> {
+		support::required_node(&self.syntax)
+	}
+	pub fn default(&self) -> SyntaxResult<TsDefault> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstraint {
@@ -2316,7 +2824,9 @@ impl TsConstraint {
 	pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![extends])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsDefault {
@@ -2326,21 +2836,27 @@ impl TsDefault {
 	pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [=])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsCallSignatureDecl {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureDecl {
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsConstructSignatureDecl {
@@ -2350,12 +2866,18 @@ impl TsConstructSignatureDecl {
 	pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T![new])
 	}
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
-	pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T ! [:]) }
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn colon_token(&self) -> Option<SyntaxToken> {
+		support::token(&self.syntax, T ! [:])
+	}
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsPropertySignature {
@@ -2365,14 +2887,18 @@ impl TsPropertySignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
+	pub fn prop(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
 	pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [?])
 	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn ty(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsMethodSignature {
@@ -2382,8 +2908,12 @@ impl TsMethodSignature {
 	pub fn readonly_token(&self) -> Option<SyntaxToken> {
 		support::token(&self.syntax, T![readonly])
 	}
-	pub fn key(&self) -> SyntaxResult<JsAnyExpression> { support::required_node(&self.syntax) }
-	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> { support::required_node(&self.syntax) }
+	pub fn key(&self) -> SyntaxResult<JsAnyExpression> {
+		support::required_node(&self.syntax)
+	}
+	pub fn type_params(&self) -> SyntaxResult<TsTypeParams> {
+		support::required_node(&self.syntax)
+	}
 	pub fn parameters(&self) -> SyntaxResult<JsParameterList> {
 		support::required_node(&self.syntax)
 	}
@@ -2393,18 +2923,24 @@ impl TsMethodSignature {
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [:])
 	}
-	pub fn return_type(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax) }
+	pub fn return_type(&self) -> SyntaxResult<TsType> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TsQualifiedPath {
 	pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedPath {
-	pub fn lhs(&self) -> SyntaxResult<TsEntityName> { support::required_node(&self.syntax) }
+	pub fn lhs(&self) -> SyntaxResult<TsEntityName> {
+		support::required_node(&self.syntax)
+	}
 	pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, T ! [.])
 	}
-	pub fn rhs(&self) -> SyntaxResult<TsTypeName> { support::required_node(&self.syntax) }
+	pub fn rhs(&self) -> SyntaxResult<TsTypeName> {
+		support::required_node(&self.syntax)
+	}
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyStatement {
@@ -2682,7 +3218,9 @@ pub enum TsNamespaceBody {
 	TsNamespaceDecl(TsNamespaceDecl),
 }
 impl AstNode for JsUnknownStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2690,7 +3228,9 @@ impl AstNode for JsUnknownStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2700,7 +3240,9 @@ impl std::fmt::Debug for JsUnknownStatement {
 	}
 }
 impl AstNode for JsUnknownExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2708,7 +3250,9 @@ impl AstNode for JsUnknownExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2718,7 +3262,9 @@ impl std::fmt::Debug for JsUnknownExpression {
 	}
 }
 impl AstNode for JsUnknownPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2726,7 +3272,9 @@ impl AstNode for JsUnknownPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2736,7 +3284,9 @@ impl std::fmt::Debug for JsUnknownPattern {
 	}
 }
 impl AstNode for JsUnknownMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2744,7 +3294,9 @@ impl AstNode for JsUnknownMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2754,7 +3306,9 @@ impl std::fmt::Debug for JsUnknownMember {
 	}
 }
 impl AstNode for JsUnknownBinding {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_BINDING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2762,7 +3316,9 @@ impl AstNode for JsUnknownBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2772,7 +3328,9 @@ impl std::fmt::Debug for JsUnknownBinding {
 	}
 }
 impl AstNode for JsUnknownAssignmentTarget {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT_TARGET }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNKNOWN_ASSIGNMENT_TARGET
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2780,7 +3338,9 @@ impl AstNode for JsUnknownAssignmentTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2790,7 +3350,9 @@ impl std::fmt::Debug for JsUnknownAssignmentTarget {
 	}
 }
 impl AstNode for Ident {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IDENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IDENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2798,7 +3360,9 @@ impl AstNode for Ident {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for Ident {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2811,7 +3375,9 @@ impl std::fmt::Debug for Ident {
 	}
 }
 impl AstNode for JsRoot {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ROOT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ROOT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2819,7 +3385,9 @@ impl AstNode for JsRoot {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsRoot {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2834,7 +3402,9 @@ impl std::fmt::Debug for JsRoot {
 	}
 }
 impl AstNode for JsDirective {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DIRECTIVE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2842,7 +3412,9 @@ impl AstNode for JsDirective {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsDirective {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2859,7 +3431,9 @@ impl std::fmt::Debug for JsDirective {
 	}
 }
 impl AstNode for JsBlockStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BLOCK_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2867,7 +3441,9 @@ impl AstNode for JsBlockStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsBlockStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2885,7 +3461,9 @@ impl std::fmt::Debug for JsBlockStatement {
 	}
 }
 impl AstNode for JsEmptyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EMPTY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2893,7 +3471,9 @@ impl AstNode for JsEmptyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsEmptyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2906,7 +3486,9 @@ impl std::fmt::Debug for JsEmptyStatement {
 	}
 }
 impl AstNode for JsExpressionStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EXPRESSION_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2914,7 +3496,9 @@ impl AstNode for JsExpressionStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsExpressionStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2928,7 +3512,9 @@ impl std::fmt::Debug for JsExpressionStatement {
 	}
 }
 impl AstNode for JsIfStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IF_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2936,7 +3522,9 @@ impl AstNode for JsIfStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsIfStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2960,7 +3548,9 @@ impl std::fmt::Debug for JsIfStatement {
 	}
 }
 impl AstNode for JsDoWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DO_WHILE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -2968,7 +3558,9 @@ impl AstNode for JsDoWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsDoWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2996,7 +3588,9 @@ impl std::fmt::Debug for JsDoWhileStatement {
 	}
 }
 impl AstNode for JsWhileStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_WHILE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3004,7 +3598,9 @@ impl AstNode for JsWhileStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsWhileStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3027,7 +3623,9 @@ impl std::fmt::Debug for JsWhileStatement {
 	}
 }
 impl AstNode for ForStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3035,7 +3633,9 @@ impl AstNode for ForStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3057,7 +3657,9 @@ impl std::fmt::Debug for ForStmt {
 	}
 }
 impl AstNode for ForInStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_IN_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_IN_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3065,7 +3667,9 @@ impl AstNode for ForInStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForInStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3087,7 +3691,9 @@ impl std::fmt::Debug for ForInStmt {
 	}
 }
 impl AstNode for ForOfStmt {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_OF_STMT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_OF_STMT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3095,7 +3701,9 @@ impl AstNode for ForOfStmt {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForOfStmt {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3117,7 +3725,9 @@ impl std::fmt::Debug for ForOfStmt {
 	}
 }
 impl AstNode for JsContinueStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONTINUE_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3125,7 +3735,9 @@ impl AstNode for JsContinueStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsContinueStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3146,7 +3758,9 @@ impl std::fmt::Debug for JsContinueStatement {
 	}
 }
 impl AstNode for JsBreakStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BREAK_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3154,7 +3768,9 @@ impl AstNode for JsBreakStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsBreakStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3175,7 +3791,9 @@ impl std::fmt::Debug for JsBreakStatement {
 	}
 }
 impl AstNode for JsReturnStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_RETURN_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3183,7 +3801,9 @@ impl AstNode for JsReturnStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsReturnStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3201,7 +3821,9 @@ impl std::fmt::Debug for JsReturnStatement {
 	}
 }
 impl AstNode for JsWithStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_WITH_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3209,7 +3831,9 @@ impl AstNode for JsWithStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsWithStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3229,7 +3853,9 @@ impl std::fmt::Debug for JsWithStatement {
 	}
 }
 impl AstNode for JsLabeledStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LABELED_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3237,7 +3863,9 @@ impl AstNode for JsLabeledStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsLabeledStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3255,7 +3883,9 @@ impl std::fmt::Debug for JsLabeledStatement {
 	}
 }
 impl AstNode for JsSwitchStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SWITCH_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3263,7 +3893,9 @@ impl AstNode for JsSwitchStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSwitchStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3297,7 +3929,9 @@ impl std::fmt::Debug for JsSwitchStatement {
 	}
 }
 impl AstNode for JsThrowStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_THROW_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3305,7 +3939,9 @@ impl AstNode for JsThrowStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsThrowStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3323,7 +3959,9 @@ impl std::fmt::Debug for JsThrowStatement {
 	}
 }
 impl AstNode for JsTryStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_TRY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3331,7 +3969,9 @@ impl AstNode for JsTryStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsTryStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3346,7 +3986,9 @@ impl std::fmt::Debug for JsTryStatement {
 	}
 }
 impl AstNode for JsTryFinallyStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_TRY_FINALLY_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3354,7 +3996,9 @@ impl AstNode for JsTryFinallyStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsTryFinallyStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3373,7 +4017,9 @@ impl std::fmt::Debug for JsTryFinallyStatement {
 	}
 }
 impl AstNode for JsDebuggerStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DEBUGGER_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3381,7 +4027,9 @@ impl AstNode for JsDebuggerStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsDebuggerStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3398,7 +4046,9 @@ impl std::fmt::Debug for JsDebuggerStatement {
 	}
 }
 impl AstNode for JsFunctionDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3406,7 +4056,9 @@ impl AstNode for JsFunctionDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsFunctionDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3438,7 +4090,9 @@ impl std::fmt::Debug for JsFunctionDeclaration {
 	}
 }
 impl AstNode for JsClassDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CLASS_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3446,7 +4100,9 @@ impl AstNode for JsClassDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsClassDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3477,7 +4133,9 @@ impl std::fmt::Debug for JsClassDeclaration {
 	}
 }
 impl AstNode for JsVariableDeclarationStatement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_STATEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATION_STATEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3485,7 +4143,9 @@ impl AstNode for JsVariableDeclarationStatement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsVariableDeclarationStatement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3502,7 +4162,9 @@ impl std::fmt::Debug for JsVariableDeclarationStatement {
 	}
 }
 impl AstNode for TsEnum {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ENUM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3510,7 +4172,9 @@ impl AstNode for TsEnum {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsEnum {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3534,7 +4198,9 @@ impl std::fmt::Debug for TsEnum {
 	}
 }
 impl AstNode for TsTypeAliasDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ALIAS_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3542,7 +4208,9 @@ impl AstNode for TsTypeAliasDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeAliasDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3558,7 +4226,9 @@ impl std::fmt::Debug for TsTypeAliasDecl {
 	}
 }
 impl AstNode for TsNamespaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NAMESPACE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3566,7 +4236,9 @@ impl AstNode for TsNamespaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNamespaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3582,7 +4254,9 @@ impl std::fmt::Debug for TsNamespaceDecl {
 	}
 }
 impl AstNode for TsModuleDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MODULE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3590,7 +4264,9 @@ impl AstNode for TsModuleDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsModuleDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3614,7 +4290,9 @@ impl std::fmt::Debug for TsModuleDecl {
 	}
 }
 impl AstNode for TsInterfaceDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INTERFACE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3622,7 +4300,9 @@ impl AstNode for TsInterfaceDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsInterfaceDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3657,7 +4337,9 @@ impl std::fmt::Debug for TsInterfaceDecl {
 	}
 }
 impl AstNode for ImportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3665,7 +4347,9 @@ impl AstNode for ImportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ImportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3697,7 +4381,9 @@ impl std::fmt::Debug for ImportDecl {
 	}
 }
 impl AstNode for ExportNamed {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_NAMED }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_NAMED
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3705,7 +4391,9 @@ impl AstNode for ExportNamed {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExportNamed {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3729,7 +4417,9 @@ impl std::fmt::Debug for ExportNamed {
 	}
 }
 impl AstNode for ExportDefaultDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DEFAULT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3737,7 +4427,9 @@ impl AstNode for ExportDefaultDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExportDefaultDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3756,7 +4448,9 @@ impl std::fmt::Debug for ExportDefaultDecl {
 	}
 }
 impl AstNode for ExportDefaultExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DEFAULT_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DEFAULT_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3764,7 +4458,9 @@ impl AstNode for ExportDefaultExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExportDefaultExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3783,7 +4479,9 @@ impl std::fmt::Debug for ExportDefaultExpr {
 	}
 }
 impl AstNode for ExportWildcard {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_WILDCARD }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_WILDCARD
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3791,7 +4489,9 @@ impl AstNode for ExportWildcard {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExportWildcard {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3813,7 +4513,9 @@ impl std::fmt::Debug for ExportWildcard {
 	}
 }
 impl AstNode for ExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3821,7 +4523,9 @@ impl AstNode for ExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3836,7 +4540,9 @@ impl std::fmt::Debug for ExportDecl {
 	}
 }
 impl AstNode for TsImportEqualsDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPORT_EQUALS_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3844,7 +4550,9 @@ impl AstNode for TsImportEqualsDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsImportEqualsDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3868,7 +4576,9 @@ impl std::fmt::Debug for TsImportEqualsDecl {
 	}
 }
 impl AstNode for TsExportAssignment {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXPORT_ASSIGNMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3876,7 +4586,9 @@ impl AstNode for TsExportAssignment {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsExportAssignment {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3895,7 +4607,9 @@ impl std::fmt::Debug for TsExportAssignment {
 	}
 }
 impl AstNode for TsNamespaceExportDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMESPACE_EXPORT_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NAMESPACE_EXPORT_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3903,7 +4617,9 @@ impl AstNode for TsNamespaceExportDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNamespaceExportDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3926,7 +4642,9 @@ impl std::fmt::Debug for TsNamespaceExportDecl {
 	}
 }
 impl AstNode for JsElseClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ELSE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3934,7 +4652,9 @@ impl AstNode for JsElseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsElseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3945,7 +4665,9 @@ impl std::fmt::Debug for JsElseClause {
 	}
 }
 impl AstNode for ForStmtInit {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_INIT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_INIT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3953,7 +4675,9 @@ impl AstNode for ForStmtInit {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForStmtInit {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3967,7 +4691,9 @@ impl std::fmt::Debug for ForStmtInit {
 	}
 }
 impl AstNode for ForStmtTest {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_TEST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_TEST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3975,7 +4701,9 @@ impl AstNode for ForStmtTest {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForStmtTest {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -3989,7 +4717,9 @@ impl std::fmt::Debug for ForStmtTest {
 	}
 }
 impl AstNode for ForStmtUpdate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == FOR_STMT_UPDATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == FOR_STMT_UPDATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -3997,7 +4727,9 @@ impl AstNode for ForStmtUpdate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ForStmtUpdate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4007,7 +4739,9 @@ impl std::fmt::Debug for ForStmtUpdate {
 	}
 }
 impl AstNode for JsVariableDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4015,7 +4749,9 @@ impl AstNode for JsVariableDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsVariableDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4026,7 +4762,9 @@ impl std::fmt::Debug for JsVariableDeclaration {
 	}
 }
 impl AstNode for JsCaseClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CASE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4034,7 +4772,9 @@ impl AstNode for JsCaseClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsCaseClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4050,7 +4790,9 @@ impl std::fmt::Debug for JsCaseClause {
 	}
 }
 impl AstNode for JsDefaultClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_DEFAULT_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4058,7 +4800,9 @@ impl AstNode for JsDefaultClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsDefaultClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4076,7 +4820,9 @@ impl std::fmt::Debug for JsDefaultClause {
 	}
 }
 impl AstNode for JsCatchClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CATCH_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4084,7 +4830,9 @@ impl AstNode for JsCatchClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsCatchClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4102,7 +4850,9 @@ impl std::fmt::Debug for JsCatchClause {
 	}
 }
 impl AstNode for JsFinallyClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FINALLY_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4110,7 +4860,9 @@ impl AstNode for JsFinallyClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsFinallyClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4124,7 +4876,9 @@ impl std::fmt::Debug for JsFinallyClause {
 	}
 }
 impl AstNode for JsCatchDeclaration {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CATCH_DECLARATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4132,7 +4886,9 @@ impl AstNode for JsCatchDeclaration {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsCatchDeclaration {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4150,7 +4906,9 @@ impl std::fmt::Debug for JsCatchDeclaration {
 	}
 }
 impl AstNode for JsArrayExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARRAY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4158,7 +4916,9 @@ impl AstNode for JsArrayExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsArrayExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4176,7 +4936,9 @@ impl std::fmt::Debug for JsArrayExpression {
 	}
 }
 impl AstNode for JsArrowFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARROW_FUNCTION_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4184,7 +4946,9 @@ impl AstNode for JsArrowFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsArrowFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4213,7 +4977,9 @@ impl std::fmt::Debug for JsArrowFunctionExpression {
 	}
 }
 impl AstNode for JsAwaitExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_AWAIT_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4221,7 +4987,9 @@ impl AstNode for JsAwaitExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsAwaitExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4235,7 +5003,9 @@ impl std::fmt::Debug for JsAwaitExpression {
 	}
 }
 impl AstNode for JsBinaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BINARY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4243,7 +5013,9 @@ impl AstNode for JsBinaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsBinaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4254,7 +5026,9 @@ impl std::fmt::Debug for JsBinaryExpression {
 	}
 }
 impl AstNode for JsClassExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CLASS_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4262,7 +5036,9 @@ impl AstNode for JsClassExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsClassExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4289,7 +5065,9 @@ impl std::fmt::Debug for JsClassExpression {
 	}
 }
 impl AstNode for JsConditionalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONDITIONAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4297,7 +5075,9 @@ impl AstNode for JsConditionalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsConditionalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4315,7 +5095,9 @@ impl std::fmt::Debug for JsConditionalExpression {
 	}
 }
 impl AstNode for JsComputedMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_COMPUTED_MEMBER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4323,7 +5105,9 @@ impl AstNode for JsComputedMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsComputedMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4345,7 +5129,9 @@ impl std::fmt::Debug for JsComputedMemberExpression {
 	}
 }
 impl AstNode for JsFunctionExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4353,7 +5139,9 @@ impl AstNode for JsFunctionExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsFunctionExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4382,7 +5170,9 @@ impl std::fmt::Debug for JsFunctionExpression {
 	}
 }
 impl AstNode for JsImportCallExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IMPORT_CALL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4390,7 +5180,9 @@ impl AstNode for JsImportCallExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsImportCallExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4412,7 +5204,9 @@ impl std::fmt::Debug for JsImportCallExpression {
 	}
 }
 impl AstNode for JsLogicalExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LOGICAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4420,7 +5214,9 @@ impl AstNode for JsLogicalExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsLogicalExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4431,7 +5227,9 @@ impl std::fmt::Debug for JsLogicalExpression {
 	}
 }
 impl AstNode for JsObjectExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_OBJECT_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4439,7 +5237,9 @@ impl AstNode for JsObjectExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsObjectExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4457,7 +5257,9 @@ impl std::fmt::Debug for JsObjectExpression {
 	}
 }
 impl AstNode for JsParenthesizedExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PARENTHESIZED_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4465,7 +5267,9 @@ impl AstNode for JsParenthesizedExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsParenthesizedExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4483,7 +5287,9 @@ impl std::fmt::Debug for JsParenthesizedExpression {
 	}
 }
 impl AstNode for JsReferenceIdentifierExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_IDENTIFIER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4491,7 +5297,9 @@ impl AstNode for JsReferenceIdentifierExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsReferenceIdentifierExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4501,7 +5309,9 @@ impl std::fmt::Debug for JsReferenceIdentifierExpression {
 	}
 }
 impl AstNode for JsSequenceExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SEQUENCE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4509,7 +5319,9 @@ impl AstNode for JsSequenceExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSequenceExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4523,7 +5335,9 @@ impl std::fmt::Debug for JsSequenceExpression {
 	}
 }
 impl AstNode for JsStaticMemberExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_STATIC_MEMBER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4531,7 +5345,9 @@ impl AstNode for JsStaticMemberExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsStaticMemberExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4543,7 +5359,9 @@ impl std::fmt::Debug for JsStaticMemberExpression {
 	}
 }
 impl AstNode for JsSuperExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SUPER_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4551,7 +5369,9 @@ impl AstNode for JsSuperExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSuperExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4564,7 +5384,9 @@ impl std::fmt::Debug for JsSuperExpression {
 	}
 }
 impl AstNode for JsThisExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_THIS_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4572,7 +5394,9 @@ impl AstNode for JsThisExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsThisExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4582,7 +5406,9 @@ impl std::fmt::Debug for JsThisExpression {
 	}
 }
 impl AstNode for JsUnaryExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_UNARY_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4590,7 +5416,9 @@ impl AstNode for JsUnaryExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsUnaryExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4601,7 +5429,9 @@ impl std::fmt::Debug for JsUnaryExpression {
 	}
 }
 impl AstNode for JsPreUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PRE_UPDATE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4609,7 +5439,9 @@ impl AstNode for JsPreUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsPreUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4620,7 +5452,9 @@ impl std::fmt::Debug for JsPreUpdateExpression {
 	}
 }
 impl AstNode for JsPostUpdateExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_POST_UPDATE_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4628,7 +5462,9 @@ impl AstNode for JsPostUpdateExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsPostUpdateExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4639,7 +5475,9 @@ impl std::fmt::Debug for JsPostUpdateExpression {
 	}
 }
 impl AstNode for JsYieldExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_YIELD_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4647,7 +5485,9 @@ impl AstNode for JsYieldExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsYieldExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4662,7 +5502,9 @@ impl std::fmt::Debug for JsYieldExpression {
 	}
 }
 impl AstNode for Template {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TEMPLATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TEMPLATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4670,7 +5512,9 @@ impl AstNode for Template {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for Template {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4683,7 +5527,9 @@ impl std::fmt::Debug for Template {
 	}
 }
 impl AstNode for NewExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NEW_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4691,7 +5537,9 @@ impl AstNode for NewExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for NewExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4704,7 +5552,9 @@ impl std::fmt::Debug for NewExpr {
 	}
 }
 impl AstNode for CallExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == CALL_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == CALL_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4712,7 +5562,9 @@ impl AstNode for CallExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for CallExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4724,7 +5576,9 @@ impl std::fmt::Debug for CallExpr {
 	}
 }
 impl AstNode for AssignExpr {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_EXPR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ASSIGN_EXPR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4732,7 +5586,9 @@ impl AstNode for AssignExpr {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for AssignExpr {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4742,7 +5598,9 @@ impl std::fmt::Debug for AssignExpr {
 	}
 }
 impl AstNode for NewTarget {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NEW_TARGET
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4750,7 +5608,9 @@ impl AstNode for NewTarget {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for NewTarget {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4765,7 +5625,9 @@ impl std::fmt::Debug for NewTarget {
 	}
 }
 impl AstNode for ImportMeta {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_META
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4773,7 +5635,9 @@ impl AstNode for ImportMeta {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ImportMeta {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4787,7 +5651,9 @@ impl std::fmt::Debug for ImportMeta {
 	}
 }
 impl AstNode for TsNonNull {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NON_NULL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4795,7 +5661,9 @@ impl AstNode for TsNonNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNonNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4806,7 +5674,9 @@ impl std::fmt::Debug for TsNonNull {
 	}
 }
 impl AstNode for TsAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ASSERTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4814,7 +5684,9 @@ impl AstNode for TsAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4834,7 +5706,9 @@ impl std::fmt::Debug for TsAssertion {
 	}
 }
 impl AstNode for TsConstAssertion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONST_ASSERTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONST_ASSERTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4842,7 +5716,9 @@ impl AstNode for TsConstAssertion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConstAssertion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4865,7 +5741,9 @@ impl std::fmt::Debug for TsConstAssertion {
 	}
 }
 impl AstNode for TsTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ARGS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4873,7 +5751,9 @@ impl AstNode for TsTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4891,7 +5771,9 @@ impl std::fmt::Debug for TsTypeArgs {
 	}
 }
 impl AstNode for ArgList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ARG_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ARG_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4899,7 +5781,9 @@ impl AstNode for ArgList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ArgList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4917,7 +5801,9 @@ impl std::fmt::Debug for ArgList {
 	}
 }
 impl AstNode for JsIdentifierBinding {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_IDENTIFIER_BINDING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4925,7 +5811,9 @@ impl AstNode for JsIdentifierBinding {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsIdentifierBinding {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4935,7 +5823,9 @@ impl std::fmt::Debug for JsIdentifierBinding {
 	}
 }
 impl AstNode for TsTypeParams {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_PARAMS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4943,7 +5833,9 @@ impl AstNode for TsTypeParams {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeParams {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4961,7 +5853,9 @@ impl std::fmt::Debug for TsTypeParams {
 	}
 }
 impl AstNode for JsParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PARAMETER_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4969,7 +5863,9 @@ impl AstNode for JsParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -4987,7 +5883,9 @@ impl std::fmt::Debug for JsParameterList {
 	}
 }
 impl AstNode for TsTypeAnnotation {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_ANNOTATION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -4995,7 +5893,9 @@ impl AstNode for TsTypeAnnotation {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeAnnotation {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5009,7 +5909,9 @@ impl std::fmt::Debug for TsTypeAnnotation {
 	}
 }
 impl AstNode for JsFunctionBody {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_FUNCTION_BODY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5017,7 +5919,9 @@ impl AstNode for JsFunctionBody {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsFunctionBody {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5036,7 +5940,9 @@ impl std::fmt::Debug for JsFunctionBody {
 	}
 }
 impl AstNode for SpreadElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SPREAD_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SPREAD_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5044,7 +5950,9 @@ impl AstNode for SpreadElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for SpreadElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5058,7 +5966,9 @@ impl std::fmt::Debug for SpreadElement {
 	}
 }
 impl AstNode for JsArrayHole {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_ARRAY_HOLE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5066,7 +5976,9 @@ impl AstNode for JsArrayHole {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsArrayHole {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5074,7 +5986,9 @@ impl std::fmt::Debug for JsArrayHole {
 	}
 }
 impl AstNode for JsLiteralMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_LITERAL_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5082,7 +5996,9 @@ impl AstNode for JsLiteralMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsLiteralMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5092,7 +6008,9 @@ impl std::fmt::Debug for JsLiteralMemberName {
 	}
 }
 impl AstNode for JsComputedMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_COMPUTED_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5100,7 +6018,9 @@ impl AstNode for JsComputedMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsComputedMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5118,7 +6038,9 @@ impl std::fmt::Debug for JsComputedMemberName {
 	}
 }
 impl AstNode for JsPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PROPERTY_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5126,7 +6048,9 @@ impl AstNode for JsPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5140,7 +6064,9 @@ impl std::fmt::Debug for JsPropertyObjectMember {
 	}
 }
 impl AstNode for JsMethodObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_METHOD_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5148,7 +6074,9 @@ impl AstNode for JsMethodObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsMethodObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5176,7 +6104,9 @@ impl std::fmt::Debug for JsMethodObjectMember {
 	}
 }
 impl AstNode for JsGetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_GETTER_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5184,7 +6114,9 @@ impl AstNode for JsGetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsGetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5208,7 +6140,9 @@ impl std::fmt::Debug for JsGetterObjectMember {
 	}
 }
 impl AstNode for JsSetterObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SETTER_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5216,7 +6150,9 @@ impl AstNode for JsSetterObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSetterObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5237,7 +6173,9 @@ impl std::fmt::Debug for JsSetterObjectMember {
 	}
 }
 impl AstNode for InitializedProp {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == INITIALIZED_PROP }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == INITIALIZED_PROP
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5245,7 +6183,9 @@ impl AstNode for InitializedProp {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for InitializedProp {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5257,7 +6197,9 @@ impl std::fmt::Debug for InitializedProp {
 	}
 }
 impl AstNode for JsShorthandPropertyObjectMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5265,7 +6207,9 @@ impl AstNode for JsShorthandPropertyObjectMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsShorthandPropertyObjectMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5275,7 +6219,9 @@ impl std::fmt::Debug for JsShorthandPropertyObjectMember {
 	}
 }
 impl AstNode for JsSpread {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SPREAD
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5283,7 +6229,9 @@ impl AstNode for JsSpread {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSpread {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5297,7 +6245,9 @@ impl std::fmt::Debug for JsSpread {
 	}
 }
 impl AstNode for JsStringLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_STRING_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5305,7 +6255,9 @@ impl AstNode for JsStringLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsStringLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5318,7 +6270,9 @@ impl std::fmt::Debug for JsStringLiteralExpression {
 	}
 }
 impl AstNode for JsNumberLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_NUMBER_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5326,7 +6280,9 @@ impl AstNode for JsNumberLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsNumberLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5339,7 +6295,9 @@ impl std::fmt::Debug for JsNumberLiteralExpression {
 	}
 }
 impl AstNode for Name {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5347,7 +6305,9 @@ impl AstNode for Name {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for Name {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5360,7 +6320,9 @@ impl std::fmt::Debug for Name {
 	}
 }
 impl AstNode for TsImplementsClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPLEMENTS_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5368,7 +6330,9 @@ impl AstNode for TsImplementsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsImplementsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5382,7 +6346,9 @@ impl std::fmt::Debug for TsImplementsClause {
 	}
 }
 impl AstNode for JsExtendsClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EXTENDS_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5390,7 +6356,9 @@ impl AstNode for JsExtendsClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsExtendsClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5407,7 +6375,9 @@ impl std::fmt::Debug for JsExtendsClause {
 	}
 }
 impl AstNode for TsExprWithTypeArgs {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPR_WITH_TYPE_ARGS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXPR_WITH_TYPE_ARGS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5415,7 +6385,9 @@ impl AstNode for TsExprWithTypeArgs {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsExprWithTypeArgs {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5429,7 +6401,9 @@ impl std::fmt::Debug for TsExprWithTypeArgs {
 	}
 }
 impl AstNode for JsPrivateClassMemberName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PRIVATE_CLASS_MEMBER_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5437,7 +6411,9 @@ impl AstNode for JsPrivateClassMemberName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsPrivateClassMemberName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5448,7 +6424,9 @@ impl std::fmt::Debug for JsPrivateClassMemberName {
 	}
 }
 impl AstNode for JsConstructorClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONSTRUCTOR_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5456,7 +6434,9 @@ impl AstNode for JsConstructorClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsConstructorClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5475,7 +6455,9 @@ impl std::fmt::Debug for JsConstructorClassMember {
 	}
 }
 impl AstNode for JsPropertyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_PROPERTY_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5483,7 +6465,9 @@ impl AstNode for JsPropertyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsPropertyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5520,7 +6504,9 @@ impl std::fmt::Debug for JsPropertyClassMember {
 	}
 }
 impl AstNode for JsMethodClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_METHOD_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5528,7 +6514,9 @@ impl AstNode for JsMethodClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsMethodClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5568,7 +6556,9 @@ impl std::fmt::Debug for JsMethodClassMember {
 	}
 }
 impl AstNode for JsGetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_GETTER_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5576,7 +6566,9 @@ impl AstNode for JsGetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsGetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5612,7 +6604,9 @@ impl std::fmt::Debug for JsGetterClassMember {
 	}
 }
 impl AstNode for JsSetterClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_SETTER_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5620,7 +6614,9 @@ impl AstNode for JsSetterClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsSetterClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5653,7 +6649,9 @@ impl std::fmt::Debug for JsSetterClassMember {
 	}
 }
 impl AstNode for JsEmptyClassMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EMPTY_CLASS_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5661,7 +6659,9 @@ impl AstNode for JsEmptyClassMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsEmptyClassMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5674,7 +6674,9 @@ impl std::fmt::Debug for JsEmptyClassMember {
 	}
 }
 impl AstNode for TsIndexSignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INDEX_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5682,7 +6684,9 @@ impl AstNode for TsIndexSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsIndexSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5709,7 +6713,9 @@ impl std::fmt::Debug for TsIndexSignature {
 	}
 }
 impl AstNode for TsAccessibility {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ACCESSIBILITY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5717,7 +6723,9 @@ impl AstNode for TsAccessibility {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsAccessibility {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5734,7 +6742,9 @@ impl std::fmt::Debug for TsAccessibility {
 	}
 }
 impl AstNode for JsConstructorParameterList {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_CONSTRUCTOR_PARAMETER_LIST
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5742,7 +6752,9 @@ impl AstNode for JsConstructorParameterList {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsConstructorParameterList {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5760,7 +6772,9 @@ impl std::fmt::Debug for JsConstructorParameterList {
 	}
 }
 impl AstNode for TsConstructorParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCTOR_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5768,7 +6782,9 @@ impl AstNode for TsConstructorParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConstructorParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5782,7 +6798,9 @@ impl std::fmt::Debug for TsConstructorParam {
 	}
 }
 impl AstNode for JsEqualValueClause {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EQUAL_VALUE_CLAUSE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_EQUAL_VALUE_CLAUSE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5790,7 +6808,9 @@ impl AstNode for JsEqualValueClause {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsEqualValueClause {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5801,7 +6821,9 @@ impl std::fmt::Debug for JsEqualValueClause {
 	}
 }
 impl AstNode for JsBigIntLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BIG_INT_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5809,7 +6831,9 @@ impl AstNode for JsBigIntLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsBigIntLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5822,7 +6846,9 @@ impl std::fmt::Debug for JsBigIntLiteralExpression {
 	}
 }
 impl AstNode for JsBooleanLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_BOOLEAN_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5830,7 +6856,9 @@ impl AstNode for JsBooleanLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsBooleanLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5843,7 +6871,9 @@ impl std::fmt::Debug for JsBooleanLiteralExpression {
 	}
 }
 impl AstNode for JsNullLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_NULL_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5851,7 +6881,9 @@ impl AstNode for JsNullLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsNullLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5864,7 +6896,9 @@ impl std::fmt::Debug for JsNullLiteralExpression {
 	}
 }
 impl AstNode for JsRegexLiteralExpression {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REGEX_LITERAL_EXPRESSION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5872,7 +6906,9 @@ impl AstNode for JsRegexLiteralExpression {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsRegexLiteralExpression {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5885,7 +6921,9 @@ impl std::fmt::Debug for JsRegexLiteralExpression {
 	}
 }
 impl AstNode for SinglePattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SINGLE_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SINGLE_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5893,7 +6931,9 @@ impl AstNode for SinglePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for SinglePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5909,7 +6949,9 @@ impl std::fmt::Debug for SinglePattern {
 	}
 }
 impl AstNode for RestPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == REST_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == REST_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5917,7 +6959,9 @@ impl AstNode for RestPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for RestPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5931,7 +6975,9 @@ impl std::fmt::Debug for RestPattern {
 	}
 }
 impl AstNode for AssignPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ASSIGN_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ASSIGN_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5939,7 +6985,9 @@ impl AstNode for AssignPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for AssignPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5952,7 +7000,9 @@ impl std::fmt::Debug for AssignPattern {
 	}
 }
 impl AstNode for ObjectPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == OBJECT_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5960,7 +7010,9 @@ impl AstNode for ObjectPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ObjectPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -5978,7 +7030,9 @@ impl std::fmt::Debug for ObjectPattern {
 	}
 }
 impl AstNode for ArrayPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == ARRAY_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == ARRAY_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -5986,7 +7040,9 @@ impl AstNode for ArrayPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ArrayPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6006,7 +7062,9 @@ impl std::fmt::Debug for ArrayPattern {
 	}
 }
 impl AstNode for ExprPattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == EXPR_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == EXPR_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6014,7 +7072,9 @@ impl AstNode for ExprPattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ExprPattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6024,7 +7084,9 @@ impl std::fmt::Debug for ExprPattern {
 	}
 }
 impl AstNode for KeyValuePattern {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == KEY_VALUE_PATTERN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == KEY_VALUE_PATTERN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6032,7 +7094,9 @@ impl AstNode for KeyValuePattern {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for KeyValuePattern {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6046,7 +7110,9 @@ impl std::fmt::Debug for KeyValuePattern {
 	}
 }
 impl AstNode for JsVariableDeclarator {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_VARIABLE_DECLARATOR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6054,7 +7120,9 @@ impl AstNode for JsVariableDeclarator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsVariableDeclarator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6065,7 +7133,9 @@ impl std::fmt::Debug for JsVariableDeclarator {
 	}
 }
 impl AstNode for WildcardImport {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == WILDCARD_IMPORT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == WILDCARD_IMPORT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6073,7 +7143,9 @@ impl AstNode for WildcardImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for WildcardImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6085,7 +7157,9 @@ impl std::fmt::Debug for WildcardImport {
 	}
 }
 impl AstNode for NamedImports {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == NAMED_IMPORTS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == NAMED_IMPORTS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6093,7 +7167,9 @@ impl AstNode for NamedImports {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for NamedImports {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6111,7 +7187,9 @@ impl std::fmt::Debug for NamedImports {
 	}
 }
 impl AstNode for ImportStringSpecifier {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_STRING_SPECIFIER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == IMPORT_STRING_SPECIFIER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6119,7 +7197,9 @@ impl AstNode for ImportStringSpecifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for ImportStringSpecifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6132,7 +7212,9 @@ impl std::fmt::Debug for ImportStringSpecifier {
 	}
 }
 impl AstNode for Specifier {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == SPECIFIER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == SPECIFIER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6140,7 +7222,9 @@ impl AstNode for Specifier {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for Specifier {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6150,7 +7234,9 @@ impl std::fmt::Debug for Specifier {
 	}
 }
 impl AstNode for JsReferenceIdentifierMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_IDENTIFIER_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6158,7 +7244,9 @@ impl AstNode for JsReferenceIdentifierMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsReferenceIdentifierMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6168,7 +7256,9 @@ impl std::fmt::Debug for JsReferenceIdentifierMember {
 	}
 }
 impl AstNode for JsReferencePrivateMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_PRIVATE_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REFERENCE_PRIVATE_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6176,7 +7266,9 @@ impl AstNode for JsReferencePrivateMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsReferencePrivateMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6187,7 +7279,9 @@ impl std::fmt::Debug for JsReferencePrivateMember {
 	}
 }
 impl AstNode for JsRestParameter {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == JS_REST_PARAMETER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6195,7 +7289,9 @@ impl AstNode for JsRestParameter {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for JsRestParameter {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6209,7 +7305,9 @@ impl std::fmt::Debug for JsRestParameter {
 	}
 }
 impl AstNode for TsExternalModuleRef {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REF }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXTERNAL_MODULE_REF
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6217,7 +7315,9 @@ impl AstNode for TsExternalModuleRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsExternalModuleRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6242,7 +7342,9 @@ impl std::fmt::Debug for TsExternalModuleRef {
 	}
 }
 impl AstNode for TsAny {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ANY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6250,7 +7352,9 @@ impl AstNode for TsAny {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsAny {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6260,7 +7364,9 @@ impl std::fmt::Debug for TsAny {
 	}
 }
 impl AstNode for TsUnknown {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNKNOWN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6268,7 +7374,9 @@ impl AstNode for TsUnknown {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsUnknown {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6281,7 +7389,9 @@ impl std::fmt::Debug for TsUnknown {
 	}
 }
 impl AstNode for TsNumber {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NUMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6289,7 +7399,9 @@ impl AstNode for TsNumber {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNumber {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6299,7 +7411,9 @@ impl std::fmt::Debug for TsNumber {
 	}
 }
 impl AstNode for TsObject {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_OBJECT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6307,7 +7421,9 @@ impl AstNode for TsObject {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsObject {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6317,7 +7433,9 @@ impl std::fmt::Debug for TsObject {
 	}
 }
 impl AstNode for TsBoolean {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_BOOLEAN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6325,7 +7443,9 @@ impl AstNode for TsBoolean {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsBoolean {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6335,7 +7455,9 @@ impl std::fmt::Debug for TsBoolean {
 	}
 }
 impl AstNode for TsBigint {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_BIGINT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6343,7 +7465,9 @@ impl AstNode for TsBigint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsBigint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6353,7 +7477,9 @@ impl std::fmt::Debug for TsBigint {
 	}
 }
 impl AstNode for TsString {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_STRING
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6361,7 +7487,9 @@ impl AstNode for TsString {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsString {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6371,7 +7499,9 @@ impl std::fmt::Debug for TsString {
 	}
 }
 impl AstNode for TsSymbol {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_SYMBOL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6379,7 +7509,9 @@ impl AstNode for TsSymbol {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsSymbol {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6389,7 +7521,9 @@ impl std::fmt::Debug for TsSymbol {
 	}
 }
 impl AstNode for TsVoid {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_VOID
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6397,7 +7531,9 @@ impl AstNode for TsVoid {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsVoid {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6407,7 +7543,9 @@ impl std::fmt::Debug for TsVoid {
 	}
 }
 impl AstNode for TsUndefined {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNDEFINED
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6415,7 +7553,9 @@ impl AstNode for TsUndefined {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsUndefined {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6428,7 +7568,9 @@ impl std::fmt::Debug for TsUndefined {
 	}
 }
 impl AstNode for TsNull {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NULL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6436,7 +7578,9 @@ impl AstNode for TsNull {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNull {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6446,7 +7590,9 @@ impl std::fmt::Debug for TsNull {
 	}
 }
 impl AstNode for TsNever {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_NEVER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6454,7 +7600,9 @@ impl AstNode for TsNever {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsNever {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6467,7 +7615,9 @@ impl std::fmt::Debug for TsNever {
 	}
 }
 impl AstNode for TsThis {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_THIS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6475,7 +7625,9 @@ impl AstNode for TsThis {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsThis {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6485,7 +7637,9 @@ impl std::fmt::Debug for TsThis {
 	}
 }
 impl AstNode for TsLiteral {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_LITERAL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_LITERAL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6493,7 +7647,9 @@ impl AstNode for TsLiteral {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsLiteral {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6503,7 +7659,9 @@ impl std::fmt::Debug for TsLiteral {
 	}
 }
 impl AstNode for TsPredicate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PREDICATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6511,7 +7669,9 @@ impl AstNode for TsPredicate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsPredicate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6522,7 +7682,9 @@ impl std::fmt::Debug for TsPredicate {
 	}
 }
 impl AstNode for TsTuple {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TUPLE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6530,7 +7692,9 @@ impl AstNode for TsTuple {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTuple {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6548,7 +7712,9 @@ impl std::fmt::Debug for TsTuple {
 	}
 }
 impl AstNode for TsParen {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PAREN }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PAREN
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6556,7 +7722,9 @@ impl AstNode for TsParen {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsParen {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6574,7 +7742,9 @@ impl std::fmt::Debug for TsParen {
 	}
 }
 impl AstNode for TsTypeRef {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_REF }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_REF
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6582,7 +7752,9 @@ impl AstNode for TsTypeRef {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeRef {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6593,7 +7765,9 @@ impl std::fmt::Debug for TsTypeRef {
 	}
 }
 impl AstNode for TsTemplate {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TEMPLATE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6601,7 +7775,9 @@ impl AstNode for TsTemplate {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTemplate {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6611,7 +7787,9 @@ impl std::fmt::Debug for TsTemplate {
 	}
 }
 impl AstNode for TsMappedType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6619,7 +7797,9 @@ impl AstNode for TsMappedType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsMappedType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6659,7 +7839,9 @@ impl std::fmt::Debug for TsMappedType {
 	}
 }
 impl AstNode for TsImport {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_IMPORT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6667,7 +7849,9 @@ impl AstNode for TsImport {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsImport {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6691,7 +7875,9 @@ impl std::fmt::Debug for TsImport {
 	}
 }
 impl AstNode for TsArray {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ARRAY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6699,7 +7885,9 @@ impl AstNode for TsArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6717,7 +7905,9 @@ impl std::fmt::Debug for TsArray {
 	}
 }
 impl AstNode for TsIndexedArray {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ARRAY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INDEXED_ARRAY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6725,7 +7915,9 @@ impl AstNode for TsIndexedArray {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsIndexedArray {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6743,7 +7935,9 @@ impl std::fmt::Debug for TsIndexedArray {
 	}
 }
 impl AstNode for TsTypeOperator {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_OPERATOR
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6751,7 +7945,9 @@ impl AstNode for TsTypeOperator {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeOperator {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6761,7 +7957,9 @@ impl std::fmt::Debug for TsTypeOperator {
 	}
 }
 impl AstNode for TsIntersection {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INTERSECTION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6769,7 +7967,9 @@ impl AstNode for TsIntersection {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsIntersection {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6779,7 +7979,9 @@ impl std::fmt::Debug for TsIntersection {
 	}
 }
 impl AstNode for TsUnion {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_UNION
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6787,7 +7989,9 @@ impl AstNode for TsUnion {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsUnion {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6797,7 +8001,9 @@ impl std::fmt::Debug for TsUnion {
 	}
 }
 impl AstNode for TsFnType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FN_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_FN_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6805,7 +8011,9 @@ impl AstNode for TsFnType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsFnType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6823,7 +8031,9 @@ impl std::fmt::Debug for TsFnType {
 	}
 }
 impl AstNode for TsConstructorType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCTOR_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6831,7 +8041,9 @@ impl AstNode for TsConstructorType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConstructorType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6850,7 +8062,9 @@ impl std::fmt::Debug for TsConstructorType {
 	}
 }
 impl AstNode for TsConditionalType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONDITIONAL_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6858,7 +8072,9 @@ impl AstNode for TsConditionalType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConditionalType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6877,7 +8093,9 @@ impl std::fmt::Debug for TsConditionalType {
 	}
 }
 impl AstNode for TsObjectType {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_OBJECT_TYPE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6885,7 +8103,9 @@ impl AstNode for TsObjectType {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsObjectType {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6903,7 +8123,9 @@ impl std::fmt::Debug for TsObjectType {
 	}
 }
 impl AstNode for TsInfer {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_INFER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6911,7 +8133,9 @@ impl AstNode for TsInfer {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsInfer {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6925,7 +8149,9 @@ impl std::fmt::Debug for TsInfer {
 	}
 }
 impl AstNode for TsTupleElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TUPLE_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6933,7 +8159,9 @@ impl AstNode for TsTupleElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTupleElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6956,7 +8184,9 @@ impl std::fmt::Debug for TsTupleElement {
 	}
 }
 impl AstNode for TsEnumMember {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_ENUM_MEMBER
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6964,7 +8194,9 @@ impl AstNode for TsEnumMember {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsEnumMember {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6976,7 +8208,9 @@ impl std::fmt::Debug for TsEnumMember {
 	}
 }
 impl AstNode for TsTemplateElement {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TEMPLATE_ELEMENT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -6984,7 +8218,9 @@ impl AstNode for TsTemplateElement {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTemplateElement {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -6998,7 +8234,9 @@ impl std::fmt::Debug for TsTemplateElement {
 	}
 }
 impl AstNode for TsMappedTypeReadonly {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE_READONLY
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7006,7 +8244,9 @@ impl AstNode for TsMappedTypeReadonly {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsMappedTypeReadonly {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7024,7 +8264,9 @@ impl std::fmt::Debug for TsMappedTypeReadonly {
 	}
 }
 impl AstNode for TsMappedTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MAPPED_TYPE_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7032,7 +8274,9 @@ impl AstNode for TsMappedTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsMappedTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7052,7 +8296,9 @@ impl std::fmt::Debug for TsMappedTypeParam {
 	}
 }
 impl AstNode for TsTypeName {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_NAME }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_NAME
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7060,7 +8306,9 @@ impl AstNode for TsTypeName {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeName {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7070,7 +8318,9 @@ impl std::fmt::Debug for TsTypeName {
 	}
 }
 impl AstNode for TsExtends {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_EXTENDS
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7078,7 +8328,9 @@ impl AstNode for TsExtends {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsExtends {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7092,7 +8344,9 @@ impl std::fmt::Debug for TsExtends {
 	}
 }
 impl AstNode for TsModuleBlock {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_MODULE_BLOCK
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7100,7 +8354,9 @@ impl AstNode for TsModuleBlock {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsModuleBlock {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7118,7 +8374,9 @@ impl std::fmt::Debug for TsModuleBlock {
 	}
 }
 impl AstNode for TsTypeParam {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAM }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_TYPE_PARAM
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7126,7 +8384,9 @@ impl AstNode for TsTypeParam {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsTypeParam {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7138,7 +8398,9 @@ impl std::fmt::Debug for TsTypeParam {
 	}
 }
 impl AstNode for TsConstraint {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRAINT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRAINT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7146,7 +8408,9 @@ impl AstNode for TsConstraint {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConstraint {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7160,7 +8424,9 @@ impl std::fmt::Debug for TsConstraint {
 	}
 }
 impl AstNode for TsDefault {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_DEFAULT
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7168,7 +8434,9 @@ impl AstNode for TsDefault {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsDefault {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7179,7 +8447,9 @@ impl std::fmt::Debug for TsDefault {
 	}
 }
 impl AstNode for TsCallSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CALL_SIGNATURE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7187,7 +8457,9 @@ impl AstNode for TsCallSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsCallSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7209,7 +8481,9 @@ impl std::fmt::Debug for TsCallSignatureDecl {
 	}
 }
 impl AstNode for TsConstructSignatureDecl {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_DECL }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_CONSTRUCT_SIGNATURE_DECL
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7217,7 +8491,9 @@ impl AstNode for TsConstructSignatureDecl {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsConstructSignatureDecl {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7240,7 +8516,9 @@ impl std::fmt::Debug for TsConstructSignatureDecl {
 	}
 }
 impl AstNode for TsPropertySignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_PROPERTY_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7248,7 +8526,9 @@ impl AstNode for TsPropertySignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsPropertySignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7271,7 +8551,9 @@ impl std::fmt::Debug for TsPropertySignature {
 	}
 }
 impl AstNode for TsMethodSignature {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_METHOD_SIGNATURE
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7279,7 +8561,9 @@ impl AstNode for TsMethodSignature {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsMethodSignature {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7310,7 +8594,9 @@ impl std::fmt::Debug for TsMethodSignature {
 	}
 }
 impl AstNode for TsQualifiedPath {
-	fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_PATH }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		kind == TS_QUALIFIED_PATH
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		if Self::can_cast(syntax.kind()) {
 			Some(Self { syntax })
@@ -7318,7 +8604,9 @@ impl AstNode for TsQualifiedPath {
 			None
 		}
 	}
-	fn syntax(&self) -> &SyntaxNode { &self.syntax }
+	fn syntax(&self) -> &SyntaxNode {
+		&self.syntax
+	}
 }
 impl std::fmt::Debug for TsQualifiedPath {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -7330,10 +8618,14 @@ impl std::fmt::Debug for TsQualifiedPath {
 	}
 }
 impl From<JsBlockStatement> for JsAnyStatement {
-	fn from(node: JsBlockStatement) -> JsAnyStatement { JsAnyStatement::JsBlockStatement(node) }
+	fn from(node: JsBlockStatement) -> JsAnyStatement {
+		JsAnyStatement::JsBlockStatement(node)
+	}
 }
 impl From<JsEmptyStatement> for JsAnyStatement {
-	fn from(node: JsEmptyStatement) -> JsAnyStatement { JsAnyStatement::JsEmptyStatement(node) }
+	fn from(node: JsEmptyStatement) -> JsAnyStatement {
+		JsAnyStatement::JsEmptyStatement(node)
+	}
 }
 impl From<JsExpressionStatement> for JsAnyStatement {
 	fn from(node: JsExpressionStatement) -> JsAnyStatement {
@@ -7341,22 +8633,34 @@ impl From<JsExpressionStatement> for JsAnyStatement {
 	}
 }
 impl From<JsIfStatement> for JsAnyStatement {
-	fn from(node: JsIfStatement) -> JsAnyStatement { JsAnyStatement::JsIfStatement(node) }
+	fn from(node: JsIfStatement) -> JsAnyStatement {
+		JsAnyStatement::JsIfStatement(node)
+	}
 }
 impl From<JsDoWhileStatement> for JsAnyStatement {
-	fn from(node: JsDoWhileStatement) -> JsAnyStatement { JsAnyStatement::JsDoWhileStatement(node) }
+	fn from(node: JsDoWhileStatement) -> JsAnyStatement {
+		JsAnyStatement::JsDoWhileStatement(node)
+	}
 }
 impl From<JsWhileStatement> for JsAnyStatement {
-	fn from(node: JsWhileStatement) -> JsAnyStatement { JsAnyStatement::JsWhileStatement(node) }
+	fn from(node: JsWhileStatement) -> JsAnyStatement {
+		JsAnyStatement::JsWhileStatement(node)
+	}
 }
 impl From<ForStmt> for JsAnyStatement {
-	fn from(node: ForStmt) -> JsAnyStatement { JsAnyStatement::ForStmt(node) }
+	fn from(node: ForStmt) -> JsAnyStatement {
+		JsAnyStatement::ForStmt(node)
+	}
 }
 impl From<ForInStmt> for JsAnyStatement {
-	fn from(node: ForInStmt) -> JsAnyStatement { JsAnyStatement::ForInStmt(node) }
+	fn from(node: ForInStmt) -> JsAnyStatement {
+		JsAnyStatement::ForInStmt(node)
+	}
 }
 impl From<ForOfStmt> for JsAnyStatement {
-	fn from(node: ForOfStmt) -> JsAnyStatement { JsAnyStatement::ForOfStmt(node) }
+	fn from(node: ForOfStmt) -> JsAnyStatement {
+		JsAnyStatement::ForOfStmt(node)
+	}
 }
 impl From<JsContinueStatement> for JsAnyStatement {
 	fn from(node: JsContinueStatement) -> JsAnyStatement {
@@ -7364,25 +8668,39 @@ impl From<JsContinueStatement> for JsAnyStatement {
 	}
 }
 impl From<JsBreakStatement> for JsAnyStatement {
-	fn from(node: JsBreakStatement) -> JsAnyStatement { JsAnyStatement::JsBreakStatement(node) }
+	fn from(node: JsBreakStatement) -> JsAnyStatement {
+		JsAnyStatement::JsBreakStatement(node)
+	}
 }
 impl From<JsReturnStatement> for JsAnyStatement {
-	fn from(node: JsReturnStatement) -> JsAnyStatement { JsAnyStatement::JsReturnStatement(node) }
+	fn from(node: JsReturnStatement) -> JsAnyStatement {
+		JsAnyStatement::JsReturnStatement(node)
+	}
 }
 impl From<JsWithStatement> for JsAnyStatement {
-	fn from(node: JsWithStatement) -> JsAnyStatement { JsAnyStatement::JsWithStatement(node) }
+	fn from(node: JsWithStatement) -> JsAnyStatement {
+		JsAnyStatement::JsWithStatement(node)
+	}
 }
 impl From<JsLabeledStatement> for JsAnyStatement {
-	fn from(node: JsLabeledStatement) -> JsAnyStatement { JsAnyStatement::JsLabeledStatement(node) }
+	fn from(node: JsLabeledStatement) -> JsAnyStatement {
+		JsAnyStatement::JsLabeledStatement(node)
+	}
 }
 impl From<JsSwitchStatement> for JsAnyStatement {
-	fn from(node: JsSwitchStatement) -> JsAnyStatement { JsAnyStatement::JsSwitchStatement(node) }
+	fn from(node: JsSwitchStatement) -> JsAnyStatement {
+		JsAnyStatement::JsSwitchStatement(node)
+	}
 }
 impl From<JsThrowStatement> for JsAnyStatement {
-	fn from(node: JsThrowStatement) -> JsAnyStatement { JsAnyStatement::JsThrowStatement(node) }
+	fn from(node: JsThrowStatement) -> JsAnyStatement {
+		JsAnyStatement::JsThrowStatement(node)
+	}
 }
 impl From<JsTryStatement> for JsAnyStatement {
-	fn from(node: JsTryStatement) -> JsAnyStatement { JsAnyStatement::JsTryStatement(node) }
+	fn from(node: JsTryStatement) -> JsAnyStatement {
+		JsAnyStatement::JsTryStatement(node)
+	}
 }
 impl From<JsTryFinallyStatement> for JsAnyStatement {
 	fn from(node: JsTryFinallyStatement) -> JsAnyStatement {
@@ -7400,7 +8718,9 @@ impl From<JsFunctionDeclaration> for JsAnyStatement {
 	}
 }
 impl From<JsClassDeclaration> for JsAnyStatement {
-	fn from(node: JsClassDeclaration) -> JsAnyStatement { JsAnyStatement::JsClassDeclaration(node) }
+	fn from(node: JsClassDeclaration) -> JsAnyStatement {
+		JsAnyStatement::JsClassDeclaration(node)
+	}
 }
 impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	fn from(node: JsVariableDeclarationStatement) -> JsAnyStatement {
@@ -7408,43 +8728,69 @@ impl From<JsVariableDeclarationStatement> for JsAnyStatement {
 	}
 }
 impl From<TsEnum> for JsAnyStatement {
-	fn from(node: TsEnum) -> JsAnyStatement { JsAnyStatement::TsEnum(node) }
+	fn from(node: TsEnum) -> JsAnyStatement {
+		JsAnyStatement::TsEnum(node)
+	}
 }
 impl From<TsTypeAliasDecl> for JsAnyStatement {
-	fn from(node: TsTypeAliasDecl) -> JsAnyStatement { JsAnyStatement::TsTypeAliasDecl(node) }
+	fn from(node: TsTypeAliasDecl) -> JsAnyStatement {
+		JsAnyStatement::TsTypeAliasDecl(node)
+	}
 }
 impl From<TsNamespaceDecl> for JsAnyStatement {
-	fn from(node: TsNamespaceDecl) -> JsAnyStatement { JsAnyStatement::TsNamespaceDecl(node) }
+	fn from(node: TsNamespaceDecl) -> JsAnyStatement {
+		JsAnyStatement::TsNamespaceDecl(node)
+	}
 }
 impl From<TsModuleDecl> for JsAnyStatement {
-	fn from(node: TsModuleDecl) -> JsAnyStatement { JsAnyStatement::TsModuleDecl(node) }
+	fn from(node: TsModuleDecl) -> JsAnyStatement {
+		JsAnyStatement::TsModuleDecl(node)
+	}
 }
 impl From<TsInterfaceDecl> for JsAnyStatement {
-	fn from(node: TsInterfaceDecl) -> JsAnyStatement { JsAnyStatement::TsInterfaceDecl(node) }
+	fn from(node: TsInterfaceDecl) -> JsAnyStatement {
+		JsAnyStatement::TsInterfaceDecl(node)
+	}
 }
 impl From<ImportDecl> for JsAnyStatement {
-	fn from(node: ImportDecl) -> JsAnyStatement { JsAnyStatement::ImportDecl(node) }
+	fn from(node: ImportDecl) -> JsAnyStatement {
+		JsAnyStatement::ImportDecl(node)
+	}
 }
 impl From<ExportNamed> for JsAnyStatement {
-	fn from(node: ExportNamed) -> JsAnyStatement { JsAnyStatement::ExportNamed(node) }
+	fn from(node: ExportNamed) -> JsAnyStatement {
+		JsAnyStatement::ExportNamed(node)
+	}
 }
 impl From<ExportDefaultDecl> for JsAnyStatement {
-	fn from(node: ExportDefaultDecl) -> JsAnyStatement { JsAnyStatement::ExportDefaultDecl(node) }
+	fn from(node: ExportDefaultDecl) -> JsAnyStatement {
+		JsAnyStatement::ExportDefaultDecl(node)
+	}
 }
 impl From<ExportDefaultExpr> for JsAnyStatement {
-	fn from(node: ExportDefaultExpr) -> JsAnyStatement { JsAnyStatement::ExportDefaultExpr(node) }
+	fn from(node: ExportDefaultExpr) -> JsAnyStatement {
+		JsAnyStatement::ExportDefaultExpr(node)
+	}
 }
 impl From<ExportWildcard> for JsAnyStatement {
-	fn from(node: ExportWildcard) -> JsAnyStatement { JsAnyStatement::ExportWildcard(node) }
+	fn from(node: ExportWildcard) -> JsAnyStatement {
+		JsAnyStatement::ExportWildcard(node)
+	}
 }
 impl From<ExportDecl> for JsAnyStatement {
-	fn from(node: ExportDecl) -> JsAnyStatement { JsAnyStatement::ExportDecl(node) }
+	fn from(node: ExportDecl) -> JsAnyStatement {
+		JsAnyStatement::ExportDecl(node)
+	}
 }
 impl From<TsImportEqualsDecl> for JsAnyStatement {
-	fn from(node: TsImportEqualsDecl) -> JsAnyStatement { JsAnyStatement::TsImportEqualsDecl(node) }
+	fn from(node: TsImportEqualsDecl) -> JsAnyStatement {
+		JsAnyStatement::TsImportEqualsDecl(node)
+	}
 }
 impl From<TsExportAssignment> for JsAnyStatement {
-	fn from(node: TsExportAssignment) -> JsAnyStatement { JsAnyStatement::TsExportAssignment(node) }
+	fn from(node: TsExportAssignment) -> JsAnyStatement {
+		JsAnyStatement::TsExportAssignment(node)
+	}
 }
 impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	fn from(node: TsNamespaceExportDecl) -> JsAnyStatement {
@@ -7452,7 +8798,9 @@ impl From<TsNamespaceExportDecl> for JsAnyStatement {
 	}
 }
 impl From<JsUnknownStatement> for JsAnyStatement {
-	fn from(node: JsUnknownStatement) -> JsAnyStatement { JsAnyStatement::JsUnknownStatement(node) }
+	fn from(node: JsUnknownStatement) -> JsAnyStatement {
+		JsAnyStatement::JsUnknownStatement(node)
+	}
 }
 impl AstNode for JsAnyStatement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -7648,7 +8996,9 @@ impl std::fmt::Debug for JsAnyStatement {
 	}
 }
 impl From<JsArrayExpression> for JsAnyExpression {
-	fn from(node: JsArrayExpression) -> JsAnyExpression { JsAnyExpression::JsArrayExpression(node) }
+	fn from(node: JsArrayExpression) -> JsAnyExpression {
+		JsAnyExpression::JsArrayExpression(node)
+	}
 }
 impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	fn from(node: JsArrowFunctionExpression) -> JsAnyExpression {
@@ -7656,7 +9006,9 @@ impl From<JsArrowFunctionExpression> for JsAnyExpression {
 	}
 }
 impl From<JsAwaitExpression> for JsAnyExpression {
-	fn from(node: JsAwaitExpression) -> JsAnyExpression { JsAnyExpression::JsAwaitExpression(node) }
+	fn from(node: JsAwaitExpression) -> JsAnyExpression {
+		JsAnyExpression::JsAwaitExpression(node)
+	}
 }
 impl From<JsBinaryExpression> for JsAnyExpression {
 	fn from(node: JsBinaryExpression) -> JsAnyExpression {
@@ -7664,7 +9016,9 @@ impl From<JsBinaryExpression> for JsAnyExpression {
 	}
 }
 impl From<JsClassExpression> for JsAnyExpression {
-	fn from(node: JsClassExpression) -> JsAnyExpression { JsAnyExpression::JsClassExpression(node) }
+	fn from(node: JsClassExpression) -> JsAnyExpression {
+		JsAnyExpression::JsClassExpression(node)
+	}
 }
 impl From<JsConditionalExpression> for JsAnyExpression {
 	fn from(node: JsConditionalExpression) -> JsAnyExpression {
@@ -7717,13 +9071,19 @@ impl From<JsStaticMemberExpression> for JsAnyExpression {
 	}
 }
 impl From<JsSuperExpression> for JsAnyExpression {
-	fn from(node: JsSuperExpression) -> JsAnyExpression { JsAnyExpression::JsSuperExpression(node) }
+	fn from(node: JsSuperExpression) -> JsAnyExpression {
+		JsAnyExpression::JsSuperExpression(node)
+	}
 }
 impl From<JsThisExpression> for JsAnyExpression {
-	fn from(node: JsThisExpression) -> JsAnyExpression { JsAnyExpression::JsThisExpression(node) }
+	fn from(node: JsThisExpression) -> JsAnyExpression {
+		JsAnyExpression::JsThisExpression(node)
+	}
 }
 impl From<JsUnaryExpression> for JsAnyExpression {
-	fn from(node: JsUnaryExpression) -> JsAnyExpression { JsAnyExpression::JsUnaryExpression(node) }
+	fn from(node: JsUnaryExpression) -> JsAnyExpression {
+		JsAnyExpression::JsUnaryExpression(node)
+	}
 }
 impl From<JsPreUpdateExpression> for JsAnyExpression {
 	fn from(node: JsPreUpdateExpression) -> JsAnyExpression {
@@ -7736,34 +9096,54 @@ impl From<JsPostUpdateExpression> for JsAnyExpression {
 	}
 }
 impl From<JsYieldExpression> for JsAnyExpression {
-	fn from(node: JsYieldExpression) -> JsAnyExpression { JsAnyExpression::JsYieldExpression(node) }
+	fn from(node: JsYieldExpression) -> JsAnyExpression {
+		JsAnyExpression::JsYieldExpression(node)
+	}
 }
 impl From<Template> for JsAnyExpression {
-	fn from(node: Template) -> JsAnyExpression { JsAnyExpression::Template(node) }
+	fn from(node: Template) -> JsAnyExpression {
+		JsAnyExpression::Template(node)
+	}
 }
 impl From<NewExpr> for JsAnyExpression {
-	fn from(node: NewExpr) -> JsAnyExpression { JsAnyExpression::NewExpr(node) }
+	fn from(node: NewExpr) -> JsAnyExpression {
+		JsAnyExpression::NewExpr(node)
+	}
 }
 impl From<CallExpr> for JsAnyExpression {
-	fn from(node: CallExpr) -> JsAnyExpression { JsAnyExpression::CallExpr(node) }
+	fn from(node: CallExpr) -> JsAnyExpression {
+		JsAnyExpression::CallExpr(node)
+	}
 }
 impl From<AssignExpr> for JsAnyExpression {
-	fn from(node: AssignExpr) -> JsAnyExpression { JsAnyExpression::AssignExpr(node) }
+	fn from(node: AssignExpr) -> JsAnyExpression {
+		JsAnyExpression::AssignExpr(node)
+	}
 }
 impl From<NewTarget> for JsAnyExpression {
-	fn from(node: NewTarget) -> JsAnyExpression { JsAnyExpression::NewTarget(node) }
+	fn from(node: NewTarget) -> JsAnyExpression {
+		JsAnyExpression::NewTarget(node)
+	}
 }
 impl From<ImportMeta> for JsAnyExpression {
-	fn from(node: ImportMeta) -> JsAnyExpression { JsAnyExpression::ImportMeta(node) }
+	fn from(node: ImportMeta) -> JsAnyExpression {
+		JsAnyExpression::ImportMeta(node)
+	}
 }
 impl From<TsNonNull> for JsAnyExpression {
-	fn from(node: TsNonNull) -> JsAnyExpression { JsAnyExpression::TsNonNull(node) }
+	fn from(node: TsNonNull) -> JsAnyExpression {
+		JsAnyExpression::TsNonNull(node)
+	}
 }
 impl From<TsAssertion> for JsAnyExpression {
-	fn from(node: TsAssertion) -> JsAnyExpression { JsAnyExpression::TsAssertion(node) }
+	fn from(node: TsAssertion) -> JsAnyExpression {
+		JsAnyExpression::TsAssertion(node)
+	}
 }
 impl From<TsConstAssertion> for JsAnyExpression {
-	fn from(node: TsConstAssertion) -> JsAnyExpression { JsAnyExpression::TsConstAssertion(node) }
+	fn from(node: TsConstAssertion) -> JsAnyExpression {
+		JsAnyExpression::TsConstAssertion(node)
+	}
 }
 impl From<JsUnknownExpression> for JsAnyExpression {
 	fn from(node: JsUnknownExpression) -> JsAnyExpression {
@@ -7960,7 +9340,9 @@ impl std::fmt::Debug for JsAnyExpression {
 	}
 }
 impl From<JsVariableDeclaration> for ForHead {
-	fn from(node: JsVariableDeclaration) -> ForHead { ForHead::JsVariableDeclaration(node) }
+	fn from(node: JsVariableDeclaration) -> ForHead {
+		ForHead::JsVariableDeclaration(node)
+	}
 }
 impl AstNode for ForHead {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8000,13 +9382,19 @@ impl std::fmt::Debug for ForHead {
 	}
 }
 impl From<JsCaseClause> for JsAnySwitchClause {
-	fn from(node: JsCaseClause) -> JsAnySwitchClause { JsAnySwitchClause::JsCaseClause(node) }
+	fn from(node: JsCaseClause) -> JsAnySwitchClause {
+		JsAnySwitchClause::JsCaseClause(node)
+	}
 }
 impl From<JsDefaultClause> for JsAnySwitchClause {
-	fn from(node: JsDefaultClause) -> JsAnySwitchClause { JsAnySwitchClause::JsDefaultClause(node) }
+	fn from(node: JsDefaultClause) -> JsAnySwitchClause {
+		JsAnySwitchClause::JsDefaultClause(node)
+	}
 }
 impl AstNode for JsAnySwitchClause {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			JS_CASE_CLAUSE => JsAnySwitchClause::JsCaseClause(JsCaseClause { syntax }),
@@ -8031,25 +9419,39 @@ impl std::fmt::Debug for JsAnySwitchClause {
 	}
 }
 impl From<SinglePattern> for Pattern {
-	fn from(node: SinglePattern) -> Pattern { Pattern::SinglePattern(node) }
+	fn from(node: SinglePattern) -> Pattern {
+		Pattern::SinglePattern(node)
+	}
 }
 impl From<RestPattern> for Pattern {
-	fn from(node: RestPattern) -> Pattern { Pattern::RestPattern(node) }
+	fn from(node: RestPattern) -> Pattern {
+		Pattern::RestPattern(node)
+	}
 }
 impl From<AssignPattern> for Pattern {
-	fn from(node: AssignPattern) -> Pattern { Pattern::AssignPattern(node) }
+	fn from(node: AssignPattern) -> Pattern {
+		Pattern::AssignPattern(node)
+	}
 }
 impl From<ObjectPattern> for Pattern {
-	fn from(node: ObjectPattern) -> Pattern { Pattern::ObjectPattern(node) }
+	fn from(node: ObjectPattern) -> Pattern {
+		Pattern::ObjectPattern(node)
+	}
 }
 impl From<ArrayPattern> for Pattern {
-	fn from(node: ArrayPattern) -> Pattern { Pattern::ArrayPattern(node) }
+	fn from(node: ArrayPattern) -> Pattern {
+		Pattern::ArrayPattern(node)
+	}
 }
 impl From<ExprPattern> for Pattern {
-	fn from(node: ExprPattern) -> Pattern { Pattern::ExprPattern(node) }
+	fn from(node: ExprPattern) -> Pattern {
+		Pattern::ExprPattern(node)
+	}
 }
 impl From<JsUnknownPattern> for Pattern {
-	fn from(node: JsUnknownPattern) -> Pattern { Pattern::JsUnknownPattern(node) }
+	fn from(node: JsUnknownPattern) -> Pattern {
+		Pattern::JsUnknownPattern(node)
+	}
 }
 impl AstNode for Pattern {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8280,10 +9682,14 @@ impl std::fmt::Debug for JsAnyArrowFunctionBody {
 	}
 }
 impl From<SpreadElement> for JsAnyArrayElement {
-	fn from(node: SpreadElement) -> JsAnyArrayElement { JsAnyArrayElement::SpreadElement(node) }
+	fn from(node: SpreadElement) -> JsAnyArrayElement {
+		JsAnyArrayElement::SpreadElement(node)
+	}
 }
 impl From<JsArrayHole> for JsAnyArrayElement {
-	fn from(node: JsArrayHole) -> JsAnyArrayElement { JsAnyArrayElement::JsArrayHole(node) }
+	fn from(node: JsArrayHole) -> JsAnyArrayElement {
+		JsAnyArrayElement::JsArrayHole(node)
+	}
 }
 impl AstNode for JsAnyArrayElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8463,7 +9869,9 @@ impl From<JsSetterObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<InitializedProp> for JsAnyObjectMember {
-	fn from(node: InitializedProp) -> JsAnyObjectMember { JsAnyObjectMember::InitializedProp(node) }
+	fn from(node: InitializedProp) -> JsAnyObjectMember {
+		JsAnyObjectMember::InitializedProp(node)
+	}
 }
 impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	fn from(node: JsShorthandPropertyObjectMember) -> JsAnyObjectMember {
@@ -8471,10 +9879,14 @@ impl From<JsShorthandPropertyObjectMember> for JsAnyObjectMember {
 	}
 }
 impl From<JsSpread> for JsAnyObjectMember {
-	fn from(node: JsSpread) -> JsAnyObjectMember { JsAnyObjectMember::JsSpread(node) }
+	fn from(node: JsSpread) -> JsAnyObjectMember {
+		JsAnyObjectMember::JsSpread(node)
+	}
 }
 impl From<JsUnknownMember> for JsAnyObjectMember {
-	fn from(node: JsUnknownMember) -> JsAnyObjectMember { JsAnyObjectMember::JsUnknownMember(node) }
+	fn from(node: JsUnknownMember) -> JsAnyObjectMember {
+		JsAnyObjectMember::JsUnknownMember(node)
+	}
 }
 impl AstNode for JsAnyObjectMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8543,7 +9955,9 @@ impl std::fmt::Debug for JsAnyObjectMember {
 	}
 }
 impl From<JsComputedMemberName> for PropName {
-	fn from(node: JsComputedMemberName) -> PropName { PropName::JsComputedMemberName(node) }
+	fn from(node: JsComputedMemberName) -> PropName {
+		PropName::JsComputedMemberName(node)
+	}
 }
 impl From<JsStringLiteralExpression> for PropName {
 	fn from(node: JsStringLiteralExpression) -> PropName {
@@ -8556,13 +9970,19 @@ impl From<JsNumberLiteralExpression> for PropName {
 	}
 }
 impl From<Ident> for PropName {
-	fn from(node: Ident) -> PropName { PropName::Ident(node) }
+	fn from(node: Ident) -> PropName {
+		PropName::Ident(node)
+	}
 }
 impl From<Name> for PropName {
-	fn from(node: Name) -> PropName { PropName::Name(node) }
+	fn from(node: Name) -> PropName {
+		PropName::Name(node)
+	}
 }
 impl From<JsUnknownBinding> for PropName {
-	fn from(node: JsUnknownBinding) -> PropName { PropName::JsUnknownBinding(node) }
+	fn from(node: JsUnknownBinding) -> PropName {
+		PropName::JsUnknownBinding(node)
+	}
 }
 impl AstNode for PropName {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8646,10 +10066,14 @@ impl From<JsEmptyClassMember> for JsAnyClassMember {
 	}
 }
 impl From<TsIndexSignature> for JsAnyClassMember {
-	fn from(node: TsIndexSignature) -> JsAnyClassMember { JsAnyClassMember::TsIndexSignature(node) }
+	fn from(node: TsIndexSignature) -> JsAnyClassMember {
+		JsAnyClassMember::TsIndexSignature(node)
+	}
 }
 impl From<JsUnknownMember> for JsAnyClassMember {
-	fn from(node: JsUnknownMember) -> JsAnyClassMember { JsAnyClassMember::JsUnknownMember(node) }
+	fn from(node: JsUnknownMember) -> JsAnyClassMember {
+		JsAnyClassMember::JsUnknownMember(node)
+	}
 }
 impl AstNode for JsAnyClassMember {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -8815,16 +10239,24 @@ impl std::fmt::Debug for JsAnyConstructorParameter {
 	}
 }
 impl From<AssignPattern> for ObjectPatternProp {
-	fn from(node: AssignPattern) -> ObjectPatternProp { ObjectPatternProp::AssignPattern(node) }
+	fn from(node: AssignPattern) -> ObjectPatternProp {
+		ObjectPatternProp::AssignPattern(node)
+	}
 }
 impl From<KeyValuePattern> for ObjectPatternProp {
-	fn from(node: KeyValuePattern) -> ObjectPatternProp { ObjectPatternProp::KeyValuePattern(node) }
+	fn from(node: KeyValuePattern) -> ObjectPatternProp {
+		ObjectPatternProp::KeyValuePattern(node)
+	}
 }
 impl From<RestPattern> for ObjectPatternProp {
-	fn from(node: RestPattern) -> ObjectPatternProp { ObjectPatternProp::RestPattern(node) }
+	fn from(node: RestPattern) -> ObjectPatternProp {
+		ObjectPatternProp::RestPattern(node)
+	}
 }
 impl From<SinglePattern> for ObjectPatternProp {
-	fn from(node: SinglePattern) -> ObjectPatternProp { ObjectPatternProp::SinglePattern(node) }
+	fn from(node: SinglePattern) -> ObjectPatternProp {
+		ObjectPatternProp::SinglePattern(node)
+	}
 }
 impl From<JsUnknownPattern> for ObjectPatternProp {
 	fn from(node: JsUnknownPattern) -> ObjectPatternProp {
@@ -8871,97 +10303,159 @@ impl std::fmt::Debug for ObjectPatternProp {
 	}
 }
 impl From<TsAny> for TsType {
-	fn from(node: TsAny) -> TsType { TsType::TsAny(node) }
+	fn from(node: TsAny) -> TsType {
+		TsType::TsAny(node)
+	}
 }
 impl From<TsUnknown> for TsType {
-	fn from(node: TsUnknown) -> TsType { TsType::TsUnknown(node) }
+	fn from(node: TsUnknown) -> TsType {
+		TsType::TsUnknown(node)
+	}
 }
 impl From<TsNumber> for TsType {
-	fn from(node: TsNumber) -> TsType { TsType::TsNumber(node) }
+	fn from(node: TsNumber) -> TsType {
+		TsType::TsNumber(node)
+	}
 }
 impl From<TsObject> for TsType {
-	fn from(node: TsObject) -> TsType { TsType::TsObject(node) }
+	fn from(node: TsObject) -> TsType {
+		TsType::TsObject(node)
+	}
 }
 impl From<TsBoolean> for TsType {
-	fn from(node: TsBoolean) -> TsType { TsType::TsBoolean(node) }
+	fn from(node: TsBoolean) -> TsType {
+		TsType::TsBoolean(node)
+	}
 }
 impl From<TsBigint> for TsType {
-	fn from(node: TsBigint) -> TsType { TsType::TsBigint(node) }
+	fn from(node: TsBigint) -> TsType {
+		TsType::TsBigint(node)
+	}
 }
 impl From<TsString> for TsType {
-	fn from(node: TsString) -> TsType { TsType::TsString(node) }
+	fn from(node: TsString) -> TsType {
+		TsType::TsString(node)
+	}
 }
 impl From<TsSymbol> for TsType {
-	fn from(node: TsSymbol) -> TsType { TsType::TsSymbol(node) }
+	fn from(node: TsSymbol) -> TsType {
+		TsType::TsSymbol(node)
+	}
 }
 impl From<TsVoid> for TsType {
-	fn from(node: TsVoid) -> TsType { TsType::TsVoid(node) }
+	fn from(node: TsVoid) -> TsType {
+		TsType::TsVoid(node)
+	}
 }
 impl From<TsUndefined> for TsType {
-	fn from(node: TsUndefined) -> TsType { TsType::TsUndefined(node) }
+	fn from(node: TsUndefined) -> TsType {
+		TsType::TsUndefined(node)
+	}
 }
 impl From<TsNull> for TsType {
-	fn from(node: TsNull) -> TsType { TsType::TsNull(node) }
+	fn from(node: TsNull) -> TsType {
+		TsType::TsNull(node)
+	}
 }
 impl From<TsNever> for TsType {
-	fn from(node: TsNever) -> TsType { TsType::TsNever(node) }
+	fn from(node: TsNever) -> TsType {
+		TsType::TsNever(node)
+	}
 }
 impl From<TsThis> for TsType {
-	fn from(node: TsThis) -> TsType { TsType::TsThis(node) }
+	fn from(node: TsThis) -> TsType {
+		TsType::TsThis(node)
+	}
 }
 impl From<TsLiteral> for TsType {
-	fn from(node: TsLiteral) -> TsType { TsType::TsLiteral(node) }
+	fn from(node: TsLiteral) -> TsType {
+		TsType::TsLiteral(node)
+	}
 }
 impl From<TsPredicate> for TsType {
-	fn from(node: TsPredicate) -> TsType { TsType::TsPredicate(node) }
+	fn from(node: TsPredicate) -> TsType {
+		TsType::TsPredicate(node)
+	}
 }
 impl From<TsTuple> for TsType {
-	fn from(node: TsTuple) -> TsType { TsType::TsTuple(node) }
+	fn from(node: TsTuple) -> TsType {
+		TsType::TsTuple(node)
+	}
 }
 impl From<TsParen> for TsType {
-	fn from(node: TsParen) -> TsType { TsType::TsParen(node) }
+	fn from(node: TsParen) -> TsType {
+		TsType::TsParen(node)
+	}
 }
 impl From<TsTypeRef> for TsType {
-	fn from(node: TsTypeRef) -> TsType { TsType::TsTypeRef(node) }
+	fn from(node: TsTypeRef) -> TsType {
+		TsType::TsTypeRef(node)
+	}
 }
 impl From<TsTemplate> for TsType {
-	fn from(node: TsTemplate) -> TsType { TsType::TsTemplate(node) }
+	fn from(node: TsTemplate) -> TsType {
+		TsType::TsTemplate(node)
+	}
 }
 impl From<TsMappedType> for TsType {
-	fn from(node: TsMappedType) -> TsType { TsType::TsMappedType(node) }
+	fn from(node: TsMappedType) -> TsType {
+		TsType::TsMappedType(node)
+	}
 }
 impl From<TsImport> for TsType {
-	fn from(node: TsImport) -> TsType { TsType::TsImport(node) }
+	fn from(node: TsImport) -> TsType {
+		TsType::TsImport(node)
+	}
 }
 impl From<TsArray> for TsType {
-	fn from(node: TsArray) -> TsType { TsType::TsArray(node) }
+	fn from(node: TsArray) -> TsType {
+		TsType::TsArray(node)
+	}
 }
 impl From<TsIndexedArray> for TsType {
-	fn from(node: TsIndexedArray) -> TsType { TsType::TsIndexedArray(node) }
+	fn from(node: TsIndexedArray) -> TsType {
+		TsType::TsIndexedArray(node)
+	}
 }
 impl From<TsTypeOperator> for TsType {
-	fn from(node: TsTypeOperator) -> TsType { TsType::TsTypeOperator(node) }
+	fn from(node: TsTypeOperator) -> TsType {
+		TsType::TsTypeOperator(node)
+	}
 }
 impl From<TsIntersection> for TsType {
-	fn from(node: TsIntersection) -> TsType { TsType::TsIntersection(node) }
+	fn from(node: TsIntersection) -> TsType {
+		TsType::TsIntersection(node)
+	}
 }
 impl From<TsUnion> for TsType {
-	fn from(node: TsUnion) -> TsType { TsType::TsUnion(node) }
+	fn from(node: TsUnion) -> TsType {
+		TsType::TsUnion(node)
+	}
 }
 impl From<TsFnType> for TsType {
-	fn from(node: TsFnType) -> TsType { TsType::TsFnType(node) }
+	fn from(node: TsFnType) -> TsType {
+		TsType::TsFnType(node)
+	}
 }
 impl From<TsConstructorType> for TsType {
-	fn from(node: TsConstructorType) -> TsType { TsType::TsConstructorType(node) }
+	fn from(node: TsConstructorType) -> TsType {
+		TsType::TsConstructorType(node)
+	}
 }
 impl From<TsConditionalType> for TsType {
-	fn from(node: TsConditionalType) -> TsType { TsType::TsConditionalType(node) }
+	fn from(node: TsConditionalType) -> TsType {
+		TsType::TsConditionalType(node)
+	}
 }
 impl From<TsObjectType> for TsType {
-	fn from(node: TsObjectType) -> TsType { TsType::TsObjectType(node) }
+	fn from(node: TsObjectType) -> TsType {
+		TsType::TsObjectType(node)
+	}
 }
 impl From<TsInfer> for TsType {
-	fn from(node: TsInfer) -> TsType { TsType::TsInfer(node) }
+	fn from(node: TsInfer) -> TsType {
+		TsType::TsInfer(node)
+	}
 }
 impl AstNode for TsType {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9098,13 +10592,19 @@ impl std::fmt::Debug for TsType {
 	}
 }
 impl From<WildcardImport> for ImportClause {
-	fn from(node: WildcardImport) -> ImportClause { ImportClause::WildcardImport(node) }
+	fn from(node: WildcardImport) -> ImportClause {
+		ImportClause::WildcardImport(node)
+	}
 }
 impl From<NamedImports> for ImportClause {
-	fn from(node: NamedImports) -> ImportClause { ImportClause::NamedImports(node) }
+	fn from(node: NamedImports) -> ImportClause {
+		ImportClause::NamedImports(node)
+	}
 }
 impl From<Name> for ImportClause {
-	fn from(node: Name) -> ImportClause { ImportClause::Name(node) }
+	fn from(node: Name) -> ImportClause {
+		ImportClause::Name(node)
+	}
 }
 impl From<ImportStringSpecifier> for ImportClause {
 	fn from(node: ImportStringSpecifier) -> ImportClause {
@@ -9150,10 +10650,14 @@ impl std::fmt::Debug for ImportClause {
 	}
 }
 impl From<JsFunctionDeclaration> for DefaultDecl {
-	fn from(node: JsFunctionDeclaration) -> DefaultDecl { DefaultDecl::JsFunctionDeclaration(node) }
+	fn from(node: JsFunctionDeclaration) -> DefaultDecl {
+		DefaultDecl::JsFunctionDeclaration(node)
+	}
 }
 impl From<JsClassDeclaration> for DefaultDecl {
-	fn from(node: JsClassDeclaration) -> DefaultDecl { DefaultDecl::JsClassDeclaration(node) }
+	fn from(node: JsClassDeclaration) -> DefaultDecl {
+		DefaultDecl::JsClassDeclaration(node)
+	}
 }
 impl AstNode for DefaultDecl {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9200,7 +10704,9 @@ impl From<JsVariableDeclarationStatement> for JsAnyExportDeclaration {
 	}
 }
 impl From<TsEnum> for JsAnyExportDeclaration {
-	fn from(node: TsEnum) -> JsAnyExportDeclaration { JsAnyExportDeclaration::TsEnum(node) }
+	fn from(node: TsEnum) -> JsAnyExportDeclaration {
+		JsAnyExportDeclaration::TsEnum(node)
+	}
 }
 impl From<TsTypeAliasDecl> for JsAnyExportDeclaration {
 	fn from(node: TsTypeAliasDecl) -> JsAnyExportDeclaration {
@@ -9292,7 +10798,9 @@ impl std::fmt::Debug for JsAnyExportDeclaration {
 	}
 }
 impl From<JsRestParameter> for JsAnyParameter {
-	fn from(node: JsRestParameter) -> JsAnyParameter { JsAnyParameter::JsRestParameter(node) }
+	fn from(node: JsRestParameter) -> JsAnyParameter {
+		JsAnyParameter::JsRestParameter(node)
+	}
 }
 impl AstNode for JsAnyParameter {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9330,7 +10838,9 @@ impl std::fmt::Debug for JsAnyParameter {
 	}
 }
 impl From<TsExternalModuleRef> for TsModuleRef {
-	fn from(node: TsExternalModuleRef) -> TsModuleRef { TsModuleRef::TsExternalModuleRef(node) }
+	fn from(node: TsExternalModuleRef) -> TsModuleRef {
+		TsModuleRef::TsExternalModuleRef(node)
+	}
 }
 impl AstNode for TsModuleRef {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9370,13 +10880,19 @@ impl std::fmt::Debug for TsModuleRef {
 	}
 }
 impl From<TsTypeName> for TsEntityName {
-	fn from(node: TsTypeName) -> TsEntityName { TsEntityName::TsTypeName(node) }
+	fn from(node: TsTypeName) -> TsEntityName {
+		TsEntityName::TsTypeName(node)
+	}
 }
 impl From<TsQualifiedPath> for TsEntityName {
-	fn from(node: TsQualifiedPath) -> TsEntityName { TsEntityName::TsQualifiedPath(node) }
+	fn from(node: TsQualifiedPath) -> TsEntityName {
+		TsEntityName::TsQualifiedPath(node)
+	}
 }
 impl AstNode for TsEntityName {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_TYPE_NAME | TS_QUALIFIED_PATH)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_TYPE_NAME => TsEntityName::TsTypeName(TsTypeName { syntax }),
@@ -9401,13 +10917,19 @@ impl std::fmt::Debug for TsEntityName {
 	}
 }
 impl From<TsThis> for TsThisOrMore {
-	fn from(node: TsThis) -> TsThisOrMore { TsThisOrMore::TsThis(node) }
+	fn from(node: TsThis) -> TsThisOrMore {
+		TsThisOrMore::TsThis(node)
+	}
 }
 impl From<TsTypeName> for TsThisOrMore {
-	fn from(node: TsTypeName) -> TsThisOrMore { TsThisOrMore::TsTypeName(node) }
+	fn from(node: TsTypeName) -> TsThisOrMore {
+		TsThisOrMore::TsTypeName(node)
+	}
 }
 impl AstNode for TsThisOrMore {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_THIS | TS_TYPE_NAME) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_THIS | TS_TYPE_NAME)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_THIS => TsThisOrMore::TsThis(TsThis { syntax }),
@@ -9432,7 +10954,9 @@ impl std::fmt::Debug for TsThisOrMore {
 	}
 }
 impl From<TsCallSignatureDecl> for TsTypeElement {
-	fn from(node: TsCallSignatureDecl) -> TsTypeElement { TsTypeElement::TsCallSignatureDecl(node) }
+	fn from(node: TsCallSignatureDecl) -> TsTypeElement {
+		TsTypeElement::TsCallSignatureDecl(node)
+	}
 }
 impl From<TsConstructSignatureDecl> for TsTypeElement {
 	fn from(node: TsConstructSignatureDecl) -> TsTypeElement {
@@ -9440,13 +10964,19 @@ impl From<TsConstructSignatureDecl> for TsTypeElement {
 	}
 }
 impl From<TsPropertySignature> for TsTypeElement {
-	fn from(node: TsPropertySignature) -> TsTypeElement { TsTypeElement::TsPropertySignature(node) }
+	fn from(node: TsPropertySignature) -> TsTypeElement {
+		TsTypeElement::TsPropertySignature(node)
+	}
 }
 impl From<TsMethodSignature> for TsTypeElement {
-	fn from(node: TsMethodSignature) -> TsTypeElement { TsTypeElement::TsMethodSignature(node) }
+	fn from(node: TsMethodSignature) -> TsTypeElement {
+		TsTypeElement::TsMethodSignature(node)
+	}
 }
 impl From<TsIndexSignature> for TsTypeElement {
-	fn from(node: TsIndexSignature) -> TsTypeElement { TsTypeElement::TsIndexSignature(node) }
+	fn from(node: TsIndexSignature) -> TsTypeElement {
+		TsTypeElement::TsIndexSignature(node)
+	}
 }
 impl AstNode for TsTypeElement {
 	fn can_cast(kind: SyntaxKind) -> bool {
@@ -9498,13 +11028,19 @@ impl std::fmt::Debug for TsTypeElement {
 	}
 }
 impl From<TsModuleBlock> for TsNamespaceBody {
-	fn from(node: TsModuleBlock) -> TsNamespaceBody { TsNamespaceBody::TsModuleBlock(node) }
+	fn from(node: TsModuleBlock) -> TsNamespaceBody {
+		TsNamespaceBody::TsModuleBlock(node)
+	}
 }
 impl From<TsNamespaceDecl> for TsNamespaceBody {
-	fn from(node: TsNamespaceDecl) -> TsNamespaceBody { TsNamespaceBody::TsNamespaceDecl(node) }
+	fn from(node: TsNamespaceDecl) -> TsNamespaceBody {
+		TsNamespaceBody::TsNamespaceDecl(node)
+	}
 }
 impl AstNode for TsNamespaceBody {
-	fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL) }
+	fn can_cast(kind: SyntaxKind) -> bool {
+		matches!(kind, TS_MODULE_BLOCK | TS_NAMESPACE_DECL)
+	}
 	fn cast(syntax: SyntaxNode) -> Option<Self> {
 		let res = match syntax.kind() {
 			TS_MODULE_BLOCK => TsNamespaceBody::TsModuleBlock(TsModuleBlock { syntax }),

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -176,20 +176,20 @@ pub(super) fn parse_parameters_list(
 				m.complete(p, ERROR);
 			}
 
+			m.complete(p, JS_REST_PARAMETER);
+
 			// FIXME: this should be handled better, we should keep trying to parse params but issue an error for each one
 			// which would allow for better recovery from `foo, ...bar, foo`
 			if p.at(T![,]) {
 				let m = p.start();
 				let range = p.cur_tok().range;
 				p.bump_any();
-				m.complete(p, JS_UNKNOWN_PATTERN);
+				m.complete(p, ERROR);
 				let err = p
 					.err_builder("rest elements may not have trailing commas")
 					.primary(range, "");
 
 				p.error(err);
-			} else {
-				m.complete(p, JS_REST_PARAMETER);
 			}
 		} else {
 			// test_err formal_params_no_binding_element

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -127,11 +127,12 @@ pub(super) fn parse_parameters_list(
 	while !p.at(EOF) && !p.at(T![')']) {
 		if first {
 			first = false;
-		} else if p.nth_at(1, T![')']) {
-			p.eat(T![,]);
-			break;
 		} else {
 			p.expect_required(T![,]);
+		}
+
+		if p.at(T![')']) {
+			break;
 		}
 
 		if p.at(T![...]) {
@@ -148,7 +149,7 @@ pub(super) fn parse_parameters_list(
 				p.error(err);
 				let m = p.start();
 				p.bump_any();
-				m.complete(p, ERROR);
+				m.complete(p, JS_UNKNOWN_PATTERN);
 			}
 
 			// type annotation `...foo: number[]`
@@ -174,7 +175,6 @@ pub(super) fn parse_parameters_list(
 				p.error(err);
 				m.complete(p, ERROR);
 			}
-			let complete = m.complete(p, JS_REST_PARAMETER);
 
 			// FIXME: this should be handled better, we should keep trying to parse params but issue an error for each one
 			// which would allow for better recovery from `foo, ...bar, foo`
@@ -182,14 +182,15 @@ pub(super) fn parse_parameters_list(
 				let m = p.start();
 				let range = p.cur_tok().range;
 				p.bump_any();
-				m.complete(p, ERROR);
+				m.complete(p, JS_UNKNOWN_PATTERN);
 				let err = p
 					.err_builder("rest elements may not have trailing commas")
 					.primary(range, "");
 
 				p.error(err);
+			} else {
+				m.complete(p, JS_REST_PARAMETER);
 			}
-			Some(complete)
 		} else {
 			// test_err formal_params_no_binding_element
 			// function foo(true) {}
@@ -225,11 +226,8 @@ pub(super) fn parse_parameters_list(
 
 					p.error(err);
 				}
-				Some(recovered_result)
-			} else {
-				None
 			}
-		};
+		}
 	}
 
 	parameters_list.complete(p, LIST);

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -23,6 +23,10 @@ const STARTS_MEMBER_NAME: TokenSet = token_set![
 // test object_expr
 // let a = {};
 // let b = {foo,}
+//
+// test_err object_expr_err
+// let a = {, foo}
+// let b = { foo bar }
 pub(super) fn object_expr(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
 	p.expect_required(T!['{']);
@@ -33,11 +37,17 @@ pub(super) fn object_expr(p: &mut Parser) -> CompletedMarker {
 		if first {
 			first = false;
 		} else {
-			p.expect(T![,]);
+			p.expect_required(T![,]);
 
 			if p.at(T!['}']) {
 				break;
 			}
+		}
+
+		// missing member
+		if p.at(T![,]) {
+			p.missing();
+			continue;
 		}
 
 		let recovered_member = object_member(p).or_recover(

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -1129,6 +1129,8 @@ pub fn parse_switch_statement(p: &mut Parser) -> ParsedSyntax {
 			temp.missing(); // discriminant
 			temp.missing(); // colon
 
+			let statements = temp.start();
+
 			let recovered_element = clause.or_recover(
 				&mut *temp,
 				ParseRecovery::new(
@@ -1140,9 +1142,11 @@ pub fn parse_switch_statement(p: &mut Parser) -> ParsedSyntax {
 			);
 
 			if recovered_element.is_err() {
+				statements.abandon(&mut *temp);
 				m.abandon(&mut *temp);
 				break;
 			} else {
+				statements.complete(&mut *temp, LIST);
 				m.complete(&mut *temp, JS_CASE_CLAUSE);
 			}
 		}

--- a/crates/rslint_parser/src/syntax/util.rs
+++ b/crates/rslint_parser/src/syntax/util.rs
@@ -137,9 +137,9 @@ pub fn check_for_stmt_lhs(p: &mut Parser, expr: JsAnyExpression, marker: &Comple
 			}
 		}
 		JsAnyExpression::JsArrayExpression(expr) => {
-			let elem_count = expr.elements().len();
+			let elem_count = expr.elements().iter().count();
 
-			for (idx, elem) in expr.elements().iter().enumerate() {
+			for (idx, elem) in expr.elements().iter().flatten().enumerate() {
 				if let ast::JsAnyArrayElement::SpreadElement(ref spread) = elem {
 					if idx != elem_count - 1 {
 						let err = p.err_builder("Spread element may only occur as the last element of an assignment target")
@@ -164,14 +164,15 @@ pub fn check_for_stmt_lhs(p: &mut Parser, expr: JsAnyExpression, marker: &Comple
 				p.error(err);
 			}
 
-			for (idx, prop) in expr.members().iter().enumerate() {
+			let members_count = expr.members().iter().count();
+			for (idx, prop) in expr.members().iter().flatten().enumerate() {
 				match prop {
 					ast::JsAnyObjectMember::JsPropertyObjectMember(prop) => {
 						if let Ok(expr) = prop.value() {
 							check_for_stmt_lhs(p, expr, marker);
 						}
 					}
-					ast::JsAnyObjectMember::JsSpread(prop) if idx != expr.members().len() - 1 => {
+					ast::JsAnyObjectMember::JsSpread(prop) if idx != members_count - 1 => {
 						if let Ok(lhs) = prop.argument() {
 							check_spread_element(p, lhs, marker);
 						}
@@ -241,10 +242,28 @@ pub fn check_for_stmt_declaration(p: &mut Parser, marker: &CompletedMarker) {
 
 	if !excess.is_empty() {
 		let start = marker
-			.offset_range(p, excess.first().unwrap().syntax().text_trimmed_range())
+			.offset_range(
+				p,
+				excess
+					.first()
+					.unwrap()
+					.as_ref()
+					.unwrap()
+					.syntax()
+					.text_trimmed_range(),
+			)
 			.start();
 		let end = marker
-			.offset_range(p, excess.last().unwrap().syntax().text_trimmed_range())
+			.offset_range(
+				p,
+				excess
+					.last()
+					.unwrap()
+					.as_ref()
+					.unwrap()
+					.syntax()
+					.text_trimmed_range(),
+			)
 			.end();
 
 		let err = p

--- a/crates/rslint_parser/src/syntax/util.rs
+++ b/crates/rslint_parser/src/syntax/util.rs
@@ -137,11 +137,9 @@ pub fn check_for_stmt_lhs(p: &mut Parser, expr: JsAnyExpression, marker: &Comple
 			}
 		}
 		JsAnyExpression::JsArrayExpression(expr) => {
-			let elem_count = expr.elements().iter().count();
-
 			for (idx, elem) in expr.elements().iter().flatten().enumerate() {
 				if let ast::JsAnyArrayElement::SpreadElement(ref spread) = elem {
-					if idx != elem_count - 1 {
+					if idx != expr.elements().len() - 1 {
 						let err = p.err_builder("Spread element may only occur as the last element of an assignment target")
                             .primary(marker.offset_range(p, spread.syntax().text_trimmed_range()), "");
 
@@ -164,7 +162,6 @@ pub fn check_for_stmt_lhs(p: &mut Parser, expr: JsAnyExpression, marker: &Comple
 				p.error(err);
 			}
 
-			let members_count = expr.members().iter().count();
 			for (idx, prop) in expr.members().iter().flatten().enumerate() {
 				match prop {
 					ast::JsAnyObjectMember::JsPropertyObjectMember(prop) => {
@@ -172,7 +169,7 @@ pub fn check_for_stmt_lhs(p: &mut Parser, expr: JsAnyExpression, marker: &Comple
 							check_for_stmt_lhs(p, expr, marker);
 						}
 					}
-					ast::JsAnyObjectMember::JsSpread(prop) if idx != members_count - 1 => {
+					ast::JsAnyObjectMember::JsSpread(prop) if idx != expr.members().len() - 1 => {
 						if let Ok(lhs) = prop.argument() {
 							check_spread_element(p, lhs, marker);
 						}

--- a/crates/rslint_parser/src/syntax_node.rs
+++ b/crates/rslint_parser/src/syntax_node.rs
@@ -33,6 +33,8 @@ pub type SyntaxElement = rome_rowan::SyntaxElement<JsLanguage>;
 pub type SyntaxNodeChildren = rome_rowan::SyntaxNodeChildren<JsLanguage>;
 pub type SyntaxElementChildren = rome_rowan::SyntaxElementChildren<JsLanguage>;
 pub type SyntaxList = rome_rowan::SyntaxList<JsLanguage>;
+pub type SyntaxSlots = rome_rowan::SyntaxSlots<JsLanguage>;
+pub type SyntaxSlot = rome_rowan::SyntaxSlot<JsLanguage>;
 
 pub use rome_rowan::{Direction, NodeOrToken};
 

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -83,7 +83,7 @@ fn parser_tests() {
 			path.file_name().unwrap().to_string_lossy().to_string(),
 			text.to_string(),
 		);
-		let mut ret = format!("{:#?}", parse.syntax());
+		let mut ret = format!("{:#?}\n\n{:#?}", parse.tree(), parse.syntax());
 
 		for diag in parse.errors() {
 			let mut write = rslint_errors::termcolor::Buffer::no_color();

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -64,18 +64,38 @@ fn try_parse(path: &str, text: &str) -> Parse<JsRoot> {
 	res.unwrap()
 }
 
+fn try_parse_with_printed_ast(path: &str, text: &str) -> (Parse<JsRoot>, String) {
+	catch_unwind(|| {
+		let parse = try_parse(path, text);
+		let formatted = format!("{:#?}", &parse.tree());
+		(parse, formatted)
+	})
+	.unwrap_or_else(|_| {
+		// Re-parsing the source here seems silly. But the problem is, that `SyntaxNode`s aren't
+		// unwind safe. That's why the same `ParseResult` can't be reused here.
+		// This should be fine because this code is only executed for local tests. No checked-in
+		// test should ever hit this line.
+		let re_parsed = try_parse(path, text);
+		panic!(
+			"Printing the AST for `{}` panicked. That means it is malformed.\n{:#?}",
+			path,
+			re_parsed.syntax()
+		);
+	})
+}
+
 #[test]
 fn parser_tests() {
 	dir_tests(&test_data_dir(), &["inline/ok"], "rast", |text, path| {
-		let parse = try_parse(path.to_str().unwrap(), text);
+		let (parse, ast) = try_parse_with_printed_ast(path.to_str().unwrap(), text);
 		let errors = parse.errors();
 		assert_errors_are_absent(errors, path, &parse.syntax());
 
-		format!("{:#?}\n\n{:#?}", parse.tree(), parse.syntax())
+		format!("{}\n\n{:#?}", ast, parse.syntax())
 	});
 
 	dir_tests(&test_data_dir(), &["inline/err"], "rast", |text, path| {
-		let parse = try_parse(path.to_str().unwrap(), text);
+		let (parse, ast) = try_parse_with_printed_ast(path.to_str().unwrap(), text);
 		let errors = parse.errors();
 		assert_errors_are_present(errors, path, &parse.syntax());
 		let mut files = SimpleFiles::new();
@@ -83,7 +103,7 @@ fn parser_tests() {
 			path.file_name().unwrap().to_string_lossy().to_string(),
 			text.to_string(),
 		);
-		let mut ret = format!("{:#?}\n\n{:#?}", parse.tree(), parse.syntax());
+		let mut ret = format!("{}\n\n{:#?}", ast, parse.syntax());
 
 		for diag in parse.errors() {
 			let mut write = rslint_errors::termcolor::Buffer::no_color();

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -1,3 +1,47 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsReferenceIdentifierExpression {
+                                name_token: IDENT@8..14 "async" [] [Whitespace(" ")],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsIdentifierBinding {
+                    name_token: IDENT@14..20 "await" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@20..23 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..26
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -1,3 +1,53 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@3..4 "(" [] [],
+                    args: [
+                        JsBinaryExpression {
+                            left: JsReferenceIdentifierExpression {
+                                name_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@8..9 "+" [] [],
+                        }
+                        ,
+                    ],
+                    r_paren_token: R_PAREN@9..10 ")" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@10..11 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@11..16 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator: PLUS@16..18 "+" [] [Whitespace(" ")],
+            },
+            semicolon_token: SEMICOLON@21..22 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsUnaryExpression {
+                    operator: BANG@22..24 "!" [Whitespace("\n")] [],
+                    argument: JsReferenceIdentifierExpression {
+                        name_token: IDENT@24..28 "foo" [] [Whitespace(" ")],
+                    },
+                },
+                operator: STAR@28..30 "*" [] [Whitespace(" ")],
+            },
+            semicolon_token: SEMICOLON@33..34 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..35
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -1,3 +1,92 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: ASYNC_KW@0..6 "async" [] [Whitespace(" ")],
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@6..7 "(" [] [],
+                    parameters: [],
+                    r_paren_token: R_PAREN@7..9 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@9..12 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@30..40 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: STAR@40..41 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@41..44 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@44..45 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@45..47 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@47..48 "{" [] [],
+                directives: [],
+                statements: [
+                    JsVariableDeclarationStatement {
+                        declaration: JsVariableDeclaration {
+                            kind_token: LET_KW@48..56 "let" [Whitespace("\n   ")] [Whitespace(" ")],
+                            declarators: [
+                                JsVariableDeclarator {
+                                    id: SinglePattern {
+                                        name: missing (required),
+                                        question_mark_token: missing (optional),
+                                        excl_token: missing (optional),
+                                        ty: missing (optional),
+                                    },
+                                    init: JsEqualValueClause {
+                                        eq_token: EQ@62..64 "=" [] [Whitespace(" ")],
+                                        expression: JsNumberLiteralExpression {
+                                            value_token: JS_NUMBER_LITERAL@64..65 "5" [] [],
+                                        },
+                                    },
+                                }
+                                ,
+                            ],
+                        },
+                        semicolon_token: SEMICOLON@65..66 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@66..68 "}" [Whitespace("\n")] [],
+            },
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@68..73 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: missing (required),
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@78..80 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@80..81 "5" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@81..82 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..83
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -1,3 +1,38 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..7 "S" [] [],
+            },
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@7..8 "{" [] [],
+            members: [
+                JsUnknownMember {
+                    items: [
+                        Node(
+                            1: JS_UNKNOWN_MEMBER@8..9
+                              0: L_CURLY@8..9 "{" [] []
+                            ,
+                        ),
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@9..10 "}" [] [],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@10..11 "}" [] [],
+                ),
+            ],
+        },
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -1,3 +1,43 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@3..4 "[" [] [],
+                r_brack_token: R_BRACK@4..5 "]" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: QUESTIONDOT@9..11 "?." [] [],
+                l_brack_token: L_BRACK@11..12 "[" [] [],
+                r_brack_token: R_BRACK@12..13 "]" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsComputedMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@13..17 "foo" [Whitespace("\n")] [],
+                },
+                optional_chain_token_token: missing (optional),
+                l_brack_token: L_BRACK@17..18 "[" [] [],
+                r_brack_token: missing (required),
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..19
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/break_stmt.rast
@@ -1,3 +1,42 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@13..15 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                directives: [],
+                statements: [
+                    JsUnknownStatement {
+                        items: [
+                            Token(
+                                BREAK_KW@17..22 "break" [] [],
+                            ),
+                            Token(
+                                SEMICOLON@22..24 ";" [] [Whitespace(" ")],
+                            ),
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@24..25 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..26
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -1,3 +1,134 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: missing (required),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@6..7 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@7..8 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@8..15 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: missing (required),
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@15..23 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@23..27 "bar" [] [Whitespace(" ")],
+                },
+            },
+            l_curly_token: L_CURLY@27..28 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@28..29 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@29..36 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: missing (required),
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@36..44 "extends" [] [Whitespace(" ")],
+                super_class: JsObjectExpression {
+                    l_curly_token: L_CURLY@44..45 "{" [] [],
+                    members: [],
+                    r_curly_token: R_CURLY@45..46 "}" [] [],
+                },
+            },
+            l_curly_token: missing (required),
+            members: [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@46..52 "class" [Whitespace("\n")] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+                JsUnknownMember {
+                    items: [
+                        Node(
+                            0: JS_LITERAL_MEMBER_NAME@52..59
+                              0: IDENT@52..59 "class" [Whitespace("\n")] [Whitespace(" ")]
+                            ,
+                        ),
+                    ],
+                },
+                JsUnknownMember {
+                    items: [
+                        Node(
+                            0: JS_LITERAL_MEMBER_NAME@59..63
+                              0: IDENT@59..63 "foo" [] [Whitespace(" ")]
+                            ,
+                        ),
+                        Node(
+                            1: JS_UNKNOWN_MEMBER@63..65
+                              0: L_CURLY@63..65 "{" [] [Whitespace(" ")]
+                            ,
+                        ),
+                    ],
+                },
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@65..69 "set" [] [Whitespace(" ")],
+                    name: missing (required),
+                    l_paren_token: missing (required),
+                    parameter: ObjectPattern {
+                        l_curly_token: L_CURLY@69..70 "{" [] [],
+                        elements: [],
+                        r_curly_token: R_CURLY@70..72 "}" [] [Whitespace(" ")],
+                    },
+                    r_paren_token: missing (required),
+                    body: missing (required),
+                },
+            ],
+            r_curly_token: R_CURLY@72..73 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@73..80 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@80..82 "A" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@82..90 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@90..94 "bar" [] [Whitespace(" ")],
+                },
+            },
+            l_curly_token: L_CURLY@106..107 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@107..108 "}" [] [],
+        },
+        JsClassDeclaration {
+            class_token: CLASS_KW@108..115 "class" [Whitespace("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@115..117 "A" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@117..125 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@125..128 "bar" [] [],
+                },
+            },
+            l_curly_token: L_CURLY@134..135 "{" [] [],
+            members: [],
+            r_curly_token: R_CURLY@135..136 "}" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..137
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -1,3 +1,30 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsConditionalExpression {
+                test: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@4..6 "?" [] [Whitespace(" ")],
+                colon_token: missing (required),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsConditionalExpression {
+                test: JsReferenceIdentifierExpression {
+                    name_token: IDENT@13..18 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                question_mark_token: QUESTION@18..20 "?" [] [Whitespace(" ")],
+                colon_token: missing (required),
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..40
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
@@ -1,3 +1,42 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@13..15 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                directives: [],
+                statements: [
+                    JsUnknownStatement {
+                        items: [
+                            Token(
+                                CONTINUE_KW@17..25 "continue" [] [],
+                            ),
+                            Token(
+                                SEMICOLON@25..27 ";" [] [Whitespace(" ")],
+                            ),
+                        ],
+                    },
+                ],
+                r_curly_token: R_CURLY@27..28 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..29
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
@@ -1,3 +1,67 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@13..15 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@15..16 "{" [] [],
+                directives: [],
+                statements: [
+                    JsDebuggerStatement {
+                        debugger_token: DEBUGGER_KW@16..27 "debugger" [Whitespace("\n\t")] [Whitespace(" ")],
+                        semicolon_token: missing (optional),
+                    },
+                    JsBlockStatement {
+                        l_curly_token: L_CURLY@27..28 "{" [] [],
+                        statements: [
+                            JsVariableDeclarationStatement {
+                                declaration: JsVariableDeclaration {
+                                    kind_token: VAR_KW@28..35 "var" [Whitespace("\n\t\t")] [Whitespace(" ")],
+                                    declarators: [
+                                        JsVariableDeclarator {
+                                            id: SinglePattern {
+                                                name: Name {
+                                                    ident_token: IDENT@35..45 "something" [] [Whitespace(" ")],
+                                                },
+                                                question_mark_token: missing (optional),
+                                                excl_token: missing (optional),
+                                                ty: missing (optional),
+                                            },
+                                            init: JsEqualValueClause {
+                                                eq_token: EQ@45..47 "=" [] [Whitespace(" ")],
+                                                expression: JsStringLiteralExpression {
+                                                    value_token: JS_STRING_LITERAL@47..54 "\"lorem\"" [] [],
+                                                },
+                                            },
+                                        }
+                                        ,
+                                    ],
+                                },
+                                semicolon_token: SEMICOLON@54..55 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@55..58 "}" [Whitespace("\n\t")] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@58..60 "}" [Whitespace("\n")] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..61
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/directives_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/directives_err.rast
@@ -1,3 +1,111 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..24 "test" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@24..25 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@25..27 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@27..28 "{" [] [],
+                directives: [
+                    JsDirective {
+                        value_token: JS_STRING_LITERAL@28..42 "\"use strict\"" [Whitespace("\n\t")] [],
+                        semicolon_token: SEMICOLON@42..43 ";" [] [],
+                    },
+                ],
+                statements: [
+                    JsFunctionDeclaration {
+                        async_token: missing (optional),
+                        function_token: FUNCTION_KW@43..54 "function" [Whitespace("\n\t")] [Whitespace(" ")],
+                        star_token: missing (optional),
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@54..61 "inner_a" [] [],
+                        },
+                        type_parameters: missing (optional),
+                        parameter_list: JsParameterList {
+                            l_paren_token: L_PAREN@61..62 "(" [] [],
+                            parameters: [],
+                            r_paren_token: R_PAREN@62..64 ")" [] [Whitespace(" ")],
+                        },
+                        return_type: missing (optional),
+                        body: JsFunctionBody {
+                            l_curly_token: L_CURLY@64..65 "{" [] [],
+                            directives: [
+                                JsDirective {
+                                    value_token: JS_STRING_LITERAL@65..80 "\"use strict\"" [Whitespace("\n\t\t")] [],
+                                    semicolon_token: SEMICOLON@80..81 ";" [] [],
+                                },
+                            ],
+                            statements: [],
+                            r_curly_token: R_CURLY@81..84 "}" [Whitespace("\n\t")] [],
+                        },
+                    },
+                    JsFunctionDeclaration {
+                        async_token: missing (optional),
+                        function_token: FUNCTION_KW@84..96 "function" [Whitespace("\n\n\t")] [Whitespace(" ")],
+                        star_token: missing (optional),
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@96..103 "inner_b" [] [],
+                        },
+                        type_parameters: missing (optional),
+                        parameter_list: JsParameterList {
+                            l_paren_token: L_PAREN@103..104 "(" [] [],
+                            parameters: [],
+                            r_paren_token: R_PAREN@104..106 ")" [] [Whitespace(" ")],
+                        },
+                        return_type: missing (optional),
+                        body: JsFunctionBody {
+                            l_curly_token: L_CURLY@106..107 "{" [] [],
+                            directives: [],
+                            statements: [
+                                JsFunctionDeclaration {
+                                    async_token: missing (optional),
+                                    function_token: FUNCTION_KW@107..119 "function" [Whitespace("\n\t\t")] [Whitespace(" ")],
+                                    star_token: missing (optional),
+                                    id: JsIdentifierBinding {
+                                        name_token: IDENT@119..130 "inner_inner" [] [],
+                                    },
+                                    type_parameters: missing (optional),
+                                    parameter_list: JsParameterList {
+                                        l_paren_token: L_PAREN@130..131 "(" [] [],
+                                        parameters: [],
+                                        r_paren_token: R_PAREN@131..133 ")" [] [Whitespace(" ")],
+                                    },
+                                    return_type: missing (optional),
+                                    body: JsFunctionBody {
+                                        l_curly_token: L_CURLY@133..134 "{" [] [],
+                                        directives: [
+                                            JsDirective {
+                                                value_token: JS_STRING_LITERAL@134..150 "\"use strict\"" [Whitespace("\n\t\t\t")] [],
+                                                semicolon_token: SEMICOLON@150..151 ";" [] [],
+                                            },
+                                        ],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@151..155 "}" [Whitespace("\n\t\t")] [],
+                                    },
+                                },
+                            ],
+                            r_curly_token: R_CURLY@155..158 "}" [Whitespace("\n\t")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@158..160 "}" [Whitespace("\n")] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..161
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -1,3 +1,57 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsDoWhileStatement {
+            do_token: DO_KW@0..3 "do" [] [Whitespace(" ")],
+            body: JsWhileStatement {
+                while_token: WHILE_KW@3..9 "while" [] [Whitespace(" ")],
+                l_paren_token: L_PAREN@9..10 "(" [] [],
+                test: JsBooleanLiteralExpression {
+                    value_token: TRUE_KW@10..14 "true" [] [],
+                },
+                r_paren_token: R_PAREN@14..15 ")" [] [],
+                body: JsDoWhileStatement {
+                    do_token: DO_KW@15..19 "do" [Whitespace("\n")] [Whitespace(" ")],
+                    body: JsWhileStatement {
+                        while_token: WHILE_KW@19..25 "while" [] [Whitespace(" ")],
+                        l_paren_token: L_PAREN@25..26 "(" [] [],
+                        test: missing (required),
+                        r_paren_token: R_PAREN@26..27 ")" [] [],
+                        body: JsDoWhileStatement {
+                            do_token: DO_KW@27..31 "do" [Whitespace("\n")] [Whitespace(" ")],
+                            body: JsWhileStatement {
+                                while_token: WHILE_KW@31..37 "while" [] [Whitespace(" ")],
+                                l_paren_token: missing (required),
+                                test: JsBooleanLiteralExpression {
+                                    value_token: TRUE_KW@37..41 "true" [] [],
+                                },
+                                r_paren_token: missing (required),
+                                body: missing (required),
+                            },
+                            while_token: missing (required),
+                            l_paren_token: missing (required),
+                            test: missing (required),
+                            r_paren_token: missing (required),
+                            semicolon_token: missing (optional),
+                        },
+                    },
+                    while_token: missing (required),
+                    l_paren_token: missing (required),
+                    test: missing (required),
+                    r_paren_token: missing (required),
+                    semicolon_token: missing (optional),
+                },
+            },
+            while_token: missing (required),
+            l_paren_token: missing (required),
+            test: missing (required),
+            r_paren_token: missing (required),
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..42
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/double_label.rast
+++ b/crates/rslint_parser/test_data/inline/err/double_label.rast
@@ -1,3 +1,39 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsLabeledStatement {
+            label_token: IDENT@0..6 "label1" [] [],
+            colon_token: COLON@6..8 ":" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@8..9 "{" [] [],
+                statements: [
+                    JsLabeledStatement {
+                        label_token: IDENT@9..17 "label2" [Whitespace("\n\t")] [],
+                        colon_token: COLON@17..19 ":" [] [Whitespace(" ")],
+                        body: JsBlockStatement {
+                            l_curly_token: L_CURLY@19..20 "{" [] [],
+                            statements: [
+                                JsLabeledStatement {
+                                    label_token: IDENT@20..29 "label1" [Whitespace("\n\t\t")] [],
+                                    colon_token: COLON@29..31 ":" [] [Whitespace(" ")],
+                                    body: JsBlockStatement {
+                                        l_curly_token: L_CURLY@31..32 "{" [] [],
+                                        statements: [],
+                                        r_curly_token: R_CURLY@32..33 "}" [] [],
+                                    },
+                                },
+                            ],
+                            r_curly_token: R_CURLY@33..36 "}" [Whitespace("\n\t")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@36..38 "}" [Whitespace("\n")] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..39
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -1,3 +1,15 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsBlockStatement {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@31..33 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..34
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -1,3 +1,128 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        ForStmt {
+            for_token: FOR_KW@0..4 "for" [] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            init: missing (optional),
+            test: missing (optional),
+            update: ForStmtUpdate {
+                expr: JsObjectExpression {
+                    l_curly_token: L_CURLY@7..8 "{" [] [],
+                    members: [],
+                    r_curly_token: R_CURLY@8..9 "}" [] [],
+                },
+            },
+            r_paren_token: missing (required),
+            cons: ForStmt {
+                for_token: FOR_KW@9..14 "for" [Whitespace("\n")] [Whitespace(" ")],
+                l_paren_token: missing (required),
+                init: ForStmtInit {
+                    inner: JsVariableDeclaration {
+                        kind_token: LET_KW@14..18 "let" [] [Whitespace(" ")],
+                        declarators: [
+                            JsVariableDeclarator {
+                                id: SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@18..20 "i" [] [Whitespace(" ")],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                },
+                                init: JsEqualValueClause {
+                                    eq_token: EQ@20..22 "=" [] [Whitespace(" ")],
+                                    expression: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@22..23 "5" [] [],
+                                    },
+                                },
+                            }
+                            ,
+                        ],
+                    },
+                    semicolon_token: missing (required),
+                },
+                test: ForStmtTest {
+                    expr: JsBinaryExpression {
+                        left: JsReferenceIdentifierExpression {
+                            name_token: IDENT@25..27 "i" [] [Whitespace(" ")],
+                        },
+                        operator: L_ANGLE@27..29 "<" [] [Whitespace(" ")],
+                    },
+                    semicolon_token: missing (required),
+                },
+                update: ForStmtUpdate {
+                    expr: JsPostUpdateExpression {
+                        operand: JsReferenceIdentifierExpression {
+                            name_token: IDENT@33..34 "i" [] [],
+                        },
+                        operator: PLUS2@34..37 "++" [] [Whitespace(" ")],
+                    },
+                },
+                r_paren_token: missing (required),
+                cons: JsBlockStatement {
+                    l_curly_token: L_CURLY@37..38 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@38..39 "}" [] [],
+                },
+            },
+        },
+        ForStmt {
+            for_token: FOR_KW@39..44 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            init: ForStmtInit {
+                inner: JsVariableDeclaration {
+                    kind_token: LET_KW@44..48 "let" [] [Whitespace(" ")],
+                    declarators: [
+                        JsVariableDeclarator {
+                            id: SinglePattern {
+                                name: Name {
+                                    ident_token: IDENT@48..50 "i" [] [Whitespace(" ")],
+                                },
+                                question_mark_token: missing (optional),
+                                excl_token: missing (optional),
+                                ty: missing (optional),
+                            },
+                            init: JsEqualValueClause {
+                                eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
+                                expression: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@52..53 "5" [] [],
+                                },
+                            },
+                        }
+                        ,
+                    ],
+                },
+                semicolon_token: missing (required),
+            },
+            test: ForStmtTest {
+                expr: JsBinaryExpression {
+                    left: JsReferenceIdentifierExpression {
+                        name_token: IDENT@55..57 "i" [] [Whitespace(" ")],
+                    },
+                    operator: L_ANGLE@57..59 "<" [] [Whitespace(" ")],
+                },
+                semicolon_token: missing (required),
+            },
+            update: ForStmtUpdate {
+                expr: JsPreUpdateExpression {
+                    operator: PLUS2@63..65 "++" [] [],
+                    operand: JsReferenceIdentifierExpression {
+                        name_token: IDENT@65..67 "i" [] [Whitespace(" ")],
+                    },
+                },
+            },
+            r_paren_token: missing (required),
+            cons: JsBlockStatement {
+                l_curly_token: L_CURLY@67..68 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@68..69 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..70
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -1,3 +1,56 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@9..10 "(" [] [],
+                parameters: [
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@10..11 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    missing separator,
+                    JsUnknownPattern {
+                        items: [
+                            Token(
+                                PLUS2@11..13 "++" [] [],
+                            ),
+                        ],
+                    }
+                    COMMA@13..15 "," [] [Whitespace(" ")],
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@15..16 "c" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@16..18 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@18..19 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@19..20 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..21
   0: (empty)
   1: LIST@0..0
@@ -45,13 +98,6 @@ error[SyntaxError]: Expected an identifier or pattern, but found none
   │
 1 │ function (a++, c) {}
   │            ^^
-
---
-error[SyntaxError]: expected a parameter but instead found ','
-  ┌─ formal_params_invalid.js:1:14
-  │
-1 │ function (a++, c) {}
-  │              ^ Expected a parameter here
 
 --
 function (a++, c) {}

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -1,3 +1,40 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [
+                    JsUnknownPattern {
+                        items: [
+                            Token(
+                                TRUE_KW@13..17 "true" [] [],
+                            ),
+                        ],
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@19..20 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@20..21 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..22
   0: (empty)
   1: LIST@0..0
@@ -24,13 +61,6 @@ error[SyntaxError]: Expected an identifier or pattern, but found none
   │
 1 │ function foo(true) {}
   │              ^^^^
-
---
-error[SyntaxError]: expected a parameter but instead found ')'
-  ┌─ formal_params_no_binding_element.js:1:18
-  │
-1 │ function foo(true) {}
-  │                  ^ Expected a parameter here
 
 --
 function foo(true) {}

--- a/crates/rslint_parser/test_data/inline/err/function_broken.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_broken.rast
@@ -1,3 +1,77 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..12 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@12..13 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@13..14 ")" [] [],
+            },
+            return_type: missing (optional),
+            body: missing (required),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_PAREN@14..15 ")" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@15..16 "}" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_PAREN@16..17 ")" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@17..18 "}" [] [],
+                ),
+            ],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@18..19 "{" [] [],
+            statements: [
+                JsBlockStatement {
+                    l_curly_token: L_CURLY@19..20 "{" [] [],
+                    statements: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@20..23 "{" [] [Whitespace("  ")],
+                            statements: [
+                                JsBlockStatement {
+                                    l_curly_token: L_CURLY@23..24 "{" [] [],
+                                    statements: [],
+                                    r_curly_token: R_CURLY@24..25 "}" [] [],
+                                },
+                            ],
+                            r_curly_token: missing (required),
+                        },
+                    ],
+                    r_curly_token: missing (required),
+                },
+            ],
+            r_curly_token: missing (required),
+        },
+    ],
+}
+
 0: JS_ROOT@0..26
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -1,3 +1,249 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..8 "function" [] [],
+            star_token: missing (optional),
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@8..9 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@9..11 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@11..12 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@12..13 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@13..23 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@23..27 "foo" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            parameter_list: missing (required),
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@27..28 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@28..29 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@29..39 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: missing (required),
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@39..40 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@40..41 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@41..51 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: STAR@51..52 "*" [] [],
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@52..53 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@53..55 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@55..56 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@56..57 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@57..64 "async" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@64..72 "function" [] [],
+            star_token: missing (optional),
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@72..73 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@73..75 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@75..76 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@76..77 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@77..84 "async" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")],
+            star_token: STAR@93..94 "*" [] [],
+            id: missing (required),
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@94..95 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@95..97 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@97..98 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@98..99 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@99..109 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: STAR@109..110 "*" [] [],
+            id: JsIdentifierBinding {
+                name_token: IDENT@110..113 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@113..114 "(" [] [],
+                parameters: [],
+                r_paren_token: R_PAREN@114..116 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@116..117 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@117..118 "}" [] [],
+            },
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    Token(
+                        IDENT@118..125 "yield" [Whitespace("\n")] [Whitespace(" ")],
+                    ),
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@125..128 "foo" [] [],
+            },
+            semicolon_token: SEMICOLON@128..129 ";" [] [],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    FUNCTION_KW@129..139 "function" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                Node(
+                    1: JS_IDENTIFIER_BINDING@139..143
+                      0: IDENT@139..143 "test" [] []
+                    ,
+                ),
+                Node(
+                    2: JS_PARAMETER_LIST@143..145
+                      0: L_PAREN@143..144 "(" [] []
+                      1: LIST@144..144
+                      2: R_PAREN@144..145 ")" [] []
+                    ,
+                ),
+                Node(
+                    3: TS_TYPE_ANNOTATION@145..154
+                      0: COLON@145..147 ":" [] [Whitespace(" ")]
+                      1: TS_NUMBER@147..154
+                        0: IDENT@147..154 "number" [] [Whitespace(" ")]
+                    ,
+                ),
+                Node(
+                    4: JS_FUNCTION_BODY@154..156
+                      0: L_CURLY@154..155 "{" [] []
+                      1: LIST@155..155
+                      2: LIST@155..155
+                      3: R_CURLY@155..156 "}" [] []
+                    ,
+                ),
+            ],
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@156..166 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@166..169 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@169..170 "(" [] [],
+                parameters: [
+                    SinglePattern {
+                        name: Name {
+                            ident_token: IDENT@170..175 "await" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@175..177 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@177..178 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@178..179 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@179..189 "function" [Whitespace("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@189..192 "foo" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@192..193 "(" [] [],
+                parameters: [
+                    SinglePattern {
+                        name: missing (required),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@198..200 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@200..201 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@201..202 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..203
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.rast
@@ -1,3 +1,78 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    Token(
+                        IDENT@0..5 "yield" [] [],
+                    ),
+                ],
+            },
+            semicolon_token: SEMICOLON@5..6 ";" [] [],
+        },
+        JsFunctionDeclaration {
+            async_token: ASYNC_KW@6..13 "async" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@13..22 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@22..26 "test" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@26..27 "(" [] [],
+                parameters: [
+                    SinglePattern {
+                        name: missing (required),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@32..34 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@34..35 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@35..36 "}" [] [],
+            },
+        },
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@36..45 "function" [Whitespace("\n")] [],
+            star_token: STAR@45..47 "*" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@47..51 "test" [] [],
+            },
+            type_parameters: missing (optional),
+            parameter_list: JsParameterList {
+                l_paren_token: L_PAREN@51..52 "(" [] [],
+                parameters: [
+                    SinglePattern {
+                        name: missing (required),
+                        question_mark_token: missing (optional),
+                        excl_token: missing (optional),
+                        ty: missing (optional),
+                    }
+                    ,
+                ],
+                r_paren_token: R_PAREN@57..59 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@59..60 "{" [] [],
+                directives: [],
+                statements: [],
+                r_curly_token: R_CURLY@60..61 "}" [] [],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..62
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/if_broken.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_broken.rast
@@ -1,3 +1,52 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..9 ")" [] [],
+            consequent: JsUnknownStatement {
+                items: [
+                    Token(
+                        R_CURLY@9..10 "}" [] [],
+                    ),
+                ],
+            },
+            else_clause: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@10..11 "}" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@11..12 "}" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@12..14 "}" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@14..15 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@15..16 "}" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..17
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -1,3 +1,115 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: missing (required),
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@10..15 "else" [] [Whitespace(" ")],
+                alternate: JsBlockStatement {
+                    l_curly_token: L_CURLY@15..16 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@16..17 "}" [] [],
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@17..21 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@21..22 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@22..26 "true" [] [],
+            },
+            r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+            consequent: missing (required),
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@28..32 "else" [] [],
+                alternate: JsIfStatement {
+                    if_token: IF_KW@32..36 "if" [Whitespace("\n")] [Whitespace(" ")],
+                    l_paren_token: missing (required),
+                    test: missing (required),
+                    r_paren_token: missing (required),
+                    consequent: missing (required),
+                    else_clause: JsElseClause {
+                        else_token: ELSE_KW@36..41 "else" [] [Whitespace(" ")],
+                        alternate: JsBlockStatement {
+                            l_curly_token: L_CURLY@41..42 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@42..43 "}" [] [],
+                        },
+                    },
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@43..47 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@47..48 "(" [] [],
+            test: missing (required),
+            r_paren_token: R_PAREN@48..50 ")" [] [Whitespace(" ")],
+            consequent: JsBlockStatement {
+                l_curly_token: L_CURLY@50..51 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@51..53 "}" [] [Whitespace(" ")],
+            },
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@53..58 "else" [] [Whitespace(" ")],
+                alternate: JsBlockStatement {
+                    l_curly_token: L_CURLY@58..59 "{" [] [],
+                    statements: [],
+                    r_curly_token: R_CURLY@59..60 "}" [] [],
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@60..64 "if" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@64..65 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@65..69 "true" [] [],
+            },
+            r_paren_token: R_PAREN@69..70 ")" [] [],
+            consequent: JsUnknownStatement {
+                items: [
+                    Token(
+                        R_CURLY@70..71 "}" [] [],
+                    ),
+                ],
+            },
+            else_clause: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@71..72 "}" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@72..73 "}" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@73..75 "}" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@75..76 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@76..77 "}" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..78
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -1,3 +1,52 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsImportCallExpression {
+                                import_token: IMPORT_KW@8..14 "import" [] [],
+                                l_paren_token: L_PAREN@14..15 "(" [] [],
+                                argument: missing (required),
+                                r_paren_token: R_PAREN@15..16 ")" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@17..21 "foo" [Whitespace("\n")] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@21..22 "(" [] [],
+                    args: [],
+                    r_paren_token: R_PAREN@22..23 ")" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@23..24 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..25
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -1,3 +1,15 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsBlockStatement {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@25..27 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..28
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -1,3 +1,18 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: missing (required),
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: missing (required),
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..24
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -1,3 +1,63 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..3 "foo" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@3..4 "(" [] [],
+                    args: [
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@4..5 "a" [] [],
+                        }
+                        COMMA@5..6 "," [] [],
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@6..7 "b" [] [],
+                        }
+                        ,
+                    ],
+                    r_paren_token: missing (required),
+                },
+            },
+            semicolon_token: SEMICOLON@7..8 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@12..13 "(" [] [],
+                    args: [
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@13..14 "a" [] [],
+                        }
+                        COMMA@14..15 "," [] [],
+                        JsReferenceIdentifierExpression {
+                            name_token: IDENT@15..17 "b" [] [Whitespace(" ")],
+                        }
+                        ,
+                    ],
+                    r_paren_token: missing (required),
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: VAR_KW@17..20 "var" [] [],
+                declarators: [],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..21
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -1,3 +1,57 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: missing (required),
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@6..7 "{" [] [],
+            members: [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    name: JsComputedMemberName {
+                        l_brack_token: L_BRACK@7..11 "[" [Whitespace("\n  ")] [],
+                        expression: JsBinaryExpression {
+                            left: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@11..13 "1" [] [Whitespace(" ")],
+                            },
+                            operator: PLUS@13..15 "+" [] [Whitespace(" ")],
+                        },
+                        r_brack_token: R_BRACK@16..18 "]" [] [Whitespace(" ")],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: JsEqualValueClause {
+                        eq_token: EQ@18..20 "=" [] [Whitespace(" ")],
+                        expression: JsArrowFunctionExpression {
+                            async_token: missing (optional),
+                            type_parameters: missing (optional),
+                            parameter_list: JsParameterList {
+                                l_paren_token: L_PAREN@20..21 "(" [] [],
+                                parameters: [],
+                                r_paren_token: R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                            },
+                            fat_arrow_token: FAT_ARROW@23..26 "=>" [] [Whitespace(" ")],
+                            return_type: missing (optional),
+                        },
+                    },
+                    semicolon_token: SEMICOLON@43..44 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@46..47 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..48
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
@@ -1,3 +1,53 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsReferenceIdentifierExpression {
+                    name_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
+                },
+                operator: QUESTION2@4..7 "??" [] [Whitespace(" ")],
+            },
+            semicolon_token: SEMICOLON@10..11 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsLogicalExpression {
+                left: JsUnaryExpression {
+                    operator: BANG@11..13 "!" [Whitespace("\n")] [],
+                    argument: JsReferenceIdentifierExpression {
+                        name_token: IDENT@13..17 "foo" [] [Whitespace(" ")],
+                    },
+                },
+                operator: AMP2@17..20 "&&" [] [Whitespace(" ")],
+            },
+            semicolon_token: SEMICOLON@23..24 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@24..28 "foo" [Whitespace("\n")] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@28..29 "(" [] [],
+                    args: [
+                        JsLogicalExpression {
+                            left: JsReferenceIdentifierExpression {
+                                name_token: IDENT@29..33 "foo" [] [Whitespace(" ")],
+                            },
+                            operator: PIPE2@33..35 "||" [] [],
+                        }
+                        ,
+                    ],
+                    r_paren_token: R_PAREN@35..36 ")" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..37
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -1,3 +1,38 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..10 "foo" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@10..11 "{" [] [],
+            members: [
+                JsGetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    get_token: GET_KW@11..17 "get" [Whitespace("\n ")] [Whitespace(" ")],
+                    name: missing (required),
+                    l_paren_token: missing (required),
+                    r_paren_token: missing (required),
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@17..18 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@18..19 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@19..21 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..22
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/object_binding_pattern.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_binding_pattern.rast
@@ -1,3 +1,200 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@4..6 "{" [] [Whitespace(" ")],
+                            elements: [
+                                JsUnknownPattern {
+                                    items: [
+                                        Token(
+                                            JS_NUMBER_LITERAL@6..8 "5" [] [Whitespace(" ")],
+                                        ),
+                                    ],
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@8..10 "}" [] [Whitespace(" ")],
+                        },
+                        init: missing (optional),
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@10..12 "}" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    EQ@12..14 "=" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@14..16 "{" [] [Whitespace(" ")],
+            statements: [
+                JsLabeledStatement {
+                    label_token: IDENT@16..20 "eval" [] [],
+                    colon_token: COLON@20..22 ":" [] [Whitespace(" ")],
+                    body: JsExpressionStatement {
+                        expression: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@22..28 "\"foo\"" [] [Whitespace(" ")],
+                        },
+                        semicolon_token: missing (optional),
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@28..29 "}" [] [],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@29..30 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@35..37 "{" [] [Whitespace(" ")],
+                            elements: [
+                                JsUnknownPattern {
+                                    items: [
+                                        Token(
+                                            IDENT@37..42 "eval" [] [Whitespace(" ")],
+                                        ),
+                                    ],
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@42..44 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@44..46 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@46..48 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@48..52 "eval" [] [],
+                                        },
+                                        colon_token: COLON@52..54 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@60..61 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@61..62 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@62..67 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@67..69 "{" [] [Whitespace(" ")],
+                            elements: [
+                                JsUnknownPattern {
+                                    items: [
+                                        Token(
+                                            JS_NUMBER_LITERAL@69..70 "5" [] [],
+                                        ),
+                                    ],
+                                }
+                                COMMA@70..72 "," [] [Whitespace(" ")],
+                                JsUnknownPattern {
+                                    items: [
+                                        Token(
+                                            JS_NUMBER_LITERAL@72..74 "6" [] [Whitespace(" ")],
+                                        ),
+                                    ],
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@74..76 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@76..78 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@78..80 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@80..84 "eval" [] [],
+                                        },
+                                        colon_token: COLON@84..86 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@92..93 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@93..94 ";" [] [],
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@94..99 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: ObjectPattern {
+                            l_curly_token: L_CURLY@99..101 "{" [] [Whitespace(" ")],
+                            elements: [
+                                KeyValuePattern {
+                                    key: Name {
+                                        ident_token: IDENT@101..108 "default" [] [],
+                                    },
+                                    colon_token: COLON@108..110 ":" [] [Whitespace(" ")],
+                                }
+                                missing separator,
+                                SinglePattern {
+                                    name: Name {
+                                        ident_token: IDENT@112..116 "bar" [] [Whitespace(" ")],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    excl_token: missing (optional),
+                                    ty: missing (optional),
+                                }
+                                ,
+                            ],
+                            r_curly_token: R_CURLY@116..118 "}" [] [Whitespace(" ")],
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@118..120 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@120..121 "{" [] [],
+                                members: [],
+                                r_curly_token: R_CURLY@121..122 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@122..123 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..124
   0: (empty)
   1: LIST@0..0
@@ -10,7 +207,7 @@
             0: OBJECT_PATTERN@4..10
               0: L_CURLY@4..6 "{" [] [Whitespace(" ")]
               1: LIST@6..8
-                0: JS_NUMBER_LITERAL_EXPRESSION@6..8
+                0: JS_UNKNOWN_PATTERN@6..8
                   0: JS_NUMBER_LITERAL@6..8 "5" [] [Whitespace(" ")]
               2: R_CURLY@8..10 "}" [] [Whitespace(" ")]
       1: (empty)
@@ -39,7 +236,7 @@
             0: OBJECT_PATTERN@35..44
               0: L_CURLY@35..37 "{" [] [Whitespace(" ")]
               1: LIST@37..42
-                0: JS_UNKNOWN_BINDING@37..42
+                0: JS_UNKNOWN_PATTERN@37..42
                   0: IDENT@37..42 "eval" [] [Whitespace(" ")]
               2: R_CURLY@42..44 "}" [] [Whitespace(" ")]
             1: JS_EQUAL_VALUE_CLAUSE@44..61
@@ -63,10 +260,10 @@
             0: OBJECT_PATTERN@67..76
               0: L_CURLY@67..69 "{" [] [Whitespace(" ")]
               1: LIST@69..74
-                0: JS_NUMBER_LITERAL_EXPRESSION@69..70
+                0: JS_UNKNOWN_PATTERN@69..70
                   0: JS_NUMBER_LITERAL@69..70 "5" [] []
                 1: COMMA@70..72 "," [] [Whitespace(" ")]
-                2: JS_NUMBER_LITERAL_EXPRESSION@72..74
+                2: JS_UNKNOWN_PATTERN@72..74
                   0: JS_NUMBER_LITERAL@72..74 "6" [] [Whitespace(" ")]
               2: R_CURLY@74..76 "}" [] [Whitespace(" ")]
             1: JS_EQUAL_VALUE_CLAUSE@76..93

--- a/crates/rslint_parser/test_data/inline/err/object_expr_err.js
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_err.js
@@ -1,0 +1,2 @@
+let a = {, foo}
+let b = { foo bar }

--- a/crates/rslint_parser/test_data/inline/err/object_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_err.rast
@@ -1,0 +1,134 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    missing element
+                                    COMMA@9..11 "," [] [Whitespace(" ")],
+                                    JsShorthandPropertyObjectMember {
+                                        name: JsReferenceIdentifierExpression {
+                                            name_token: IDENT@11..14 "foo" [] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@14..15 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@20..22 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@22..24 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@24..26 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@26..30 "foo" [] [Whitespace(" ")],
+                                        },
+                                        colon_token: missing (required),
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@34..35 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
+0: JS_ROOT@0..36
+  0: (empty)
+  1: LIST@0..0
+  2: LIST@0..35
+    0: JS_VARIABLE_DECLARATION_STATEMENT@0..15
+      0: JS_VARIABLE_DECLARATION@0..15
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: LIST@4..15
+          0: JS_VARIABLE_DECLARATOR@4..15
+            0: SINGLE_PATTERN@4..6
+              0: NAME@4..6
+                0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: JS_EQUAL_VALUE_CLAUSE@6..15
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: JS_OBJECT_EXPRESSION@8..15
+                0: L_CURLY@8..9 "{" [] []
+                1: LIST@9..14
+                  0: (empty)
+                  1: COMMA@9..11 "," [] [Whitespace(" ")]
+                  2: JS_SHORTHAND_PROPERTY_OBJECT_MEMBER@11..14
+                    0: JS_REFERENCE_IDENTIFIER_EXPRESSION@11..14
+                      0: IDENT@11..14 "foo" [] []
+                2: R_CURLY@14..15 "}" [] []
+      1: (empty)
+    1: JS_VARIABLE_DECLARATION_STATEMENT@15..35
+      0: JS_VARIABLE_DECLARATION@15..35
+        0: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")]
+        1: LIST@20..35
+          0: JS_VARIABLE_DECLARATOR@20..35
+            0: SINGLE_PATTERN@20..22
+              0: NAME@20..22
+                0: IDENT@20..22 "b" [] [Whitespace(" ")]
+            1: JS_EQUAL_VALUE_CLAUSE@22..35
+              0: EQ@22..24 "=" [] [Whitespace(" ")]
+              1: JS_OBJECT_EXPRESSION@24..35
+                0: L_CURLY@24..26 "{" [] [Whitespace(" ")]
+                1: LIST@26..34
+                  0: JS_PROPERTY_OBJECT_MEMBER@26..34
+                    0: JS_LITERAL_MEMBER_NAME@26..30
+                      0: IDENT@26..30 "foo" [] [Whitespace(" ")]
+                    1: (empty)
+                    2: JS_REFERENCE_IDENTIFIER_EXPRESSION@30..34
+                      0: IDENT@30..34 "bar" [] [Whitespace(" ")]
+                2: R_CURLY@34..35 "}" [] []
+      1: (empty)
+  3: EOF@35..36 "" [Whitespace("\n")] []
+--
+error[SyntaxError]: expected `:` but instead found `bar`
+  ┌─ object_expr_err.js:2:15
+  │
+2 │ let b = { foo bar }
+  │               ^^^ unexpected
+
+--
+let a = {, foo}
+let b = { foo bar }

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -1,3 +1,133 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: missing (required),
+                                        colon_token: COLON@17..19 ":" [] [Whitespace(" ")],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@25..26 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@26..31 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@31..33 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@33..35 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@35..36 "{" [] [],
+                                members: [
+                                    JsUnknownMember {
+                                        items: [
+                                            Token(
+                                                L_CURLY@36..37 "{" [] [],
+                                            ),
+                                        ],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@37..38 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_CURLY@38..39 "}" [] [],
+                ),
+            ],
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@39..49 "test_err" [Whitespace("\n")] [Whitespace(" ")],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@49..83 "object_expr_non_ident_literal_prop" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@83..88 "let" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@88..90 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@90..92 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@92..93 "{" [] [],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@93..94 "5" [] [],
+                                        },
+                                        colon_token: missing (required),
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@94..95 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..96
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_method.rast
@@ -1,3 +1,53 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@10..13 "foo" [] [],
+                                        },
+                                        colon_token: missing (required),
+                                    }
+                                    missing separator,
+                                    JsUnknownMember {
+                                        items: [
+                                            Token(
+                                                R_PAREN@13..15 ")" [] [Whitespace(" ")],
+                                            ),
+                                        ],
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@15..16 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..17
   0: (empty)
   1: LIST@0..0
@@ -19,7 +69,8 @@
                     0: JS_LITERAL_MEMBER_NAME@10..13
                       0: IDENT@10..13 "foo" [] []
                     1: (empty)
-                  1: JS_UNKNOWN_MEMBER@13..15
+                  1: (empty)
+                  2: JS_UNKNOWN_MEMBER@13..15
                     0: R_PAREN@13..15 ")" [] [Whitespace(" ")]
                 2: R_CURLY@15..16 "}" [] []
       1: (empty)

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -1,3 +1,45 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: JS_NUMBER_LITERAL@9..10 "5" [] [],
+                                        },
+                                        colon_token: missing (required),
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@10..11 "}" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..12
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
@@ -1,3 +1,62 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: [
+                                    JsSetterObjectMember {
+                                        set_token: SET_KW@9..15 "set" [Whitespace("\n ")] [Whitespace(" ")],
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@15..18 "foo" [] [],
+                                        },
+                                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                                        parameter: missing (required),
+                                        r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@21..22 "{" [] [],
+                                            directives: [],
+                                            statements: [
+                                                JsReturnStatement {
+                                                    return_token: RETURN_KW@22..34 "return" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                    argument: JsNumberLiteralExpression {
+                                                        value_token: JS_NUMBER_LITERAL@34..35 "5" [] [],
+                                                    },
+                                                    semicolon_token: SEMICOLON@35..36 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@36..39 "}" [Whitespace("\n ")] [],
+                                        },
+                                    }
+                                    ,
+                                ],
+                                r_curly_token: R_CURLY@39..41 "}" [Whitespace("\n")] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..42
   0: (empty)
   1: LIST@0..0
@@ -20,11 +79,9 @@
                     1: JS_LITERAL_MEMBER_NAME@15..18
                       0: IDENT@15..18 "foo" [] []
                     2: L_PAREN@18..19 "(" [] []
-                    3: JS_UNKNOWN_PATTERN@19..21
-                      0: R_PAREN@19..21 ")" [] [Whitespace(" ")]
-                    4: (empty)
-                    5: (empty)
-                    6: JS_FUNCTION_BODY@21..39
+                    3: (empty)
+                    4: R_PAREN@19..21 ")" [] [Whitespace(" ")]
+                    5: JS_FUNCTION_BODY@21..39
                       0: L_CURLY@21..22 "{" [] []
                       1: LIST@22..22
                       2: LIST@22..36
@@ -45,18 +102,11 @@ error[SyntaxError]: Expected an identifier or pattern, but found none
   │          ^
 
 --
-error[SyntaxError]: expected a parameter but instead found '{'
-  ┌─ object_expr_setter.js:2:12
+error[SyntaxError]: expected a parameter but instead found ')'
+  ┌─ object_expr_setter.js:2:10
   │
 2 │  set foo() {
-  │            ^ Expected a parameter here
-
---
-error[SyntaxError]: expected `')'` but instead found `{`
-  ┌─ object_expr_setter.js:2:12
-  │
-2 │  set foo() {
-  │            ^ unexpected
+  │          ^ Expected a parameter here
 
 --
 let b = {

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -1,3 +1,110 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@0..1 "(" [] [],
+                    parameters: [
+                        JsUnknownPattern {
+                            items: [
+                                Token(
+                                    JS_NUMBER_LITERAL@1..3 "5" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    PLUS@3..5 "+" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    JS_NUMBER_LITERAL@5..6 "5" [] [],
+                                ),
+                            ],
+                        }
+                        ,
+                    ],
+                    r_paren_token: R_PAREN@6..8 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@8..11 "=>" [] [Whitespace(" ")],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@13..15 "(" [Whitespace("\n")] [],
+                expression: JsSequenceExpression {
+                    left: JsReferenceIdentifierExpression {
+                        name_token: IDENT@15..16 "a" [] [],
+                    },
+                    comma_token: COMMA@16..18 "," [] [Whitespace(" ")],
+                },
+                r_paren_token: missing (required),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsReferenceIdentifierExpression {
+                name_token: IDENT@19..20 "b" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    R_PAREN@20..22 ")" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    FAT_ARROW@22..25 "=>" [] [Whitespace(" ")],
+                ),
+            ],
+        },
+        JsBlockStatement {
+            l_curly_token: L_CURLY@25..26 "{" [] [],
+            statements: [],
+            r_curly_token: R_CURLY@26..27 "}" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsArrowFunctionExpression {
+                async_token: missing (optional),
+                type_parameters: missing (optional),
+                parameter_list: JsParameterList {
+                    l_paren_token: L_PAREN@27..29 "(" [Whitespace("\n")] [],
+                    parameters: [
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@29..30 "a" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        COMMA@30..32 "," [] [Whitespace(" ")],
+                        SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@32..33 "b" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        }
+                        ,
+                    ],
+                    r_paren_token: R_PAREN@33..35 ")" [] [Whitespace(" ")],
+                },
+                fat_arrow_token: FAT_ARROW@35..37 "=>" [] [],
+                return_type: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..38
   0: (empty)
   1: LIST@0..0
@@ -7,11 +114,10 @@
         0: JS_PARAMETER_LIST@0..8
           0: L_PAREN@0..1 "(" [] []
           1: LIST@1..6
-            0: JS_UNKNOWN_PATTERN@1..3
+            0: JS_UNKNOWN_PATTERN@1..6
               0: JS_NUMBER_LITERAL@1..3 "5" [] [Whitespace(" ")]
-            1: JS_UNKNOWN_PATTERN@3..6
-              0: PLUS@3..5 "+" [] [Whitespace(" ")]
-              1: JS_NUMBER_LITERAL@5..6 "5" [] []
+              1: PLUS@3..5 "+" [] [Whitespace(" ")]
+              2: JS_NUMBER_LITERAL@5..6 "5" [] []
           2: R_PAREN@6..8 ")" [] [Whitespace(" ")]
         1: FAT_ARROW@8..11 "=>" [] [Whitespace(" ")]
         2: JS_FUNCTION_BODY@11..13
@@ -66,13 +172,6 @@ error[SyntaxError]: Expected an identifier or pattern, but found none
   │
 1 │ (5 + 5) => {}
   │  ^
-
---
-error[SyntaxError]: expected a parameter but instead found '+ 5'
-  ┌─ paren_or_arrow_expr_invalid_params.js:1:4
-  │
-1 │ (5 + 5) => {}
-  │    ^^^ Expected a parameter here
 
 --
 error[SyntaxError]: Expected an expression, but found none

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -1,3 +1,47 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: missing (required),
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@9..11 ";" [] [Whitespace(" ")],
+        },
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsReferenceIdentifierExpression {
+                    name_token: IDENT@11..14 "foo" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@14..15 "(" [] [],
+                    args: [],
+                    r_paren_token: R_PAREN@15..16 ")" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..18
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -1,3 +1,35 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsUnknownStatement {
+            items: [
+                Token(
+                    RETURN_KW@0..6 "return" [] [],
+                ),
+                Token(
+                    SEMICOLON@6..7 ";" [] [],
+                ),
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                Token(
+                    RETURN_KW@7..15 "return" [Whitespace("\n")] [Whitespace(" ")],
+                ),
+                Node(
+                    1: JS_REFERENCE_IDENTIFIER_EXPRESSION@15..18
+                      0: IDENT@15..18 "foo" [] []
+                    ,
+                ),
+                Token(
+                    SEMICOLON@18..19 ";" [] [],
+                ),
+            ],
+        },
+    ],
+}
+
 0: JS_ROOT@0..20
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -1,3 +1,42 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@8..10 "=" [] [Whitespace(" ")],
+                            expression: JsReferenceIdentifierExpression {
+                                name_token: IDENT@10..14 "bar" [] [Whitespace(" ")],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsThrowStatement {
+            throw_token: THROW_KW@14..20 "throw" [] [Whitespace(" ")],
+            argument: JsReferenceIdentifierExpression {
+                name_token: IDENT@20..23 "foo" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..24
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
@@ -1,3 +1,40 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..14 "Setters" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@14..15 "{" [] [],
+            members: [
+                JsSetterClassMember {
+                    access_modifier: missing (optional),
+                    abstract_token: missing (optional),
+                    static_token: missing (optional),
+                    set_token: SET_KW@15..22 "set" [Whitespace("\n  ")] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@22..25 "foo" [] [],
+                    },
+                    l_paren_token: L_PAREN@25..26 "(" [] [],
+                    parameter: missing (required),
+                    r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@28..29 "{" [] [],
+                        directives: [],
+                        statements: [],
+                        r_curly_token: R_CURLY@29..30 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@30..32 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..33
   0: (empty)
   1: LIST@0..0
@@ -13,11 +50,9 @@
           1: JS_LITERAL_MEMBER_NAME@22..25
             0: IDENT@22..25 "foo" [] []
           2: L_PAREN@25..26 "(" [] []
-          3: JS_UNKNOWN_PATTERN@26..28
-            0: R_PAREN@26..28 ")" [] [Whitespace(" ")]
-          4: (empty)
-          5: (empty)
-          6: JS_FUNCTION_BODY@28..30
+          3: (empty)
+          4: R_PAREN@26..28 ")" [] [Whitespace(" ")]
+          5: JS_FUNCTION_BODY@28..30
             0: L_CURLY@28..29 "{" [] []
             1: LIST@29..29
             2: LIST@29..29
@@ -32,18 +67,11 @@ error[SyntaxError]: Expected an identifier or pattern, but found none
   │           ^
 
 --
-error[SyntaxError]: expected a parameter but instead found '{'
-  ┌─ setter_class_member.js:2:13
+error[SyntaxError]: expected a parameter but instead found ')'
+  ┌─ setter_class_member.js:2:11
   │
 2 │   set foo() {}
-  │             ^ Expected a parameter here
-
---
-error[SyntaxError]: expected `')'` but instead found `{`
-  ┌─ setter_class_member.js:2:13
-  │
-2 │   set foo() {}
-  │             ^ unexpected
+  │           ^ Expected a parameter here
 
 --
 class Setters {

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -1,3 +1,16 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsExpressionStatement {
+            expression: Template {
+                backtick_token: BACKTICK@17..18 "`" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..20
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
@@ -1,3 +1,111 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsClassDeclaration {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..11 "Test" [] [Whitespace(" ")],
+            },
+            implements_clause: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@11..19 "extends" [] [Whitespace(" ")],
+                super_class: JsReferenceIdentifierExpression {
+                    name_token: IDENT@19..21 "B" [] [Whitespace(" ")],
+                },
+            },
+            l_curly_token: L_CURLY@21..22 "{" [] [],
+            members: [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@22..28 "test" [Whitespace("\n\t")] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameter_list: JsParameterList {
+                        l_paren_token: L_PAREN@28..29 "(" [] [],
+                        parameters: [],
+                        r_paren_token: R_PAREN@29..31 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@31..32 "{" [] [],
+                        directives: [],
+                        statements: [
+                            JsExpressionStatement {
+                                expression: CallExpr {
+                                    type_args: missing (optional),
+                                    callee: JsUnknownExpression {
+                                        items: [
+                                            Token(
+                                                SUPER_KW@32..40 "super" [Whitespace("\n\t\t")] [],
+                                            ),
+                                        ],
+                                    },
+                                    arguments: ArgList {
+                                        l_paren_token: L_PAREN@40..41 "(" [] [],
+                                        args: [],
+                                        r_paren_token: R_PAREN@41..42 ")" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@42..43 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: CallExpr {
+                                    type_args: missing (optional),
+                                    callee: JsStaticMemberExpression {
+                                        object: JsUnknownExpression {
+                                            items: [
+                                                Token(
+                                                    SUPER_KW@43..51 "super" [Whitespace("\n\t\t")] [],
+                                                ),
+                                            ],
+                                        },
+                                        operator: QUESTIONDOT@51..53 "?." [] [],
+                                        member: JsReferenceIdentifierMember {
+                                            name_token: IDENT@53..57 "test" [] [],
+                                        },
+                                    },
+                                    arguments: ArgList {
+                                        l_paren_token: L_PAREN@57..58 "(" [] [],
+                                        args: [],
+                                        r_paren_token: R_PAREN@58..59 ")" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@59..60 ";" [] [],
+                            },
+                        ],
+                        r_curly_token: R_CURLY@60..63 "}" [Whitespace("\n\t")] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@63..65 "}" [Whitespace("\n")] [],
+        },
+        JsExpressionStatement {
+            expression: CallExpr {
+                type_args: missing (optional),
+                callee: JsUnknownExpression {
+                    items: [
+                        Token(
+                            SUPER_KW@65..72 "super" [Whitespace("\n\n")] [],
+                        ),
+                    ],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@72..73 "(" [] [],
+                    args: [],
+                    r_paren_token: R_PAREN@73..74 ")" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@74..75 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..76
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_double_default.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_double_default.rast
@@ -1,0 +1,85 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@0..7 "switch" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@7..8 "(" [] [],
+            discriminant: JsReferenceIdentifierExpression {
+                name_token: IDENT@8..11 "foo" [] [],
+            },
+            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+            l_curly_token: L_CURLY@13..14 "{" [] [],
+            cases: [
+                JsDefaultClause {
+                    default_token: DEFAULT_KW@14..23 "default" [Whitespace("\n\t")] [],
+                    colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                    consequent: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@25..26 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@26..27 "}" [] [],
+                        },
+                    ],
+                },
+                JsDefaultClause {
+                    default_token: DEFAULT_KW@27..36 "default" [Whitespace("\n\t")] [],
+                    colon_token: COLON@36..38 ":" [] [Whitespace(" ")],
+                    consequent: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@38..39 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@39..40 "}" [] [],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@40..42 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
+0: JS_ROOT@0..43
+  0: (empty)
+  1: LIST@0..0
+  2: LIST@0..42
+    0: JS_SWITCH_STATEMENT@0..42
+      0: SWITCH_KW@0..7 "switch" [] [Whitespace(" ")]
+      1: L_PAREN@7..8 "(" [] []
+      2: JS_REFERENCE_IDENTIFIER_EXPRESSION@8..11
+        0: IDENT@8..11 "foo" [] []
+      3: R_PAREN@11..13 ")" [] [Whitespace(" ")]
+      4: L_CURLY@13..14 "{" [] []
+      5: LIST@14..40
+        0: JS_DEFAULT_CLAUSE@14..27
+          0: DEFAULT_KW@14..23 "default" [Whitespace("\n\t")] []
+          1: COLON@23..25 ":" [] [Whitespace(" ")]
+          2: LIST@25..27
+            0: JS_BLOCK_STATEMENT@25..27
+              0: L_CURLY@25..26 "{" [] []
+              1: LIST@26..26
+              2: R_CURLY@26..27 "}" [] []
+        1: JS_DEFAULT_CLAUSE@27..40
+          0: DEFAULT_KW@27..36 "default" [Whitespace("\n\t")] []
+          1: COLON@36..38 ":" [] [Whitespace(" ")]
+          2: LIST@38..40
+            0: JS_BLOCK_STATEMENT@38..40
+              0: L_CURLY@38..39 "{" [] []
+              1: LIST@39..39
+              2: R_CURLY@39..40 "}" [] []
+      6: R_CURLY@40..42 "}" [Whitespace("\n")] []
+  3: EOF@42..43 "" [Whitespace("\n")] []
+--
+error[SyntaxError]: Multiple default clauses inside of a switch statement are not allowed
+  ┌─ switch_stmt_double_default.js:3:2
+  │
+2 │     default: {}
+  │     ---------- the first default clause is defined here
+3 │     default: {}
+  │     ^^^^^^^^^^ a second clause here is not allowed
+
+--
+switch (foo) {
+	default: {}
+	default: {}
+}

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -33,7 +33,24 @@ JsRoot {
                     case_token: missing (required),
                     test: missing (required),
                     colon_token: missing (required),
-                    consequent: [],
+                    consequent: [
+                        JsUnknownStatement {
+                            items: [
+                                Token(
+                                    VAR_KW@33..37 "var" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    IDENT@37..39 "i" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    EQ@39..41 "=" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    JS_NUMBER_LITERAL@41..43 "0" [] [Whitespace(" ")],
+                                ),
+                            ],
+                        },
+                    ],
                 },
             ],
             r_curly_token: R_CURLY@43..44 "}" [] [],
@@ -49,7 +66,27 @@ JsRoot {
                     case_token: missing (required),
                     test: missing (required),
                     colon_token: missing (required),
-                    consequent: [],
+                    consequent: [
+                        JsUnknownStatement {
+                            items: [
+                                Token(
+                                    VAR_KW@54..58 "var" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    IDENT@58..60 "i" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    EQ@60..62 "=" [] [Whitespace(" ")],
+                                ),
+                                Token(
+                                    JS_NUMBER_LITERAL@62..63 "0" [] [],
+                                ),
+                                Token(
+                                    SEMICOLON@63..65 ";" [] [Whitespace(" ")],
+                                ),
+                            ],
+                        },
+                    ],
                 },
                 JsCaseClause {
                     case_token: CASE_KW@65..70 "case" [] [Whitespace(" ")],
@@ -139,11 +176,12 @@ JsRoot {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: JS_UNKNOWN_STATEMENT@33..43
-            0: VAR_KW@33..37 "var" [] [Whitespace(" ")]
-            1: IDENT@37..39 "i" [] [Whitespace(" ")]
-            2: EQ@39..41 "=" [] [Whitespace(" ")]
-            3: JS_NUMBER_LITERAL@41..43 "0" [] [Whitespace(" ")]
+          3: LIST@33..43
+            0: JS_UNKNOWN_STATEMENT@33..43
+              0: VAR_KW@33..37 "var" [] [Whitespace(" ")]
+              1: IDENT@37..39 "i" [] [Whitespace(" ")]
+              2: EQ@39..41 "=" [] [Whitespace(" ")]
+              3: JS_NUMBER_LITERAL@41..43 "0" [] [Whitespace(" ")]
       5: R_CURLY@43..44 "}" [] []
     3: JS_SWITCH_STATEMENT@44..81
       0: SWITCH_KW@44..52 "switch" [Whitespace("\n")] [Whitespace(" ")]
@@ -155,12 +193,13 @@ JsRoot {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: JS_UNKNOWN_STATEMENT@54..65
-            0: VAR_KW@54..58 "var" [] [Whitespace(" ")]
-            1: IDENT@58..60 "i" [] [Whitespace(" ")]
-            2: EQ@60..62 "=" [] [Whitespace(" ")]
-            3: JS_NUMBER_LITERAL@62..63 "0" [] []
-            4: SEMICOLON@63..65 ";" [] [Whitespace(" ")]
+          3: LIST@54..65
+            0: JS_UNKNOWN_STATEMENT@54..65
+              0: VAR_KW@54..58 "var" [] [Whitespace(" ")]
+              1: IDENT@58..60 "i" [] [Whitespace(" ")]
+              2: EQ@60..62 "=" [] [Whitespace(" ")]
+              3: JS_NUMBER_LITERAL@62..63 "0" [] []
+              4: SEMICOLON@63..65 ";" [] [Whitespace(" ")]
         1: JS_CASE_CLAUSE@65..80
           0: CASE_KW@65..70 "case" [] [Whitespace(" ")]
           1: JS_STRING_LITERAL_EXPRESSION@70..75

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -1,3 +1,114 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@0..7 "switch" [] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            discriminant: JsReferenceIdentifierExpression {
+                name_token: IDENT@7..11 "foo" [] [Whitespace(" ")],
+            },
+            r_paren_token: missing (required),
+            l_curly_token: L_CURLY@11..12 "{" [] [],
+            cases: [],
+            r_curly_token: R_CURLY@12..13 "}" [] [],
+        },
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@13..21 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            discriminant: missing (required),
+            r_paren_token: missing (required),
+            l_curly_token: L_CURLY@21..22 "{" [] [],
+            cases: [],
+            r_curly_token: R_CURLY@22..23 "}" [] [],
+        },
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@23..31 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            discriminant: missing (required),
+            r_paren_token: missing (required),
+            l_curly_token: L_CURLY@31..33 "{" [] [Whitespace(" ")],
+            cases: [
+                JsCaseClause {
+                    case_token: missing (required),
+                    test: missing (required),
+                    colon_token: missing (required),
+                    consequent: [],
+                },
+            ],
+            r_curly_token: R_CURLY@43..44 "}" [] [],
+        },
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@44..52 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            discriminant: missing (required),
+            r_paren_token: missing (required),
+            l_curly_token: L_CURLY@52..54 "{" [] [Whitespace(" ")],
+            cases: [
+                JsCaseClause {
+                    case_token: missing (required),
+                    test: missing (required),
+                    colon_token: missing (required),
+                    consequent: [],
+                },
+                JsCaseClause {
+                    case_token: CASE_KW@65..70 "case" [] [Whitespace(" ")],
+                    test: JsStringLiteralExpression {
+                        value_token: JS_STRING_LITERAL@70..75 "\"bar\"" [] [],
+                    },
+                    colon_token: COLON@75..77 ":" [] [Whitespace(" ")],
+                    consequent: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@77..78 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@78..80 "}" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@80..81 "}" [] [],
+        },
+        JsSwitchStatement {
+            switch_token: SWITCH_KW@81..89 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@89..90 "(" [] [],
+            discriminant: JsReferenceIdentifierExpression {
+                name_token: IDENT@90..93 "foo" [] [],
+            },
+            r_paren_token: R_PAREN@93..95 ")" [] [Whitespace(" ")],
+            l_curly_token: L_CURLY@95..96 "{" [] [],
+            cases: [
+                JsDefaultClause {
+                    default_token: DEFAULT_KW@96..105 "default" [Whitespace("\n\t")] [],
+                    colon_token: COLON@105..107 ":" [] [Whitespace(" ")],
+                    consequent: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@107..108 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@108..109 "}" [] [],
+                        },
+                    ],
+                },
+                JsCaseClause {
+                    case_token: missing (required),
+                    test: JsUnaryExpression {
+                        operator: missing (required),
+                        argument: missing (required),
+                    },
+                    colon_token: COLON@118..120 ":" [] [Whitespace(" ")],
+                    consequent: [
+                        JsBlockStatement {
+                            l_curly_token: L_CURLY@120..121 "{" [] [],
+                            statements: [],
+                            r_curly_token: R_CURLY@121..122 "}" [] [],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@122..124 "}" [Whitespace("\n")] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..125
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
@@ -1,3 +1,35 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: Template {
+                                backtick_token: BACKTICK@8..9 "`" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..20
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -1,3 +1,35 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsThrowStatement {
+            throw_token: THROW_KW@0..5 "throw" [] [],
+            argument: missing (required),
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: NewExpr {
+                new_token: NEW_KW@5..10 "new" [Whitespace("\n")] [Whitespace(" ")],
+                type_args: missing (optional),
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@10..15 "Error" [] [],
+                },
+                arguments: ArgList {
+                    l_paren_token: L_PAREN@15..16 "(" [] [],
+                    args: [
+                        JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@16..26 "\"oh no :(\"" [] [],
+                        }
+                        ,
+                    ],
+                    r_paren_token: R_PAREN@26..27 ")" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+}
+
 0: JS_ROOT@0..28
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -1,3 +1,33 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "s" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: missing (required),
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..18
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -1,3 +1,89 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: VAR_KW@0..4 "var" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@6..7 "=" [] [],
+                            expression: JsUnknownExpression {
+                                items: [
+                                    Token(
+                                        SEMICOLON@7..8 ";" [] [],
+                                    ),
+                                ],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: CONST_KW@8..15 "const" [Whitespace("\n")] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@15..17 "a" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@17..19 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@19..21 "5" [] [Whitespace(" ")],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsVariableDeclarationStatement {
+            declaration: JsVariableDeclaration {
+                kind_token: LET_KW@21..25 "let" [] [Whitespace(" ")],
+                declarators: [
+                    JsVariableDeclarator {
+                        id: SinglePattern {
+                            name: Name {
+                                ident_token: IDENT@25..27 "b" [] [Whitespace(" ")],
+                            },
+                            question_mark_token: missing (optional),
+                            excl_token: missing (optional),
+                            ty: missing (optional),
+                        },
+                        init: JsEqualValueClause {
+                            eq_token: EQ@27..29 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@29..30 "5" [] [],
+                            },
+                        },
+                    }
+                    ,
+                ],
+            },
+            semicolon_token: SEMICOLON@30..31 ";" [] [],
+        },
+    ],
+}
+
 0: JS_ROOT@0..32
   0: (empty)
   1: LIST@0..0

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -1,3 +1,62 @@
+JsRoot {
+    interpreter_token: missing (optional),
+    directives: [],
+    statements: [
+        JsWhileStatement {
+            while_token: WHILE_KW@0..6 "while" [] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@6..11 "true" [] [Whitespace(" ")],
+            },
+            r_paren_token: missing (required),
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@11..12 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@12..13 "}" [] [],
+            },
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@13..20 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            test: missing (required),
+            r_paren_token: missing (required),
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@20..21 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@21..22 "}" [] [],
+            },
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@22..29 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@29..30 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@30..35 "true" [] [Whitespace(" ")],
+            },
+            r_paren_token: missing (required),
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@35..36 "{" [] [],
+                statements: [],
+                r_curly_token: R_CURLY@36..37 "}" [] [],
+            },
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@37..44 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: missing (required),
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@44..48 "true" [] [],
+            },
+            r_paren_token: R_PAREN@48..50 ")" [] [Whitespace(" ")],
+            body: JsUnknownStatement {
+                items: [
+                    Token(
+                        R_CURLY@50..51 "}" [] [],
+                    ),
+                ],
+            },
+        },
+    ],
+}
+
 0: JS_ROOT@0..52
   0: (empty)
   1: LIST@0..0


### PR DESCRIPTION
## Summary

I initially proposed that the `AstSeparatedList` should panic whenever a separator or node is missing. However, that means that the only way for the parser to recover from a missing separator (e.g. `a b`) or from a missing node (`,a`) is to create an empty token (COMMA with "text": "") or an empty element.

Having these empty tokens and nodes breaks with the convention used in the rest of the AST facade where missing required elements return a `SyntaxError::MissingRequiredChild`.

This PR changes the `AstSeparatedListElement` to store the node and separator tokens as `SyntaxResult<T>`s and removes the `panics` in the implementation.

This allows us now to also add the `Ast` snapshot to the failing dir tests.

## Test Plan

Updated the `AstSeparatedList` tests. Verified that the error tests now print AST trees.