### PR TITLE
making marker dropbomb optional on release

### DIFF
--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -14,7 +14,10 @@ rslint_lexer = { path = "../rslint_lexer", version = "0.2", features = ["highlig
 rome_rowan = { path = "../rome_rowan", version = "0.0.0" }
 num-bigint = "0.3.0"
 lexical = { version = "5.2.0", features = ["radix"] }
-drop_bomb = "0.1.5"
+drop_bomb = { version = "0.1.5", optional = true }
 
 [dev-dependencies]
 expect-test = "1.0"
+
+[features]
+force-markerbomb = ["drop_bomb"]

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -14,10 +14,10 @@ rslint_lexer = { path = "../rslint_lexer", version = "0.2", features = ["highlig
 rome_rowan = { path = "../rome_rowan", version = "0.0.0" }
 num-bigint = "0.3.0"
 lexical = { version = "5.2.0", features = ["radix"] }
-drop_bomb = { version = "0.1.5", optional = true }
+drop_bomb = { version = "0.1.5" }
 
 [dev-dependencies]
 expect-test = "1.0"
 
 [features]
-force-markerbomb = ["drop_bomb"]
+force-markerbomb = []

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -24,9 +24,6 @@ pub use single_token_parse_recovery::SingleTokenParseRecovery;
 pub use crate::parser::parse_recovery::{ParseRecovery, RecoveryError, RecoveryResult};
 use crate::*;
 
-#[cfg(any(debug_assertions, feature = "force-markerbomb"))]
-use drop_bomb::DropBomb;
-
 /// Captures the progress of the parser and allows to test if the parsing is still making progress
 #[derive(Debug, Eq, Ord, PartialOrd, PartialEq, Hash, Default)]
 pub struct ParserProgress(Option<usize>);
@@ -476,26 +473,25 @@ impl<'t> Parser<'t> {
 }
 
 #[derive(Debug)]
-pub struct MarkerDropBomb
-{
+pub struct MarkerDropBomb {
 	#[cfg(any(debug_assertions, feature = "force-markerbomb"))]
-	bomb: DropBomb,
+	bomb: drop_bomb::DropBomb,
 }
 
 impl MarkerDropBomb {
-    pub fn defuse(&mut self) {
+	pub fn defuse(&mut self) {
 		#[cfg(any(debug_assertions, feature = "force-markerbomb"))]
 		self.bomb.defuse();
 	}
 }
 
 impl Default for MarkerDropBomb {
-    fn default() -> Self {
+	fn default() -> Self {
 		Self {
 			#[cfg(any(debug_assertions, feature = "force-markerbomb"))]
-			bomb: DropBomb::new("Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent."),		
+			bomb: drop_bomb::DropBomb::new("Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent."),		
 		}
-    }
+	}
 }
 
 /// A structure signifying the start of parsing of a syntax tree node
@@ -518,7 +514,7 @@ impl Marker {
 			start,
 			old_start: pos,
 			child_idx: None,
-			bomb: MarkerDropBomb::default()
+			bomb: MarkerDropBomb::default(),
 		}
 	}
 


### PR DESCRIPTION
We added https://github.com/matklad/drop_bomb to ```rslint_parser::Marker``` to, very politely, panic if you forget to deal correctly with ```Marker```s. 

It is really helpful when developing but it has a performance impact that we can avoid in release mode. This PR makes the bomp do nothing in release, letting the optimizer to completely scrap it, but also allow the bomb to be opted-in by the ```force-markerbomb``` feature.

The performance gain is smaller than when I investigated this for the first time, but still nice to have.

Before
```
https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
                        time:   [84.660 ms 86.023 ms 87.527 ms]
```

After
```
https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
                        time:   [82.035 ms 82.676 ms 83.358 ms]
```

The bomb can be forced using

```
cargo run -p xtask --features "rslint_parser/force-markerbomb" --release -- coverage-libs --filter=three
```

for more see: https://github.com/rome/tools/issues/1901