### PR TITLE
test(xtask): Enable all test262 tests for parser coverage

### DIFF
--- a/xtask/src/coverage/files.rs
+++ b/xtask/src/coverage/files.rs
@@ -128,7 +128,12 @@ pub fn get_test_files(query: Option<&str>, pool: &Pool, json: bool) -> Vec<TestF
 					let code = read_to_string(entry.path()).ok()?;
 					let meta = read_metadata(&code).ok()?;
 					let path = entry.into_path();
-					Some(TestFile { meta, code, path }).filter(|file| file.meta.features.is_empty())
+					Some(TestFile { meta, code, path }).filter(|file| {
+						file.meta
+							.negative
+							.as_ref()
+							.map_or(true, |negative| negative.phase == Phase::Parse)
+					})
 				}
 
 				if let Some(file) = parse_file(file) {


### PR DESCRIPTION
closes #1891

## Summary
It's safe to enable all test262 tests, we aim to pass them all 🏆 

## Test Plan
```
cargo run -p xtask --release -- coverage
```

