### PR TITLE
Parser Progressing Assertion

### DIFF
--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -12,7 +12,6 @@ use drop_bomb::DropBomb;
 use rslint_errors::Diagnostic;
 use rslint_syntax::SyntaxKind::EOF;
 use std::borrow::BorrowMut;
-use std::cell::Cell;
 use std::ops::Range;
 
 pub use parse_error::*;
@@ -29,6 +28,7 @@ pub struct ParserProgress(Option<usize>);
 
 impl ParserProgress {
 	/// Returns true if the current parser position is passed this position
+	#[inline]
 	pub fn has_progressed(&self, p: &Parser) -> bool {
 		match self.0 {
 			None => true,
@@ -40,11 +40,12 @@ impl ParserProgress {
 	/// ## Panics
 	///
 	/// Panics if the parser is still at this position
+	#[inline]
 	pub fn assert_progressing(&mut self, p: &Parser) {
 		assert!(
 			self.has_progressed(p),
 			"The parser is no longer progressing. Stuck at {:?}",
-			p.cur_src()
+			p.cur_tok()
 		);
 
 		self.0 = Some(p.token_pos());

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -23,6 +23,34 @@ pub use single_token_parse_recovery::SingleTokenParseRecovery;
 pub use crate::parser::parse_recovery::{ParseRecovery, RecoveryError, RecoveryResult};
 use crate::*;
 
+/// Captures the progress of the parser and allows to test if the parsing is still making progress
+#[derive(Debug, Eq, Ord, PartialOrd, PartialEq, Hash, Default)]
+pub struct ParserProgress(Option<usize>);
+
+impl ParserProgress {
+	/// Returns true if the current parser position is passed this position
+	pub fn has_progressed(&self, p: &Parser) -> bool {
+		match self.0 {
+			None => true,
+			Some(pos) => pos < p.token_pos(),
+		}
+	}
+
+	/// Asserts that the parsing is still making progress.
+	/// ## Panics
+	///
+	/// Panics if the parser is still at this position
+	pub fn assert_progressing(&mut self, p: &Parser) {
+		assert!(
+			self.has_progressed(p),
+			"The parser is no longer progressing. Stuck at {:?}",
+			p.cur_src()
+		);
+
+		self.0 = Some(p.token_pos());
+	}
+}
+
 /// An extremely fast, error tolerant, completely lossless JavaScript parser
 ///
 /// The Parser yields lower level events instead of nodes.
@@ -91,9 +119,6 @@ pub struct Parser<'t> {
 	pub file_id: usize,
 	tokens: TokenSource<'t>,
 	pub(crate) events: Vec<Event>,
-	// This is for tracking if the parser is infinitely recursing.
-	// We use a cell so we dont need &mut self on `nth()`
-	steps: Cell<u32>,
 	pub state: ParserState,
 	pub syntax: Syntax,
 	pub errors: Vec<ParserError>,
@@ -118,7 +143,6 @@ impl<'t> Parser<'t> {
 			file_id,
 			tokens,
 			events: vec![],
-			steps: Cell::new(0),
 			state,
 			syntax,
 			errors: vec![],
@@ -127,15 +151,6 @@ impl<'t> Parser<'t> {
 
 	pub(crate) fn typescript(&self) -> bool {
 		self.syntax.file_kind == FileKind::TypeScript
-	}
-
-	fn overflow_check(&self) {
-		let steps = self.steps.get();
-		assert!(
-			steps <= 10_000_000,
-			"The parser seems to be recursing forever",
-		);
-		self.steps.set(steps + 1);
 	}
 
 	/// Get the source code of a token
@@ -168,7 +183,6 @@ impl<'t> Parser<'t> {
 
 	/// Look ahead at a token, **The max lookahead is 4**.
 	pub fn nth_tok(&self, n: usize) -> Token {
-		self.overflow_check();
 		self.tokens.lookahead_nth(n)
 	}
 

--- a/crates/rslint_parser/src/syntax/assignment_target.rs
+++ b/crates/rslint_parser/src/syntax/assignment_target.rs
@@ -1,4 +1,4 @@
-use crate::parser::ParsedSyntax;
+use crate::parser::{ParsedSyntax, ParserProgress};
 use crate::syntax::class::parse_equal_value_clause;
 use crate::syntax::expr::{
 	conditional_expr, expr, expr_or_assignment, identifier_name, unary_expr, EXPR_RECOVERY_SET,
@@ -140,7 +140,10 @@ fn parse_array_assignment_target(p: &mut Parser) -> ParsedSyntax {
 	p.bump(T!['[']);
 	let elements = p.start();
 
+	let mut progress = ParserProgress::default();
 	while !p.at(EOF) && !p.at(T![']']) {
+		progress.assert_progressing(p);
+
 		if p.at(T![,]) {
 			p.start().complete(p, SyntaxKind::JS_ARRAY_HOLE);
 			p.bump_any();
@@ -228,8 +231,11 @@ fn parse_object_assignment_target(p: &mut Parser) -> ParsedSyntax {
 
 	p.bump(T!['{']);
 	let elements = p.start();
+	let mut progress = ParserProgress::default();
 
 	while !p.at(T!['}']) {
+		progress.assert_progressing(p);
+
 		if p.at(T![,]) {
 			p.missing(); // missing element
 			p.bump_any();

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1,6 +1,6 @@
 #[allow(deprecated)]
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
-use crate::parser::ParsedSyntax;
+use crate::parser::{ParsedSyntax, ParserProgress};
 use crate::syntax::decl::{parse_formal_param_pat, parse_parameter_list, parse_parameters_list};
 use crate::syntax::expr::expr_or_assignment;
 use crate::syntax::function::{function_body, ts_parameter_types, ts_return_type};
@@ -136,7 +136,9 @@ fn implements_clause(p: &mut Parser) {
 		maybe_err.abandon(&mut *p)
 	}
 
+	let mut progress = ParserProgress::default();
 	while p.cur_src() == "implements" {
+		progress.assert_progressing(p);
 		let start = p.cur_tok().range.start;
 		let m = p.start();
 		p.bump_any();
@@ -177,7 +179,9 @@ fn extends_clause(p: &mut Parser) {
 	}
 
 	// handle `extends foo extends bar` explicitly
+	let mut progress = ParserProgress::default();
 	while p.at(T![extends]) {
+		progress.assert_progressing(p);
 		let m = p.start();
 		p.bump_any();
 
@@ -196,7 +200,9 @@ fn extends_clause(p: &mut Parser) {
 fn class_members(p: &mut Parser) -> CompletedMarker {
 	let members = p.start();
 
+	let mut progress = ParserProgress::default();
 	while !p.at(EOF) && !p.at(T!['}']) {
+		progress.assert_progressing(p);
 		class_member(p);
 	}
 

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -5,6 +5,7 @@ use super::pat::pattern;
 use super::typescript::*;
 #[allow(deprecated)]
 use crate::parser::ParsedSyntax::{Absent, Present};
+use crate::parser::ParserProgress;
 use crate::syntax::function::function_body;
 use crate::syntax::js_parse_error;
 use crate::{SyntaxKind::*, *};
@@ -115,8 +116,11 @@ pub(super) fn parse_parameters_list(
 	p.state.allow_object_expr = p.expect_required(T!['(']);
 
 	let parameters_list = p.start();
+	let mut progress = ParserProgress::default();
 
 	while !p.at(EOF) && !p.at(T![')']) {
+		progress.assert_progressing(p);
+
 		if first {
 			first = false;
 		} else {

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -9,6 +9,7 @@ use super::typescript::*;
 use super::util::*;
 #[allow(deprecated)]
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
+use crate::parser::ParserProgress;
 use crate::syntax::assignment_target::{
 	expression_to_assignment_target, expression_to_simple_assignment_target,
 	parse_simple_assignment_target, SimpleAssignmentTargetExprKind,
@@ -436,7 +437,10 @@ pub fn subscripts(p: &mut Parser, mut lhs: CompletedMarker, no_call: bool) -> Co
 	// foo()?.baz[].
 	// BAR`b
 	let mut should_try_parsing_ts = true;
+	let mut progress = ParserProgress::default();
 	while !p.at(EOF) {
+		progress.assert_progressing(p);
+
 		match p.cur() {
 			T![?.] if p.nth_at(1, T!['(']) => {
 				lhs = {
@@ -613,8 +617,11 @@ pub fn args(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
 	p.expect_required(T!['(']);
 	let args_list = p.start();
+	let mut progress = ParserProgress::default();
 
 	while !p.at(EOF) && !p.at(T![')']) {
+		progress.assert_progressing(p);
+
 		if p.at(T![...]) {
 			spread_element(p);
 		} else {
@@ -1169,8 +1176,11 @@ pub fn array_expr(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
 	p.expect_required(T!['[']);
 	let elements_list = p.start();
+	let mut progress = ParserProgress::default();
 
 	while !p.at(EOF) {
+		progress.assert_progressing(p);
+
 		while p.at(T![,]) {
 			p.start().complete(p, SyntaxKind::JS_ARRAY_HOLE);
 			p.eat(T![,]);

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -1,7 +1,7 @@
 #[allow(deprecated)]
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
-use crate::parser::ParsedSyntax;
 use crate::parser::ParsedSyntax::{Absent, Present};
+use crate::parser::{ParsedSyntax, ParserProgress};
 use crate::syntax::decl::{parse_formal_param_pat, parse_parameter_list};
 use crate::syntax::expr::{expr, expr_or_assignment};
 use crate::syntax::function::{function_body, ts_parameter_types, ts_return_type};
@@ -33,6 +33,7 @@ pub(super) fn object_expr(p: &mut Parser) -> CompletedMarker {
 	let props_list = p.start();
 	let mut first = true;
 
+	let mut progress = ParserProgress::default();
 	while !p.at(EOF) && !p.at(T!['}']) {
 		if first {
 			first = false;
@@ -43,6 +44,8 @@ pub(super) fn object_expr(p: &mut Parser) -> CompletedMarker {
 				break;
 			}
 		}
+
+		progress.assert_progressing(p);
 
 		// missing member
 		if p.at(T![,]) {

--- a/crates/rslint_parser/src/syntax/pat.rs
+++ b/crates/rslint_parser/src/syntax/pat.rs
@@ -1,6 +1,7 @@
 use super::expr::{expr_or_assignment, identifier_name, lhs_expr};
 #[allow(deprecated)]
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
+use crate::parser::ParserProgress;
 use crate::syntax::expr::{parse_identifier, parse_literal_expression};
 use crate::syntax::object::computed_member_name;
 use crate::JsSyntaxFeature::StrictMode;
@@ -175,8 +176,11 @@ pub fn array_binding_pattern(
 	p.expect_required(T!['[']);
 
 	let elements_list = p.start();
+	let mut progress = ParserProgress::default();
 
 	while !p.at(EOF) && !p.at(T![']']) {
+		progress.assert_progressing(p);
+
 		if p.eat(T![,]) {
 			continue;
 		}
@@ -216,8 +220,11 @@ pub fn object_binding_pattern(p: &mut Parser, parameters: bool) -> CompletedMark
 	p.expect_required(T!['{']);
 	let props_list = p.start();
 	let mut first = true;
+	let mut progress = ParserProgress::default();
 
 	while !p.at(EOF) && !p.at(T!['}']) {
+		progress.assert_progressing(p);
+
 		if first {
 			first = false;
 		} else {

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -6,6 +6,7 @@ use super::expr::{expr, expr_or_assignment, identifier_name, primary_expr};
 use super::pat::parse_identifier_binding;
 use super::stmt::{semi, statements, variable_declaration_statement};
 use super::typescript::*;
+use crate::parser::ParserProgress;
 use crate::syntax::class::class_declaration;
 use crate::syntax::function::function_declaration;
 use crate::syntax::object::object_expr;
@@ -41,7 +42,11 @@ fn named_list(p: &mut Parser) -> Marker {
 	p.expect_required(T!['{']);
 	let mut first = true;
 	let specifiers_list = p.start();
+	let mut progress = ParserProgress::default();
+
 	while !p.at(EOF) && !p.at(T!['}']) {
+		progress.assert_progressing(p);
+
 		if first {
 			first = false;
 		} else if p.at(T![,]) && p.nth_at(1, T!['}']) {
@@ -468,8 +473,11 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 
 		let mut first = true;
 		let specifiers = p.start();
+		let mut progress = ParserProgress::default();
 
 		while (!p.at(EOF) && p.at(T![,])) || crate::at_ident_name!(p) {
+			progress.assert_progressing(p);
+
 			if first {
 				first = false;
 			} else if p.eat(T![,]) && p.at(T!['}']) {


### PR DESCRIPTION
## Summary

RSLint used an `oferflow_check` inside of the parser that verified if the parser did less than 50 000 000 steps to parse the current file and otherwise panics, saying that the parser is recursing forever. 

The nicety about this approach is that it doesn't require explicit checks during parsing. However, it has a few downsides:

* It panics for very large file 
* Overflow checks are only necessary in while loops
* The panic happens anytime, but not necessarily in the loop that stopped progressing and the parser goes on and on for a long time until it reached the step limit

This PR introduces a `ParseProgress` struct that allows asserting whatever the parser is making progress. This new struct must be used in every `while` loop. 

This gives us nice stack traces:

```
Parser
thread 'main' panicked at 'The parser is no longer progressing. Stuck at Token { kind: DOT, range: 84430..84431, len: 1 }', crates\rslint_parser\src\parser.rs:46:9
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35\/library\std\src\panicking.rs:517
   1: std::panicking::begin_panic_fmt
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35\/library\std\src\panicking.rs:460
   2: rslint_parser::parser::ParserProgress::assert_progressing
             at .\crates\rslint_parser\src\parser.rs:46
   3: rslint_parser::syntax::pat::object_binding_pattern
             at .\crates\rslint_parser\src\syntax\pat.rs:226
   4: rslint_parser::syntax::pat::pattern
             at .\crates\rslint_parser\src\syntax\pat.rs:21
   5: rslint_parser::syntax::decl::parse_formal_param_pat
             at .\crates\rslint_parser\src\syntax\decl.rs:27
   6: core::ops::function::Fn::call<enum$<rslint_parser::parser::parsed_syntax::ParsedSyntax, 0, 360, Present> (*)(ref_mut$<rslint_parser::parser::Parser>),tuple$<ref_mut$<rslint_parser::parser::Parser> > >
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35\library\core\src\ops\function.rs:70
   7: rslint_parser::syntax::decl::parse_parameters_list<enum$<rslint_parser::parser::parsed_syntax::ParsedSyntax, 0, 360, Present> (*)(ref_mut$<rslint_parser::parser::Parser>)>
             at .\crates\rslint_parser\src\syntax\decl.rs:196
   8: rslint_parser::syntax::decl::parse_parameter_list
             at .\crates\rslint_parser\src\syntax\decl.rs:105
   9: rslint_parser::syntax::expr::paren_or_arrow_expr::closure$2
             at .\crates\rslint_parser\src\syntax\expr.rs:754
  10: rslint_parser::syntax::expr::paren_or_arrow_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:769
  11: rslint_parser::syntax::expr::primary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:980
  12: rslint_parser::syntax::expr::member_or_new_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:421
  13: rslint_parser::syntax::expr::lhs_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1234
  14: rslint_parser::syntax::expr::postfix_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1278
  15: rslint_parser::syntax::expr::unary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1378
  16: rslint_parser::syntax::expr::binary_or_logical_expression
             at .\crates\rslint_parser\src\syntax\expr.rs:231
  17: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:213
  18: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  19: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
  20: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:218
  21: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  22: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
  23: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:852
  24: rslint_parser::parser::Parser::expr_with_semi_recovery
             at .\crates\rslint_parser\src\parser.rs:517
  25: rslint_parser::syntax::stmt::parse_return_statement
             at .\crates\rslint_parser\src\syntax\stmt.rs:426
  26: rslint_parser::syntax::stmt::stmt<rslint_parser::token_set::TokenSet>
             at .\crates\rslint_parser\src\syntax\stmt.rs:115
  27: rslint_parser::syntax::stmt::parse_if_statement
             at .\crates\rslint_parser\src\syntax\stmt.rs:651
  28: rslint_parser::syntax::stmt::stmt<enum$<core::option::Option<rslint_parser::token_set::TokenSet> > >
             at .\crates\rslint_parser\src\syntax\stmt.rs:102
  29: rslint_parser::syntax::stmt::statements<enum$<core::option::Option<rslint_parser::token_set::TokenSet> > >
             at .\crates\rslint_parser\src\syntax\stmt.rs:606
  30: rslint_parser::syntax::stmt::parse_block_impl
             at .\crates\rslint_parser\src\syntax\stmt.rs:479
  31: rslint_parser::syntax::function::function_body
             at .\crates\rslint_parser\src\syntax\function.rs:139
  32: rslint_parser::syntax::function::function
             at .\crates\rslint_parser\src\syntax\function.rs:120
  33: rslint_parser::syntax::function::function_expression
             at .\crates\rslint_parser\src\syntax\function.rs:52
  34: rslint_parser::syntax::expr::primary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:949
  35: rslint_parser::syntax::expr::member_or_new_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:421
  36: rslint_parser::syntax::expr::lhs_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1234
  37: rslint_parser::syntax::expr::postfix_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1278
  38: rslint_parser::syntax::expr::unary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1378
  39: rslint_parser::syntax::expr::binary_or_logical_expression
             at .\crates\rslint_parser\src\syntax\expr.rs:231
  40: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:213
  41: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  42: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
  43: rslint_parser::syntax::object::object_member
             at .\crates\rslint_parser\src\syntax\object.rs:174
  44: rslint_parser::syntax::object::object_expr
             at .\crates\rslint_parser\src\syntax\object.rs:56
  45: rslint_parser::syntax::expr::primary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:982
  46: rslint_parser::syntax::expr::member_or_new_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:421
  47: rslint_parser::syntax::expr::lhs_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1234
  48: rslint_parser::syntax::expr::postfix_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1278
  49: rslint_parser::syntax::expr::unary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1378
  50: rslint_parser::syntax::expr::binary_or_logical_expression
             at .\crates\rslint_parser\src\syntax\expr.rs:231
  51: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:213
  52: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  53: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
  54: rslint_parser::syntax::expr::args
             at .\crates\rslint_parser\src\syntax\expr.rs:628
  55: rslint_parser::syntax::expr::lhs_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1259
  56: rslint_parser::syntax::expr::postfix_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1278
  57: rslint_parser::syntax::expr::unary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1378
  58: rslint_parser::syntax::expr::binary_or_logical_expression
             at .\crates\rslint_parser\src\syntax\expr.rs:231
  59: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:213
  60: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  61: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
  62: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:852
  63: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  64: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  65: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  66: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  67: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  68: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  69: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  70: rslint_parser::syntax::expr::expr
             at .\crates\rslint_parser\src\syntax\expr.rs:858
  71: rslint_parser::parser::Parser::expr_with_semi_recovery
             at .\crates\rslint_parser\src\parser.rs:517
  72: rslint_parser::syntax::stmt::expr_statement
             at .\crates\rslint_parser\src\syntax\stmt.rs:215
  73: rslint_parser::syntax::stmt::stmt<enum$<core::option::Option<rslint_parser::token_set::TokenSet> > >
             at .\crates\rslint_parser\src\syntax\stmt.rs:134
  74: rslint_parser::syntax::stmt::statements<enum$<core::option::Option<rslint_parser::token_set::TokenSet> > >
             at .\crates\rslint_parser\src\syntax\stmt.rs:606
  75: rslint_parser::syntax::stmt::parse_block_impl
             at .\crates\rslint_parser\src\syntax\stmt.rs:479
  76: rslint_parser::syntax::function::function_body
             at .\crates\rslint_parser\src\syntax\function.rs:139
  77: rslint_parser::syntax::function::function
             at .\crates\rslint_parser\src\syntax\function.rs:120
  78: rslint_parser::syntax::function::function_expression
             at .\crates\rslint_parser\src\syntax\function.rs:52
  79: rslint_parser::syntax::expr::primary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:949
  80: rslint_parser::syntax::expr::member_or_new_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:421
  81: rslint_parser::syntax::expr::lhs_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1234
  82: rslint_parser::syntax::expr::postfix_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1278
  83: rslint_parser::syntax::expr::unary_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:1378
  84: rslint_parser::syntax::expr::binary_or_logical_expression
             at .\crates\rslint_parser\src\syntax\expr.rs:231
  85: rslint_parser::syntax::expr::conditional_expr
             at .\crates\rslint_parser\src\syntax\expr.rs:213
  86: rslint_parser::syntax::expr::assign_expr_base
             at .\crates\rslint_parser\src\syntax\expr.rs:153
  87: rslint_parser::syntax::expr::expr_or_assignment
             at .\crates\rslint_parser\src\syntax\expr.rs:139
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

It's clear that the parser is no longer progressing inside of the `pattern` parsing. This will hopefully be fixed soon with the new binding parsing. 

We may want to decide in the future to flip the assertion to debug only when the parser is stable enough.

## Test Plan

Verified that the same libraries are recursing forever. 

