### PR TITLE
fix(rslint_parser): some recursing forever

### DIFF
--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -22,9 +22,12 @@ pub(super) fn parse_formal_param_pat(p: &mut Parser) -> ParsedSyntax {
 		}
 	}
 
+	let checkpoint = p.checkpoint();
 	let pat = if let Some(pattern) = pattern(p, true, false) {
 		pattern
 	} else {
+		p.rewind(checkpoint);
+
 		m.abandon(p);
 		// TODO: not correct in case there was any typescript modifier. Revisit when patterns are refactored
 		return ParsedSyntax::Absent;

--- a/crates/rslint_parser/src/syntax/pat.rs
+++ b/crates/rslint_parser/src/syntax/pat.rs
@@ -94,13 +94,11 @@ pub fn pattern(p: &mut Parser, parameters: bool, assignment: bool) -> Option<Com
 				ts = ts.union(token_set![T!['{']]);
 			}
 			if parameters {
-				ts = ts.union(token_set![T![,], T![')']])
+				ts = ts.union(token_set![T![,], T![')']]);
 			}
-			p.error(err);
-			return match ParseRecovery::new(JS_UNKNOWN_PATTERN, ts).recover(p) {
-				Ok(recovered) => Some(recovered),
-				Err(_) => None,
-			};
+			#[allow(deprecated)]
+			SingleTokenParseRecovery::with_error(ts, JS_UNKNOWN_PATTERN, err).recover(p);
+			return None;
 		}
 	})
 }

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -92,11 +92,11 @@ error[SyntaxError]: expected `,` but instead found `++`
   │            ^^ unexpected
 
 --
-error[SyntaxError]: Expected an identifier or pattern, but found none
+error[SyntaxError]: expected a parameter but instead found '++'
   ┌─ formal_params_invalid.js:1:12
   │
 1 │ function (a++, c) {}
-  │            ^^
+  │            ^^ Expected a parameter here
 
 --
 function (a++, c) {}

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -55,11 +55,11 @@ JsRoot {
         3: R_CURLY@20..21 "}" [] []
   3: EOF@21..22 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Expected an identifier or pattern, but found none
+error[SyntaxError]: expected a parameter but instead found 'true'
   ┌─ formal_params_no_binding_element.js:1:14
   │
 1 │ function foo(true) {}
-  │              ^^^^
+  │              ^^^^ Expected a parameter here
 
 --
 function foo(true) {}

--- a/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
@@ -93,13 +93,6 @@ JsRoot {
       1: (empty)
   3: EOF@41..42 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Expected an identifier or pattern, but found none
-  ┌─ object_expr_setter.js:2:10
-  │
-2 │  set foo() {
-  │          ^
-
---
 error[SyntaxError]: expected a parameter but instead found ')'
   ┌─ object_expr_setter.js:2:10
   │

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -165,11 +165,11 @@ JsRoot {
       1: (empty)
   3: EOF@37..38 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Expected an identifier or pattern, but found none
+error[SyntaxError]: expected a parameter but instead found '5 + 5'
   ┌─ paren_or_arrow_expr_invalid_params.js:1:2
   │
 1 │ (5 + 5) => {}
-  │  ^
+  │  ^^^^^ Expected a parameter here
 
 --
 error[SyntaxError]: Expected an expression, but found none

--- a/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
@@ -60,13 +60,6 @@ JsRoot {
       4: R_CURLY@30..32 "}" [Whitespace("\n")] []
   3: EOF@32..33 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Expected an identifier or pattern, but found none
-  ┌─ setter_class_member.js:2:11
-  │
-2 │   set foo() {}
-  │           ^
-
---
 error[SyntaxError]: expected a parameter but instead found ')'
   ┌─ setter_class_member.js:2:11
   │


### PR DESCRIPTION

## Summary
#1829 introduced a bug where the parser now is recursing forever for some libraries like `Vue`.

The problem seems to be from the change from `SingleTokenParseRecovery` in `pat` to use `ParseRecovery` instead. However, this change is necessary because parameter lists may otherwise contain two elements that are not separated by a comma.

This PR adds a somewhat hacky fix since I'm rewriting `patterns` anyway. It reverts `pat` to use `SingleTokenParseRecovery` but takes a snapshot in `parse_formal_param_pat` and rewinds if `pattern` returned `None`.

This fixes most recursing forever issues. There are still some more but they aren't specific to #1829

