### PR TITLE
fix(rslint_parser): Fix parsing of TS keywords

### DIFF
--- a/crates/rslint_parser/src/ast.rs
+++ b/crates/rslint_parser/src/ast.rs
@@ -617,8 +617,6 @@ mod tests {
 		// list([,3])
 		let list = build_list(vec![(None, Some(",")), (Some(3), None)]);
 
-		dbg!(&list.syntax_list.node());
-
 		assert_eq!(list.len(), 2);
 		assert!(!list.is_empty());
 		assert_eq!(list.separators().count(), 1);

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -107,20 +107,6 @@ pub(crate) fn maybe_ts_type_annotation(p: &mut Parser) -> Option<Range<usize>> {
 	}
 }
 
-pub(crate) fn ts_expr_stmt(p: &mut Parser) -> Option<CompletedMarker> {
-	match p.cur_src() {
-		"declare" => ts_declare(p),
-		"global" => {
-			if p.nth_at(1, T!['{']) {
-				ts_ambient_external_module_decl(p, false)
-			} else {
-				None
-			}
-		}
-		_ => ts_decl(p),
-	}
-}
-
 pub(crate) fn ts_declare(p: &mut Parser) -> Option<CompletedMarker> {
 	debug_assert_eq!(p.cur_src(), "declare");
 	let p = &mut *p.with_state(ParserState {

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -339,14 +339,14 @@ error[SyntaxError]: Illegal use of `eval` as an identifier in strict mode
   │     ^^^^
 
 --
-error[SyntaxError]: Illegal use of `let` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `let` as an identifier in strict mode
   ┌─ binding_identifier_invalid.js:6:5
   │
 6 │ let let = 5;
   │     ^^^
 
 --
-error[SyntaxError]: Illegal use of `let` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `let` as an identifier in strict mode
   ┌─ binding_identifier_invalid.js:7:7
   │
 7 │ const let = 5;

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -459,7 +459,7 @@ error[SyntaxError]: expected a name for the function in a function declaration, 
   │                 ^
 
 --
-error[SyntaxError]: Illegal use of `yield` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
   ┌─ function_decl_err.js:8:1
   │
 8 │ yield foo;
@@ -490,7 +490,7 @@ error[SyntaxError]: Illegal use of `await` as an identifier inside of a module
    │              ^^^^^
 
 --
-error[SyntaxError]: Illegal use of `yield` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
    ┌─ function_decl_err.js:11:14
    │
 11 │ function foo(yield) {}

--- a/crates/rslint_parser/test_data/inline/err/identifier.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier.rast
@@ -46,7 +46,7 @@ JsModule {
       1: SEMICOLON@12..13 ";" [] []
   3: EOF@13..14 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Illegal use of `yield` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
   ┌─ identifier.js:1:1
   │
 1 │ yield;

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.js
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.js
@@ -2,3 +2,6 @@ yield;
 await;
 async function test(await) {}
 function* test(yield) {}
+enum;
+implements;
+interface;

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.rast
@@ -80,14 +80,50 @@ JsModule {
                 r_curly_token: R_CURLY@67..68 "}" [] [],
             },
         },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsUnknown {
+                        items: [
+                            IDENT@68..73 "enum" [Whitespace("\n")] [],
+                        ],
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@73..74 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsUnknown {
+                        items: [
+                            IDENT@74..85 "implements" [Whitespace("\n")] [],
+                        ],
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@85..86 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsUnknown {
+                        items: [
+                            IDENT@86..96 "interface" [Whitespace("\n")] [],
+                        ],
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@96..97 ";" [] [],
+        },
     ],
-    eof_token: EOF@68..69 "" [Whitespace("\n")] [],
+    eof_token: EOF@97..98 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..69
+0: JS_MODULE@0..98
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..68
+  2: JS_MODULE_ITEM_LIST@0..97
     0: JS_EXPRESSION_STATEMENT@0..6
       0: JS_UNKNOWN_EXPRESSION@0..5
         0: JS_UNKNOWN@0..5
@@ -136,9 +172,24 @@ JsModule {
         1: JS_DIRECTIVE_LIST@67..67
         2: JS_STATEMENT_LIST@67..67
         3: R_CURLY@67..68 "}" [] []
-  3: EOF@68..69 "" [Whitespace("\n")] []
+    4: JS_EXPRESSION_STATEMENT@68..74
+      0: JS_UNKNOWN_EXPRESSION@68..73
+        0: JS_UNKNOWN@68..73
+          0: IDENT@68..73 "enum" [Whitespace("\n")] []
+      1: SEMICOLON@73..74 ";" [] []
+    5: JS_EXPRESSION_STATEMENT@74..86
+      0: JS_UNKNOWN_EXPRESSION@74..85
+        0: JS_UNKNOWN@74..85
+          0: IDENT@74..85 "implements" [Whitespace("\n")] []
+      1: SEMICOLON@85..86 ";" [] []
+    6: JS_EXPRESSION_STATEMENT@86..97
+      0: JS_UNKNOWN_EXPRESSION@86..96
+        0: JS_UNKNOWN@86..96
+          0: IDENT@86..96 "interface" [Whitespace("\n")] []
+      1: SEMICOLON@96..97 ";" [] []
+  3: EOF@97..98 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: Illegal use of `yield` as an identifier in strict mode
+error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
   ┌─ identifier_err.js:1:1
   │
 1 │ yield;
@@ -166,7 +217,31 @@ error[SyntaxError]: Illegal use of `yield` as an identifier in generator functio
   │                ^^^^^
 
 --
+error[SyntaxError]: Illegal use of reserved keyword `enum` as an identifier
+  ┌─ identifier_err.js:5:1
+  │
+5 │ enum;
+  │ ^^^^
+
+--
+error[SyntaxError]: Illegal use of reserved keyword `implements` as an identifier in strict mode
+  ┌─ identifier_err.js:6:1
+  │
+6 │ implements;
+  │ ^^^^^^^^^^
+
+--
+error[SyntaxError]: Illegal use of reserved keyword `interface` as an identifier in strict mode
+  ┌─ identifier_err.js:7:1
+  │
+7 │ interface;
+  │ ^^^^^^^^^
+
+--
 yield;
 await;
 async function test(await) {}
 function* test(yield) {}
+enum;
+implements;
+interface;

--- a/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.js
@@ -1,0 +1,6 @@
+declare = 1;
+abstract = 2;
+namespace = 3;
+type = 4;
+module = 5;
+global = 6;

--- a/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.rast
@@ -1,0 +1,133 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@0..8 "declare" [] [Whitespace(" ")],
+                },
+                operator_token: EQ@8..10 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@10..11 "1" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@11..12 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@12..22 "abstract" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@22..24 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@24..25 "2" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@25..26 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@26..37 "namespace" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@37..39 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@39..40 "3" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@40..41 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@41..47 "type" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@47..49 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@49..50 "4" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@50..51 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@51..59 "module" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@59..61 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@61..62 "5" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@62..63 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@63..71 "global" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@71..73 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@73..74 "6" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@74..75 ";" [] [],
+        },
+    ],
+    eof_token: EOF@75..76 "" [Whitespace("\n")] [],
+}
+
+0: JS_MODULE@0..76
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..75
+    0: JS_EXPRESSION_STATEMENT@0..12
+      0: JS_ASSIGNMENT_EXPRESSION@0..11
+        0: JS_IDENTIFIER_ASSIGNMENT@0..8
+          0: IDENT@0..8 "declare" [] [Whitespace(" ")]
+        1: EQ@8..10 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@10..11
+          0: JS_NUMBER_LITERAL@10..11 "1" [] []
+      1: SEMICOLON@11..12 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@12..26
+      0: JS_ASSIGNMENT_EXPRESSION@12..25
+        0: JS_IDENTIFIER_ASSIGNMENT@12..22
+          0: IDENT@12..22 "abstract" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@22..24 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@24..25
+          0: JS_NUMBER_LITERAL@24..25 "2" [] []
+      1: SEMICOLON@25..26 ";" [] []
+    2: JS_EXPRESSION_STATEMENT@26..41
+      0: JS_ASSIGNMENT_EXPRESSION@26..40
+        0: JS_IDENTIFIER_ASSIGNMENT@26..37
+          0: IDENT@26..37 "namespace" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@37..39 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@39..40
+          0: JS_NUMBER_LITERAL@39..40 "3" [] []
+      1: SEMICOLON@40..41 ";" [] []
+    3: JS_EXPRESSION_STATEMENT@41..51
+      0: JS_ASSIGNMENT_EXPRESSION@41..50
+        0: JS_IDENTIFIER_ASSIGNMENT@41..47
+          0: IDENT@41..47 "type" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@47..49 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@49..50
+          0: JS_NUMBER_LITERAL@49..50 "4" [] []
+      1: SEMICOLON@50..51 ";" [] []
+    4: JS_EXPRESSION_STATEMENT@51..63
+      0: JS_ASSIGNMENT_EXPRESSION@51..62
+        0: JS_IDENTIFIER_ASSIGNMENT@51..59
+          0: IDENT@51..59 "module" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@59..61 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@61..62
+          0: JS_NUMBER_LITERAL@61..62 "5" [] []
+      1: SEMICOLON@62..63 ";" [] []
+    5: JS_EXPRESSION_STATEMENT@63..75
+      0: JS_ASSIGNMENT_EXPRESSION@63..74
+        0: JS_IDENTIFIER_ASSIGNMENT@63..71
+          0: IDENT@63..71 "global" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@71..73 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@73..74
+          0: JS_NUMBER_LITERAL@73..74 "6" [] []
+      1: SEMICOLON@74..75 ";" [] []
+  3: EOF@75..76 "" [Whitespace("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.js
@@ -1,0 +1,6 @@
+// SCRIPT
+interface = 1;
+private = 2;
+protected = 3;
+public = 4;
+implements = 5;

--- a/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.rast
@@ -1,0 +1,113 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@0..20 "interface" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@20..22 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@22..23 "1" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@23..24 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@24..33 "private" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@33..35 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@35..36 "2" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@36..37 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@37..48 "protected" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@48..50 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@50..51 "3" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@51..52 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@52..60 "public" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@60..62 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@62..63 "4" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@63..64 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@64..76 "implements" [Whitespace("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@76..78 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@78..79 "5" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@79..80 ";" [] [],
+        },
+    ],
+    eof_token: EOF@80..81 "" [Whitespace("\n")] [],
+}
+
+0: JS_SCRIPT@0..81
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..80
+    0: JS_EXPRESSION_STATEMENT@0..24
+      0: JS_ASSIGNMENT_EXPRESSION@0..23
+        0: JS_IDENTIFIER_ASSIGNMENT@0..20
+          0: IDENT@0..20 "interface" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@20..22 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@22..23
+          0: JS_NUMBER_LITERAL@22..23 "1" [] []
+      1: SEMICOLON@23..24 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@24..37
+      0: JS_ASSIGNMENT_EXPRESSION@24..36
+        0: JS_IDENTIFIER_ASSIGNMENT@24..33
+          0: IDENT@24..33 "private" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@33..35 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@35..36
+          0: JS_NUMBER_LITERAL@35..36 "2" [] []
+      1: SEMICOLON@36..37 ";" [] []
+    2: JS_EXPRESSION_STATEMENT@37..52
+      0: JS_ASSIGNMENT_EXPRESSION@37..51
+        0: JS_IDENTIFIER_ASSIGNMENT@37..48
+          0: IDENT@37..48 "protected" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@48..50 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@50..51
+          0: JS_NUMBER_LITERAL@50..51 "3" [] []
+      1: SEMICOLON@51..52 ";" [] []
+    3: JS_EXPRESSION_STATEMENT@52..64
+      0: JS_ASSIGNMENT_EXPRESSION@52..63
+        0: JS_IDENTIFIER_ASSIGNMENT@52..60
+          0: IDENT@52..60 "public" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@60..62 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@62..63
+          0: JS_NUMBER_LITERAL@62..63 "4" [] []
+      1: SEMICOLON@63..64 ";" [] []
+    4: JS_EXPRESSION_STATEMENT@64..80
+      0: JS_ASSIGNMENT_EXPRESSION@64..79
+        0: JS_IDENTIFIER_ASSIGNMENT@64..76
+          0: IDENT@64..76 "implements" [Whitespace("\n")] [Whitespace(" ")]
+        1: EQ@76..78 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@78..79
+          0: JS_NUMBER_LITERAL@78..79 "5" [] []
+      1: SEMICOLON@79..80 ";" [] []
+  3: EOF@80..81 "" [Whitespace("\n")] []


### PR DESCRIPTION
## Summary
declare, abstract, namespace, type, enum, module, global, interface, private, protected, and public are typescript keywords but valid identifiers in JS.

This PR removes the TS parsing logic for now and ensures these identifiers are correctly parsed.

## Test Plan

`compiler.js` no longer reports any errors.
