### PR TITLE
performance: Remove cloning of parser

### DIFF
--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -115,7 +115,6 @@ impl ParserProgress {
 ///
 /// assert_eq!(typed_expr.expression().unwrap().syntax().text(), "delete b");
 /// ```
-#[derive(Clone)]
 pub struct Parser<'t> {
 	pub file_id: usize,
 	tokens: TokenSource<'t>,

--- a/crates/rslint_parser/src/token_source.rs
+++ b/crates/rslint_parser/src/token_source.rs
@@ -3,7 +3,6 @@ use rslint_lexer::is_linebreak;
 use std::collections::HashSet;
 
 /// The source of tokens for the parser
-#[derive(Clone)]
 pub struct TokenSource<'t> {
 	source: &'t str,
 	/// Hashset of offsets for tokens which occur after a linebreak.

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -122,6 +122,8 @@ pub fn run(filter: String) {
 					};
 					println!("\tTime");
 					println!("\t\ttook {:?}", parser_timing.stop());
+
+					println!("{:?}", errors);
 					#[cfg(feature = "dhat-on")]
 					let stats = print_diff(stats, dhat::get_stats().unwrap());
 

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -122,8 +122,6 @@ pub fn run(filter: String) {
 					};
 					println!("\tTime");
 					println!("\t\ttook {:?}", parser_timing.stop());
-
-					println!("{:?}", errors);
 					#[cfg(feature = "dhat-on")]
 					let stats = print_diff(stats, dhat::get_stats().unwrap());
 


### PR DESCRIPTION
## Summary

@xunilrj analysis showed that cloning the whole parser considerably reduces the parsing performance. 

The two places where we cloned the parser now have been in

`try_parse_ts` and inside `paren_or_arrow_expr`. 

* `try_parse_ts`: `rewind` used to panic but it seems that the bindings refactoring removed the code that caused the panic. It's now safe to use `rewind`.
* `paren_or_arrow_expr`: No idea what that code was doing. Removing it doesn't regress coverage, nor any test. I also compared the errors when parsing the libraries and there's no difference as well. Let's re-add it when we now what it is used for (with proper tests and such)

Some parse time goodies

* `vue.global.prod`: From 291ms to 12.4ms
* `react.production`: From 754us to 355us
* `dojo`: From 12ms to 2ms
* `d3.min` from 3s to 20ms (wtf?) 
* `pixi.min` from 1.9s to `21ms`
* `three.min` from 2.7s to 28ms

Part of #1837

## Test Plan

Compared coverage, ran unit tests
