### PR TITLE
test(formatter): fail js tests with parser errors

### DIFF
--- a/crates/rome_formatter/tests/spec_test.rs
+++ b/crates/rome_formatter/tests/spec_test.rs
@@ -1,5 +1,6 @@
 use rome_core::create_app;
-use rome_formatter::{format_file, FormatOptions};
+use rome_formatter::{format, FormatOptions};
+use rome_path::RomePath;
 use std::fs;
 use std::path::Path;
 
@@ -32,8 +33,10 @@ pub fn run(spec_input_file: &str, expected_file: &str) {
 		expected_file.display(),
 	);
 
-	let result = format_file(file_path, FormatOptions::default(), &app);
-	let expected_output = fs::read_to_string(expected_file).unwrap();
+	let mut rome_path = RomePath::new(file_path).deduce_handler(&app);
+	let result = format(&mut rome_path, FormatOptions::default());
+	let element = result.expect("no errors");
 
-	assert_eq!(&expected_output, result.code());
+	let expected_output = fs::read_to_string(expected_file).unwrap();
+	assert_eq!(&expected_output, element.code());
 }


### PR DESCRIPTION
## Summary
Fail js tests with parser errors.

When implementing the formatter todos, I encountered numerous parsing errors that produced undefined behavior, erroring out with errors should aid implementing the formatter. 

## Test Plan
```
cargo test -p rome_formatter js
```

Result
```
failures:

---- formatter::js::block_stmt_err stdout ----
thread 'formatter::js::block_stmt_err' panicked at 'without error: ParserError([Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "Expected a statement or declaration, but found none", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "Expected a statement or declaration here", span: FileSpan { file: 0, range: 65..66 } }), children: [], suggestions: [], footers: [] }, Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "expected a statement but instead found 'let recovered     = \"no\"'", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "Expected a statement here", span: FileSpan { file: 0, range: 68..92 } }), children: [], suggestions: [], footers: [] }, Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "expected `'}'` but instead the file ends", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "the file ends here", span: FileSpan { file: 0, range: 93..93 } }), children: [], suggestions: [], footers: [] }])', crates/rome_formatter/tests/spec_test.rs:31:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- formatter::js::if_stmt_err stdout ----
thread 'formatter::js::if_stmt_err' panicked at 'without error: ParserError([Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "expected `'('` but instead found `test`", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "unexpected", span: FileSpan { file: 0, range: 36..40 } }), children: [], suggestions: [], footers: [] }, Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "expected `')'` but instead found `{`", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "unexpected", span: FileSpan { file: 0, range: 41..42 } }), children: [], suggestions: [], footers: [] }, Diagnostic { file_id: 0, severity: Error, code: Some("SyntaxError"), title: "expected `'}'` but instead the file ends", tag: None, primary: Some(SubDiagnostic { severity: Error, msg: "the file ends here", span: FileSpan { file: 0, range: 168..168 } }), children: [], suggestions: [], footers: [] }])', crates/rome_formatter/tests/spec_test.rs:31:26


failures:
    formatter::js::block_stmt_err
    formatter::js::if_stmt_err
```


**Note**: These two tests are expected to produce errors, I don't know what should be the correct way to handle these.