### PR TITLE
Disable Block Scope Redeclaration tests

### DIFF
--- a/xtask/src/coverage/files.rs
+++ b/xtask/src/coverage/files.rs
@@ -129,10 +129,15 @@ pub fn get_test_files(query: Option<&str>, pool: &Pool, json: bool) -> Vec<TestF
 					let meta = read_metadata(&code).ok()?;
 					let path = entry.into_path();
 					Some(TestFile { meta, code, path }).filter(|file| {
-						file.meta
-							.negative
-							.as_ref()
-							.map_or(true, |negative| negative.phase == Phase::Parse)
+						file.meta.negative.as_ref().map_or(true, |negative| {
+							let parse = negative.phase == Phase::Parse;
+							// Block Scope Redeclaration check is not on the roadmap. Align with Babel.
+							let path_str = file.path.to_string_lossy();
+							if parse && path_str.contains("block-scope/syntax/redeclaration") {
+								return false;
+							}
+							parse
+						})
 					})
 				}
 


### PR DESCRIPTION
Source: https://github.com/rome/tools/issues/1909#issuecomment-1007559627
> We may also want to consider not implementing block scope re-declaration checks inside of the parser because it may be expensive to keep all these hash maps, especially with the way our parser state is modelled today. 
