### PR TITLE
fix(rslint_parser): Fix object assignment property to allow for non identifier member names

### DIFF
--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -1287,7 +1287,9 @@ pub struct JsObjectAssignmentPatternProperty {
 	pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectAssignmentPatternProperty {
-	pub fn member(&self) -> SyntaxResult<JsName> { support::required_node(&self.syntax, 0usize) }
+	pub fn member(&self) -> SyntaxResult<JsAnyObjectMemberName> {
+		support::required_node(&self.syntax, 0usize)
+	}
 	pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
 		support::required_token(&self.syntax, 1usize)
 	}

--- a/crates/rslint_parser/src/ast/generated/syntax_factory.rs
+++ b/crates/rslint_parser/src/ast/generated/syntax_factory.rs
@@ -3244,7 +3244,7 @@ impl SyntaxFactory for JsSyntaxFactory {
 				let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
 				let mut current_element = elements.next();
 				if let Some(element) = &current_element {
-					if JsName::can_cast(element.kind()) {
+					if JsAnyObjectMemberName::can_cast(element.kind()) {
 						slots.mark_present();
 						current_element = elements.next();
 					}

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -144,9 +144,7 @@ pub(super) fn parse_literal_expression(p: &mut Parser) -> ParsedSyntax {
 
 /// Parses an expression that might turn out to be an assignment target if an assignment operator is found
 pub(crate) fn parse_expr_or_assignment(p: &mut Parser) -> ParsedSyntax {
-	if p.at(T![<])
-		&& (token_set![T![ident], T![await], T![yield]].contains(p.nth(1)) || p.nth(1).is_keyword())
-	{
+	if p.at(T![<]) && is_nth_at_identifier_name(p, 1) {
 		let res = try_parse_ts(p, |p| {
 			let m = p.start();
 			if ts_type_params(p).is_none() {

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -3,7 +3,7 @@ use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
 use crate::parser::ParsedSyntax::{Absent, Present};
 use crate::parser::{ParsedSyntax, RecoveryResult};
 use crate::syntax::decl::{parse_formal_param_pat, parse_parameter_list};
-use crate::syntax::expr::{parse_expr_or_assignment, parse_expression};
+use crate::syntax::expr::{is_at_identifier_name, parse_expr_or_assignment, parse_expression};
 use crate::syntax::function::{
 	function_body, parse_ts_parameter_types, parse_ts_type_annotation_or_error,
 };
@@ -151,8 +151,7 @@ fn parse_object_member(p: &mut Parser) -> ParsedSyntax {
 		_ => {
 			let checkpoint = p.checkpoint();
 			let m = p.start();
-			let identifier_member_name =
-				matches!(p.cur(), T![ident] | T![await] | T![yield]) || p.cur().is_keyword();
+			let identifier_member_name = is_at_identifier_name(p);
 			let member_name = parse_object_member_name(p)
 				.or_add_diagnostic(p, js_parse_error::expected_object_member);
 

--- a/crates/rslint_parser/test_data/inline/err/property_assignment_target_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/property_assignment_target_err.rast
@@ -281,11 +281,11 @@ JsModule {
       1: SEMICOLON@72..73 ";" [] []
   3: EOF@73..74 "" [Whitespace("\n")] []
 --
-error[SyntaxError]: expected an identifier but instead found ':'
+error[SyntaxError]: expected an identifier, a string literal, a number literal, or a computed property but instead found ':'
   ┌─ property_assignment_target_err.js:1:3
   │
 1 │ ({:y} = {});
-  │   ^ Expected an identifier here
+  │   ^ Expected an identifier, a string literal, a number literal, or a computed property here
 
 --
 error[SyntaxError]: expected an identifier but instead found '='
@@ -295,11 +295,11 @@ error[SyntaxError]: expected an identifier but instead found '='
   │   ^ Expected an identifier here
 
 --
-error[SyntaxError]: expected an identifier but instead found ':'
+error[SyntaxError]: expected an identifier, a string literal, a number literal, or a computed property but instead found ':'
   ┌─ property_assignment_target_err.js:3:3
   │
 3 │ ({:="test"} = {});
-  │   ^ Expected an identifier here
+  │   ^ Expected an identifier, a string literal, a number literal, or a computed property here
 
 --
 error[SyntaxError]: expected an identifier, or an assignment target but instead found '='
@@ -309,11 +309,11 @@ error[SyntaxError]: expected an identifier, or an assignment target but instead 
   │    ^ Expected an identifier, or an assignment target here
 
 --
-error[SyntaxError]: expected an identifier but instead found ':'
+error[SyntaxError]: expected an identifier, a string literal, a number literal, or a computed property but instead found ':'
   ┌─ property_assignment_target_err.js:4:3
   │
 4 │ ({:=} = {});
-  │   ^ Expected an identifier here
+  │   ^ Expected an identifier, a string literal, a number literal, or a computed property here
 
 --
 error[SyntaxError]: expected an identifier, or an assignment target but instead found '='

--- a/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
@@ -26,9 +26,9 @@ JsModule {
                                                 statements: JsStatementList [
                                                     JsThrowStatement {
                                                         throw_token: THROW_KW@14..25 "throw" [Whitespace("\n    ")] [Whitespace(" ")],
-                                                        argument: NewExpr {
+                                                        argument: JsNewExpression {
                                                             new_token: NEW_KW@25..29 "new" [] [Whitespace(" ")],
-                                                            object: JsIdentifierExpression {
+                                                            callee: JsIdentifierExpression {
                                                                 name: JsReferenceIdentifier {
                                                                     value_token: IDENT@29..41 "Test262Error" [] [],
                                                                 },
@@ -142,9 +142,9 @@ JsModule {
                                                     statements: JsStatementList [
                                                         JsThrowStatement {
                                                             throw_token: THROW_KW@164..175 "throw" [Whitespace("\n    ")] [Whitespace(" ")],
-                                                            argument: NewExpr {
+                                                            argument: JsNewExpression {
                                                                 new_token: NEW_KW@175..179 "new" [] [Whitespace(" ")],
-                                                                object: JsIdentifierExpression {
+                                                                callee: JsIdentifierExpression {
                                                                     name: JsReferenceIdentifier {
                                                                         value_token: IDENT@179..191 "Test262Error" [] [],
                                                                     },
@@ -269,7 +269,7 @@ JsModule {
                         2: JS_STATEMENT_LIST@14..82
                           0: JS_THROW_STATEMENT@14..82
                             0: THROW_KW@14..25 "throw" [Whitespace("\n    ")] [Whitespace(" ")]
-                            1: NEW_EXPR@25..81
+                            1: JS_NEW_EXPRESSION@25..81
                               0: NEW_KW@25..29 "new" [] [Whitespace(" ")]
                               1: JS_IDENTIFIER_EXPRESSION@29..41
                                 0: JS_REFERENCE_IDENTIFIER@29..41
@@ -350,7 +350,7 @@ JsModule {
                           2: JS_STATEMENT_LIST@164..232
                             0: JS_THROW_STATEMENT@164..232
                               0: THROW_KW@164..175 "throw" [Whitespace("\n    ")] [Whitespace(" ")]
-                              1: NEW_EXPR@175..231
+                              1: JS_NEW_EXPRESSION@175..231
                                 0: NEW_KW@175..179 "new" [] [Whitespace(" ")]
                                 1: JS_IDENTIFIER_EXPRESSION@179..191
                                   0: JS_REFERENCE_IDENTIFIER@179..191

--- a/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
@@ -120,8 +120,8 @@ JsModule {
                         l_curly_token: L_CURLY@146..148 "{" [] [Whitespace(" ")],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@148..149 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@148..149 "x" [] [],
                                 },
                                 colon_token: COLON@149..151 ":" [] [Whitespace(" ")],
                                 pattern: JsStaticMemberAssignment {
@@ -330,7 +330,7 @@ JsModule {
             0: L_CURLY@146..148 "{" [] [Whitespace(" ")]
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@148..286
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@148..286
-                0: JS_NAME@148..149
+                0: JS_LITERAL_MEMBER_NAME@148..149
                   0: IDENT@148..149 "x" [] []
                 1: COLON@149..151 ":" [] [Whitespace(" ")]
                 2: JS_STATIC_MEMBER_ASSIGNMENT@151..281

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -191,8 +191,8 @@ JsModule {
                         l_curly_token: L_CURLY@146..148 "{" [] [Whitespace(" ")],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@148..151 "bar" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@148..151 "bar" [] [],
                                 },
                                 colon_token: COLON@151..153 ":" [] [Whitespace(" ")],
                                 pattern: JsArrayAssignmentPattern {
@@ -385,7 +385,7 @@ JsModule {
             0: L_CURLY@146..148 "{" [] [Whitespace(" ")]
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@148..189
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@148..166
-                0: JS_NAME@148..151
+                0: JS_LITERAL_MEMBER_NAME@148..151
                   0: IDENT@148..151 "bar" [] []
                 1: COLON@151..153 ":" [] [Whitespace(" ")]
                 2: JS_ARRAY_ASSIGNMENT_PATTERN@153..166

--- a/crates/rslint_parser/test_data/inline/ok/object_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_assignment_target.rast
@@ -64,8 +64,8 @@ JsModule {
                         l_curly_token: L_CURLY@33..35 "{" [] [Whitespace(" ")],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@35..38 "bar" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@35..38 "bar" [] [],
                                 },
                                 colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
                                 pattern: JsArrayAssignmentPattern {
@@ -173,7 +173,7 @@ JsModule {
             0: L_CURLY@33..35 "{" [] [Whitespace(" ")]
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@35..76
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@35..53
-                0: JS_NAME@35..38
+                0: JS_LITERAL_MEMBER_NAME@35..38
                   0: IDENT@35..38 "bar" [] []
                 1: COLON@38..40 ":" [] [Whitespace(" ")]
                 2: JS_ARRAY_ASSIGNMENT_PATTERN@40..53

--- a/crates/rslint_parser/test_data/inline/ok/property_assignment_target.js
+++ b/crates/rslint_parser/test_data/inline/ok/property_assignment_target.js
@@ -5,3 +5,4 @@
 ({x: z["computed"]}= {});
 ({x = "default"}= {});
 ({x: y = "default"}= {});
+({0: y, [computed]: z} = {});

--- a/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
@@ -37,8 +37,8 @@ JsModule {
                         l_curly_token: L_CURLY@12..13 "{" [] [],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@13..14 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@13..14 "x" [] [],
                                 },
                                 colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
                                 pattern: JsIdentifierAssignment {
@@ -68,8 +68,8 @@ JsModule {
                         l_curly_token: L_CURLY@26..27 "{" [] [],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@27..28 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@27..28 "x" [] [],
                                 },
                                 colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
                                 pattern: JsStaticMemberAssignment {
@@ -122,8 +122,8 @@ JsModule {
                         l_curly_token: L_CURLY@49..50 "{" [] [],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@50..51 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@50..51 "x" [] [],
                                 },
                                 colon_token: COLON@51..53 ":" [] [Whitespace(" ")],
                                 pattern: JsParenthesizedAssignment {
@@ -161,8 +161,8 @@ JsModule {
                         l_curly_token: L_CURLY@67..68 "{" [] [],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@68..69 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@68..69 "x" [] [],
                                 },
                                 colon_token: COLON@69..71 ":" [] [Whitespace(" ")],
                                 pattern: JsComputedMemberAssignment {
@@ -233,8 +233,8 @@ JsModule {
                         l_curly_token: L_CURLY@116..117 "{" [] [],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@117..118 "x" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@117..118 "x" [] [],
                                 },
                                 colon_token: COLON@118..120 ":" [] [Whitespace(" ")],
                                 pattern: JsIdentifierAssignment {
@@ -261,14 +261,62 @@ JsModule {
             },
             semicolon_token: SEMICOLON@139..140 ";" [] [],
         },
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@140..142 "(" [Whitespace("\n")] [],
+                expression: JsAssignmentExpression {
+                    left: JsObjectAssignmentPattern {
+                        l_curly_token: L_CURLY@142..143 "{" [] [],
+                        properties: JsObjectAssignmentPatternPropertyList [
+                            JsObjectAssignmentPatternProperty {
+                                member: JsLiteralMemberName {
+                                    value: JS_NUMBER_LITERAL@143..144 "0" [] [],
+                                },
+                                colon_token: COLON@144..146 ":" [] [Whitespace(" ")],
+                                pattern: JsIdentifierAssignment {
+                                    name_token: IDENT@146..147 "y" [] [],
+                                },
+                                init: missing (optional),
+                            },
+                            COMMA@147..149 "," [] [Whitespace(" ")],
+                            JsObjectAssignmentPatternProperty {
+                                member: JsComputedMemberName {
+                                    l_brack_token: L_BRACK@149..150 "[" [] [],
+                                    expression: JsIdentifierExpression {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@150..158 "computed" [] [],
+                                        },
+                                    },
+                                    r_brack_token: R_BRACK@158..159 "]" [] [],
+                                },
+                                colon_token: COLON@159..161 ":" [] [Whitespace(" ")],
+                                pattern: JsIdentifierAssignment {
+                                    name_token: IDENT@161..162 "z" [] [],
+                                },
+                                init: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@162..164 "}" [] [Whitespace(" ")],
+                    },
+                    operator_token: EQ@164..166 "=" [] [Whitespace(" ")],
+                    right: JsObjectExpression {
+                        l_curly_token: L_CURLY@166..167 "{" [] [],
+                        members: JsObjectMemberList [],
+                        r_curly_token: R_CURLY@167..168 "}" [] [],
+                    },
+                },
+                r_paren_token: R_PAREN@168..169 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@169..170 ";" [] [],
+        },
     ],
-    eof_token: EOF@140..141 "" [Whitespace("\n")] [],
+    eof_token: EOF@170..171 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..141
+0: JS_MODULE@0..171
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..140
+  2: JS_MODULE_ITEM_LIST@0..170
     0: JS_EXPRESSION_STATEMENT@0..10
       0: JS_PARENTHESIZED_EXPRESSION@0..9
         0: L_PAREN@0..1 "(" [] []
@@ -296,7 +344,7 @@ JsModule {
             0: L_CURLY@12..13 "{" [] []
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@13..17
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@13..17
-                0: JS_NAME@13..14
+                0: JS_LITERAL_MEMBER_NAME@13..14
                   0: IDENT@13..14 "x" [] []
                 1: COLON@14..16 ":" [] [Whitespace(" ")]
                 2: JS_IDENTIFIER_ASSIGNMENT@16..17
@@ -318,7 +366,7 @@ JsModule {
             0: L_CURLY@26..27 "{" [] []
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@27..40
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@27..40
-                0: JS_NAME@27..28
+                0: JS_LITERAL_MEMBER_NAME@27..28
                   0: IDENT@27..28 "x" [] []
                 1: COLON@28..30 ":" [] [Whitespace(" ")]
                 2: JS_STATIC_MEMBER_ASSIGNMENT@30..40
@@ -356,7 +404,7 @@ JsModule {
             0: L_CURLY@49..50 "{" [] []
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@50..58
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@50..58
-                0: JS_NAME@50..51
+                0: JS_LITERAL_MEMBER_NAME@50..51
                   0: IDENT@50..51 "x" [] []
                 1: COLON@51..53 ":" [] [Whitespace(" ")]
                 2: JS_PARENTHESIZED_ASSIGNMENT@53..58
@@ -384,7 +432,7 @@ JsModule {
             0: L_CURLY@67..68 "{" [] []
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@68..84
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@68..84
-                0: JS_NAME@68..69
+                0: JS_LITERAL_MEMBER_NAME@68..69
                   0: IDENT@68..69 "x" [] []
                 1: COLON@69..71 ":" [] [Whitespace(" ")]
                 2: JS_COMPUTED_MEMBER_ASSIGNMENT@71..84
@@ -434,7 +482,7 @@ JsModule {
             0: L_CURLY@116..117 "{" [] []
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@117..133
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@117..133
-                0: JS_NAME@117..118
+                0: JS_LITERAL_MEMBER_NAME@117..118
                   0: IDENT@117..118 "x" [] []
                 1: COLON@118..120 ":" [] [Whitespace(" ")]
                 2: JS_IDENTIFIER_ASSIGNMENT@120..122
@@ -451,4 +499,38 @@ JsModule {
             2: R_CURLY@137..138 "}" [] []
         2: R_PAREN@138..139 ")" [] []
       1: SEMICOLON@139..140 ";" [] []
-  3: EOF@140..141 "" [Whitespace("\n")] []
+    7: JS_EXPRESSION_STATEMENT@140..170
+      0: JS_PARENTHESIZED_EXPRESSION@140..169
+        0: L_PAREN@140..142 "(" [Whitespace("\n")] []
+        1: JS_ASSIGNMENT_EXPRESSION@142..168
+          0: JS_OBJECT_ASSIGNMENT_PATTERN@142..164
+            0: L_CURLY@142..143 "{" [] []
+            1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@143..162
+              0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@143..147
+                0: JS_LITERAL_MEMBER_NAME@143..144
+                  0: JS_NUMBER_LITERAL@143..144 "0" [] []
+                1: COLON@144..146 ":" [] [Whitespace(" ")]
+                2: JS_IDENTIFIER_ASSIGNMENT@146..147
+                  0: IDENT@146..147 "y" [] []
+                3: (empty)
+              1: COMMA@147..149 "," [] [Whitespace(" ")]
+              2: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@149..162
+                0: JS_COMPUTED_MEMBER_NAME@149..159
+                  0: L_BRACK@149..150 "[" [] []
+                  1: JS_IDENTIFIER_EXPRESSION@150..158
+                    0: JS_REFERENCE_IDENTIFIER@150..158
+                      0: IDENT@150..158 "computed" [] []
+                  2: R_BRACK@158..159 "]" [] []
+                1: COLON@159..161 ":" [] [Whitespace(" ")]
+                2: JS_IDENTIFIER_ASSIGNMENT@161..162
+                  0: IDENT@161..162 "z" [] []
+                3: (empty)
+            2: R_CURLY@162..164 "}" [] [Whitespace(" ")]
+          1: EQ@164..166 "=" [] [Whitespace(" ")]
+          2: JS_OBJECT_EXPRESSION@166..168
+            0: L_CURLY@166..167 "{" [] []
+            1: JS_OBJECT_MEMBER_LIST@167..167
+            2: R_CURLY@167..168 "}" [] []
+        2: R_PAREN@168..169 ")" [] []
+      1: SEMICOLON@169..170 ";" [] []
+  3: EOF@170..171 "" [Whitespace("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
@@ -200,8 +200,8 @@ JsModule {
                         l_curly_token: L_CURLY@119..121 "{" [] [Whitespace(" ")],
                         properties: JsObjectAssignmentPatternPropertyList [
                             JsObjectAssignmentPatternProperty {
-                                member: JsName {
-                                    value_token: IDENT@121..122 "b" [] [],
+                                member: JsLiteralMemberName {
+                                    value: IDENT@121..122 "b" [] [],
                                 },
                                 colon_token: COLON@122..124 ":" [] [Whitespace(" ")],
                                 pattern: JsObjectAssignmentPattern {
@@ -376,7 +376,7 @@ JsModule {
             0: L_CURLY@119..121 "{" [] [Whitespace(" ")]
             1: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST@121..133
               0: JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY@121..133
-                0: JS_NAME@121..122
+                0: JS_LITERAL_MEMBER_NAME@121..122
                   0: IDENT@121..122 "b" [] []
                 1: COLON@122..124 ":" [] [Whitespace(" ")]
                 2: JS_OBJECT_ASSIGNMENT_PATTERN@124..133

--- a/xtask/js.ungram
+++ b/xtask/js.ungram
@@ -777,7 +777,7 @@ JsObjectAssignmentPatternShorthandProperty =
 // ({ x: a } = b) or ({ x: a = "test" } = b)
 //    ^^^^              ^^^^^^^^^^^^^
 JsObjectAssignmentPatternProperty =
-	member: JsName
+	member: JsAnyObjectMemberName
 	':'
 	pattern: JsAnyAssignmentPattern
 	init: JsInitializerClause?


### PR DESCRIPTION
## Summary

Object assignment patterns allow for any valid member name. RSlint's grammar defines that correctly for bindings but not for assignment targets.

This PR changes the definition of `JsObjectAssignmentPatternProperty` to allow any valid member name and fixes the parsing.

## Test Plan

Added new tests covering computed and literal member names. 
