### PR TITLE
xtask coverage-libs using criterion to better assess performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -1759,9 +1759,11 @@ dependencies = [
  "ascii_table",
  "colored",
  "convert_case",
+ "criterion",
  "dhat",
  "humansize",
  "indicatif",
+ "itertools",
  "num_cpus",
  "once_cell",
  "pico-args",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -34,6 +34,8 @@ timing = "0.2.3"
 ansi_rgb = "0.2.0"
 dhat = { version = "0.2.4", optional = true }
 humansize = "1.1.1"
+itertools = "0.10.3"
+criterion = "0.3.5"
 
 [features]
 dhat-on = ["dhat"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,7 +65,11 @@ fn main() -> Result<()> {
 				.opt_value_from_str("--filter")
 				.unwrap()
 				.unwrap_or_else(|| ".*".to_string());
-			xtask::libs::run(filter);
+			let criterion: bool = args
+				.opt_value_from_str("--criterion")
+				.unwrap()
+				.unwrap_or(true);
+			xtask::libs::run(filter, criterion);
 			Ok(())
 		}
 		_ => {


### PR DESCRIPTION
How to run

```
cargo run -p xtask --release -- coverage-libs --filter=jquery
```

Result

```
[jquery.min.js] - using [target/jquery.min.js]
Gnuplot not found, using plotters backend
Benchmarking https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
Benchmarking https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js: Warming up for 3.0000 s
Benchmarking https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js: Collecting 100 samples in estimated 6.1669 s (500 iterations)
Benchmarking https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js: Analyzing
https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
                        time:   [11.744 ms 11.977 ms 12.241 ms]
                        change: [-2.3855% -0.0651% +2.6054%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmark: https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
        Tokenization: 1.470025ms
        Parsing:      4.849397ms
        Tree_sink:    6.092388ms
                      ----------
        Total:        12.41181ms
        Diagnostics
                Warning: 2

Summary
-------
jquery.min.js,Total Time,12.41181ms,tokenization,1.470025ms,parsing,4.849397ms,tree_sink,6.092388ms
```

The time returned by ```criterion``` and  the time split by parts sometimes varies a lot, like the example above.

Criterion can be disabled with

```
cargo run -p xtask --release -- coverage-libs --filter=jquery --criterion=false
```

The "Total Time" line is interesting to run with the oneliners below and gather a summary.

Poweshell
```
cargo run -p xtask --release -- coverage-libs --criterion=false|sls "Total Time"
```

Linux
```
cargo run -p xtask --release -- coverage-libs --criterion=false|grep "Total Time"
```
