### PR TITLE
Fix assignment to array or object expression members

### DIFF
--- a/crates/rslint_parser/src/syntax/pattern.rs
+++ b/crates/rslint_parser/src/syntax/pattern.rs
@@ -156,33 +156,31 @@ pub(crate) trait ParseObjectPattern {
 		let elements = p.start();
 		let mut progress = ParserProgress::default();
 
-		{
-			while !p.at(T!['}']) {
-				progress.assert_progressing(p);
+		while !p.at(T!['}']) {
+			progress.assert_progressing(p);
 
-				if p.at(T![,]) {
-					// missing element
-					p.error(Self::expected_property_pattern_error(p, p.cur_tok().range));
-					p.bump_any(); // bump ,
-					continue;
-				}
-				let recovery_set = ParseRecovery::new(
-					Self::unknown_pattern_kind(),
-					token_set!(EOF, T![,], T!['}'], T![...], T![;], T![')']),
-				)
-				.enable_recovery_on_line_break();
+			if p.at(T![,]) {
+				// missing element
+				p.error(Self::expected_property_pattern_error(p, p.cur_tok().range));
+				p.bump_any(); // bump ,
+				continue;
+			}
+			let recovery_set = ParseRecovery::new(
+				Self::unknown_pattern_kind(),
+				token_set!(EOF, T![,], T!['}'], T![...], T![;], T![')']),
+			)
+			.enable_recovery_on_line_break();
 
-				let recover_result = self
-					.parse_any_property_pattern(p, &recovery_set)
-					.or_recover(p, &recovery_set, Self::expected_property_pattern_error);
+			let recover_result = self
+				.parse_any_property_pattern(p, &recovery_set)
+				.or_recover(p, &recovery_set, Self::expected_property_pattern_error);
 
-				if recover_result.is_err() {
-					break;
-				}
+			if recover_result.is_err() {
+				break;
+			}
 
-				if !p.at(T!['}']) {
-					p.expect(T![,]);
-				}
+			if !p.at(T!['}']) {
+				p.expect(T![,]);
 			}
 		}
 

--- a/crates/rslint_parser/test_data/inline/err/array_assignment_target_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/array_assignment_target_err.rast
@@ -105,27 +105,30 @@ JsModule {
                 left: JsArrayAssignmentPattern {
                     l_brack_token: L_BRACK@70..72 "[" [Whitespace("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
-                        JsArrayAssignmentPattern {
-                            l_brack_token: L_BRACK@72..73 "[" [] [],
-                            elements: JsArrayAssignmentPatternElementList [
-                                JsIdentifierAssignment {
-                                    name_token: IDENT@73..75 "a" [] [Whitespace(" ")],
-                                },
-                                missing separator,
-                                JsIdentifierAssignment {
-                                    name_token: IDENT@75..76 "b" [] [],
-                                },
-                            ],
-                            r_brack_token: R_BRACK@76..78 "]" [] [Whitespace(" ")],
-                        },
-                        missing separator,
-                        JsArrayAssignmentPattern {
+                        JsComputedMemberAssignment {
+                            object: JsArrayExpression {
+                                l_brack_token: L_BRACK@72..73 "[" [] [],
+                                elements: JsArrayElementList [
+                                    JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@73..75 "a" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                    missing separator,
+                                    JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@75..76 "b" [] [],
+                                        },
+                                    },
+                                ],
+                                r_brack_token: R_BRACK@76..78 "]" [] [Whitespace(" ")],
+                            },
                             l_brack_token: L_BRACK@78..79 "[" [] [],
-                            elements: JsArrayAssignmentPatternElementList [
-                                JsIdentifierAssignment {
-                                    name_token: IDENT@79..80 "c" [] [],
+                            member: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@79..80 "c" [] [],
                                 },
-                            ],
+                            },
                             r_brack_token: R_BRACK@80..81 "]" [] [],
                         },
                     ],
@@ -245,22 +248,23 @@ JsModule {
         0: JS_ARRAY_ASSIGNMENT_PATTERN@70..82
           0: L_BRACK@70..72 "[" [Whitespace("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@72..81
-            0: JS_ARRAY_ASSIGNMENT_PATTERN@72..78
-              0: L_BRACK@72..73 "[" [] []
-              1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@73..76
-                0: JS_IDENTIFIER_ASSIGNMENT@73..75
-                  0: IDENT@73..75 "a" [] [Whitespace(" ")]
-                1: (empty)
-                2: JS_IDENTIFIER_ASSIGNMENT@75..76
-                  0: IDENT@75..76 "b" [] []
-              2: R_BRACK@76..78 "]" [] [Whitespace(" ")]
-            1: (empty)
-            2: JS_ARRAY_ASSIGNMENT_PATTERN@78..81
-              0: L_BRACK@78..79 "[" [] []
-              1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@79..80
-                0: JS_IDENTIFIER_ASSIGNMENT@79..80
+            0: JS_COMPUTED_MEMBER_ASSIGNMENT@72..81
+              0: JS_ARRAY_EXPRESSION@72..78
+                0: L_BRACK@72..73 "[" [] []
+                1: JS_ARRAY_ELEMENT_LIST@73..76
+                  0: JS_IDENTIFIER_EXPRESSION@73..75
+                    0: JS_REFERENCE_IDENTIFIER@73..75
+                      0: IDENT@73..75 "a" [] [Whitespace(" ")]
+                  1: (empty)
+                  2: JS_IDENTIFIER_EXPRESSION@75..76
+                    0: JS_REFERENCE_IDENTIFIER@75..76
+                      0: IDENT@75..76 "b" [] []
+                2: R_BRACK@76..78 "]" [] [Whitespace(" ")]
+              1: L_BRACK@78..79 "[" [] []
+              2: JS_IDENTIFIER_EXPRESSION@79..80
+                0: JS_REFERENCE_IDENTIFIER@79..80
                   0: IDENT@79..80 "c" [] []
-              2: R_BRACK@80..81 "]" [] []
+              3: R_BRACK@80..81 "]" [] []
           2: R_BRACK@81..82 "]" [] []
         1: EQ@82..84 "=" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@84..88
@@ -321,20 +325,6 @@ error[SyntaxError]: expected an identifier, or an assignment target but instead 
   │
 3 │ [a = , = "test"] = test;
   │        ^ Expected an identifier, or an assignment target here
-
---
-error[SyntaxError]: expected `,` but instead found `b`
-  ┌─ array_assignment_target_err.js:4:5
-  │
-4 │ [[a b] [c]]= test;
-  │     ^ unexpected
-
---
-error[SyntaxError]: expected `,` but instead found `[`
-  ┌─ array_assignment_target_err.js:4:8
-  │
-4 │ [[a b] [c]]= test;
-  │        ^ unexpected
 
 --
 error[SyntaxError]: expected `,` but instead found `:`

--- a/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.js
+++ b/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.js
@@ -1,0 +1,16 @@
+[{
+  get y() {
+    throw new Test262Error('The property should not be accessed.');
+  },
+  set y(val) {
+    setValue = val;
+  }
+}.y = 42] = [23];
+({ x: {
+  get y() {
+    throw new Test262Error('The property should not be accessed.');
+  },
+  set y(val) {
+    setValue = val;
+  }
+}.y = 42 } = { x: 23 });

--- a/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
@@ -1,0 +1,412 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsArrayAssignmentPattern {
+                    l_brack_token: L_BRACK@0..1 "[" [] [],
+                    elements: JsArrayAssignmentPatternElementList [
+                        JsAssignmentWithDefault {
+                            pattern: JsStaticMemberAssignment {
+                                object: JsObjectExpression {
+                                    l_curly_token: L_CURLY@1..2 "{" [] [],
+                                    members: JsObjectMemberList [
+                                        JsGetterObjectMember {
+                                            get_token: GET_KW@2..9 "get" [Whitespace("\n  ")] [Whitespace(" ")],
+                                            name: JsLiteralMemberName {
+                                                value: IDENT@9..10 "y" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@10..11 "(" [] [],
+                                            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
+                                            return_type: missing (optional),
+                                            body: JsFunctionBody {
+                                                l_curly_token: L_CURLY@13..14 "{" [] [],
+                                                directives: JsDirectiveList [],
+                                                statements: JsStatementList [
+                                                    JsThrowStatement {
+                                                        throw_token: THROW_KW@14..25 "throw" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                        argument: NewExpr {
+                                                            new_token: NEW_KW@25..29 "new" [] [Whitespace(" ")],
+                                                            object: JsIdentifierExpression {
+                                                                name: JsReferenceIdentifier {
+                                                                    value_token: IDENT@29..41 "Test262Error" [] [],
+                                                                },
+                                                            },
+                                                            type_args: missing (optional),
+                                                            arguments: JsCallArguments {
+                                                                l_paren_token: L_PAREN@41..42 "(" [] [],
+                                                                args: JsCallArgumentList [
+                                                                    JsStringLiteralExpression {
+                                                                        value_token: JS_STRING_LITERAL@42..80 "'The property should not be accessed.'" [] [],
+                                                                    },
+                                                                ],
+                                                                r_paren_token: R_PAREN@80..81 ")" [] [],
+                                                            },
+                                                        },
+                                                        semicolon_token: SEMICOLON@81..82 ";" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@82..86 "}" [Whitespace("\n  ")] [],
+                                            },
+                                        },
+                                        COMMA@86..87 "," [] [],
+                                        JsSetterObjectMember {
+                                            set_token: SET_KW@87..94 "set" [Whitespace("\n  ")] [Whitespace(" ")],
+                                            name: JsLiteralMemberName {
+                                                value: IDENT@94..95 "y" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@95..96 "(" [] [],
+                                            parameter: JsIdentifierBinding {
+                                                name_token: IDENT@96..99 "val" [] [],
+                                            },
+                                            r_paren_token: R_PAREN@99..101 ")" [] [Whitespace(" ")],
+                                            body: JsFunctionBody {
+                                                l_curly_token: L_CURLY@101..102 "{" [] [],
+                                                directives: JsDirectiveList [],
+                                                statements: JsStatementList [
+                                                    JsExpressionStatement {
+                                                        expression: JsAssignmentExpression {
+                                                            left: JsIdentifierAssignment {
+                                                                name_token: IDENT@102..116 "setValue" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                            },
+                                                            operator_token: EQ@116..118 "=" [] [Whitespace(" ")],
+                                                            right: JsIdentifierExpression {
+                                                                name: JsReferenceIdentifier {
+                                                                    value_token: IDENT@118..121 "val" [] [],
+                                                                },
+                                                            },
+                                                        },
+                                                        semicolon_token: SEMICOLON@121..122 ";" [] [],
+                                                    },
+                                                ],
+                                                r_curly_token: R_CURLY@122..126 "}" [Whitespace("\n  ")] [],
+                                            },
+                                        },
+                                    ],
+                                    r_curly_token: R_CURLY@126..128 "}" [Whitespace("\n")] [],
+                                },
+                                dot_token: DOT@128..129 "." [] [],
+                                member: JsName {
+                                    value_token: IDENT@129..131 "y" [] [Whitespace(" ")],
+                                },
+                            },
+                            eq_token: EQ@131..133 "=" [] [Whitespace(" ")],
+                            default: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@133..135 "42" [] [],
+                            },
+                        },
+                    ],
+                    r_brack_token: R_BRACK@135..137 "]" [] [Whitespace(" ")],
+                },
+                operator_token: EQ@137..139 "=" [] [Whitespace(" ")],
+                right: JsArrayExpression {
+                    l_brack_token: L_BRACK@139..140 "[" [] [],
+                    elements: JsArrayElementList [
+                        JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@140..142 "23" [] [],
+                        },
+                    ],
+                    r_brack_token: R_BRACK@142..143 "]" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@143..144 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@144..146 "(" [Whitespace("\n")] [],
+                expression: JsAssignmentExpression {
+                    left: JsObjectAssignmentPattern {
+                        l_curly_token: L_CURLY@146..148 "{" [] [Whitespace(" ")],
+                        properties: JsObjectAssignmentPatternPropertyList [
+                            JsObjectAssignmentPatternProperty {
+                                member: JsName {
+                                    value_token: IDENT@148..149 "x" [] [],
+                                },
+                                colon_token: COLON@149..151 ":" [] [Whitespace(" ")],
+                                pattern: JsStaticMemberAssignment {
+                                    object: JsObjectExpression {
+                                        l_curly_token: L_CURLY@151..152 "{" [] [],
+                                        members: JsObjectMemberList [
+                                            JsGetterObjectMember {
+                                                get_token: GET_KW@152..159 "get" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@159..160 "y" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@160..161 "(" [] [],
+                                                r_paren_token: R_PAREN@161..163 ")" [] [Whitespace(" ")],
+                                                return_type: missing (optional),
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@163..164 "{" [] [],
+                                                    directives: JsDirectiveList [],
+                                                    statements: JsStatementList [
+                                                        JsThrowStatement {
+                                                            throw_token: THROW_KW@164..175 "throw" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                            argument: NewExpr {
+                                                                new_token: NEW_KW@175..179 "new" [] [Whitespace(" ")],
+                                                                object: JsIdentifierExpression {
+                                                                    name: JsReferenceIdentifier {
+                                                                        value_token: IDENT@179..191 "Test262Error" [] [],
+                                                                    },
+                                                                },
+                                                                type_args: missing (optional),
+                                                                arguments: JsCallArguments {
+                                                                    l_paren_token: L_PAREN@191..192 "(" [] [],
+                                                                    args: JsCallArgumentList [
+                                                                        JsStringLiteralExpression {
+                                                                            value_token: JS_STRING_LITERAL@192..230 "'The property should not be accessed.'" [] [],
+                                                                        },
+                                                                    ],
+                                                                    r_paren_token: R_PAREN@230..231 ")" [] [],
+                                                                },
+                                                            },
+                                                            semicolon_token: SEMICOLON@231..232 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@232..236 "}" [Whitespace("\n  ")] [],
+                                                },
+                                            },
+                                            COMMA@236..237 "," [] [],
+                                            JsSetterObjectMember {
+                                                set_token: SET_KW@237..244 "set" [Whitespace("\n  ")] [Whitespace(" ")],
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@244..245 "y" [] [],
+                                                },
+                                                l_paren_token: L_PAREN@245..246 "(" [] [],
+                                                parameter: JsIdentifierBinding {
+                                                    name_token: IDENT@246..249 "val" [] [],
+                                                },
+                                                r_paren_token: R_PAREN@249..251 ")" [] [Whitespace(" ")],
+                                                body: JsFunctionBody {
+                                                    l_curly_token: L_CURLY@251..252 "{" [] [],
+                                                    directives: JsDirectiveList [],
+                                                    statements: JsStatementList [
+                                                        JsExpressionStatement {
+                                                            expression: JsAssignmentExpression {
+                                                                left: JsIdentifierAssignment {
+                                                                    name_token: IDENT@252..266 "setValue" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                                },
+                                                                operator_token: EQ@266..268 "=" [] [Whitespace(" ")],
+                                                                right: JsIdentifierExpression {
+                                                                    name: JsReferenceIdentifier {
+                                                                        value_token: IDENT@268..271 "val" [] [],
+                                                                    },
+                                                                },
+                                                            },
+                                                            semicolon_token: SEMICOLON@271..272 ";" [] [],
+                                                        },
+                                                    ],
+                                                    r_curly_token: R_CURLY@272..276 "}" [Whitespace("\n  ")] [],
+                                                },
+                                            },
+                                        ],
+                                        r_curly_token: R_CURLY@276..278 "}" [Whitespace("\n")] [],
+                                    },
+                                    dot_token: DOT@278..279 "." [] [],
+                                    member: JsName {
+                                        value_token: IDENT@279..281 "y" [] [Whitespace(" ")],
+                                    },
+                                },
+                                init: JsInitializerClause {
+                                    eq_token: EQ@281..283 "=" [] [Whitespace(" ")],
+                                    expression: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@283..286 "42" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                        ],
+                        r_curly_token: R_CURLY@286..288 "}" [] [Whitespace(" ")],
+                    },
+                    operator_token: EQ@288..290 "=" [] [Whitespace(" ")],
+                    right: JsObjectExpression {
+                        l_curly_token: L_CURLY@290..292 "{" [] [Whitespace(" ")],
+                        members: JsObjectMemberList [
+                            JsPropertyObjectMember {
+                                name: JsLiteralMemberName {
+                                    value: IDENT@292..293 "x" [] [],
+                                },
+                                colon_token: COLON@293..295 ":" [] [Whitespace(" ")],
+                                value: JsNumberLiteralExpression {
+                                    value_token: JS_NUMBER_LITERAL@295..298 "23" [] [Whitespace(" ")],
+                                },
+                            },
+                        ],
+                        r_curly_token: R_CURLY@298..299 "}" [] [],
+                    },
+                },
+                r_paren_token: R_PAREN@299..300 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@300..301 ";" [] [],
+        },
+    ],
+    eof_token: EOF@301..302 "" [Whitespace("\n")] [],
+}
+
+0: JS_MODULE@0..302
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..301
+    0: JS_EXPRESSION_STATEMENT@0..144
+      0: JS_ASSIGNMENT_EXPRESSION@0..143
+        0: JS_ARRAY_ASSIGNMENT_PATTERN@0..137
+          0: L_BRACK@0..1 "[" [] []
+          1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@1..135
+            0: JS_ASSIGNMENT_WITH_DEFAULT@1..135
+              0: JS_STATIC_MEMBER_ASSIGNMENT@1..131
+                0: JS_OBJECT_EXPRESSION@1..128
+                  0: L_CURLY@1..2 "{" [] []
+                  1: JS_OBJECT_MEMBER_LIST@2..126
+                    0: JS_GETTER_OBJECT_MEMBER@2..86
+                      0: GET_KW@2..9 "get" [Whitespace("\n  ")] [Whitespace(" ")]
+                      1: JS_LITERAL_MEMBER_NAME@9..10
+                        0: IDENT@9..10 "y" [] []
+                      2: L_PAREN@10..11 "(" [] []
+                      3: R_PAREN@11..13 ")" [] [Whitespace(" ")]
+                      4: (empty)
+                      5: JS_FUNCTION_BODY@13..86
+                        0: L_CURLY@13..14 "{" [] []
+                        1: JS_DIRECTIVE_LIST@14..14
+                        2: JS_STATEMENT_LIST@14..82
+                          0: JS_THROW_STATEMENT@14..82
+                            0: THROW_KW@14..25 "throw" [Whitespace("\n    ")] [Whitespace(" ")]
+                            1: NEW_EXPR@25..81
+                              0: NEW_KW@25..29 "new" [] [Whitespace(" ")]
+                              1: JS_IDENTIFIER_EXPRESSION@29..41
+                                0: JS_REFERENCE_IDENTIFIER@29..41
+                                  0: IDENT@29..41 "Test262Error" [] []
+                              2: (empty)
+                              3: JS_CALL_ARGUMENTS@41..81
+                                0: L_PAREN@41..42 "(" [] []
+                                1: JS_CALL_ARGUMENT_LIST@42..80
+                                  0: JS_STRING_LITERAL_EXPRESSION@42..80
+                                    0: JS_STRING_LITERAL@42..80 "'The property should not be accessed.'" [] []
+                                2: R_PAREN@80..81 ")" [] []
+                            2: SEMICOLON@81..82 ";" [] []
+                        3: R_CURLY@82..86 "}" [Whitespace("\n  ")] []
+                    1: COMMA@86..87 "," [] []
+                    2: JS_SETTER_OBJECT_MEMBER@87..126
+                      0: SET_KW@87..94 "set" [Whitespace("\n  ")] [Whitespace(" ")]
+                      1: JS_LITERAL_MEMBER_NAME@94..95
+                        0: IDENT@94..95 "y" [] []
+                      2: L_PAREN@95..96 "(" [] []
+                      3: JS_IDENTIFIER_BINDING@96..99
+                        0: IDENT@96..99 "val" [] []
+                      4: R_PAREN@99..101 ")" [] [Whitespace(" ")]
+                      5: JS_FUNCTION_BODY@101..126
+                        0: L_CURLY@101..102 "{" [] []
+                        1: JS_DIRECTIVE_LIST@102..102
+                        2: JS_STATEMENT_LIST@102..122
+                          0: JS_EXPRESSION_STATEMENT@102..122
+                            0: JS_ASSIGNMENT_EXPRESSION@102..121
+                              0: JS_IDENTIFIER_ASSIGNMENT@102..116
+                                0: IDENT@102..116 "setValue" [Whitespace("\n    ")] [Whitespace(" ")]
+                              1: EQ@116..118 "=" [] [Whitespace(" ")]
+                              2: JS_IDENTIFIER_EXPRESSION@118..121
+                                0: JS_REFERENCE_IDENTIFIER@118..121
+                                  0: IDENT@118..121 "val" [] []
+                            1: SEMICOLON@121..122 ";" [] []
+                        3: R_CURLY@122..126 "}" [Whitespace("\n  ")] []
+                  2: R_CURLY@126..128 "}" [Whitespace("\n")] []
+                1: DOT@128..129 "." [] []
+                2: JS_NAME@129..131
+                  0: IDENT@129..131 "y" [] [Whitespace(" ")]
+              1: EQ@131..133 "=" [] [Whitespace(" ")]
+              2: JS_NUMBER_LITERAL_EXPRESSION@133..135
+                0: JS_NUMBER_LITERAL@133..135 "42" [] []
+          2: R_BRACK@135..137 "]" [] [Whitespace(" ")]
+        1: EQ@137..139 "=" [] [Whitespace(" ")]
+        2: JS_ARRAY_EXPRESSION@139..143
+          0: L_BRACK@139..140 "[" [] []
+          1: JS_ARRAY_ELEMENT_LIST@140..142
+            0: JS_NUMBER_LITERAL_EXPRESSION@140..142
+              0: JS_NUMBER_LITERAL@140..142 "23" [] []
+          2: R_BRACK@142..143 "]" [] []
+      1: SEMICOLON@143..144 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@144..301
+      0: JS_PARENTHESIZED_EXPRESSION@144..300
+        0: L_PAREN@144..146 "(" [Whitespace("\n")] []
+        1: JS_ASSIGNMENT_EXPRESSION@146..299
+          0: JS_OBJECT_ASSIGNMENT_PATTERN@146..288
+            0: L_CURLY@146..148 "{" [] [Whitespace(" ")]
+            1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@148..286
+              0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@148..286
+                0: JS_NAME@148..149
+                  0: IDENT@148..149 "x" [] []
+                1: COLON@149..151 ":" [] [Whitespace(" ")]
+                2: JS_STATIC_MEMBER_ASSIGNMENT@151..281
+                  0: JS_OBJECT_EXPRESSION@151..278
+                    0: L_CURLY@151..152 "{" [] []
+                    1: JS_OBJECT_MEMBER_LIST@152..276
+                      0: JS_GETTER_OBJECT_MEMBER@152..236
+                        0: GET_KW@152..159 "get" [Whitespace("\n  ")] [Whitespace(" ")]
+                        1: JS_LITERAL_MEMBER_NAME@159..160
+                          0: IDENT@159..160 "y" [] []
+                        2: L_PAREN@160..161 "(" [] []
+                        3: R_PAREN@161..163 ")" [] [Whitespace(" ")]
+                        4: (empty)
+                        5: JS_FUNCTION_BODY@163..236
+                          0: L_CURLY@163..164 "{" [] []
+                          1: JS_DIRECTIVE_LIST@164..164
+                          2: JS_STATEMENT_LIST@164..232
+                            0: JS_THROW_STATEMENT@164..232
+                              0: THROW_KW@164..175 "throw" [Whitespace("\n    ")] [Whitespace(" ")]
+                              1: NEW_EXPR@175..231
+                                0: NEW_KW@175..179 "new" [] [Whitespace(" ")]
+                                1: JS_IDENTIFIER_EXPRESSION@179..191
+                                  0: JS_REFERENCE_IDENTIFIER@179..191
+                                    0: IDENT@179..191 "Test262Error" [] []
+                                2: (empty)
+                                3: JS_CALL_ARGUMENTS@191..231
+                                  0: L_PAREN@191..192 "(" [] []
+                                  1: JS_CALL_ARGUMENT_LIST@192..230
+                                    0: JS_STRING_LITERAL_EXPRESSION@192..230
+                                      0: JS_STRING_LITERAL@192..230 "'The property should not be accessed.'" [] []
+                                  2: R_PAREN@230..231 ")" [] []
+                              2: SEMICOLON@231..232 ";" [] []
+                          3: R_CURLY@232..236 "}" [Whitespace("\n  ")] []
+                      1: COMMA@236..237 "," [] []
+                      2: JS_SETTER_OBJECT_MEMBER@237..276
+                        0: SET_KW@237..244 "set" [Whitespace("\n  ")] [Whitespace(" ")]
+                        1: JS_LITERAL_MEMBER_NAME@244..245
+                          0: IDENT@244..245 "y" [] []
+                        2: L_PAREN@245..246 "(" [] []
+                        3: JS_IDENTIFIER_BINDING@246..249
+                          0: IDENT@246..249 "val" [] []
+                        4: R_PAREN@249..251 ")" [] [Whitespace(" ")]
+                        5: JS_FUNCTION_BODY@251..276
+                          0: L_CURLY@251..252 "{" [] []
+                          1: JS_DIRECTIVE_LIST@252..252
+                          2: JS_STATEMENT_LIST@252..272
+                            0: JS_EXPRESSION_STATEMENT@252..272
+                              0: JS_ASSIGNMENT_EXPRESSION@252..271
+                                0: JS_IDENTIFIER_ASSIGNMENT@252..266
+                                  0: IDENT@252..266 "setValue" [Whitespace("\n    ")] [Whitespace(" ")]
+                                1: EQ@266..268 "=" [] [Whitespace(" ")]
+                                2: JS_IDENTIFIER_EXPRESSION@268..271
+                                  0: JS_REFERENCE_IDENTIFIER@268..271
+                                    0: IDENT@268..271 "val" [] []
+                              1: SEMICOLON@271..272 ";" [] []
+                          3: R_CURLY@272..276 "}" [Whitespace("\n  ")] []
+                    2: R_CURLY@276..278 "}" [Whitespace("\n")] []
+                  1: DOT@278..279 "." [] []
+                  2: JS_NAME@279..281
+                    0: IDENT@279..281 "y" [] [Whitespace(" ")]
+                3: JS_INITIALIZER_CLAUSE@281..286
+                  0: EQ@281..283 "=" [] [Whitespace(" ")]
+                  1: JS_NUMBER_LITERAL_EXPRESSION@283..286
+                    0: JS_NUMBER_LITERAL@283..286 "42" [] [Whitespace(" ")]
+            2: R_CURLY@286..288 "}" [] [Whitespace(" ")]
+          1: EQ@288..290 "=" [] [Whitespace(" ")]
+          2: JS_OBJECT_EXPRESSION@290..299
+            0: L_CURLY@290..292 "{" [] [Whitespace(" ")]
+            1: JS_OBJECT_MEMBER_LIST@292..298
+              0: JS_PROPERTY_OBJECT_MEMBER@292..298
+                0: JS_LITERAL_MEMBER_NAME@292..293
+                  0: IDENT@292..293 "x" [] []
+                1: COLON@293..295 ":" [] [Whitespace(" ")]
+                2: JS_NUMBER_LITERAL_EXPRESSION@295..298
+                  0: JS_NUMBER_LITERAL@295..298 "23" [] [Whitespace(" ")]
+            2: R_CURLY@298..299 "}" [] []
+        2: R_PAREN@299..300 ")" [] []
+      1: SEMICOLON@300..301 ";" [] []
+  3: EOF@301..302 "" [Whitespace("\n")] []


### PR DESCRIPTION
The tests added in #1893 revealed that our parser incorrectly parses the inner assignment target (`[1, 2][0]`) in `[[1,2][0] = 42] = [23]` as an array assignment target instead of a computed member expression. The same is true when using an object as the left-hand side of a member expression inside an assignment pattern.

This diff fixes this by first parsing the expression and only converting it to an assignment if it is an `array` or `object` expression
