### PR TITLE
chor(rslint_parser): Remove list workarounds for trivia/error nodes

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -1201,7 +1201,18 @@ impl<L: Language> Iterator for SyntaxSlots<L> {
 	type Item = SyntaxSlot<L>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.raw.as_mut()?.next().map(|raw| raw.into())
+		self.raw.as_mut()?.next().map(SyntaxSlot::from)
+	}
+
+	fn nth(&mut self, n: usize) -> Option<Self::Item> {
+		self.raw.as_mut()?.nth(n).map(SyntaxSlot::from)
+	}
+
+	fn last(mut self) -> Option<Self::Item>
+	where
+		Self: Sized,
+	{
+		self.raw.as_mut()?.last().map(SyntaxSlot::from)
 	}
 }
 

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -1605,6 +1605,24 @@ impl<'a> Iterator for SyntaxSlots {
 		}
 	}
 
+	fn last(self) -> Option<Self::Item>
+	where
+		Self: Sized,
+	{
+		let mut slots = self.parent.green_ref().slots();
+		let slots_len = slots.len() as usize;
+
+		if (self.next_position as usize) < slots_len {
+			let position = slots_len - 1;
+			slots
+				.nth(position)
+				.map(|slot| self.map_slot(slot, position as u32))
+		} else {
+			// already at/passed the end
+			None
+		}
+	}
+
 	fn nth(&mut self, n: usize) -> Option<Self::Item> {
 		self.next_position += n as u32;
 		self.next()
@@ -1616,6 +1634,7 @@ impl ExactSizeIterator for SyntaxSlots {
 		self.parent.green_ref().slots().len()
 	}
 }
+
 impl FusedIterator for SyntaxSlots {}
 
 /// Iterator to visit a node's slots in pre-order.

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -581,15 +581,14 @@ pub(crate) fn parse_statements(
 						.primary(m.range(p), "not allowed inside scripts");
 
 					p.error(err);
-					m.change_kind(p, ERROR);
-				}
-				if !top_level {
+					m.change_kind(p, JS_UNKNOWN_STATEMENT);
+				} else if !top_level {
 					let err = p
 						.err_builder("Illegal use of an import declaration not at the top level")
 						.primary(m.range(p), "move this declaration to the top level");
 
 					p.error(err);
-					m.change_kind(p, ERROR);
+					m.change_kind(p, JS_UNKNOWN_STATEMENT);
 				}
 			}
 			// test_err export_decl_not_top_level
@@ -604,15 +603,14 @@ pub(crate) fn parse_statements(
 						.primary(m.range(p), "not allowed inside scripts");
 
 					p.error(err);
-					m.change_kind(p, ERROR);
-				}
-				if !top_level {
+					m.change_kind(p, JS_UNKNOWN_STATEMENT);
+				} else if !top_level {
 					let err = p
 						.err_builder("Illegal use of an import declaration not at the top level")
 						.primary(m.range(p), "move this declaration to the top level");
 
 					p.error(err);
-					m.change_kind(p, ERROR);
+					m.change_kind(p, JS_UNKNOWN_STATEMENT);
 				}
 			}
 			_ => {

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -50,11 +50,19 @@ fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
 	let res = catch_unwind(|| {
 		// Files containing a // SCRIPT comment are parsed as script and not as module
 		// This is needed to test features that are restricted in strict mode.
-		if text.contains("// SCRIPT") {
+		let parse = if text.contains("// SCRIPT") {
 			parse_text(text, 0).cast::<JsAnyRoot>().unwrap()
 		} else {
 			parse_module(text, 0).cast::<JsAnyRoot>().unwrap()
-		}
+		};
+
+		assert_eq!(
+			parse.syntax().to_string(),
+			text,
+			"Original source and re-printed tree differ"
+		);
+
+		parse
 	});
 	assert!(
 		!res.is_err(),

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -4,7 +4,28 @@ JsModule {
     items: [
         JsBlockStatement {
             l_curly_token: L_CURLY@0..1 "{" [] [],
-            statements: [],
+            statements: [
+                JsUnknownStatement {
+                    items: [
+                        Token(
+                            EXPORT_KW@1..10 "export" [Whitespace("\n ")] [Whitespace(" ")],
+                        ),
+                        Node(
+                            1: EXPORT_NAMED@10..31
+                              0: L_CURLY@10..12 "{" [] [Whitespace(" ")]
+                              1: LIST@12..17
+                                0: SPECIFIER@12..17
+                                  0: NAME@12..17
+                                    0: IDENT@12..17 "pain" [] [Whitespace(" ")]
+                              2: R_CURLY@17..19 "}" [] [Whitespace(" ")]
+                              3: FROM_KW@19..24 "from" [] [Whitespace(" ")]
+                              4: JS_STRING_LITERAL@24..30 "\"life\"" [] []
+                              5: SEMICOLON@30..31 ";" [] []
+                            ,
+                        ),
+                    ],
+                },
+            ],
             r_curly_token: R_CURLY@31..33 "}" [Whitespace("\n")] [],
         },
     ],
@@ -17,7 +38,7 @@ JsModule {
     0: JS_BLOCK_STATEMENT@0..33
       0: L_CURLY@0..1 "{" [] []
       1: LIST@1..31
-        0: ERROR@1..31
+        0: JS_UNKNOWN_STATEMENT@1..31
           0: EXPORT_KW@1..10 "export" [Whitespace("\n ")] [Whitespace(" ")]
           1: EXPORT_NAMED@10..31
             0: L_CURLY@10..12 "{" [] [Whitespace(" ")]

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -4,7 +4,30 @@ JsModule {
     items: [
         JsBlockStatement {
             l_curly_token: L_CURLY@0..1 "{" [] [],
-            statements: [],
+            statements: [
+                JsUnknownStatement {
+                    items: [
+                        Token(
+                            IMPORT_KW@1..10 "import" [Whitespace("\n ")] [Whitespace(" ")],
+                        ),
+                        Node(
+                            1: LIST@10..14
+                              0: JS_IDENTIFIER_BINDING@10..14
+                                0: IDENT@10..14 "foo" [] [Whitespace(" ")]
+                            ,
+                        ),
+                        Token(
+                            FROM_KW@14..19 "from" [] [Whitespace(" ")],
+                        ),
+                        Token(
+                            JS_STRING_LITERAL@19..24 "\"bar\"" [] [],
+                        ),
+                        Token(
+                            SEMICOLON@24..25 ";" [] [],
+                        ),
+                    ],
+                },
+            ],
             r_curly_token: R_CURLY@25..27 "}" [Whitespace("\n")] [],
         },
     ],
@@ -17,7 +40,7 @@ JsModule {
     0: JS_BLOCK_STATEMENT@0..27
       0: L_CURLY@0..1 "{" [] []
       1: LIST@1..25
-        0: ERROR@1..25
+        0: JS_UNKNOWN_STATEMENT@1..25
           0: IMPORT_KW@1..10 "import" [Whitespace("\n ")] [Whitespace(" ")]
           1: LIST@10..14
             0: JS_IDENTIFIER_BINDING@10..14


### PR DESCRIPTION
## Summary

The node list had to gracefully handle the case where a list could contain trivia nodes or errors.

This is no longer needed because trivia is now stored inside of tokens and (most) error nodes have been replaced with `Unknown*` nodes that can be casted to `N`. That's why this PR removes the workarounds

