### PR TITLE
`or_missing*` helpers for `ParsedSyntax<ConditionalSyntax>`

### DIFF
--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -15,7 +15,7 @@ use std::borrow::BorrowMut;
 use std::ops::Range;
 
 pub use parse_error::*;
-pub use parsed_syntax::{ConditionalSyntax, InvalidParsedSyntax, ParsedSyntax};
+pub use parsed_syntax::{ConditionalSyntax, InvalidSyntax, ParsedSyntax};
 #[allow(deprecated)]
 pub use single_token_parse_recovery::SingleTokenParseRecovery;
 

--- a/crates/rslint_parser/src/syntax/assignment_target.rs
+++ b/crates/rslint_parser/src/syntax/assignment_target.rs
@@ -257,16 +257,11 @@ impl ParseObjectPattern for ObjectAssignmentTarget {
 				.or_missing_with_error(p, expected_assignment_target);
 			JS_OBJECT_PROPERTY_ASSIGNMENT_TARGET
 		} else {
-			match parse_identifier_assignment_target(p) {
-				Present(Invalid(identifier)) => {
-					valid = false;
-					identifier.abandon(p);
-				}
-				Absent => {
-					p.missing();
-					p.error(expected_identifier(p, p.cur_tok().range))
-				}
-				_ => {}
+			if let Err(invalid) =
+				parse_identifier_assignment_target(p).or_missing_with_error(p, expected_identifier)
+			{
+				valid = false;
+				invalid.abandon(p);
 			}
 			JS_SHORTHAND_PROPERTY_ASSIGNMENT_TARGET
 		};

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -193,11 +193,13 @@ JsRoot {
       1: STAR@40..41 "*" [] []
       2: JS_IDENTIFIER_BINDING@41..44
         0: IDENT@41..44 "foo" [] []
-      3: JS_PARAMETER_LIST@44..47
+      3: (empty)
+      4: JS_PARAMETER_LIST@44..47
         0: L_PAREN@44..45 "(" [] []
         1: LIST@45..45
         2: R_PAREN@45..47 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@47..68
+      5: (empty)
+      6: JS_FUNCTION_BODY@47..68
         0: L_CURLY@47..48 "{" [] []
         1: LIST@48..48
         2: LIST@48..66

--- a/crates/rslint_parser/test_data/inline/err/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/break_stmt.rast
@@ -45,11 +45,13 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..15
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..15
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..13
         2: R_PAREN@13..15 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@15..25
+      4: (empty)
+      5: JS_FUNCTION_BODY@15..25
         0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
         1: LIST@17..17
         2: LIST@17..24

--- a/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
@@ -45,11 +45,13 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..15
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..15
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..13
         2: R_PAREN@13..15 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@15..28
+      4: (empty)
+      5: JS_FUNCTION_BODY@15..28
         0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
         1: LIST@17..17
         2: LIST@17..27

--- a/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
@@ -64,11 +64,13 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..15
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..15
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..13
         2: R_PAREN@13..15 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@15..60
+      4: (empty)
+      5: JS_FUNCTION_BODY@15..60
         0: L_CURLY@15..16 "{" [] []
         1: LIST@16..16
         2: LIST@16..58

--- a/crates/rslint_parser/test_data/inline/err/directives_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/directives_err.rast
@@ -114,11 +114,13 @@ JsRoot {
       0: FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@20..24
         0: IDENT@20..24 "test" [] []
-      2: JS_PARAMETER_LIST@24..27
+      2: (empty)
+      3: JS_PARAMETER_LIST@24..27
         0: L_PAREN@24..25 "(" [] []
         1: LIST@25..25
         2: R_PAREN@25..27 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@27..160
+      4: (empty)
+      5: JS_FUNCTION_BODY@27..160
         0: L_CURLY@27..28 "{" [] []
         1: LIST@28..43
           0: JS_DIRECTIVE@28..43
@@ -129,11 +131,13 @@ JsRoot {
             0: FUNCTION_KW@43..54 "function" [Whitespace("\n\t")] [Whitespace(" ")]
             1: JS_IDENTIFIER_BINDING@54..61
               0: IDENT@54..61 "inner_a" [] []
-            2: JS_PARAMETER_LIST@61..64
+            2: (empty)
+            3: JS_PARAMETER_LIST@61..64
               0: L_PAREN@61..62 "(" [] []
               1: LIST@62..62
               2: R_PAREN@62..64 ")" [] [Whitespace(" ")]
-            3: JS_FUNCTION_BODY@64..84
+            4: (empty)
+            5: JS_FUNCTION_BODY@64..84
               0: L_CURLY@64..65 "{" [] []
               1: LIST@65..81
                 0: JS_DIRECTIVE@65..81
@@ -145,11 +149,13 @@ JsRoot {
             0: FUNCTION_KW@84..96 "function" [Whitespace("\n\n\t")] [Whitespace(" ")]
             1: JS_IDENTIFIER_BINDING@96..103
               0: IDENT@96..103 "inner_b" [] []
-            2: JS_PARAMETER_LIST@103..106
+            2: (empty)
+            3: JS_PARAMETER_LIST@103..106
               0: L_PAREN@103..104 "(" [] []
               1: LIST@104..104
               2: R_PAREN@104..106 ")" [] [Whitespace(" ")]
-            3: JS_FUNCTION_BODY@106..158
+            4: (empty)
+            5: JS_FUNCTION_BODY@106..158
               0: L_CURLY@106..107 "{" [] []
               1: LIST@107..107
               2: LIST@107..155
@@ -157,11 +163,13 @@ JsRoot {
                   0: FUNCTION_KW@107..119 "function" [Whitespace("\n\t\t")] [Whitespace(" ")]
                   1: JS_IDENTIFIER_BINDING@119..130
                     0: IDENT@119..130 "inner_inner" [] []
-                  2: JS_PARAMETER_LIST@130..133
+                  2: (empty)
+                  3: JS_PARAMETER_LIST@130..133
                     0: L_PAREN@130..131 "(" [] []
                     1: LIST@131..131
                     2: R_PAREN@131..133 ")" [] [Whitespace(" ")]
-                  3: JS_FUNCTION_BODY@133..155
+                  4: (empty)
+                  5: JS_FUNCTION_BODY@133..155
                     0: L_CURLY@133..134 "{" [] []
                     1: LIST@134..151
                       0: JS_DIRECTIVE@134..151

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -47,7 +47,8 @@ JsRoot {
     0: JS_FUNCTION_DECLARATION@0..20
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: (empty)
-      2: JS_PARAMETER_LIST@9..18
+      2: (empty)
+      3: JS_PARAMETER_LIST@9..18
         0: L_PAREN@9..10 "(" [] []
         1: LIST@10..16
           0: JS_IDENTIFIER_BINDING@10..11
@@ -59,7 +60,8 @@ JsRoot {
           4: JS_IDENTIFIER_BINDING@15..16
             0: IDENT@15..16 "c" [] []
         2: R_PAREN@16..18 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@18..20
+      4: (empty)
+      5: JS_FUNCTION_BODY@18..20
         0: L_CURLY@18..19 "{" [] []
         1: LIST@19..19
         2: LIST@19..19

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -42,13 +42,15 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..19
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..19
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..17
           0: JS_UNKNOWN_BINDING@13..17
             0: TRUE_KW@13..17 "true" [] []
         2: R_PAREN@17..19 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@19..21
+      4: (empty)
+      5: JS_FUNCTION_BODY@19..21
         0: L_CURLY@19..20 "{" [] []
         1: LIST@20..20
         2: LIST@20..20

--- a/crates/rslint_parser/test_data/inline/err/function_broken.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_broken.rast
@@ -68,11 +68,13 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..14
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..14
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..13
         2: R_PAREN@13..14 ")" [] []
-      3: (empty)
+      4: (empty)
+      5: (empty)
     1: JS_UNKNOWN_STATEMENT@14..18
       0: R_PAREN@14..15 ")" [] []
       1: R_CURLY@15..16 "}" [] []

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -158,21 +158,21 @@ JsRoot {
                     ,
                 ),
                 Node(
-                    2: JS_PARAMETER_LIST@143..145
+                    3: JS_PARAMETER_LIST@143..145
                       0: L_PAREN@143..144 "(" [] []
                       1: LIST@144..144
                       2: R_PAREN@144..145 ")" [] []
                     ,
                 ),
                 Node(
-                    3: TS_TYPE_ANNOTATION@145..154
+                    4: TS_TYPE_ANNOTATION@145..154
                       0: COLON@145..147 ":" [] [Whitespace(" ")]
                       1: TS_NUMBER@147..154
                         0: IDENT@147..154 "number" [] [Whitespace(" ")]
                     ,
                 ),
                 Node(
-                    4: JS_FUNCTION_BODY@154..156
+                    5: JS_FUNCTION_BODY@154..156
                       0: L_CURLY@154..155 "{" [] []
                       1: LIST@155..155
                       2: LIST@155..155
@@ -249,11 +249,13 @@ JsRoot {
     0: JS_FUNCTION_DECLARATION@0..13
       0: FUNCTION_KW@0..8 "function" [] []
       1: (empty)
-      2: JS_PARAMETER_LIST@8..11
+      2: (empty)
+      3: JS_PARAMETER_LIST@8..11
         0: L_PAREN@8..9 "(" [] []
         1: LIST@9..9
         2: R_PAREN@9..11 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@11..13
+      4: (empty)
+      5: JS_FUNCTION_BODY@11..13
         0: L_CURLY@11..12 "{" [] []
         1: LIST@12..12
         2: LIST@12..12
@@ -263,7 +265,9 @@ JsRoot {
       1: JS_IDENTIFIER_BINDING@23..27
         0: IDENT@23..27 "foo" [] [Whitespace(" ")]
       2: (empty)
-      3: JS_FUNCTION_BODY@27..29
+      3: (empty)
+      4: (empty)
+      5: JS_FUNCTION_BODY@27..29
         0: L_CURLY@27..28 "{" [] []
         1: LIST@28..28
         2: LIST@28..28
@@ -272,7 +276,9 @@ JsRoot {
       0: FUNCTION_KW@29..39 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
-      3: JS_FUNCTION_BODY@39..41
+      3: (empty)
+      4: (empty)
+      5: JS_FUNCTION_BODY@39..41
         0: L_CURLY@39..40 "{" [] []
         1: LIST@40..40
         2: LIST@40..40
@@ -281,11 +287,13 @@ JsRoot {
       0: FUNCTION_KW@41..51 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: STAR@51..52 "*" [] []
       2: (empty)
-      3: JS_PARAMETER_LIST@52..55
+      3: (empty)
+      4: JS_PARAMETER_LIST@52..55
         0: L_PAREN@52..53 "(" [] []
         1: LIST@53..53
         2: R_PAREN@53..55 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@55..57
+      5: (empty)
+      6: JS_FUNCTION_BODY@55..57
         0: L_CURLY@55..56 "{" [] []
         1: LIST@56..56
         2: LIST@56..56
@@ -294,11 +302,13 @@ JsRoot {
       0: ASYNC_KW@57..64 "async" [Whitespace("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@64..72 "function" [] []
       2: (empty)
-      3: JS_PARAMETER_LIST@72..75
+      3: (empty)
+      4: JS_PARAMETER_LIST@72..75
         0: L_PAREN@72..73 "(" [] []
         1: LIST@73..73
         2: R_PAREN@73..75 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@75..77
+      5: (empty)
+      6: JS_FUNCTION_BODY@75..77
         0: L_CURLY@75..76 "{" [] []
         1: LIST@76..76
         2: LIST@76..76
@@ -308,11 +318,13 @@ JsRoot {
       1: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")]
       2: STAR@93..94 "*" [] []
       3: (empty)
-      4: JS_PARAMETER_LIST@94..97
+      4: (empty)
+      5: JS_PARAMETER_LIST@94..97
         0: L_PAREN@94..95 "(" [] []
         1: LIST@95..95
         2: R_PAREN@95..97 ")" [] [Whitespace(" ")]
-      5: JS_FUNCTION_BODY@97..99
+      6: (empty)
+      7: JS_FUNCTION_BODY@97..99
         0: L_CURLY@97..98 "{" [] []
         1: LIST@98..98
         2: LIST@98..98
@@ -322,11 +334,13 @@ JsRoot {
       1: STAR@109..110 "*" [] []
       2: JS_IDENTIFIER_BINDING@110..113
         0: IDENT@110..113 "foo" [] []
-      3: JS_PARAMETER_LIST@113..116
+      3: (empty)
+      4: JS_PARAMETER_LIST@113..116
         0: L_PAREN@113..114 "(" [] []
         1: LIST@114..114
         2: R_PAREN@114..116 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@116..118
+      5: (empty)
+      6: JS_FUNCTION_BODY@116..118
         0: L_CURLY@116..117 "{" [] []
         1: LIST@117..117
         2: LIST@117..117
@@ -343,15 +357,16 @@ JsRoot {
       0: FUNCTION_KW@129..139 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@139..143
         0: IDENT@139..143 "test" [] []
-      2: JS_PARAMETER_LIST@143..145
+      2: (empty)
+      3: JS_PARAMETER_LIST@143..145
         0: L_PAREN@143..144 "(" [] []
         1: LIST@144..144
         2: R_PAREN@144..145 ")" [] []
-      3: TS_TYPE_ANNOTATION@145..154
+      4: TS_TYPE_ANNOTATION@145..154
         0: COLON@145..147 ":" [] [Whitespace(" ")]
         1: TS_NUMBER@147..154
           0: IDENT@147..154 "number" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@154..156
+      5: JS_FUNCTION_BODY@154..156
         0: L_CURLY@154..155 "{" [] []
         1: LIST@155..155
         2: LIST@155..155
@@ -360,13 +375,15 @@ JsRoot {
       0: FUNCTION_KW@156..166 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@166..169
         0: IDENT@166..169 "foo" [] []
-      2: JS_PARAMETER_LIST@169..177
+      2: (empty)
+      3: JS_PARAMETER_LIST@169..177
         0: L_PAREN@169..170 "(" [] []
         1: LIST@170..175
           0: JS_UNKNOWN_BINDING@170..175
             0: IDENT@170..175 "await" [] []
         2: R_PAREN@175..177 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@177..179
+      4: (empty)
+      5: JS_FUNCTION_BODY@177..179
         0: L_CURLY@177..178 "{" [] []
         1: LIST@178..178
         2: LIST@178..178
@@ -375,13 +392,15 @@ JsRoot {
       0: FUNCTION_KW@179..189 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@189..192
         0: IDENT@189..192 "foo" [] []
-      2: JS_PARAMETER_LIST@192..200
+      2: (empty)
+      3: JS_PARAMETER_LIST@192..200
         0: L_PAREN@192..193 "(" [] []
         1: LIST@193..198
           0: JS_UNKNOWN_BINDING@193..198
             0: IDENT@193..198 "yield" [] []
         2: R_PAREN@198..200 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@200..202
+      4: (empty)
+      5: JS_FUNCTION_BODY@200..202
         0: L_CURLY@200..201 "{" [] []
         1: LIST@201..201
         2: LIST@201..201

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.rast
@@ -100,13 +100,15 @@ JsRoot {
       1: FUNCTION_KW@20..29 "function" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@29..33
         0: IDENT@29..33 "test" [] []
-      3: JS_PARAMETER_LIST@33..41
+      3: (empty)
+      4: JS_PARAMETER_LIST@33..41
         0: L_PAREN@33..34 "(" [] []
         1: LIST@34..39
           0: JS_UNKNOWN_BINDING@34..39
             0: IDENT@34..39 "await" [] []
         2: R_PAREN@39..41 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@41..43
+      5: (empty)
+      6: JS_FUNCTION_BODY@41..43
         0: L_CURLY@41..42 "{" [] []
         1: LIST@42..42
         2: LIST@42..42
@@ -116,13 +118,15 @@ JsRoot {
       1: STAR@52..54 "*" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@54..58
         0: IDENT@54..58 "test" [] []
-      3: JS_PARAMETER_LIST@58..66
+      3: (empty)
+      4: JS_PARAMETER_LIST@58..66
         0: L_PAREN@58..59 "(" [] []
         1: LIST@59..64
           0: JS_UNKNOWN_BINDING@59..64
             0: IDENT@59..64 "yield" [] []
         2: R_PAREN@64..66 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@66..68
+      5: (empty)
+      6: JS_FUNCTION_BODY@66..68
         0: L_CURLY@66..67 "{" [] []
         1: LIST@67..67
         2: LIST@67..67

--- a/crates/rslint_parser/test_data/inline/err/rest_property_binding_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/rest_property_binding_err.rast
@@ -355,11 +355,13 @@ JsRoot {
       1: FUNCTION_KW@134..143 "function" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@143..147
         0: IDENT@143..147 "test" [] []
-      3: JS_PARAMETER_LIST@147..150
+      3: (empty)
+      4: JS_PARAMETER_LIST@147..150
         0: L_PAREN@147..148 "(" [] []
         1: LIST@148..148
         2: R_PAREN@148..150 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@150..177
+      5: (empty)
+      6: JS_FUNCTION_BODY@150..177
         0: L_CURLY@150..151 "{" [] []
         1: LIST@151..151
         2: LIST@151..175

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -94,11 +94,13 @@ JsRoot {
                 0: ASYNC_KW@8..14 "async" [] [Whitespace(" ")]
                 1: FUNCTION_KW@14..22 "function" [] []
                 2: (empty)
-                3: JS_PARAMETER_LIST@22..25
+                3: (empty)
+                4: JS_PARAMETER_LIST@22..25
                   0: L_PAREN@22..23 "(" [] []
                   1: LIST@23..23
                   2: R_PAREN@23..25 ")" [] [Whitespace(" ")]
-                4: JS_FUNCTION_BODY@25..27
+                5: (empty)
+                6: JS_FUNCTION_BODY@25..27
                   0: L_CURLY@25..26 "{" [] []
                   1: LIST@26..26
                   2: LIST@26..26
@@ -118,11 +120,13 @@ JsRoot {
                 1: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")]
                 2: JS_IDENTIFIER_BINDING@52..55
                   0: IDENT@52..55 "foo" [] []
-                3: JS_PARAMETER_LIST@55..58
+                3: (empty)
+                4: JS_PARAMETER_LIST@55..58
                   0: L_PAREN@55..56 "(" [] []
                   1: LIST@56..56
                   2: R_PAREN@56..58 ")" [] [Whitespace(" ")]
-                4: JS_FUNCTION_BODY@58..60
+                5: (empty)
+                6: JS_FUNCTION_BODY@58..60
                   0: L_CURLY@58..59 "{" [] []
                   1: LIST@59..59
                   2: LIST@59..59

--- a/crates/rslint_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/await_expression.rast
@@ -106,11 +106,13 @@ JsRoot {
       1: FUNCTION_KW@6..15 "function" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@15..19
         0: IDENT@15..19 "test" [] []
-      3: JS_PARAMETER_LIST@19..22
+      3: (empty)
+      4: JS_PARAMETER_LIST@19..22
         0: L_PAREN@19..20 "(" [] []
         1: LIST@20..20
         2: R_PAREN@20..22 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@22..76
+      5: (empty)
+      6: JS_FUNCTION_BODY@22..76
         0: L_CURLY@22..23 "{" [] []
         1: LIST@23..23
         2: LIST@23..74
@@ -156,11 +158,13 @@ JsRoot {
       1: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@93..98
         0: IDENT@93..98 "inner" [] []
-      3: JS_PARAMETER_LIST@98..101
+      3: (empty)
+      4: JS_PARAMETER_LIST@98..101
         0: L_PAREN@98..99 "(" [] []
         1: LIST@99..99
         2: R_PAREN@99..101 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@101..115
+      5: (empty)
+      6: JS_FUNCTION_BODY@101..115
         0: L_CURLY@101..102 "{" [] []
         1: LIST@102..102
         2: LIST@102..113

--- a/crates/rslint_parser/test_data/inline/ok/directives.rast
+++ b/crates/rslint_parser/test_data/inline/ok/directives.rast
@@ -209,11 +209,13 @@ JsRoot {
       0: FUNCTION_KW@67..78 "function" [Whitespace("\n\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@78..82
         0: IDENT@78..82 "test" [] []
-      2: JS_PARAMETER_LIST@82..85
+      2: (empty)
+      3: JS_PARAMETER_LIST@82..85
         0: L_PAREN@82..83 "(" [] []
         1: LIST@83..83
         2: R_PAREN@83..85 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@85..152
+      4: (empty)
+      5: JS_FUNCTION_BODY@85..152
         0: L_CURLY@85..86 "{" [] []
         1: LIST@86..101
           0: JS_DIRECTIVE@86..101
@@ -243,11 +245,13 @@ JsRoot {
         1: JS_FUNCTION_EXPRESSION@155..234
           0: FUNCTION_KW@155..164 "function" [] [Whitespace(" ")]
           1: (empty)
-          2: JS_PARAMETER_LIST@164..167
+          2: (empty)
+          3: JS_PARAMETER_LIST@164..167
             0: L_PAREN@164..165 "(" [] []
             1: LIST@165..165
             2: R_PAREN@165..167 ")" [] [Whitespace(" ")]
-          3: JS_FUNCTION_BODY@167..234
+          4: (empty)
+          5: JS_FUNCTION_BODY@167..234
             0: L_CURLY@167..168 "{" [] []
             1: LIST@168..183
               0: JS_DIRECTIVE@168..183

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -129,11 +129,13 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..12
         0: IDENT@9..12 "foo" [] []
-      2: JS_PARAMETER_LIST@12..15
+      2: (empty)
+      3: JS_PARAMETER_LIST@12..15
         0: L_PAREN@12..13 "(" [] []
         1: LIST@13..13
         2: R_PAREN@13..15 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@15..17
+      4: (empty)
+      5: JS_FUNCTION_BODY@15..17
         0: L_CURLY@15..16 "{" [] []
         1: LIST@16..16
         2: LIST@16..16
@@ -143,11 +145,13 @@ JsRoot {
       1: STAR@27..28 "*" [] []
       2: JS_IDENTIFIER_BINDING@28..31
         0: IDENT@28..31 "foo" [] []
-      3: JS_PARAMETER_LIST@31..34
+      3: (empty)
+      4: JS_PARAMETER_LIST@31..34
         0: L_PAREN@31..32 "(" [] []
         1: LIST@32..32
         2: R_PAREN@32..34 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@34..36
+      5: (empty)
+      6: JS_FUNCTION_BODY@34..36
         0: L_CURLY@34..35 "{" [] []
         1: LIST@35..35
         2: LIST@35..35
@@ -158,11 +162,13 @@ JsRoot {
       2: STAR@52..53 "*" [] []
       3: JS_IDENTIFIER_BINDING@53..56
         0: IDENT@53..56 "foo" [] []
-      4: JS_PARAMETER_LIST@56..59
+      4: (empty)
+      5: JS_PARAMETER_LIST@56..59
         0: L_PAREN@56..57 "(" [] []
         1: LIST@57..57
         2: R_PAREN@57..59 ")" [] [Whitespace(" ")]
-      5: JS_FUNCTION_BODY@59..61
+      6: (empty)
+      7: JS_FUNCTION_BODY@59..61
         0: L_CURLY@59..60 "{" [] []
         1: LIST@60..60
         2: LIST@60..60
@@ -172,11 +178,13 @@ JsRoot {
       1: FUNCTION_KW@68..77 "function" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@77..80
         0: IDENT@77..80 "foo" [] []
-      3: JS_PARAMETER_LIST@80..83
+      3: (empty)
+      4: JS_PARAMETER_LIST@80..83
         0: L_PAREN@80..81 "(" [] []
         1: LIST@81..81
         2: R_PAREN@81..83 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@83..85
+      5: (empty)
+      6: JS_FUNCTION_BODY@83..85
         0: L_CURLY@83..84 "{" [] []
         1: LIST@84..84
         2: LIST@84..84
@@ -186,11 +194,13 @@ JsRoot {
       1: STAR@95..96 "*" [] []
       2: JS_IDENTIFIER_BINDING@96..99
         0: IDENT@96..99 "foo" [] []
-      3: JS_PARAMETER_LIST@99..102
+      3: (empty)
+      4: JS_PARAMETER_LIST@99..102
         0: L_PAREN@99..100 "(" [] []
         1: LIST@100..100
         2: R_PAREN@100..102 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@102..118
+      5: (empty)
+      6: JS_FUNCTION_BODY@102..118
         0: L_CURLY@102..103 "{" [] []
         1: LIST@103..103
         2: LIST@103..116

--- a/crates/rslint_parser/test_data/inline/ok/function_declaration_script.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_declaration_script.rast
@@ -38,13 +38,15 @@ JsRoot {
       0: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@19..23
         0: IDENT@19..23 "test" [] []
-      2: JS_PARAMETER_LIST@23..31
+      2: (empty)
+      3: JS_PARAMETER_LIST@23..31
         0: L_PAREN@23..24 "(" [] []
         1: LIST@24..29
           0: JS_IDENTIFIER_BINDING@24..29
             0: IDENT@24..29 "await" [] []
         2: R_PAREN@29..31 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@31..33
+      4: (empty)
+      5: JS_FUNCTION_BODY@31..33
         0: L_CURLY@31..32 "{" [] []
         1: LIST@32..32
         2: LIST@32..32

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -93,11 +93,13 @@ JsRoot {
               1: JS_FUNCTION_EXPRESSION@8..21
                 0: FUNCTION_KW@8..16 "function" [] []
                 1: (empty)
-                2: JS_PARAMETER_LIST@16..19
+                2: (empty)
+                3: JS_PARAMETER_LIST@16..19
                   0: L_PAREN@16..17 "(" [] []
                   1: LIST@17..17
                   2: R_PAREN@17..19 ")" [] [Whitespace(" ")]
-                3: JS_FUNCTION_BODY@19..21
+                4: (empty)
+                5: JS_FUNCTION_BODY@19..21
                   0: L_CURLY@19..20 "{" [] []
                   1: LIST@20..20
                   2: LIST@20..20
@@ -116,11 +118,13 @@ JsRoot {
                 0: FUNCTION_KW@30..39 "function" [] [Whitespace(" ")]
                 1: JS_IDENTIFIER_BINDING@39..42
                   0: IDENT@39..42 "foo" [] []
-                2: JS_PARAMETER_LIST@42..45
+                2: (empty)
+                3: JS_PARAMETER_LIST@42..45
                   0: L_PAREN@42..43 "(" [] []
                   1: LIST@43..43
                   2: R_PAREN@43..45 ")" [] [Whitespace(" ")]
-                3: JS_FUNCTION_BODY@45..47
+                4: (empty)
+                5: JS_FUNCTION_BODY@45..47
                   0: L_CURLY@45..46 "{" [] []
                   1: LIST@46..46
                   2: LIST@46..46

--- a/crates/rslint_parser/test_data/inline/ok/parameter_list.rast
+++ b/crates/rslint_parser/test_data/inline/ok/parameter_list.rast
@@ -55,7 +55,8 @@ JsRoot {
       0: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@9..34
         0: IDENT@9..34 "evalInComputedPropertyKey" [] []
-      2: JS_PARAMETER_LIST@34..60
+      2: (empty)
+      3: JS_PARAMETER_LIST@34..60
         0: L_PAREN@34..35 "(" [] []
         1: LIST@35..58
           0: JS_OBJECT_BINDING@35..58
@@ -73,7 +74,8 @@ JsRoot {
                 3: (empty)
             2: R_CURLY@57..58 "}" [] []
         2: R_PAREN@58..60 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@60..62
+      4: (empty)
+      5: JS_FUNCTION_BODY@60..62
         0: L_CURLY@60..61 "{" [] []
         1: LIST@61..61
         2: LIST@61..61

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -173,11 +173,13 @@ JsRoot {
       0: FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@62..65
         0: IDENT@62..65 "foo" [] []
-      2: JS_PARAMETER_LIST@65..68
+      2: (empty)
+      3: JS_PARAMETER_LIST@65..68
         0: L_PAREN@65..66 "(" [] []
         1: LIST@66..66
         2: R_PAREN@66..68 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@68..83
+      4: (empty)
+      5: JS_FUNCTION_BODY@68..83
         0: L_CURLY@68..70 "{" [] [Whitespace(" ")]
         1: LIST@70..70
         2: LIST@70..82

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -81,7 +81,8 @@ JsRoot {
       0: FUNCTION_KW@0..20 "function" [Comments("// SCRIPT"), Whitespace("\n\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@20..21
         0: IDENT@20..21 "f" [] []
-      2: JS_PARAMETER_LIST@21..28
+      2: (empty)
+      3: JS_PARAMETER_LIST@21..28
         0: L_PAREN@21..22 "(" [] []
         1: LIST@22..26
           0: JS_IDENTIFIER_BINDING@22..23
@@ -90,7 +91,8 @@ JsRoot {
           2: JS_IDENTIFIER_BINDING@25..26
             0: IDENT@25..26 "o" [] []
         2: R_PAREN@26..28 ")" [] [Whitespace(" ")]
-      3: JS_FUNCTION_BODY@28..64
+      4: (empty)
+      5: JS_FUNCTION_BODY@28..64
         0: L_CURLY@28..29 "{" [] []
         1: LIST@29..29
         2: LIST@29..62

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -64,11 +64,13 @@ JsRoot {
       1: STAR@9..10 "*" [] []
       2: JS_IDENTIFIER_BINDING@10..13
         0: IDENT@10..13 "foo" [] []
-      3: JS_PARAMETER_LIST@13..16
+      3: (empty)
+      4: JS_PARAMETER_LIST@13..16
         0: L_PAREN@13..14 "(" [] []
         1: LIST@14..14
         2: R_PAREN@14..16 ")" [] [Whitespace(" ")]
-      4: JS_FUNCTION_BODY@16..52
+      5: (empty)
+      6: JS_FUNCTION_BODY@16..52
         0: L_CURLY@16..17 "{" [] []
         1: LIST@17..17
         2: LIST@17..50


### PR DESCRIPTION


## Summary

`ParsedSyntax<ConditionalSyntax>` currently offered no helpers to mark the result as missing and adding an error. This resulted in quite some cumbersome code.

This PR adds the `or_missing` and `or_missing_with_error` helpers and uses the new helpers on the call sites.

This PR also renames `InvalidParsedSyntax` to `InvalidSyntax` to align it with `ConditionalSyntax`

## Test Plan

The tests output changes because it now adds the "missing" markers for parameter types and return types.
