### PR TITLE
fix(rslint_parser): libs parse diagnostics

### DIFF
--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -82,6 +82,7 @@ pub(crate) fn parse_import(p: &mut Parser) -> ParsedSyntax {
 	let import = p.start();
 	p.bump_any();
 
+	debug_assert!(p.state.name_map.is_empty());
 	p.state.duplicate_binding_parent = Some("import");
 
 	parse_import_clause(p).or_add_diagnostic(p, |p, range| {

--- a/crates/rslint_parser/test_data/inline/err/break_stmt.js
+++ b/crates/rslint_parser/test_data/inline/err/break_stmt.js
@@ -1,1 +1,4 @@
 function foo() { break; }
+while (true) {
+  break foo;
+}

--- a/crates/rslint_parser/test_data/inline/err/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/break_stmt.rast
@@ -30,14 +30,33 @@ JsModule {
                 r_curly_token: R_CURLY@24..25 "}" [] [],
             },
         },
+        JsWhileStatement {
+            while_token: WHILE_KW@25..32 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@32..33 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@33..37 "true" [] [],
+            },
+            r_paren_token: R_PAREN@37..39 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@39..40 "{" [] [],
+                statements: JsStatementList [
+                    JsBreakStatement {
+                        break_token: BREAK_KW@40..49 "break" [Whitespace("\n  ")] [Whitespace(" ")],
+                        label_token: IDENT@49..52 "foo" [] [],
+                        semicolon_token: SEMICOLON@52..53 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@53..55 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
-    eof_token: EOF@25..26 "" [Whitespace("\n")] [],
+    eof_token: EOF@55..56 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..26
+0: JS_MODULE@0..56
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..25
+  2: JS_MODULE_ITEM_LIST@0..55
     0: JS_FUNCTION_DECLARATION@0..25
       0: (empty)
       1: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
@@ -58,7 +77,21 @@ JsModule {
             0: BREAK_KW@17..22 "break" [] []
             1: SEMICOLON@22..24 ";" [] [Whitespace(" ")]
         3: R_CURLY@24..25 "}" [] []
-  3: EOF@25..26 "" [Whitespace("\n")] []
+    1: JS_WHILE_STATEMENT@25..55
+      0: WHILE_KW@25..32 "while" [Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@32..33 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@33..37
+        0: TRUE_KW@33..37 "true" [] []
+      3: R_PAREN@37..39 ")" [] [Whitespace(" ")]
+      4: JS_BLOCK_STATEMENT@39..55
+        0: L_CURLY@39..40 "{" [] []
+        1: JS_STATEMENT_LIST@40..53
+          0: JS_BREAK_STATEMENT@40..53
+            0: BREAK_KW@40..49 "break" [Whitespace("\n  ")] [Whitespace(" ")]
+            1: IDENT@49..52 "foo" [] []
+            2: SEMICOLON@52..53 ";" [] []
+        2: R_CURLY@53..55 "}" [Whitespace("\n")] []
+  3: EOF@55..56 "" [Whitespace("\n")] []
 --
 error[SyntaxError]: Invalid break not inside of a switch, loop, or labelled statement
   ┌─ break_stmt.js:1:18
@@ -67,4 +100,14 @@ error[SyntaxError]: Invalid break not inside of a switch, loop, or labelled stat
   │                  ^^^^^
 
 --
+error[SyntaxError]: Use of undefined statement label `foo`
+  ┌─ break_stmt.js:3:9
+  │
+3 │   break foo;
+  │         ^^^ This label is used, but it is never defined
+
+--
 function foo() { break; }
+while (true) {
+  break foo;
+}

--- a/crates/rslint_parser/test_data/inline/err/continue_stmt.js
+++ b/crates/rslint_parser/test_data/inline/err/continue_stmt.js
@@ -1,1 +1,4 @@
 function foo() { continue; }
+while (true) {
+  continue foo;
+}

--- a/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
@@ -30,14 +30,33 @@ JsModule {
                 r_curly_token: R_CURLY@27..28 "}" [] [],
             },
         },
+        JsWhileStatement {
+            while_token: WHILE_KW@28..35 "while" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@35..36 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@36..40 "true" [] [],
+            },
+            r_paren_token: R_PAREN@40..42 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@42..43 "{" [] [],
+                statements: JsStatementList [
+                    JsContinueStatement {
+                        continue_token: CONTINUE_KW@43..55 "continue" [Whitespace("\n  ")] [Whitespace(" ")],
+                        label_token: IDENT@55..58 "foo" [] [],
+                        semicolon_token: SEMICOLON@58..59 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@59..61 "}" [Whitespace("\n")] [],
+            },
+        },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@61..62 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..29
+0: JS_MODULE@0..62
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..28
+  2: JS_MODULE_ITEM_LIST@0..61
     0: JS_FUNCTION_DECLARATION@0..28
       0: (empty)
       1: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
@@ -58,7 +77,21 @@ JsModule {
             0: CONTINUE_KW@17..25 "continue" [] []
             1: SEMICOLON@25..27 ";" [] [Whitespace(" ")]
         3: R_CURLY@27..28 "}" [] []
-  3: EOF@28..29 "" [Whitespace("\n")] []
+    1: JS_WHILE_STATEMENT@28..61
+      0: WHILE_KW@28..35 "while" [Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@35..36 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@36..40
+        0: TRUE_KW@36..40 "true" [] []
+      3: R_PAREN@40..42 ")" [] [Whitespace(" ")]
+      4: JS_BLOCK_STATEMENT@42..61
+        0: L_CURLY@42..43 "{" [] []
+        1: JS_STATEMENT_LIST@43..59
+          0: JS_CONTINUE_STATEMENT@43..59
+            0: CONTINUE_KW@43..55 "continue" [Whitespace("\n  ")] [Whitespace(" ")]
+            1: IDENT@55..58 "foo" [] []
+            2: SEMICOLON@58..59 ";" [] []
+        2: R_CURLY@59..61 "}" [Whitespace("\n")] []
+  3: EOF@61..62 "" [Whitespace("\n")] []
 --
 error[SyntaxError]: Invalid continue not inside of a loop
   ┌─ continue_stmt.js:1:18
@@ -67,4 +100,14 @@ error[SyntaxError]: Invalid continue not inside of a loop
   │                  ^^^^^^^^
 
 --
+error[SyntaxError]: Use of undefined statement label `foo`
+  ┌─ continue_stmt.js:3:12
+  │
+3 │   continue foo;
+  │            ^^^ This label is used, but it is never defined
+
+--
 function foo() { continue; }
+while (true) {
+  continue foo;
+}

--- a/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
@@ -511,16 +511,6 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │ ...Which is required to end this statement
 
 --
-error[SyntaxError]: Duplicate statement labels are not allowed
-  ┌─ import_assertion_err.js:5:10
-  │
-2 │ import "foo" \u{61}ssert { type: "json" };
-  │                            ---- `type` is first used as a label here
-  ·
-5 │ assert { type: "json" }
-  │          ^^^^ a second use of `type` here is not allowed
-
---
 error[SyntaxError]: Duplicate assertion keys are not allowed
   ┌─ import_assertion_err.js:6:37
   │

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.js
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.js
@@ -1,5 +1,6 @@
-foo: {}
-rust: {}
-break;
-break foo;
-break rust
+while (true) {
+  break;
+	foo: {
+   break foo;
+	}
+}

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -2,71 +2,71 @@ JsModule {
     interpreter_token: missing (optional),
     directives: JsDirectiveList [],
     items: JsModuleItemList [
-        JsLabeledStatement {
-            label_token: IDENT@0..3 "foo" [] [],
-            colon_token: COLON@3..5 ":" [] [Whitespace(" ")],
-            body: JsBlockStatement {
-                l_curly_token: L_CURLY@5..6 "{" [] [],
-                statements: JsStatementList [],
-                r_curly_token: R_CURLY@6..7 "}" [] [],
+        JsWhileStatement {
+            while_token: WHILE_KW@0..6 "while" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@6..7 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@7..11 "true" [] [],
             },
-        },
-        JsLabeledStatement {
-            label_token: IDENT@7..12 "rust" [Whitespace("\n")] [],
-            colon_token: COLON@12..14 ":" [] [Whitespace(" ")],
+            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
             body: JsBlockStatement {
-                l_curly_token: L_CURLY@14..15 "{" [] [],
-                statements: JsStatementList [],
-                r_curly_token: R_CURLY@15..16 "}" [] [],
+                l_curly_token: L_CURLY@13..14 "{" [] [],
+                statements: JsStatementList [
+                    JsBreakStatement {
+                        break_token: BREAK_KW@14..22 "break" [Whitespace("\n  ")] [],
+                        label_token: missing (optional),
+                        semicolon_token: SEMICOLON@22..23 ";" [] [],
+                    },
+                    JsLabeledStatement {
+                        label_token: IDENT@23..28 "foo" [Whitespace("\n\t")] [],
+                        colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                        body: JsBlockStatement {
+                            l_curly_token: L_CURLY@30..31 "{" [] [],
+                            statements: JsStatementList [
+                                JsBreakStatement {
+                                    break_token: BREAK_KW@31..41 "break" [Whitespace("\n   ")] [Whitespace(" ")],
+                                    label_token: IDENT@41..44 "foo" [] [],
+                                    semicolon_token: SEMICOLON@44..45 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@45..48 "}" [Whitespace("\n\t")] [],
+                        },
+                    },
+                ],
+                r_curly_token: R_CURLY@48..50 "}" [Whitespace("\n")] [],
             },
-        },
-        JsBreakStatement {
-            break_token: BREAK_KW@16..22 "break" [Whitespace("\n")] [],
-            label_token: missing (optional),
-            semicolon_token: SEMICOLON@22..23 ";" [] [],
-        },
-        JsBreakStatement {
-            break_token: BREAK_KW@23..30 "break" [Whitespace("\n")] [Whitespace(" ")],
-            label_token: IDENT@30..33 "foo" [] [],
-            semicolon_token: SEMICOLON@33..34 ";" [] [],
-        },
-        JsBreakStatement {
-            break_token: BREAK_KW@34..41 "break" [Whitespace("\n")] [Whitespace(" ")],
-            label_token: IDENT@41..45 "rust" [] [],
-            semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@45..46 "" [Whitespace("\n")] [],
+    eof_token: EOF@50..51 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..46
+0: JS_MODULE@0..51
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..45
-    0: JS_LABELED_STATEMENT@0..7
-      0: IDENT@0..3 "foo" [] []
-      1: COLON@3..5 ":" [] [Whitespace(" ")]
-      2: JS_BLOCK_STATEMENT@5..7
-        0: L_CURLY@5..6 "{" [] []
-        1: JS_STATEMENT_LIST@6..6
-        2: R_CURLY@6..7 "}" [] []
-    1: JS_LABELED_STATEMENT@7..16
-      0: IDENT@7..12 "rust" [Whitespace("\n")] []
-      1: COLON@12..14 ":" [] [Whitespace(" ")]
-      2: JS_BLOCK_STATEMENT@14..16
-        0: L_CURLY@14..15 "{" [] []
-        1: JS_STATEMENT_LIST@15..15
-        2: R_CURLY@15..16 "}" [] []
-    2: JS_BREAK_STATEMENT@16..23
-      0: BREAK_KW@16..22 "break" [Whitespace("\n")] []
-      1: (empty)
-      2: SEMICOLON@22..23 ";" [] []
-    3: JS_BREAK_STATEMENT@23..34
-      0: BREAK_KW@23..30 "break" [Whitespace("\n")] [Whitespace(" ")]
-      1: IDENT@30..33 "foo" [] []
-      2: SEMICOLON@33..34 ";" [] []
-    4: JS_BREAK_STATEMENT@34..45
-      0: BREAK_KW@34..41 "break" [Whitespace("\n")] [Whitespace(" ")]
-      1: IDENT@41..45 "rust" [] []
-      2: (empty)
-  3: EOF@45..46 "" [Whitespace("\n")] []
+  2: JS_MODULE_ITEM_LIST@0..50
+    0: JS_WHILE_STATEMENT@0..50
+      0: WHILE_KW@0..6 "while" [] [Whitespace(" ")]
+      1: L_PAREN@6..7 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@7..11
+        0: TRUE_KW@7..11 "true" [] []
+      3: R_PAREN@11..13 ")" [] [Whitespace(" ")]
+      4: JS_BLOCK_STATEMENT@13..50
+        0: L_CURLY@13..14 "{" [] []
+        1: JS_STATEMENT_LIST@14..48
+          0: JS_BREAK_STATEMENT@14..23
+            0: BREAK_KW@14..22 "break" [Whitespace("\n  ")] []
+            1: (empty)
+            2: SEMICOLON@22..23 ";" [] []
+          1: JS_LABELED_STATEMENT@23..48
+            0: IDENT@23..28 "foo" [Whitespace("\n\t")] []
+            1: COLON@28..30 ":" [] [Whitespace(" ")]
+            2: JS_BLOCK_STATEMENT@30..48
+              0: L_CURLY@30..31 "{" [] []
+              1: JS_STATEMENT_LIST@31..45
+                0: JS_BREAK_STATEMENT@31..45
+                  0: BREAK_KW@31..41 "break" [Whitespace("\n   ")] [Whitespace(" ")]
+                  1: IDENT@41..44 "foo" [] []
+                  2: SEMICOLON@44..45 ";" [] []
+              2: R_CURLY@45..48 "}" [Whitespace("\n\t")] []
+        2: R_CURLY@48..50 "}" [Whitespace("\n")] []
+  3: EOF@50..51 "" [Whitespace("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.js
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.js
@@ -1,6 +1,7 @@
-foo: {}
 while (true) {
   continue;
-  continue foo;
+  foo: {
+    continue foo;
+	 }
   continue
 }

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -2,79 +2,80 @@ JsModule {
     interpreter_token: missing (optional),
     directives: JsDirectiveList [],
     items: JsModuleItemList [
-        JsLabeledStatement {
-            label_token: IDENT@0..3 "foo" [] [],
-            colon_token: COLON@3..5 ":" [] [Whitespace(" ")],
-            body: JsBlockStatement {
-                l_curly_token: L_CURLY@5..6 "{" [] [],
-                statements: JsStatementList [],
-                r_curly_token: R_CURLY@6..7 "}" [] [],
-            },
-        },
         JsWhileStatement {
-            while_token: WHILE_KW@7..14 "while" [Whitespace("\n")] [Whitespace(" ")],
-            l_paren_token: L_PAREN@14..15 "(" [] [],
+            while_token: WHILE_KW@0..6 "while" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@6..7 "(" [] [],
             test: JsBooleanLiteralExpression {
-                value_token: TRUE_KW@15..19 "true" [] [],
+                value_token: TRUE_KW@7..11 "true" [] [],
             },
-            r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+            r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
             body: JsBlockStatement {
-                l_curly_token: L_CURLY@21..22 "{" [] [],
+                l_curly_token: L_CURLY@13..14 "{" [] [],
                 statements: JsStatementList [
                     JsContinueStatement {
-                        continue_token: CONTINUE_KW@22..33 "continue" [Whitespace("\n  ")] [],
+                        continue_token: CONTINUE_KW@14..25 "continue" [Whitespace("\n  ")] [],
                         label_token: missing (optional),
-                        semicolon_token: SEMICOLON@33..34 ";" [] [],
+                        semicolon_token: SEMICOLON@25..26 ";" [] [],
+                    },
+                    JsLabeledStatement {
+                        label_token: IDENT@26..32 "foo" [Whitespace("\n  ")] [],
+                        colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                        body: JsBlockStatement {
+                            l_curly_token: L_CURLY@34..35 "{" [] [],
+                            statements: JsStatementList [
+                                JsContinueStatement {
+                                    continue_token: CONTINUE_KW@35..49 "continue" [Whitespace("\n    ")] [Whitespace(" ")],
+                                    label_token: IDENT@49..52 "foo" [] [],
+                                    semicolon_token: SEMICOLON@52..53 ";" [] [],
+                                },
+                            ],
+                            r_curly_token: R_CURLY@53..57 "}" [Whitespace("\n\t ")] [],
+                        },
                     },
                     JsContinueStatement {
-                        continue_token: CONTINUE_KW@34..46 "continue" [Whitespace("\n  ")] [Whitespace(" ")],
-                        label_token: IDENT@46..49 "foo" [] [],
-                        semicolon_token: SEMICOLON@49..50 ";" [] [],
-                    },
-                    JsContinueStatement {
-                        continue_token: CONTINUE_KW@50..61 "continue" [Whitespace("\n  ")] [],
+                        continue_token: CONTINUE_KW@57..68 "continue" [Whitespace("\n  ")] [],
                         label_token: missing (optional),
                         semicolon_token: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@61..63 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@68..70 "}" [Whitespace("\n")] [],
             },
         },
     ],
-    eof_token: EOF@63..64 "" [Whitespace("\n")] [],
+    eof_token: EOF@70..71 "" [Whitespace("\n")] [],
 }
 
-0: JS_MODULE@0..64
+0: JS_MODULE@0..71
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..63
-    0: JS_LABELED_STATEMENT@0..7
-      0: IDENT@0..3 "foo" [] []
-      1: COLON@3..5 ":" [] [Whitespace(" ")]
-      2: JS_BLOCK_STATEMENT@5..7
-        0: L_CURLY@5..6 "{" [] []
-        1: JS_STATEMENT_LIST@6..6
-        2: R_CURLY@6..7 "}" [] []
-    1: JS_WHILE_STATEMENT@7..63
-      0: WHILE_KW@7..14 "while" [Whitespace("\n")] [Whitespace(" ")]
-      1: L_PAREN@14..15 "(" [] []
-      2: JS_BOOLEAN_LITERAL_EXPRESSION@15..19
-        0: TRUE_KW@15..19 "true" [] []
-      3: R_PAREN@19..21 ")" [] [Whitespace(" ")]
-      4: JS_BLOCK_STATEMENT@21..63
-        0: L_CURLY@21..22 "{" [] []
-        1: JS_STATEMENT_LIST@22..61
-          0: JS_CONTINUE_STATEMENT@22..34
-            0: CONTINUE_KW@22..33 "continue" [Whitespace("\n  ")] []
+  2: JS_MODULE_ITEM_LIST@0..70
+    0: JS_WHILE_STATEMENT@0..70
+      0: WHILE_KW@0..6 "while" [] [Whitespace(" ")]
+      1: L_PAREN@6..7 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@7..11
+        0: TRUE_KW@7..11 "true" [] []
+      3: R_PAREN@11..13 ")" [] [Whitespace(" ")]
+      4: JS_BLOCK_STATEMENT@13..70
+        0: L_CURLY@13..14 "{" [] []
+        1: JS_STATEMENT_LIST@14..68
+          0: JS_CONTINUE_STATEMENT@14..26
+            0: CONTINUE_KW@14..25 "continue" [Whitespace("\n  ")] []
             1: (empty)
-            2: SEMICOLON@33..34 ";" [] []
-          1: JS_CONTINUE_STATEMENT@34..50
-            0: CONTINUE_KW@34..46 "continue" [Whitespace("\n  ")] [Whitespace(" ")]
-            1: IDENT@46..49 "foo" [] []
-            2: SEMICOLON@49..50 ";" [] []
-          2: JS_CONTINUE_STATEMENT@50..61
-            0: CONTINUE_KW@50..61 "continue" [Whitespace("\n  ")] []
+            2: SEMICOLON@25..26 ";" [] []
+          1: JS_LABELED_STATEMENT@26..57
+            0: IDENT@26..32 "foo" [Whitespace("\n  ")] []
+            1: COLON@32..34 ":" [] [Whitespace(" ")]
+            2: JS_BLOCK_STATEMENT@34..57
+              0: L_CURLY@34..35 "{" [] []
+              1: JS_STATEMENT_LIST@35..53
+                0: JS_CONTINUE_STATEMENT@35..53
+                  0: CONTINUE_KW@35..49 "continue" [Whitespace("\n    ")] [Whitespace(" ")]
+                  1: IDENT@49..52 "foo" [] []
+                  2: SEMICOLON@52..53 ";" [] []
+              2: R_CURLY@53..57 "}" [Whitespace("\n\t ")] []
+          2: JS_CONTINUE_STATEMENT@57..68
+            0: CONTINUE_KW@57..68 "continue" [Whitespace("\n  ")] []
             1: (empty)
             2: (empty)
-        2: R_CURLY@61..63 "}" [Whitespace("\n")] []
-  3: EOF@63..64 "" [Whitespace("\n")] []
+        2: R_CURLY@68..70 "}" [Whitespace("\n")] []
+  3: EOF@70..71 "" [Whitespace("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/labeled_statement.js
+++ b/crates/rslint_parser/test_data/inline/ok/labeled_statement.js
@@ -1,0 +1,3 @@
+label1: 1
+label1: 1
+label2: 2

--- a/crates/rslint_parser/test_data/inline/ok/labeled_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/labeled_statement.rast
@@ -1,0 +1,64 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsLabeledStatement {
+            label_token: IDENT@0..6 "label1" [] [],
+            colon_token: COLON@6..8 ":" [] [Whitespace(" ")],
+            body: JsExpressionStatement {
+                expression: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@8..9 "1" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsLabeledStatement {
+            label_token: IDENT@9..16 "label1" [Whitespace("\n")] [],
+            colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
+            body: JsExpressionStatement {
+                expression: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@18..19 "1" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsLabeledStatement {
+            label_token: IDENT@19..26 "label2" [Whitespace("\n")] [],
+            colon_token: COLON@26..28 ":" [] [Whitespace(" ")],
+            body: JsExpressionStatement {
+                expression: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@28..29 "2" [] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@29..30 "" [Whitespace("\n")] [],
+}
+
+0: JS_MODULE@0..30
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..29
+    0: JS_LABELED_STATEMENT@0..9
+      0: IDENT@0..6 "label1" [] []
+      1: COLON@6..8 ":" [] [Whitespace(" ")]
+      2: JS_EXPRESSION_STATEMENT@8..9
+        0: JS_NUMBER_LITERAL_EXPRESSION@8..9
+          0: JS_NUMBER_LITERAL@8..9 "1" [] []
+        1: (empty)
+    1: JS_LABELED_STATEMENT@9..19
+      0: IDENT@9..16 "label1" [Whitespace("\n")] []
+      1: COLON@16..18 ":" [] [Whitespace(" ")]
+      2: JS_EXPRESSION_STATEMENT@18..19
+        0: JS_NUMBER_LITERAL_EXPRESSION@18..19
+          0: JS_NUMBER_LITERAL@18..19 "1" [] []
+        1: (empty)
+    2: JS_LABELED_STATEMENT@19..29
+      0: IDENT@19..26 "label2" [Whitespace("\n")] []
+      1: COLON@26..28 ":" [] [Whitespace(" ")]
+      2: JS_EXPRESSION_STATEMENT@28..29
+        0: JS_NUMBER_LITERAL_EXPRESSION@28..29
+          0: JS_NUMBER_LITERAL@28..29 "2" [] []
+        1: (empty)
+  3: EOF@29..30 "" [Whitespace("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/scoped_declarations.js
+++ b/crates/rslint_parser/test_data/inline/ok/scoped_declarations.js
@@ -1,0 +1,5 @@
+let a = {
+  test() {
+    let a = "inner";
+  }
+};

--- a/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
+++ b/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
@@ -1,0 +1,125 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                        },
+                        excl_token: missing (optional),
+                        type_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..9 "{" [] [],
+                                members: JsObjectMemberList [
+                                    JsMethodObjectMember {
+                                        async_token: missing (optional),
+                                        star_token: missing (optional),
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@9..16 "test" [Whitespace("\n  ")] [],
+                                        },
+                                        type_params: missing (optional),
+                                        parameters: JsParameters {
+                                            l_paren_token: L_PAREN@16..17 "(" [] [],
+                                            items: JsParameterList [],
+                                            r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
+                                        },
+                                        return_type: missing (optional),
+                                        body: JsFunctionBody {
+                                            l_curly_token: L_CURLY@19..20 "{" [] [],
+                                            directives: JsDirectiveList [],
+                                            statements: JsStatementList [
+                                                JsVariableStatement {
+                                                    declarations: JsVariableDeclarations {
+                                                        kind: LET_KW@20..29 "let" [Whitespace("\n    ")] [Whitespace(" ")],
+                                                        items: JsVariableDeclarationList [
+                                                            JsVariableDeclaration {
+                                                                id: JsIdentifierBinding {
+                                                                    name_token: IDENT@29..31 "a" [] [Whitespace(" ")],
+                                                                },
+                                                                excl_token: missing (optional),
+                                                                type_annotation: missing (optional),
+                                                                initializer: JsInitializerClause {
+                                                                    eq_token: EQ@31..33 "=" [] [Whitespace(" ")],
+                                                                    expression: JsStringLiteralExpression {
+                                                                        value_token: JS_STRING_LITERAL@33..40 "\"inner\"" [] [],
+                                                                    },
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                    semicolon_token: SEMICOLON@40..41 ";" [] [],
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@41..45 "}" [Whitespace("\n  ")] [],
+                                        },
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@47..48 ";" [] [],
+        },
+    ],
+    eof_token: EOF@48..49 "" [Whitespace("\n")] [],
+}
+
+0: JS_MODULE@0..49
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..48
+    0: JS_VARIABLE_STATEMENT@0..48
+      0: JS_VARIABLE_DECLARATIONS@0..47
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@4..47
+          0: JS_VARIABLE_DECLARATION@4..47
+            0: JS_IDENTIFIER_BINDING@4..6
+              0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: (empty)
+            3: JS_INITIALIZER_CLAUSE@6..47
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: JS_OBJECT_EXPRESSION@8..47
+                0: L_CURLY@8..9 "{" [] []
+                1: JS_OBJECT_MEMBER_LIST@9..45
+                  0: JS_METHOD_OBJECT_MEMBER@9..45
+                    0: (empty)
+                    1: (empty)
+                    2: JS_LITERAL_MEMBER_NAME@9..16
+                      0: IDENT@9..16 "test" [Whitespace("\n  ")] []
+                    3: (empty)
+                    4: JS_PARAMETERS@16..19
+                      0: L_PAREN@16..17 "(" [] []
+                      1: JS_PARAMETER_LIST@17..17
+                      2: R_PAREN@17..19 ")" [] [Whitespace(" ")]
+                    5: (empty)
+                    6: JS_FUNCTION_BODY@19..45
+                      0: L_CURLY@19..20 "{" [] []
+                      1: JS_DIRECTIVE_LIST@20..20
+                      2: JS_STATEMENT_LIST@20..41
+                        0: JS_VARIABLE_STATEMENT@20..41
+                          0: JS_VARIABLE_DECLARATIONS@20..40
+                            0: LET_KW@20..29 "let" [Whitespace("\n    ")] [Whitespace(" ")]
+                            1: JS_VARIABLE_DECLARATION_LIST@29..40
+                              0: JS_VARIABLE_DECLARATION@29..40
+                                0: JS_IDENTIFIER_BINDING@29..31
+                                  0: IDENT@29..31 "a" [] [Whitespace(" ")]
+                                1: (empty)
+                                2: (empty)
+                                3: JS_INITIALIZER_CLAUSE@31..40
+                                  0: EQ@31..33 "=" [] [Whitespace(" ")]
+                                  1: JS_STRING_LITERAL_EXPRESSION@33..40
+                                    0: JS_STRING_LITERAL@33..40 "\"inner\"" [] []
+                          1: SEMICOLON@40..41 ";" [] []
+                      3: R_CURLY@41..45 "}" [Whitespace("\n  ")] []
+                2: R_CURLY@45..47 "}" [Whitespace("\n")] []
+      1: SEMICOLON@47..48 ";" [] []
+  3: EOF@48..49 "" [Whitespace("\n")] []

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -106,12 +106,12 @@ pub fn run(filter: String, criterion: bool) {
 					let mut criterion = criterion::Criterion::default().without_plots();
 					criterion.bench_function(lib, |b| {
 						b.iter(|| {
-							let _ = criterion::black_box(rslint_parser::parse_module(code, 0));
+							let _ = criterion::black_box(rslint_parser::parse_text(code, 0));
 						})
 					});
 				} else {
 					//warmup
-					rslint_parser::parse_module(code, 0);
+					rslint_parser::parse_text(code, 0);
 				}
 
 				let result = benchmark_lib(&id, code);
@@ -150,7 +150,7 @@ fn benchmark_lib(id: &str, code: &str) -> BenchmarkResult {
 	let parser_timer = timing::start();
 	let (events, parsing_diags, tokens) = {
 		let mut parser =
-			rslint_parser::Parser::new(tok_source, 0, rslint_parser::Syntax::default().module());
+			rslint_parser::Parser::new(tok_source, 0, rslint_parser::Syntax::default().script());
 		rslint_parser::syntax::program::parse(&mut parser);
 		let (events, parsing_diags) = parser.finish();
 		(events, parsing_diags, tokens)


### PR DESCRIPTION
## Summary

This PR fixes the remaining diagnostic when parsing the `coverage-libs` libs.

### Labels

The parser tracked all defined labels but never removed them when leaving the labeled statement. That's why the parser reported diagnostics for eligibly duplicated label declarations if any label was re-used anywhere in the program

```js
a: {
  a: {} // not ok
}
a: {} // ok
```

### Variable declarations

The parser generates diagnostics if a `let` or `const` declaration defines the same identifier twice. However, re-declaring the same identifier inside of the initializer is totally fine:

```js
let a = () => { let a = 10; } // this is ok
let a, a; // this isn't
```

### Parse libs as scripts

Parse the libs with `script` to avoid the warning that the `use strict` directive is redundant.


### Perf

This seems to slightly improve perf (a few ms, up to 10ms). My guess is that this is because the `name_map` is now empty in the most cases where the parser clones the `ParserState`. 

## Test Plan

Added new test cases to prevent future regressions. Fixed the incorrect `break` and `continue` statement tests.
