### PR TITLE
Enable class field support

### DIFF
--- a/crates/rslint_parser/src/lib.rs
+++ b/crates/rslint_parser/src/lib.rs
@@ -171,15 +171,12 @@ macro_rules! match_ast {
     }};
 }
 
-/// A structure describing the syntax features the parser will accept. The
-/// default is an ECMAScript 2021 Script without any proposals.
+/// A structure describing the syntax features the parser will accept.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Syntax {
 	pub file_kind: FileKind,
 	pub top_level_await: bool,
 	pub global_return: bool,
-	pub class_fields: bool,
-	pub decorators: bool,
 }
 
 impl Syntax {
@@ -204,16 +201,6 @@ impl Syntax {
 		self
 	}
 
-	pub fn class_fields(mut self) -> Self {
-		self.class_fields = true;
-		self
-	}
-
-	pub fn decorators(mut self) -> Self {
-		self.decorators = true;
-		self
-	}
-
 	pub fn script(mut self) -> Self {
 		self.file_kind = FileKind::Script;
 		self
@@ -221,12 +208,12 @@ impl Syntax {
 
 	pub fn module(mut self) -> Self {
 		self.file_kind = FileKind::Module;
-		self.class_fields()
+		self
 	}
 
 	pub fn typescript(mut self) -> Self {
 		self.file_kind = FileKind::TypeScript;
-		self.class_fields().decorators().top_level_await()
+		self.top_level_await()
 	}
 }
 

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -687,17 +687,7 @@ fn property_class_member_body(p: &mut Parser, member_marker: Marker) -> Complete
 		p.error(err);
 	}
 
-	let complete = member_marker.complete(p, JS_PROPERTY_CLASS_MEMBER);
-
-	if !p.syntax.class_fields {
-		let err = p
-			.err_builder("class fields are unsupported")
-			.primary(complete.range(p), "");
-
-		p.error(err);
-	}
-
-	complete
+	member_marker.complete(p, JS_PROPERTY_CLASS_MEMBER)
 }
 
 /// Eats the ? token for optional member. Emits an error if this isn't typescript

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -514,6 +514,7 @@ pub fn subscripts(p: &mut Parser, mut lhs: CompletedMarker, no_call: bool) -> Co
 // foo.for
 // foo?.for
 // foo?.bar
+// foo.#bar
 pub fn static_member_expression(
 	p: &mut Parser,
 	lhs: CompletedMarker,

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -522,18 +522,7 @@ pub fn static_member_expression(
 	let m = lhs.precede(p);
 	p.expect_required(operator);
 
-	let member_name = any_reference_member(p);
-
-	if !p.syntax.class_fields {
-		if let Some(priv_range) = member_name.filter(|x| x.kind() == JS_REFERENCE_PRIVATE_MEMBER) {
-			let err = p
-				.err_builder("private identifiers are unsupported")
-				.primary(priv_range.range(p), "");
-
-			p.error(err);
-			return m.complete(p, ERROR);
-		}
-	}
+	any_reference_member(p);
 
 	m.complete(p, JS_STATIC_MEMBER_EXPRESSION)
 }

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.js
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.js
@@ -4,3 +4,4 @@ foo.yield
 foo.for
 foo?.for
 foo?.bar
+foo.#bar

--- a/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/dot_expr.rast
@@ -74,13 +74,26 @@ JsRoot {
             },
             semicolon_token: missing (optional),
         },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsReferenceIdentifierExpression {
+                    name_token: IDENT@53..57 "foo" [Whitespace("\n")] [],
+                },
+                operator: DOT@57..58 "." [] [],
+                member: JsReferencePrivateMember {
+                    hash_token: HASH@58..59 "#" [] [],
+                    name_token: IDENT@59..62 "bar" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
     ],
 }
 
-0: JS_ROOT@0..54
+0: JS_ROOT@0..63
   0: (empty)
   1: LIST@0..0
-  2: LIST@0..53
+  2: LIST@0..62
     0: JS_EXPRESSION_STATEMENT@0..7
       0: JS_STATIC_MEMBER_EXPRESSION@0..7
         0: JS_REFERENCE_IDENTIFIER_EXPRESSION@0..3
@@ -129,4 +142,13 @@ JsRoot {
         2: JS_REFERENCE_IDENTIFIER_MEMBER@50..53
           0: IDENT@50..53 "bar" [] []
       1: (empty)
-  3: EOF@53..54 "" [Whitespace("\n")] []
+    6: JS_EXPRESSION_STATEMENT@53..62
+      0: JS_STATIC_MEMBER_EXPRESSION@53..62
+        0: JS_REFERENCE_IDENTIFIER_EXPRESSION@53..57
+          0: IDENT@53..57 "foo" [Whitespace("\n")] []
+        1: DOT@57..58 "." [] []
+        2: JS_REFERENCE_PRIVATE_MEMBER@58..62
+          0: HASH@58..59 "#" [] []
+          1: IDENT@59..62 "bar" [] []
+      1: (empty)
+  3: EOF@62..63 "" [Whitespace("\n")] []


### PR DESCRIPTION
## Summary

Class fields have been standardised. Let's remove the syntax error.

This PR further removes the `decorators` flag because we don't support decorators.

We'll likely need to redo this (especially file kind). For example, TypeScript is a dialect that supports script or module.

## Test Plan

Added a static member expression test
