### PR TITLE
feat(rome_formatter): retain comments in the formatter output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ version = "0.0.0"
 name = "rome_formatter"
 version = "0.0.0"
 dependencies = [
+ "cfg-if",
  "insta",
  "rome_core",
  "rome_path",

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -10,6 +10,7 @@ rslint_parser = { path = "../rslint_parser" }
 rome_rowan = { path = "../rome_rowan" }
 rome_path = { version = "0.0.0", path = "../rome_path" }
 rome_core = { version = "0.0.0", path = "../rome_core" }
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -864,6 +864,12 @@ impl From<Indent> for FormatElement {
     }
 }
 
+impl From<Option<FormatElement>> for FormatElement {
+    fn from(element: Option<FormatElement>) -> Self {
+        element.unwrap_or_else(empty_element)
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -155,6 +155,17 @@ pub fn token<S: Into<String>>(text: S) -> FormatElement {
     }
 }
 
+/// Push a [FormatElement] to the end of the current line
+///
+/// ## Examples
+///
+/// ```
+/// use rome_formatter::{FormatOptions, token, format_element, line_suffix, format_elements};
+///
+/// let elements = format_elements![token("a"), line_suffix(token("c")), token("b")];
+///
+/// assert_eq!("abc", format_element(&elements, FormatOptions::default()).code());
+/// ```
 #[inline]
 pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
     FormatElement::LineSuffix(Box::new(element.into()))

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -155,6 +155,11 @@ pub fn token<S: Into<String>>(text: S) -> FormatElement {
     }
 }
 
+#[inline]
+pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
+    FormatElement::LineSuffix(Box::new(element.into()))
+}
+
 /// Inserts a single space. Allows to separate different tokens.
 ///
 /// ## Examples
@@ -608,6 +613,8 @@ pub enum FormatElement {
 
     /// A token that should be printed as is, see [token] for documentation and examples.
     Token(Token),
+
+    LineSuffix(Box<FormatElement>),
 }
 
 /// Inserts a new line
@@ -766,6 +773,7 @@ impl FormatElement {
                 FormatElement::List(List::new(content))
             }
             FormatElement::Token(s) => token(s.trim_start()),
+            FormatElement::LineSuffix(s) => FormatElement::LineSuffix(Box::new(s.trim_start())),
         }
     }
 
@@ -810,6 +818,7 @@ impl FormatElement {
                 }
             }
             FormatElement::Token(s) => token(s.trim_end()),
+            FormatElement::LineSuffix(s) => FormatElement::LineSuffix(Box::new(s.trim_end())),
         }
     }
 }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -254,12 +254,10 @@ impl Formatter {
                 } else {
                     self.format_token(&separator)?
                 }
+            } else if index == last_index {
+                if_group_breaks(separator_factory())
             } else {
-                if index == last_index {
-                    if_group_breaks(separator_factory())
-                } else {
-                    separator_factory()
-                }
+                separator_factory()
             };
 
             result.push(format_elements![node, separator]);

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -47,6 +47,29 @@ impl Formatter {
         ]))
     }
 
+    /// Formats a group delimited by an opening and closing token,
+    /// such as a function body delimited by '{' and '}' tokens
+    ///
+    /// Calling this method is required to correctly handle the comments attached
+    /// to the opening and closing tokens and insert them inside the group block
+    pub(crate) fn format_delimited_group(
+        &self,
+        open_token: &SyntaxToken,
+        content: impl FnOnce(FormatElement, FormatElement) -> FormatResult<FormatElement>,
+        close_token: &SyntaxToken,
+    ) -> FormatResult<FormatElement> {
+        Ok(format_elements![
+            self.print_trivia(open_token.leading_trivia()),
+            token(open_token.text_trimmed()),
+            content(
+                self.print_trivia(open_token.trailing_trivia()),
+                self.print_trivia(close_token.leading_trivia()),
+            )?,
+            token(close_token.text_trimmed()),
+            self.print_trivia(close_token.trailing_trivia()),
+        ])
+    }
+
     /// Recursively formats the ast node and all its children
     ///
     /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -1,9 +1,12 @@
+use crate::format_element::line_suffix;
 use crate::printer::Printer;
 use crate::{
-    concat_elements, format_elements, token, FormatElement, FormatOptions, FormatResult, Formatted,
-    ToFormatElement,
+    concat_elements, empty_element, format_elements, hard_line_break, if_group_breaks,
+    if_group_fits_on_single_line, join_elements, space_token, token, FormatElement, FormatOptions,
+    FormatResult, Formatted, ToFormatElement,
 };
-use rome_rowan::SyntaxElement;
+use rome_rowan::api::{SyntaxTrivia, SyntaxTriviaPieceComments};
+use rome_rowan::{Language, SyntaxElement};
 use rslint_parser::{AstNode, AstSeparatedList, SyntaxNode, SyntaxToken};
 
 /// Handles the formatting of a CST and stores the options how the CST should be formatted (user preferences).
@@ -52,25 +55,27 @@ impl Formatter {
         &self,
         node: T,
     ) -> FormatResult<FormatElement> {
-        Ok(concat_elements(vec![
-            self.format_node_start(node.syntax()),
+        let leading = self.format_node_start(node.syntax());
+        let trailing = self.format_node_end(node.syntax());
+        Ok(format_elements![
+            leading,
             node.to_format_element(self)?,
-            self.format_node_end(node.syntax()),
-        ]))
+            trailing,
+        ])
     }
 
     /// Helper function that returns what should be printed before the node that work on
     /// the non-generic [SyntaxNode] to avoid unrolling the logic for every [AstNode] type.
     fn format_node_start(&self, _node: &SyntaxNode) -> FormatElement {
-        // TODO: Set the marker for the start source map location, add leading comments, ...
-        concat_elements(vec![])
+        // TODO: Set the marker for the start source map location, ...
+        empty_element()
     }
 
     /// Helper function that returns what should be printed after the node that work on
     /// the non-generic [SyntaxNode] to avoid unrolling the logic for every [AstNode] type.
     fn format_node_end(&self, _node: &SyntaxNode) -> FormatElement {
-        // TODO: Sets the marker for the end source map location, add trailing comments, ...
-        concat_elements(vec![])
+        // TODO: Sets the marker for the end source map location, ...
+        empty_element()
     }
 
     /// Formats the passed in token.
@@ -100,7 +105,30 @@ impl Formatter {
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
     pub fn format_token(&self, syntax_token: &SyntaxToken) -> FormatResult<FormatElement> {
-        Ok(token(syntax_token.text_trimmed()))
+        Ok(format_elements![
+            self.print_leading_trivia(syntax_token),
+            token(syntax_token.text_trimmed()),
+            self.print_trailing_trivia(syntax_token),
+        ])
+    }
+
+    pub fn format_or_create_token(
+        &self,
+        token: Option<SyntaxToken>,
+        token_factory: impl FnOnce() -> FormatElement,
+    ) -> FormatResult<FormatElement> {
+        if let Some(token) = token {
+            self.format_token(&token)
+        } else {
+            Ok(token_factory())
+        }
+    }
+
+    pub fn format_comment<L: Language>(
+        &self,
+        trivia: SyntaxTriviaPieceComments<L>,
+    ) -> FormatElement {
+        token(trivia.text().trim())
     }
 
     /// Formats each child and returns the result as a list.
@@ -133,11 +161,15 @@ impl Formatter {
         for (index, element) in list.elements().enumerate() {
             let node = self.format_node(element.node()?)?;
             if let Some(separator) = element.trailing_separator()? {
-                let formatted_separator = self.format_token(&separator)?;
                 if index == list.len() - 1 {
-                    result.push(node)
+                    result.push(node);
+                    // Print the trivia for the last trailing separator token
+                    // without printing the token itself since that depends
+                    // on the outer group being broken or not
+                    result.push(self.print_leading_trivia(&separator));
+                    result.push(self.print_trailing_trivia(&separator));
                 } else {
-                    result.push(format_elements![node, formatted_separator]);
+                    result.push(format_elements![node, self.format_token(&separator)?]);
                 }
             } else {
                 result.push(node);
@@ -145,6 +177,124 @@ impl Formatter {
         }
 
         Ok(result.into_iter())
+    }
+
+    fn print_leading_trivia(&self, token: &SyntaxToken) -> FormatElement {
+        let is_leading_token = token
+            .parent()
+            .and_then(|parent| parent.first_token())
+            .map_or(false, |first_token| *token == first_token);
+
+        if !is_leading_token {
+            return self.print_inner_trivia(token.leading_trivia());
+        }
+
+        // False positive: the trivias need to be collected in a vector as they
+        // are iterated on in reverse order later, but SyntaxTriviaPiecesIterator
+        // doesn't implement DoubleEndedIterator (rust-lang/rust-clippy#8132)
+        #[allow(clippy::needless_collect)]
+        let pieces: Vec<_> = token.leading_trivia().pieces().collect();
+
+        let mut line_count = 0;
+        let mut elements = Vec::new();
+
+        for piece in pieces.into_iter().rev() {
+            if let Some(comment) = piece.as_comments() {
+                let is_single_line = comment.text().trim_start().starts_with("//");
+
+                let comment = self.format_comment(comment);
+                if !comment.is_empty() {
+                    let line_break = if is_single_line {
+                        hard_line_break()
+                    } else {
+                        match line_count {
+                            0 => space_token(),
+                            1 => hard_line_break(),
+                            _ => format_elements![hard_line_break(), hard_line_break()],
+                        }
+                    };
+
+                    elements.push(format_elements![comment, line_break]);
+                }
+
+                line_count = 0;
+            }
+
+            if piece.as_newline().is_some() {
+                line_count += 1;
+            }
+        }
+
+        concat_elements(elements.into_iter().rev())
+    }
+
+    fn print_trailing_trivia(&self, token: &SyntaxToken) -> FormatElement {
+        let is_trailing_token = token
+            .parent()
+            .and_then(|parent| parent.last_token())
+            .map_or(false, |last_token| *token == last_token);
+
+        if !is_trailing_token {
+            return self.print_inner_trivia(token.trailing_trivia());
+        }
+
+        let mut line_count = 0;
+        let mut elements = Vec::new();
+
+        for piece in token.trailing_trivia().pieces() {
+            if let Some(comment) = piece.as_comments() {
+                let is_single_line = comment.text().trim_start().starts_with("//");
+
+                let comment = self.format_comment(comment);
+                if !comment.is_empty() {
+                    elements.push(if line_count >= 1 {
+                        line_suffix(format_elements![
+                            if line_count > 1 {
+                                hard_line_break()
+                            } else {
+                                space_token()
+                            },
+                            hard_line_break(),
+                            comment
+                        ])
+                    } else if !is_single_line {
+                        format_elements![
+                            if_group_breaks(line_suffix(format_elements![
+                                space_token(),
+                                comment.clone()
+                            ])),
+                            if_group_fits_on_single_line(format_elements![space_token(), comment]),
+                        ]
+                    } else {
+                        line_suffix(format_elements![space_token(), comment])
+                    });
+                }
+
+                line_count = 0;
+            }
+
+            if piece.as_newline().is_some() {
+                line_count += 1;
+            }
+        }
+
+        concat_elements(elements)
+    }
+
+    fn print_inner_trivia<L: Language>(&self, trivia: SyntaxTrivia<L>) -> FormatElement {
+        join_elements(
+            hard_line_break(),
+            trivia.pieces().filter_map(|piece| {
+                piece.as_comments().and_then(|comments| {
+                    let comments = self.format_comment(comments);
+                    if !comments.is_empty() {
+                        Some(format_elements![space_token(), comments, hard_line_break()])
+                    } else {
+                        None
+                    }
+                })
+            }),
+        )
     }
 
     /// "Formats" a node according to its original formatting in the source text. Being able to format

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -63,7 +63,7 @@ use rslint_parser::SyntaxError;
 
 pub use format_element::{
     block_indent, concat_elements, empty_element, group_elements, hard_line_break, if_group_breaks,
-    if_group_fits_on_single_line, indent, join_elements, soft_indent, soft_line_break,
+    if_group_fits_on_single_line, indent, join_elements, line_suffix, soft_indent, soft_line_break,
     soft_line_break_or_space, space_token, token, FormatElement,
 };
 pub use printer::Printer;

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -165,10 +165,8 @@ pub struct Formatted {
 }
 
 impl Formatted {
-    pub fn new(code: &str) -> Self {
-        Self {
-            code: String::from(code),
-        }
+    pub fn new(code: String) -> Self {
+        Self { code }
     }
 
     pub fn code(&self) -> &String {

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -1,3 +1,5 @@
+use std::iter::once;
+
 use crate::format_element::{ConditionalGroupContent, Group, GroupPrintMode, LineMode};
 use crate::{FormatElement, FormatOptions, Formatted, IndentStyle};
 
@@ -81,12 +83,12 @@ struct LineBreakRequiredError;
 
 /// Prints the format elements into a string
 #[derive(Debug, Clone, Default)]
-pub struct Printer {
+pub struct Printer<'a> {
     options: PrinterOptions,
-    state: PrinterState,
+    state: PrinterState<'a>,
 }
 
-impl Printer {
+impl<'a> Printer<'a> {
     pub fn new<T: Into<PrinterOptions>>(options: T) -> Self {
         Self {
             options: options.into(),
@@ -95,7 +97,7 @@ impl Printer {
     }
 
     /// Prints the passed in element as well as all its content
-    pub fn print(mut self, element: &FormatElement) -> Formatted {
+    pub fn print(mut self, element: &'a FormatElement) -> Formatted {
         let mut queue = ElementCallQueue::new();
 
         queue.enqueue(PrintElementCall::new(element, PrintElementArgs::default()));
@@ -104,18 +106,20 @@ impl Printer {
             queue.extend(self.print_element(print_element_call.element, print_element_call.args));
         }
 
-        Formatted::new(self.state.buffer.as_str())
+        Formatted::new(self.state.buffer)
     }
 
     /// Prints a single element and returns the elements to queue (that should be printed next).
-    fn print_element<'a>(
+    fn print_element(
         &mut self,
         element: &'a FormatElement,
         args: PrintElementArgs,
     ) -> Vec<PrintElementCall<'a>> {
         match element {
             FormatElement::Space => {
-                self.state.pending_spaces += 1;
+                if self.state.line_width > 0 {
+                    self.state.pending_space = true;
+                }
                 vec![]
             }
             FormatElement::Empty => vec![],
@@ -132,9 +136,9 @@ impl Printer {
                 }
 
                 // Print pending spaces
-                if self.state.pending_spaces > 0 {
-                    self.print_str(" ".repeat(self.state.pending_spaces as usize).as_str());
-                    self.state.pending_spaces = 0;
+                if self.state.pending_space {
+                    self.print_str(" ");
+                    self.state.pending_space = false;
                 }
 
                 self.print_str(token);
@@ -178,9 +182,24 @@ impl Printer {
             }
 
             FormatElement::Line { .. } => {
-                self.print_str("\n");
-                self.state.pending_spaces = 0;
-                self.state.pending_indent = args.indent;
+                if !self.state.line_suffixes.is_empty() {
+                    self.state
+                        .line_suffixes
+                        .drain(..)
+                        .chain(once(PrintElementCall::new(element, args)))
+                        .collect()
+                } else {
+                    self.print_str("\n");
+                    self.state.pending_space = false;
+                    self.state.pending_indent = args.indent;
+                    vec![]
+                }
+            }
+
+            FormatElement::LineSuffix(suffix) => {
+                self.state
+                    .line_suffixes
+                    .push(PrintElementCall::new(&**suffix, args));
                 vec![]
             }
         }
@@ -191,7 +210,7 @@ impl Printer {
     /// or printing the group exceeds the configured maximal print width.
     fn try_print_flat(
         &mut self,
-        element: &FormatElement,
+        element: &'a FormatElement,
         args: PrintElementArgs,
     ) -> Result<(), LineBreakRequiredError> {
         let snapshot = self.state.snapshot();
@@ -212,7 +231,7 @@ impl Printer {
         Ok(())
     }
 
-    fn try_print_flat_element<'a>(
+    fn try_print_flat_element(
         &mut self,
         element: &'a FormatElement,
         args: PrintElementArgs,
@@ -239,7 +258,9 @@ impl Printer {
             FormatElement::Line(line) => {
                 match line.mode {
                     LineMode::SoftOrSpace => {
-                        self.state.pending_spaces += 1;
+                        if self.state.line_width > 0 {
+                            self.state.pending_space = true;
+                        }
                         vec![]
                     }
                     // We want a flat structure, so omit soft line wraps
@@ -263,6 +284,8 @@ impl Printer {
                 ..
             }) => vec![],
 
+            FormatElement::LineSuffix { .. } => return Err(LineBreakRequiredError),
+
             FormatElement::Empty
             | FormatElement::Space
             | FormatElement::Indent { .. }
@@ -278,7 +301,6 @@ impl Printer {
         for char in content.chars() {
             if char == '\n' {
                 for char in self.options.line_ending.as_str().chars() {
-                    self.state.generated_index += 1;
                     self.state.buffer.push(char);
                 }
 
@@ -287,7 +309,6 @@ impl Printer {
                 self.state.line_width = 0;
             } else {
                 self.state.buffer.push(char);
-                self.state.generated_index += 1;
                 self.state.generated_column += 1;
 
                 let char_width = if char == '\t' {
@@ -306,28 +327,23 @@ impl Printer {
 /// Stores the result of the print operation (buffer and mappings) and at what
 /// position the printer currently is.
 #[derive(Default, Debug, Clone)]
-struct PrinterState {
+struct PrinterState<'a> {
     buffer: String,
     pending_indent: u16,
-    pending_spaces: u16,
-    generated_index: usize,
+    pending_space: bool,
     generated_line: usize,
     generated_column: usize,
     line_width: usize,
     // mappings: Mapping[];
-    // We'll need to clone the line suffixes elements into the state.
-    // I guess that's fine. They're only used for comments and should, therefore, be very limited
-    // in size.
-    // lineSuffixes: [FormatElement, PrintElementArgs][];
+    line_suffixes: Vec<PrintElementCall<'a>>,
 }
 
-impl PrinterState {
+impl<'a> PrinterState<'a> {
     /// Allows creating a snapshot of the state that can be restored using [restore]
     pub fn snapshot(&self) -> PrinterStateSnapshot {
         PrinterStateSnapshot {
-            pending_spaces: self.pending_spaces,
+            pending_space: self.pending_space,
             pending_indents: self.pending_indent,
-            generated_index: self.generated_index,
             generated_line: self.generated_line,
             generated_column: self.generated_column,
             line_width: self.line_width,
@@ -337,9 +353,8 @@ impl PrinterState {
 
     /// Restores the printer state to the state stored in the snapshot.
     pub fn restore(&mut self, snapshot: PrinterStateSnapshot) {
-        self.pending_spaces = snapshot.pending_spaces;
+        self.pending_space = snapshot.pending_space;
         self.pending_indent = snapshot.pending_indents;
-        self.generated_index = snapshot.generated_index;
         self.generated_column = snapshot.generated_column;
         self.generated_line = snapshot.generated_line;
         self.line_width = snapshot.line_width;
@@ -350,8 +365,7 @@ impl PrinterState {
 /// Snapshot of a printer state.
 struct PrinterStateSnapshot {
     pending_indents: u16,
-    pending_spaces: u16,
-    generated_index: usize,
+    pending_space: bool,
     generated_column: usize,
     generated_line: usize,
     line_width: usize,
@@ -414,13 +428,14 @@ impl<'a> ElementCallQueue<'a> {
     }
 
     #[inline]
-    fn extend(&mut self, calls: Vec<PrintElementCall<'a>>) {
-        let mut calls = calls;
+    fn extend<T>(&mut self, calls: T)
+    where
+        T: IntoIterator<Item = PrintElementCall<'a>>,
+        T::IntoIter: DoubleEndedIterator,
+    {
         // Reverse the calls because elements are removed from the back of the vec
         // in reversed insertion order
-        calls.reverse();
-
-        self.0.extend(calls);
+        self.0.extend(calls.into_iter().rev());
     }
 
     #[inline]

--- a/crates/rome_formatter/src/ts/arg_list.rs
+++ b/crates/rome_formatter/src/ts/arg_list.rs
@@ -1,21 +1,21 @@
 use crate::{
-    format_elements, group_elements, join_elements, space_token, FormatElement, FormatResult,
-    Formatter, ToFormatElement,
+    format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
+    FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsCallArguments;
 
 impl ToFormatElement for JsCallArguments {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let args = formatter.format_separated(self.args())?;
+        let args_tokens = formatter.format_separated(self.args(), || token(","))?;
 
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_paren_token()?,
             |leading, trailing| {
-                Ok(format_elements![
+                Ok(soft_indent(format_elements![
                     leading,
-                    join_elements(space_token(), args),
-                    trailing,
-                ])
+                    join_elements(soft_line_break_or_space(), args_tokens),
+                    trailing
+                ]))
             },
             &self.r_paren_token()?,
         )?))

--- a/crates/rome_formatter/src/ts/arg_list.rs
+++ b/crates/rome_formatter/src/ts/arg_list.rs
@@ -8,10 +8,16 @@ impl ToFormatElement for JsCallArguments {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let args = formatter.format_separated(self.args())?;
 
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_paren_token()?)?,
-            join_elements(space_token(), args),
-            formatter.format_token(&self.r_paren_token()?)?
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_paren_token()?,
+            |leading, trailing| {
+                Ok(format_elements![
+                    leading,
+                    join_elements(space_token(), args),
+                    trailing,
+                ])
+            },
+            &self.r_paren_token()?,
+        )?))
     }
 }

--- a/crates/rome_formatter/src/ts/arg_list.rs
+++ b/crates/rome_formatter/src/ts/arg_list.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsCallArguments {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let args_tokens = formatter.format_separated(self.args(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
@@ -1,5 +1,5 @@
 use crate::{
-    format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space,
+    format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
     FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{
@@ -9,7 +9,7 @@ use rslint_parser::ast::{
 
 impl ToFormatElement for JsArrayAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let elements = formatter.format_separated(self.elements())?;
+        let elements = formatter.format_separated(self.elements(), || token(","))?;
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_brack_token()?,
             |leading, trailing| {

--- a/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
@@ -10,7 +10,7 @@ use rslint_parser::ast::{
 impl ToFormatElement for JsArrayAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let elements = formatter.format_separated(self.elements(), || token(","))?;
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_brack_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
@@ -10,11 +10,17 @@ use rslint_parser::ast::{
 impl ToFormatElement for JsArrayAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let elements = formatter.format_separated(self.elements())?;
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_brack_token()?)?,
-            soft_indent(join_elements(soft_line_break_or_space(), elements)),
-            formatter.format_token(&self.r_brack_token()?)?,
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_brack_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    join_elements(soft_line_break_or_space(), elements),
+                    trailing,
+                ]))
+            },
+            &self.r_brack_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -12,7 +12,7 @@ use rslint_parser::ast::{
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let properties = formatter.format_separated(self.properties(), || token(","))?;
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
             |leading, trailing| {
                 Ok(format_elements![

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -11,13 +11,21 @@ use rslint_parser::ast::{
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let properties = formatter.format_separated(self.properties())?;
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_curly_token()?)?,
-            space_token(),
-            soft_indent(join_elements(soft_line_break_or_space(), properties)),
-            space_token(),
-            formatter.format_token(&self.r_curly_token()?)?,
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_curly_token()?,
+            |leading, trailing| {
+                Ok(format_elements![
+                    space_token(),
+                    soft_indent(format_elements![
+                        leading,
+                        join_elements(soft_line_break_or_space(), properties),
+                        trailing
+                    ]),
+                    space_token(),
+                ])
+            },
+            &self.r_curly_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -1,6 +1,7 @@
 use crate::{
     empty_element, format_elements, group_elements, join_elements, soft_indent,
-    soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 use rslint_parser::ast::{
     JsAnyObjectAssignmentPatternMember, JsObjectAssignmentPattern,
@@ -10,7 +11,7 @@ use rslint_parser::ast::{
 
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let properties = formatter.format_separated(self.properties())?;
+        let properties = formatter.format_separated(self.properties(), || token(","))?;
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_curly_token()?,
             |leading, trailing| {

--- a/crates/rome_formatter/src/ts/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/function_body.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl ToFormatElement for JsFunctionBody {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_delimited_group(
+        formatter.format_delimited(
             &self.l_curly_token()?,
             |leading, trailing| {
                 Ok(block_indent(format_elements![

--- a/crates/rome_formatter/src/ts/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/function_body.rs
@@ -7,10 +7,16 @@ use crate::{
 
 impl ToFormatElement for JsFunctionBody {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(format_elements![
-            formatter.format_token(&self.l_curly_token()?)?,
-            block_indent(format_statements(self.statements(), formatter)),
-            formatter.format_token(&self.r_curly_token()?)?
-        ])
+        formatter.format_delimited_group(
+            &self.l_curly_token()?,
+            |leading, trailing| {
+                Ok(block_indent(format_elements![
+                    leading,
+                    format_statements(self.statements(), formatter),
+                    trailing,
+                ]))
+            },
+            &self.r_curly_token()?,
+        )
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
@@ -8,14 +8,18 @@ impl ToFormatElement for JsArrayBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let elements = formatter.format_separated(self.elements())?;
 
-        Ok(group_elements(format_elements!(
-            formatter.format_token(&self.l_brack_token()?)?,
-            soft_indent(format_elements![
-                join_elements(soft_line_break_or_space(), elements),
-                if_group_breaks(token(",")),
-            ]),
-            formatter.format_token(&self.r_brack_token()?)?,
-        )))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_brack_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    join_elements(soft_line_break_or_space(), elements),
+                    if_group_breaks(token(",")),
+                    trailing
+                ]))
+            },
+            &self.r_brack_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsArrayBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let elements = formatter.format_separated(self.elements(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_brack_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
@@ -1,12 +1,12 @@
 use crate::{
-    format_elements, group_elements, if_group_breaks, join_elements, soft_indent,
-    soft_line_break_or_space, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space, token,
+    FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{JsAnyArrayBindingPatternElement, JsArrayBindingPattern};
 
 impl ToFormatElement for JsArrayBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let elements = formatter.format_separated(self.elements())?;
+        let elements = formatter.format_separated(self.elements(), || token(","))?;
 
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_brack_token()?,
@@ -14,7 +14,6 @@ impl ToFormatElement for JsArrayBindingPattern {
                 Ok(soft_indent(format_elements![
                     leading,
                     join_elements(soft_line_break_or_space(), elements),
-                    if_group_breaks(token(",")),
                     trailing
                 ]))
             },

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -12,16 +12,22 @@ impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let properties = formatter.format_separated(self.properties())?;
 
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_curly_token()?)?,
-            space_token(),
-            soft_indent(format_elements![
-                join_elements(soft_line_break_or_space(), properties),
-                if_group_breaks(token(",")),
-            ]),
-            space_token(),
-            formatter.format_token(&self.r_curly_token()?)?
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_curly_token()?,
+            |leading, trailing| {
+                Ok(format_elements![
+                    space_token(),
+                    leading,
+                    soft_indent(format_elements![
+                        join_elements(soft_line_break_or_space(), properties),
+                        if_group_breaks(token(",")),
+                    ]),
+                    trailing,
+                    space_token(),
+                ])
+            },
+            &self.r_curly_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -1,5 +1,5 @@
 use crate::{
-    empty_element, format_elements, group_elements, if_group_breaks, join_elements, soft_indent,
+    empty_element, format_elements, group_elements, join_elements, soft_indent,
     soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
@@ -10,19 +10,18 @@ use rslint_parser::ast::{
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let properties = formatter.format_separated(self.properties())?;
+        let properties = formatter.format_separated(self.properties(), || token(","))?;
 
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_curly_token()?,
             |leading, trailing| {
                 Ok(format_elements![
                     space_token(),
-                    leading,
                     soft_indent(format_elements![
+                        leading,
                         join_elements(soft_line_break_or_space(), properties),
-                        if_group_breaks(token(",")),
+                        trailing,
                     ]),
-                    trailing,
                     space_token(),
                 ])
             },

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -12,7 +12,7 @@ impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let properties = formatter.format_separated(self.properties(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
             |leading, trailing| {
                 Ok(format_elements![

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -23,14 +23,17 @@ impl ToFormatElement for JsAnyClass {
             id,
             extends,
             space_token(),
-            group_elements(format_elements![
-                formatter.format_token(&self.l_curly_token()?)?,
-                block_indent(join_elements(
-                    hard_line_break(),
-                    formatter.format_nodes(self.members())?
-                )),
-                formatter.format_token(&self.r_curly_token()?)?
-            ])
+            group_elements(formatter.format_delimited_group(
+                &self.l_curly_token()?,
+                |leading, trailing| {
+                    Ok(block_indent(format_elements![
+                        leading,
+                        join_elements(hard_line_break(), formatter.format_nodes(self.members())?),
+                        trailing,
+                    ]))
+                },
+                &self.r_curly_token()?
+            )?)
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -23,7 +23,7 @@ impl ToFormatElement for JsAnyClass {
             id,
             extends,
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_curly_token()?,
                 |leading, trailing| {
                     Ok(block_indent(format_elements![

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -22,14 +22,18 @@ impl ToFormatElement for JsConstructorParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let params = formatter.format_separated(self.parameters())?;
 
-        Ok(group_elements(format_elements!(
-            formatter.format_token(&self.l_paren_token()?)?,
-            soft_indent(format_elements![
-                join_elements(soft_line_break_or_space(), params),
-                if_group_breaks(token(",")),
-            ]),
-            formatter.format_token(&self.r_paren_token()?)?,
-        )))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_paren_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    join_elements(soft_line_break_or_space(), params),
+                    if_group_breaks(token(",")),
+                    trailing,
+                ]))
+            },
+            &self.r_paren_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -21,7 +21,7 @@ impl ToFormatElement for JsConstructorParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let params = formatter.format_separated(self.parameters(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -1,7 +1,6 @@
 use crate::{
-    format_elements, group_elements, if_group_breaks, join_elements, soft_indent,
-    soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, group_elements, join_elements, soft_indent, soft_line_break_or_space,
+    space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{
     JsAnyConstructorParameter, JsConstructorClassMember, JsConstructorParameters,
@@ -20,7 +19,7 @@ impl ToFormatElement for JsConstructorClassMember {
 
 impl ToFormatElement for JsConstructorParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let params = formatter.format_separated(self.parameters())?;
+        let params = formatter.format_separated(self.parameters(), || token(","))?;
 
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_paren_token()?,
@@ -28,7 +27,6 @@ impl ToFormatElement for JsConstructorParameters {
                 Ok(soft_indent(format_elements![
                     leading,
                     join_elements(soft_line_break_or_space(), params),
-                    if_group_breaks(token(",")),
                     trailing,
                 ]))
             },

--- a/crates/rome_formatter/src/ts/class/empty_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/empty_class_member.rs
@@ -3,6 +3,6 @@ use rslint_parser::ast::JsEmptyClassMember;
 
 impl ToFormatElement for JsEmptyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_replaced_token(&self.semicolon_token()?, empty_element())
+        formatter.format_replaced(&self.semicolon_token()?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/ts/class/empty_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/empty_class_member.rs
@@ -2,7 +2,7 @@ use crate::{empty_element, FormatElement, FormatResult, Formatter, ToFormatEleme
 use rslint_parser::ast::JsEmptyClassMember;
 
 impl ToFormatElement for JsEmptyClassMember {
-    fn to_format_element(&self, _: &Formatter) -> FormatResult<FormatElement> {
-        Ok(empty_element())
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        formatter.format_replaced_token(&self.semicolon_token()?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/ts/class/method_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/method_class_member.rs
@@ -11,11 +11,13 @@ impl ToFormatElement for JsMethodClassMember {
         } else {
             empty_element()
         };
+        let star_token = formatter.format_or_create_token(self.star_token(), empty_element)?;
         let name = formatter.format_node(self.name()?)?;
         let params = formatter.format_node(self.parameters()?)?;
         let body = formatter.format_node(self.body()?)?;
         Ok(format_elements![
             static_token,
+            star_token,
             name,
             params,
             space_token(),

--- a/crates/rome_formatter/src/ts/class/method_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/method_class_member.rs
@@ -11,7 +11,7 @@ impl ToFormatElement for JsMethodClassMember {
         } else {
             empty_element()
         };
-        let star_token = formatter.format_or_create_token(self.star_token(), empty_element)?;
+        let star_token = formatter.format_token(&self.star_token())?;
         let name = formatter.format_node(self.name()?)?;
         let params = formatter.format_node(self.parameters()?)?;
         let body = formatter.format_node(self.body()?)?;

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -18,11 +18,13 @@ impl ToFormatElement for JsPropertyClassMember {
             empty_element()
         };
 
+        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+
         Ok(format_elements![
             static_token,
             formatter.format_node(self.name()?)?,
             init,
-            token(";")
+            semicolon
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -18,7 +18,9 @@ impl ToFormatElement for JsPropertyClassMember {
             empty_element()
         };
 
-        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+        let semicolon = formatter
+            .format_token(&self.semicolon_token())?
+            .unwrap_or_else(|| token(';'));
 
         Ok(format_elements![
             static_token,

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -22,15 +22,9 @@ pub fn format_directives(directives: JsDirectiveList, formatter: &Formatter) -> 
 
 impl ToFormatElement for JsDirective {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let semicolon = if let Some(token) = self.semicolon_token() {
-            formatter.format_token(&token)?
-        } else {
-            token(';')
-        };
-
         Ok(format_elements![
             formatter.format_token(&self.value_token()?)?,
-            semicolon,
+            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -8,14 +8,17 @@ pub fn format_directives(directives: JsDirectiveList, formatter: &Formatter) -> 
     join_elements(
         hard_line_break(),
         directives.iter().map(|directive| {
-            formatter
-                .format_node(directive.clone())
-                .unwrap_or_else(|_| {
+            let snapshot = formatter.snapshot();
+            match formatter.format_node(directive.clone()) {
+                Ok(result) => result,
+                Err(_) => {
+                    formatter.restore(snapshot);
                     formatter
                         .format_raw(directive.syntax())
                         .trim_start()
                         .trim_end()
-                })
+                }
+            }
         }),
     )
 }

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -27,7 +27,9 @@ impl ToFormatElement for JsDirective {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.value_token()?)?,
-            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?,
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';')),
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -15,17 +15,21 @@ impl ToFormatElement for JsArrayExpression {
             if_group_breaks(token(","))
         };
 
-        Ok(group_elements(format_elements!(
-            formatter.format_token(&self.l_brack_token()?)?,
-            soft_indent(format_elements![
-                join_elements(
-                    soft_line_break_or_space(),
-                    formatter.format_separated(elements)?
-                ),
-                trailing_comma,
-            ]),
-            formatter.format_token(&self.r_brack_token()?)?,
-        )))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_brack_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    join_elements(
+                        soft_line_break_or_space(),
+                        formatter.format_separated(elements)?
+                    ),
+                    trailing_comma,
+                    trailing,
+                ]))
+            },
+            &self.r_brack_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -31,15 +31,11 @@ impl ToFormatElement for JsArrayExpression {
                             } else {
                                 token(",")
                             }
+                        } else if let Some(separator) = element.trailing_separator()? {
+                            formatter
+                                .format_replaced_token(&separator, if_group_breaks(token(",")))?
                         } else {
-                            if let Some(separator) = element.trailing_separator()? {
-                                formatter.format_replaced_token(
-                                    &separator,
-                                    if_group_breaks(token(",")),
-                                )?
-                            } else {
-                                if_group_breaks(token(","))
-                            }
+                            if_group_breaks(token(","))
                         };
 
                         Ok(format_elements![node, separator])

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -2,29 +2,53 @@ use crate::{
     empty_element, format_elements, group_elements, if_group_breaks, join_elements, soft_indent,
     soft_line_break_or_space, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
-use rslint_parser::ast::{JsArrayExpression, JsArrayHole};
-use rslint_parser::AstSeparatedList;
+use rslint_parser::{
+    ast::{JsArrayExpression, JsArrayHole},
+    AstSeparatedList,
+};
 
 impl ToFormatElement for JsArrayExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let elements = self.elements();
 
-        let trailing_comma = if elements.len() == 0 {
-            empty_element()
-        } else {
-            if_group_breaks(token(","))
-        };
-
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_brack_token()?,
             |leading, trailing| {
+                // Specifically do not use format_separated as array expressions need
+                // separators inserted after empty expressions regardless of the
+                // formatting since this makes a semantic difference
+                let last_index = elements.len().saturating_sub(1);
+                let results = elements
+                    .elements()
+                    .enumerate()
+                    .map(|(index, element)| {
+                        let node = formatter.format_node(element.node()?)?;
+
+                        let separator = if node.is_empty() || index != last_index {
+                            // If the previous element was empty or this is not the last element, always print a separator
+                            if let Some(separator) = element.trailing_separator()? {
+                                formatter.format_token(&separator)?
+                            } else {
+                                token(",")
+                            }
+                        } else {
+                            if let Some(separator) = element.trailing_separator()? {
+                                formatter.format_replaced_token(
+                                    &separator,
+                                    if_group_breaks(token(",")),
+                                )?
+                            } else {
+                                if_group_breaks(token(","))
+                            }
+                        };
+
+                        Ok(format_elements![node, separator])
+                    })
+                    .collect::<FormatResult<Vec<_>>>()?;
+
                 Ok(soft_indent(format_elements![
                     leading,
-                    join_elements(
-                        soft_line_break_or_space(),
-                        formatter.format_separated(elements)?
-                    ),
-                    trailing_comma,
+                    join_elements(soft_line_break_or_space(), results),
                     trailing,
                 ]))
             },

--- a/crates/rome_formatter/src/ts/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/call_expression.rs
@@ -1,13 +1,10 @@
-use crate::{
-    empty_element, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
-};
+use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsCallExpression;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let name = formatter.format_node(self.callee()?)?;
-        let option =
-            formatter.format_or_create_token(self.optional_chain_token_token(), empty_element)?;
+        let option = formatter.format_token(&self.optional_chain_token_token())?;
         let arguments = formatter.format_node(self.arguments()?)?;
 
         Ok(format_elements![name, option, arguments])

--- a/crates/rome_formatter/src/ts/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/call_expression.rs
@@ -1,11 +1,15 @@
-use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{
+    empty_element, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
+};
 use rslint_parser::ast::JsCallExpression;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let name = formatter.format_node(self.callee()?)?;
+        let option =
+            formatter.format_or_create_token(self.optional_chain_token_token(), empty_element)?;
         let arguments = formatter.format_node(self.arguments()?)?;
 
-        Ok(format_elements![name, arguments])
+        Ok(format_elements![name, option, arguments])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/literal_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/literal_expression.rs
@@ -18,7 +18,7 @@ impl ToFormatElement for JsStringLiteralExpression {
             token(quoted)
         };
 
-        formatter.format_replaced_token(&value_token, content)
+        formatter.format_replaced(&value_token, content)
     }
 }
 

--- a/crates/rome_formatter/src/ts/expressions/literal_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/literal_expression.rs
@@ -5,18 +5,20 @@ use rslint_parser::ast::{
 };
 
 impl ToFormatElement for JsStringLiteralExpression {
-    fn to_format_element(&self, _: &Formatter) -> FormatResult<FormatElement> {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let value_token = self.value_token()?;
         let quoted = value_token.text_trimmed();
 
         // uses single quotes
-        if quoted.starts_with('\'') {
+        let content = if quoted.starts_with('\'') {
             let s = &quoted[1..quoted.len() - 1];
             let s = format!("\"{}\"", s);
-            Ok(token(s))
+            token(s)
         } else {
-            Ok(token(quoted))
-        }
+            token(quoted)
+        };
+
+        formatter.format_replaced_token(&value_token, content)
     }
 }
 

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -1,7 +1,7 @@
 use crate::{
-    empty_element, format_elements, group_elements, if_group_breaks, if_group_fits_on_single_line,
-    join_elements, soft_indent, soft_line_break_or_space, space_token, token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    empty_element, format_elements, group_elements, if_group_fits_on_single_line, join_elements,
+    soft_indent, soft_line_break_or_space, space_token, token, FormatElement, FormatResult,
+    Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsObjectExpression;
 use rslint_parser::AstSeparatedList;
@@ -25,9 +25,8 @@ impl ToFormatElement for JsObjectExpression {
                         leading,
                         join_elements(
                             soft_line_break_or_space(),
-                            formatter.format_separated(members)?
+                            formatter.format_separated(members, || token(","))?
                         ),
-                        if_group_breaks(token(",")),
                         trailing
                     ]),
                     space,

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -16,18 +16,24 @@ impl ToFormatElement for JsObjectExpression {
             if_group_fits_on_single_line(space_token())
         };
 
-        Ok(group_elements(format_elements!(
-            formatter.format_token(&self.l_curly_token()?)?,
-            space.clone(),
-            soft_indent(format_elements![
-                join_elements(
-                    soft_line_break_or_space(),
-                    formatter.format_separated(members)?
-                ),
-                if_group_breaks(token(",")),
-            ]),
-            space,
-            formatter.format_token(&self.r_curly_token()?)?,
-        )))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_curly_token()?,
+            |leading, trailing| {
+                Ok(format_elements!(
+                    space.clone(),
+                    soft_indent(format_elements![
+                        leading,
+                        join_elements(
+                            soft_line_break_or_space(),
+                            formatter.format_separated(members)?
+                        ),
+                        if_group_breaks(token(",")),
+                        trailing
+                    ]),
+                    space,
+                ))
+            },
+            &self.r_curly_token()?,
+        )?))
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -16,7 +16,7 @@ impl ToFormatElement for JsObjectExpression {
             if_group_fits_on_single_line(space_token())
         };
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
             |leading, trailing| {
                 Ok(format_elements!(

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -1,5 +1,5 @@
 use crate::{
-    empty_element, format_elements, group_elements, if_group_breaks, join_elements, soft_indent,
+    empty_element, format_elements, group_elements, join_elements, soft_indent,
     soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
@@ -7,7 +7,7 @@ use rslint_parser::ast::{JsAnyParameter, JsParameter, JsParameters, JsRestParame
 
 impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let param_tokens = formatter.format_separated(self.items())?;
+        let param_tokens = formatter.format_separated(self.items(), || token(","))?;
 
         Ok(group_elements(formatter.format_delimited_group(
             &self.l_paren_token()?,
@@ -15,7 +15,6 @@ impl ToFormatElement for JsParameters {
                 Ok(soft_indent(format_elements![
                     leading,
                     join_elements(soft_line_break_or_space(), param_tokens),
-                    if_group_breaks(token(",")),
                     trailing,
                 ]))
             },

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -9,14 +9,18 @@ impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let param_tokens = formatter.format_separated(self.items())?;
 
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_paren_token()?)?,
-            soft_indent(format_elements![
-                join_elements(soft_line_break_or_space(), param_tokens),
-                if_group_breaks(token(",")),
-            ]),
-            formatter.format_token(&self.r_paren_token()?)?
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_paren_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    join_elements(soft_line_break_or_space(), param_tokens),
+                    if_group_breaks(token(",")),
+                    trailing,
+                ]))
+            },
+            &self.r_paren_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -9,7 +9,7 @@ impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let param_tokens = formatter.format_separated(self.items(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/script.rs
+++ b/crates/rome_formatter/src/ts/script.rs
@@ -23,6 +23,8 @@ impl ToFormatElement for JsScript {
 
         elements.push(format_statements(self.statements(), formatter));
 
+        elements.push(formatter.format_token(&self.eof_token()?)?);
+
         Ok(format_elements![
             concat_elements(elements),
             hard_line_break()

--- a/crates/rome_formatter/src/ts/statements/block.rs
+++ b/crates/rome_formatter/src/ts/statements/block.rs
@@ -18,7 +18,7 @@ impl ToFormatElement for JsBlockStatement {
                 formatter.format_token(&self.r_curly_token()?)?
             ])
         } else {
-            formatter.format_delimited_group(
+            formatter.format_delimited(
                 &self.l_curly_token()?,
                 |leading, trailing| Ok(block_indent(format_elements![leading, stmts, trailing])),
                 &self.r_curly_token()?,

--- a/crates/rome_formatter/src/ts/statements/block.rs
+++ b/crates/rome_formatter/src/ts/statements/block.rs
@@ -11,17 +11,19 @@ impl ToFormatElement for JsBlockStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let stmts = format_statements(self.statements(), formatter);
 
-        let body = if is_non_collapsable_empty_block(self) {
-            hard_line_break()
+        if is_non_collapsable_empty_block(self) {
+            Ok(format_elements![
+                formatter.format_token(&self.l_curly_token()?)?,
+                hard_line_break(),
+                formatter.format_token(&self.r_curly_token()?)?
+            ])
         } else {
-            block_indent(stmts)
-        };
-
-        Ok(format_elements![
-            formatter.format_token(&self.l_curly_token()?)?,
-            body,
-            formatter.format_token(&self.r_curly_token()?)?
-        ])
+            formatter.format_delimited_group(
+                &self.l_curly_token()?,
+                |leading, trailing| Ok(block_indent(format_elements![leading, stmts, trailing])),
+                &self.r_curly_token()?,
+            )
+        }
     }
 }
 

--- a/crates/rome_formatter/src/ts/statements/break_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/break_statement.rs
@@ -12,7 +12,9 @@ impl ToFormatElement for JsBreakStatement {
             empty_element()
         };
 
-        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+        let semicolon = formatter
+            .format_token(&self.semicolon_token())?
+            .unwrap_or_else(|| token(';'));
 
         Ok(format_elements![
             formatter.format_token(&self.break_token()?)?,

--- a/crates/rome_formatter/src/ts/statements/break_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/break_statement.rs
@@ -12,10 +12,12 @@ impl ToFormatElement for JsBreakStatement {
             empty_element()
         };
 
+        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+
         Ok(format_elements![
             formatter.format_token(&self.break_token()?)?,
             label,
-            token(";")
+            semicolon,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/continue_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/continue_statement.rs
@@ -12,7 +12,9 @@ impl ToFormatElement for JsContinueStatement {
             empty_element()
         };
 
-        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+        let semicolon = formatter
+            .format_token(&self.semicolon_token())?
+            .unwrap_or_else(|| token(';'));
 
         Ok(format_elements![
             formatter.format_token(&self.continue_token()?)?,

--- a/crates/rome_formatter/src/ts/statements/continue_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/continue_statement.rs
@@ -12,10 +12,12 @@ impl ToFormatElement for JsContinueStatement {
             empty_element()
         };
 
+        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+
         Ok(format_elements![
             formatter.format_token(&self.continue_token()?)?,
             label,
-            token(";")
+            semicolon
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/debugger_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/debugger_statement.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsDebuggerStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.debugger_token()?)?,
-            token(";")
+            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/debugger_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/debugger_statement.rs
@@ -5,7 +5,9 @@ impl ToFormatElement for JsDebuggerStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.debugger_token()?)?,
-            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';'))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -13,7 +13,7 @@ impl ToFormatElement for JsDoWhileStatement {
             space_token(),
             formatter.format_token(&self.while_token()?)?,
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(soft_indent(format_elements![
                     leading,
@@ -22,7 +22,9 @@ impl ToFormatElement for JsDoWhileStatement {
                 ])),
                 &self.r_paren_token()?,
             )?),
-            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';'))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -13,11 +13,15 @@ impl ToFormatElement for JsDoWhileStatement {
             space_token(),
             formatter.format_token(&self.while_token()?)?,
             space_token(),
-            group_elements(format_elements![
-                formatter.format_token(&self.l_paren_token()?)?,
-                soft_indent(formatter.format_node(self.test()?)?),
-                formatter.format_token(&self.r_paren_token()?)?
-            ]),
+            group_elements(formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(soft_indent(format_elements![
+                    leading,
+                    formatter.format_node(self.test()?)?,
+                    trailing,
+                ])),
+                &self.r_paren_token()?,
+            )?),
             formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
         ])
     }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -18,7 +18,7 @@ impl ToFormatElement for JsDoWhileStatement {
                 soft_indent(formatter.format_node(self.test()?)?),
                 formatter.format_token(&self.r_paren_token()?)?
             ]),
-            token(";")
+            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/empty_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/empty_statement.rs
@@ -2,7 +2,7 @@ use crate::{empty_element, FormatElement, FormatResult, Formatter, ToFormatEleme
 use rslint_parser::ast::JsEmptyStatement;
 
 impl ToFormatElement for JsEmptyStatement {
-    fn to_format_element(&self, _formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(empty_element())
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        formatter.format_replaced_token(&self.semicolon_token()?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/ts/statements/empty_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/empty_statement.rs
@@ -3,6 +3,6 @@ use rslint_parser::ast::JsEmptyStatement;
 
 impl ToFormatElement for JsEmptyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_replaced_token(&self.semicolon_token()?, empty_element())
+        formatter.format_replaced(&self.semicolon_token()?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/ts/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/expression_statement.rs
@@ -6,7 +6,9 @@ impl ToFormatElement for JsExpressionStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_node(self.expression()?)?,
-            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';'))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/expression_statement.rs
@@ -6,7 +6,7 @@ impl ToFormatElement for JsExpressionStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_node(self.expression()?)?,
-            token(";")
+            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_in_statement.rs
@@ -16,7 +16,7 @@ impl ToFormatElement for JsForInStatement {
         Ok(format_elements![
             for_token,
             space_token(),
-            formatter.format_delimited_group(
+            formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(group_elements(soft_indent(format_elements![
                     leading,

--- a/crates/rome_formatter/src/ts/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_in_statement.rs
@@ -8,25 +8,27 @@ use crate::{
 impl ToFormatElement for JsForInStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let for_token = formatter.format_token(&self.for_token()?)?;
-        let l_paren = formatter.format_token(&self.l_paren_token()?)?;
         let initializer = formatter.format_node(self.initializer()?)?;
         let in_token = formatter.format_token(&self.in_token()?)?;
         let expression = formatter.format_node(self.expression()?)?;
-        let r_paren = formatter.format_token(&self.r_paren_token()?)?;
         let body = formatter.format_node(self.body()?)?;
 
         Ok(format_elements![
             for_token,
             space_token(),
-            l_paren,
-            group_elements(soft_indent(format_elements![
-                initializer,
-                soft_line_break_or_space(),
-                in_token,
-                soft_line_break_or_space(),
-                expression,
-            ])),
-            r_paren,
+            formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
+                    leading,
+                    initializer,
+                    soft_line_break_or_space(),
+                    in_token,
+                    soft_line_break_or_space(),
+                    expression,
+                    trailing,
+                ]))),
+                &self.r_paren_token()?
+            )?,
             space_token(),
             body
         ])

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -16,7 +16,7 @@ impl ToFormatElement for JsForOfStatement {
         Ok(format_elements![
             for_token,
             space_token(),
-            formatter.format_delimited_group(
+            formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(group_elements(soft_indent(format_elements![
                     leading,

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -8,25 +8,27 @@ use crate::{
 impl ToFormatElement for JsForOfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let for_token = formatter.format_token(&self.for_token()?)?;
-        let l_paren = formatter.format_token(&self.l_paren_token()?)?;
         let initializer = formatter.format_node(self.initializer()?)?;
         let of_token = formatter.format_token(&self.of_token()?)?;
         let expression = formatter.format_node(self.expression()?)?;
-        let r_paren = formatter.format_token(&self.r_paren_token()?)?;
         let body = formatter.format_node(self.body()?)?;
 
         Ok(format_elements![
             for_token,
             space_token(),
-            l_paren,
-            group_elements(soft_indent(format_elements![
-                initializer,
-                soft_line_break_or_space(),
-                of_token,
-                soft_line_break_or_space(),
-                expression,
-            ])),
-            r_paren,
+            formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
+                    leading,
+                    initializer,
+                    soft_line_break_or_space(),
+                    of_token,
+                    soft_line_break_or_space(),
+                    expression,
+                    trailing,
+                ]))),
+                &self.r_paren_token()?
+            )?,
             space_token(),
             body
         ])

--- a/crates/rome_formatter/src/ts/statements/for_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/for_stmt.rs
@@ -38,7 +38,7 @@ impl ToFormatElement for JsForStatement {
         Ok(group_elements(format_elements![
             formatter.format_token(&self.for_token()?)?,
             space_token(),
-            formatter.format_delimited_group(
+            formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(group_elements(soft_indent(format_elements![
                     leading, inner, trailing

--- a/crates/rome_formatter/src/ts/statements/for_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/for_stmt.rs
@@ -38,9 +38,13 @@ impl ToFormatElement for JsForStatement {
         Ok(group_elements(format_elements![
             formatter.format_token(&self.for_token()?)?,
             space_token(),
-            formatter.format_token(&self.l_paren_token()?)?,
-            group_elements(soft_indent(inner)),
-            formatter.format_token(&self.r_paren_token()?)?,
+            formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
+                    leading, inner, trailing
+                ]))),
+                &self.r_paren_token()?,
+            )?,
             space_token(),
             formatter.format_node(self.body()?)?
         ]))

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -16,7 +16,7 @@ impl ToFormatElement for JsIfStatement {
             group_elements(format_elements![
                 formatter.format_token(&self.if_token()?)?,
                 space_token(),
-                group_elements(formatter.format_delimited_group(
+                group_elements(formatter.format_delimited(
                     &self.l_paren_token()?,
                     |leading, trailing| Ok(soft_indent(format_elements![
                         leading,

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -16,11 +16,15 @@ impl ToFormatElement for JsIfStatement {
             group_elements(format_elements![
                 formatter.format_token(&self.if_token()?)?,
                 space_token(),
-                group_elements(format_elements![
-                    formatter.format_token(&self.l_paren_token()?)?,
-                    soft_indent(formatter.format_node(self.test()?)?),
-                    formatter.format_token(&self.r_paren_token()?)?
-                ]),
+                group_elements(formatter.format_delimited_group(
+                    &self.l_paren_token()?,
+                    |leading, trailing| Ok(soft_indent(format_elements![
+                        leading,
+                        formatter.format_node(self.test()?)?,
+                        trailing
+                    ])),
+                    &self.r_paren_token()?,
+                )?),
                 space_token(),
             ]),
             formatter.format_node(self.consequent()?)?,

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -29,9 +29,14 @@ pub fn format_statements(stmts: JsStatementList, formatter: &Formatter) -> Forma
     join_elements(
         hard_line_break(),
         stmts.iter().map(|stmt| {
-            formatter
-                .format_node(stmt.clone())
-                .unwrap_or_else(|_| formatter.format_raw(stmt.syntax()).trim_start().trim_end())
+            let snapshot = formatter.snapshot();
+            match formatter.format_node(stmt.clone()) {
+                Ok(result) => result,
+                Err(_) => {
+                    formatter.restore(snapshot);
+                    formatter.format_raw(stmt.syntax()).trim_start().trim_end()
+                }
+            }
         }),
     )
 }

--- a/crates/rome_formatter/src/ts/statements/return_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/return_statement.rs
@@ -12,7 +12,11 @@ impl ToFormatElement for JsReturnStatement {
             tokens.push(formatter.format_node(argument)?);
         }
 
-        tokens.push(formatter.format_or_create_token(self.semicolon_token(), || token(';'))?);
+        tokens.push(
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';')),
+        );
 
         Ok(concat_elements(tokens))
     }

--- a/crates/rome_formatter/src/ts/statements/return_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/return_statement.rs
@@ -12,7 +12,7 @@ impl ToFormatElement for JsReturnStatement {
             tokens.push(formatter.format_node(argument)?);
         }
 
-        tokens.push(token(";"));
+        tokens.push(formatter.format_or_create_token(self.semicolon_token(), || token(';'))?);
 
         Ok(concat_elements(tokens))
     }

--- a/crates/rome_formatter/src/ts/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/switch_statement.rs
@@ -11,7 +11,7 @@ impl ToFormatElement for JsSwitchStatement {
         Ok(format_elements![
             formatter.format_token(&self.switch_token()?)?,
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(soft_indent(format_elements![
                     leading,
@@ -21,7 +21,7 @@ impl ToFormatElement for JsSwitchStatement {
                 &self.r_paren_token()?,
             )?),
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_curly_token()?,
                 |leading, trailing| {
                     Ok(block_indent(format_elements![

--- a/crates/rome_formatter/src/ts/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/throw_statement.rs
@@ -7,11 +7,14 @@ impl ToFormatElement for JsThrowStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let throw_token = formatter.format_token(&self.throw_token()?)?;
         let exception = formatter.format_node(self.argument()?)?;
+
+        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+
         Ok(format_elements![
             throw_token,
             space_token(),
             exception,
-            token(";")
+            semicolon
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/throw_statement.rs
@@ -8,7 +8,9 @@ impl ToFormatElement for JsThrowStatement {
         let throw_token = formatter.format_token(&self.throw_token()?)?;
         let exception = formatter.format_node(self.argument()?)?;
 
-        let semicolon = formatter.format_or_create_token(self.semicolon_token(), || token(';'))?;
+        let semicolon = formatter
+            .format_token(&self.semicolon_token())?
+            .unwrap_or_else(|| token(';'));
 
         Ok(format_elements![
             throw_token,

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -59,11 +59,17 @@ impl ToFormatElement for JsCatchClause {
 
 impl ToFormatElement for JsCatchDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(format_elements![
-            formatter.format_token(&self.l_paren_token()?)?,
-            soft_indent(formatter.format_node(self.binding()?)?),
-            formatter.format_token(&self.r_paren_token()?)?
-        ]))
+        Ok(group_elements(formatter.format_delimited_group(
+            &self.l_paren_token()?,
+            |leading, trailing| {
+                Ok(soft_indent(format_elements![
+                    leading,
+                    formatter.format_node(self.binding()?)?,
+                    trailing,
+                ]))
+            },
+            &self.r_paren_token()?,
+        )?))
     }
 }
 

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -59,7 +59,7 @@ impl ToFormatElement for JsCatchClause {
 
 impl ToFormatElement for JsCatchDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited_group(
+        Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
             |leading, trailing| {
                 Ok(soft_indent(format_elements![

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsVariableStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_node(self.declarations()?)?,
-            token(";"),
+            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -12,7 +12,9 @@ impl ToFormatElement for JsVariableStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_node(self.declarations()?)?,
-            formatter.format_or_create_token(self.semicolon_token(), || token(';'))?,
+            formatter
+                .format_token(&self.semicolon_token())?
+                .unwrap_or_else(|| token(';')),
         ])
     }
 }
@@ -29,7 +31,7 @@ impl ToFormatElement for JsVariableDeclarations {
                 let node = formatter.format_node(element.node()?)?;
                 let separator = if let Some(separator) = element.trailing_separator()? {
                     if index == last_index {
-                        formatter.format_replaced_token(&separator, empty_element())?
+                        formatter.format_replaced(&separator, empty_element())?
                     } else {
                         formatter.format_token(&separator)?
                     }

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -1,8 +1,12 @@
 use crate::{
-    empty_element, format_elements, join_elements, space_token, token, FormatElement, FormatResult,
-    Formatter, ToFormatElement,
+    empty_element, format_elements, group_elements, indent, join_elements,
+    soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
-use rslint_parser::ast::{JsVariableDeclaration, JsVariableDeclarations, JsVariableStatement};
+use rslint_parser::{
+    ast::{JsVariableDeclaration, JsVariableDeclarations, JsVariableStatement},
+    AstSeparatedList,
+};
 
 impl ToFormatElement for JsVariableStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -15,14 +19,50 @@ impl ToFormatElement for JsVariableStatement {
 
 impl ToFormatElement for JsVariableDeclarations {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let items = self.items();
+        let last_index = items.len().saturating_sub(1);
+
+        let items = items
+            .elements()
+            .enumerate()
+            .map(|(index, element)| {
+                let node = formatter.format_node(element.node()?)?;
+                let separator = if let Some(separator) = element.trailing_separator()? {
+                    if index == last_index {
+                        formatter.format_replaced_token(&separator, empty_element())?
+                    } else {
+                        formatter.format_token(&separator)?
+                    }
+                } else {
+                    if index == last_index {
+                        empty_element()
+                    } else {
+                        token(",")
+                    }
+                };
+
+                Ok(format_elements![node, separator])
+            })
+            .collect::<FormatResult<Vec<_>>>()?;
+
+        let mut items = items.into_iter();
+
+        let leading_element = items.next();
+        let trailing_elements = join_elements(soft_line_break_or_space(), items);
+
         Ok(format_elements![
             formatter.format_token(&self.kind()?)?,
             space_token(),
-            join_elements(
-                space_token(),
-                // TODO #1726 break multiple declarations across multiple lines if exceeding line width
-                formatter.format_separated(self.items())?
-            ),
+            group_elements(concat_elements(leading_element.into_iter().chain(
+                if !trailing_elements.is_empty() {
+                    Some(indent(format_elements![
+                        soft_line_break_or_space(),
+                        trailing_elements
+                    ]))
+                } else {
+                    None
+                }
+            ))),
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -33,12 +33,10 @@ impl ToFormatElement for JsVariableDeclarations {
                     } else {
                         formatter.format_token(&separator)?
                     }
+                } else if index == last_index {
+                    empty_element()
                 } else {
-                    if index == last_index {
-                        empty_element()
-                    } else {
-                        token(",")
-                    }
+                    token(",")
                 };
 
                 Ok(format_elements![node, separator])

--- a/crates/rome_formatter/src/ts/statements/while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/while_statement.rs
@@ -9,11 +9,15 @@ impl ToFormatElement for JsWhileStatement {
         Ok(format_elements![
             formatter.format_token(&self.while_token()?)?,
             space_token(),
-            group_elements(format_elements![
-                formatter.format_token(&self.l_paren_token()?)?,
-                soft_indent(formatter.format_node(self.test()?)?),
-                formatter.format_token(&self.r_paren_token()?)?
-            ]),
+            group_elements(formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(soft_indent(format_elements![
+                    leading,
+                    formatter.format_node(self.test()?)?,
+                    trailing,
+                ])),
+                &self.r_paren_token()?,
+            )?),
             space_token(),
             formatter.format_node(self.body()?)?
         ])

--- a/crates/rome_formatter/src/ts/statements/while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/while_statement.rs
@@ -9,7 +9,7 @@ impl ToFormatElement for JsWhileStatement {
         Ok(format_elements![
             formatter.format_token(&self.while_token()?)?,
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(soft_indent(format_elements![
                     leading,

--- a/crates/rome_formatter/src/ts/statements/with_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/with_statement.rs
@@ -9,11 +9,15 @@ impl ToFormatElement for JsWithStatement {
         Ok(format_elements![
             formatter.format_token(&self.with_token()?)?,
             space_token(),
-            group_elements(format_elements![
-                formatter.format_token(&self.l_paren_token()?)?,
-                soft_indent(formatter.format_node(self.object()?)?),
-                formatter.format_token(&self.r_paren_token()?)?
-            ]),
+            group_elements(formatter.format_delimited_group(
+                &self.l_paren_token()?,
+                |leading, trailing| Ok(soft_indent(format_elements![
+                    leading,
+                    formatter.format_node(self.object()?)?,
+                    trailing,
+                ])),
+                &self.r_paren_token()?,
+            )?),
             space_token(),
             formatter.format_node(self.body()?)?
         ])

--- a/crates/rome_formatter/src/ts/statements/with_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/with_statement.rs
@@ -9,7 +9,7 @@ impl ToFormatElement for JsWithStatement {
         Ok(format_elements![
             formatter.format_token(&self.with_token()?)?,
             space_token(),
-            group_elements(formatter.format_delimited_group(
+            group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |leading, trailing| Ok(soft_indent(format_elements![
                     leading,

--- a/crates/rome_formatter/tests/specs/js/array/spaces.js.snap
+++ b/crates/rome_formatter/tests/specs/js/array/spaces.js.snap
@@ -12,8 +12,8 @@ let e = [2,2,1,3];
 
 ---
 # Output
-let a = [];
-let b = [,];
+let a = [,];
+let b = [, ,];
 let c = [, , 1];
 let d = [, , 1, 1];
 let e = [2, 2, 1, 3];

--- a/crates/rome_formatter/tests/specs/js/arrow/arrow_nested.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/arrow_nested.js.snap
@@ -34,24 +34,32 @@ runtimeAgent.getProperties(
 
 ---
 # Output
-Seq(typeDef.interface.groups).forEach((group) => Seq(group.members).forEach((
-	member,
-	memberName,
-) => markdownDoc(member.doc, {
-	typePath: typePath.concat(memberName.slice(1)),
-	signatures: member.signatures,
-})));
-const promiseFromCallback = (fn) => new Promise((resolve, reject) => fn((
-	err,
-	result,
-) => {
-	if (err) return reject(err);
-	return resolve(result);
-}));
-runtimeAgent.getProperties(objectId, false, // ownProperties
-false, // accessorPropertiesOnly
-false, // generatePreview
-(error, properties, internalProperties) => {
-	return 1;
-});
+Seq(typeDef.interface.groups).forEach(
+	(group) => Seq(group.members).forEach(
+		(member, memberName) => markdownDoc(
+			member.doc,
+			{
+				typePath: typePath.concat(memberName.slice(1)),
+				signatures: member.signatures,
+			},
+		),
+	),
+);
+const promiseFromCallback = (fn) => new Promise(
+	(resolve, reject) => fn(
+		(err, result) => {
+			if (err) return reject(err);
+			return resolve(result);
+		},
+	),
+);
+runtimeAgent.getProperties(
+	objectId,
+	false, // ownProperties
+	false, // accessorPropertiesOnly
+	false, // generatePreview
+	(error, properties, internalProperties) => {
+		return 1;
+	},
+);
 

--- a/crates/rome_formatter/tests/specs/js/arrow/arrow_nested.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/arrow_nested.js.snap
@@ -48,11 +48,10 @@ const promiseFromCallback = (fn) => new Promise((resolve, reject) => fn((
 	if (err) return reject(err);
 	return resolve(result);
 }));
-runtimeAgent.getProperties(objectId, false, false, false, (
-	error,
-	properties,
-	internalProperties,
-) => {
+runtimeAgent.getProperties(objectId, false, // ownProperties
+false, // accessorPropertiesOnly
+false, // generatePreview
+(error, properties, internalProperties) => {
 	return 1;
 });
 

--- a/crates/rome_formatter/tests/specs/js/arrow/call.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/call.js.snap
@@ -51,31 +51,43 @@ romise.then(result => result.veryLongVariable.veryLongPropertyName > someOtherVa
 
 ---
 # Output
-const testResults = results.testResults.map((testResult) => formatResult(testResult, formatter, reporter));
-it("mocks regexp instances", () => {
-	expect( // () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
-	).not.toThrow();
-});
+const testResults = results.testResults.map(
+	(testResult) => formatResult(testResult, formatter, reporter),
+);
+it(
+	"mocks regexp instances",
+	() => {
+		expect(
+			// () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+		).not.toThrow();
+	},
+);
 expect(() => asyncRequest({ url: "/test-endpoint" }));
 // .toThrowError(/Required parameter/);
 expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }));
 // .toThrowError(/Required parameter/);
-expect(() => asyncRequest({
-	url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url",
-}));
+expect(
+	() => asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
+);
 // .toThrowError(/Required parameter/);
 expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not.toThrowError();
-expect(() => asyncRequest({
-	type: "foo",
-	url: "/test-endpoint-but-with-a-long-url",
-})).not.toThrowError();
-const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map((
-	response,
-) => response.data);
-const b = Observable.fromPromise(axiosInstance.get(url)).map((response) => response.data);
-func(veryLoooooooooooooooooooooooongName, (veryLooooooooooooooooooooooooongName) => veryLoooooooooooooooongName.something());
+expect(
+	() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
+).not.toThrowError();
+const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(
+	(response) => response.data,
+);
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+	(response) => response.data,
+);
+func(
+	veryLoooooooooooooooooooooooongName,
+	(veryLooooooooooooooooooooooooongName) => veryLoooooooooooooooongName.something(),
+);
 const composition = (ViewComponent, ContainerComponent) => class extends React.Component {
 	static propTypes = {};
 };
-romise.then((result) => result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail");
+romise.then(
+	(result) => result.veryLongVariable.veryLongPropertyName > someOtherVariable ? "ok" : "fail",
+);
 

--- a/crates/rome_formatter/tests/specs/js/arrow/call.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/call.js.snap
@@ -53,13 +53,17 @@ romise.then(result => result.veryLongVariable.veryLongPropertyName > someOtherVa
 # Output
 const testResults = results.testResults.map((testResult) => formatResult(testResult, formatter, reporter));
 it("mocks regexp instances", () => {
-	expect().not.toThrow();
+	expect( // () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+	).not.toThrow();
 });
 expect(() => asyncRequest({ url: "/test-endpoint" }));
+// .toThrowError(/Required parameter/);
 expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }));
+// .toThrowError(/Required parameter/);
 expect(() => asyncRequest({
 	url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url",
 }));
+// .toThrowError(/Required parameter/);
 expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not.toThrowError();
 expect(() => asyncRequest({
 	type: "foo",

--- a/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
@@ -36,6 +36,5 @@ const mw = (store) => (next) => (action) => {
 };
 const middleware = (options) => (req, res, next) => {
 	// ...
-
 };
 

--- a/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
@@ -34,5 +34,6 @@ const bar = (a) => (b) => (c) => a + b + c;
 const mw = (store) => (next) => (action) => {
 	return next(action);
 };
-const middleware = (options) => (req, res, next) => {};
+const middleware = (options) => (req, res, next) => { // ...
+};
 

--- a/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/currying.js.snap
@@ -34,6 +34,8 @@ const bar = (a) => (b) => (c) => a + b + c;
 const mw = (store) => (next) => (action) => {
 	return next(action);
 };
-const middleware = (options) => (req, res, next) => { // ...
+const middleware = (options) => (req, res, next) => {
+	// ...
+
 };
 

--- a/crates/rome_formatter/tests/specs/js/arrow/params.js.snap
+++ b/crates/rome_formatter/tests/specs/js/arrow/params.js.snap
@@ -328,7 +328,9 @@ foo(
 
 ---
 # Output
-fooooooooooooooooooooooooooooooooooooooooooooooooooo((action) => (next) => dispatch(action));
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+	(action) => (next) => dispatch(action),
+);
 foo(({ a, b }) => {});
 foo(({ a, b }) => {});
 foo(({ a, b }) => {});

--- a/crates/rome_formatter/tests/specs/js/assignment/assignment.js.snap
+++ b/crates/rome_formatter/tests/specs/js/assignment/assignment.js.snap
@@ -62,5 +62,5 @@ a[b] = c[d];
 	dddddddddd: eeeeeeeeee,
 	ffffffffff: gggggggggg = hhhhhhhhhh,
 	...jjjjjjjjjj
- } = x);
+} = x);
 

--- a/crates/rome_formatter/tests/specs/js/assignment/assignment.js.snap
+++ b/crates/rome_formatter/tests/specs/js/assignment/assignment.js.snap
@@ -53,7 +53,7 @@ a[b] = c[d];
 [
 	fooooooooooooooooooooooooooooooooooooooooooooooooo,
 	barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr,
-	bazzzzzzzzzzzzzzzzzzzzzzzzzz
+	bazzzzzzzzzzzzzzzzzzzzzzzzzz,
 ] = d;
 ({ a, b = c, d: e, f: g = h, ...j } = x);
 ({
@@ -61,6 +61,6 @@ a[b] = c[d];
 	bbbbbbbbbb = cccccccccc,
 	dddddddddd: eeeeeeeeee,
 	ffffffffff: gggggggggg = hhhhhhhhhh,
-	...jjjjjjjjjj
+	...jjjjjjjjjj,
 } = x);
 

--- a/crates/rome_formatter/tests/specs/js/binding/identifier_binding.js
+++ b/crates/rome_formatter/tests/specs/js/binding/identifier_binding.js
@@ -1,1 +1,3 @@
 let x = y
+
+let abcde = "very long value that will cause a line break", fghij = "this should end up on the next line"

--- a/crates/rome_formatter/tests/specs/js/binding/identifier_binding.js.snap
+++ b/crates/rome_formatter/tests/specs/js/binding/identifier_binding.js.snap
@@ -6,7 +6,11 @@ expression: identifier_binding.js
 # Input
 let x = y
 
+let abcde = "very long value that will cause a line break", fghij = "this should end up on the next line"
+
 ---
 # Output
 let x = y;
+let abcde = "very long value that will cause a line break",
+	fghij = "this should end up on the next line";
 

--- a/crates/rome_formatter/tests/specs/js/binding/object_binding.js.snap
+++ b/crates/rome_formatter/tests/specs/js/binding/object_binding.js.snap
@@ -19,5 +19,5 @@ let {
 	bbbbbbbbbbbbbbbbbbbb = cccccccccccccccccccc,
 	dddddddddddddddddddd: eeeeeeeeeeeeeeeeeeee = ffffffffffffffffffff,
 	...gggggggggggggggggggg,
- } = h;
+} = h;
 

--- a/crates/rome_formatter/tests/specs/js/class/private_method.js.snap
+++ b/crates/rome_formatter/tests/specs/js/class/private_method.js.snap
@@ -25,7 +25,7 @@ class Foo {
 # Output
 class Foo {
 	a = 1;
-	#a() {
+	*#a() {
 		yield bar();
 	}
 	#b = 2;

--- a/crates/rome_formatter/tests/specs/js/comments.js
+++ b/crates/rome_formatter/tests/specs/js/comments.js
@@ -18,6 +18,24 @@ expression(
 );
 
 
+expression( "something" // line comment 
+);
+
+
+expression( "something" /** something **/  );
+
+expression(/** something **/ "something" 
+          );
+
+expression(
+    /** something **/
+    "something" 
+);
+
+const array0 = [/*0*/];
+const array1 = [/*0*/,/*1*/];
+const array2 = [/*0*/,/*1*/,/*2*/];
+
 /* block comment */
 statement();
 

--- a/crates/rome_formatter/tests/specs/js/comments.js
+++ b/crates/rome_formatter/tests/specs/js/comments.js
@@ -1,0 +1,29 @@
+import {
+    func, // trailing comma removal
+} from 'module';
+
+
+expression(/* block comment */);
+
+expression(
+    /* block comment */
+);
+
+
+expression( // line comment
+);
+
+expression(
+    // line comment
+);
+
+
+/* block comment */
+statement();
+
+statement(); /* block comment */
+
+// line comment
+statement();
+
+statement(); // inline

--- a/crates/rome_formatter/tests/specs/js/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/comments.js.snap
@@ -24,6 +24,24 @@ expression(
 );
 
 
+expression( "something" // line comment 
+);
+
+
+expression( "something" /** something **/  );
+
+expression(/** something **/ "something" 
+          );
+
+expression(
+    /** something **/
+    "something" 
+);
+
+const array0 = [/*0*/];
+const array1 = [/*0*/,/*1*/];
+const array2 = [/*0*/,/*1*/,/*2*/];
+
 /* block comment */
 statement();
 
@@ -38,17 +56,32 @@ statement(); // inline
 import {
     func, // trailing comma removal
 } from 'module';
-expression( /* block comment */
+expression( /* block comment */ );
+expression(
+	/* block comment */
 );
-expression( /* block comment */
+expression(
+	// line comment
 );
-expression( // line comment
+expression(
+	// line comment
 );
-expression( // line comment
+expression(
+	"something", // line comment
 );
+expression("something" /** something **/ );
+expression( /** something **/ "something");
+expression(
+	/** something **/
+	"something",
+);
+const array0 = [ /*0*/ ];
+const array1 = [ /*0*/ , /*1*/ ];
+const array2 = [ /*0*/ , /*1*/ , /*2*/ ];
 /* block comment */
 statement();
 statement(); /* block comment */
 // line comment
 statement();
 statement(); // inline
+

--- a/crates/rome_formatter/tests/specs/js/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/comments.js.snap
@@ -1,0 +1,54 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+expression: comments.js
+
+---
+# Input
+import {
+    func, // trailing comma removal
+} from 'module';
+
+
+expression(/* block comment */);
+
+expression(
+    /* block comment */
+);
+
+
+expression( // line comment
+);
+
+expression(
+    // line comment
+);
+
+
+/* block comment */
+statement();
+
+statement(); /* block comment */
+
+// line comment
+statement();
+
+statement(); // inline
+---
+# Output
+import {
+    func, // trailing comma removal
+} from 'module';
+expression( /* block comment */
+);
+expression( /* block comment */
+);
+expression( // line comment
+);
+expression( // line comment
+);
+/* block comment */
+statement();
+statement(); /* block comment */
+// line comment
+statement();
+statement(); // inline

--- a/crates/rome_formatter/tests/specs/js/expression/new_expression.js.snap
+++ b/crates/rome_formatter/tests/specs/js/expression/new_expression.js.snap
@@ -12,5 +12,9 @@ new c(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,cccccccccccc
 # Output
 new a();
 new b(x);
-new c(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccccccccccc);
+new c(
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+	cccccccccccccccccccccccccccccc,
+);
 

--- a/crates/rome_formatter/tests/specs/js/function/function.js.snap
+++ b/crates/rome_formatter/tests/specs/js/function/function.js.snap
@@ -54,9 +54,11 @@ function* Foo() {
 }
 function foo() {
 	let [ref, setRef] = useState();
-	useEffect(() => {
-		setRef();
-	});
+	useEffect(
+		() => {
+			setRef();
+		},
+	);
 	return ref;
 }
 

--- a/crates/rome_formatter/tests/specs/js/import/import_call.js.snap
+++ b/crates/rome_formatter/tests/specs/js/import/import_call.js.snap
@@ -12,7 +12,8 @@ import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Output
 import(x);
 import("x");
-import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, {
-	assert: { type: "json" },
-});
+import(
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+	{ assert: { type: "json" } },
+);
 

--- a/crates/rome_formatter/tests/specs/js/number/number.js.snap
+++ b/crates/rome_formatter/tests/specs/js/number/number.js.snap
@@ -10,5 +10,5 @@ expression: number.js
 ---
 # Output
 1.23e4;
-1000e3;
+1000e3; // FIXME handle number with scientific notation #1294
 

--- a/crates/rome_formatter/tests/specs/js/parentheses/parentheses.js.snap
+++ b/crates/rome_formatter/tests/specs/js/parentheses/parentheses.js.snap
@@ -18,11 +18,11 @@ const foo = class extends (Bar ?? Baz) {}
 
 ---
 # Output
-(foo++)();
+(foo++)?.();
 async () => {
-	(await foo)();
+	(await foo)?.();
 };
-(+foo)();
+(+foo)?.();
 +(+foo);
 class Foo extends (+Bar) {}
 class Foo extends (Bar ?? Baz) {}

--- a/crates/rome_formatter/tests/specs/js/statement/if_else.js.snap
+++ b/crates/rome_formatter/tests/specs/js/statement/if_else.js.snap
@@ -74,9 +74,11 @@ if (Math.random() > 0.5) {
 }
 if (Math.random() > 0.5) {
 	console.log(1);
-} else if (Math.random() > 0.5) {
+} // wow
+else if (Math.random() > 0.5) {
 	console.log(2);
-} else {
+} // so cool
+else {
 	console.log(3);
 }
 if (true) {

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -195,6 +195,33 @@ impl<L: Language> SyntaxTriviaPiece<L> {
         TextRange::at(self.offset, self.text_len())
     }
 
+    /// Cast this trivia piece to [SyntaxTriviaPieceNewline].
+    ///
+    /// ```
+    /// use rome_rowan::*;
+    /// use rome_rowan::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
+    /// use std::iter::Iterator;
+    /// let mut node = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT,|builder| {
+    ///     builder.token_with_trivia(
+    ///         RawLanguageKind::LET_TOKEN,
+    ///         "\n/**/let \t\t",
+    ///         &[TriviaPiece::Newline(1), TriviaPiece::Comments(4, false)],
+    ///         &[TriviaPiece::Newline(3)],
+    ///     );
+    /// });
+    /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
+    /// let w = pieces[0].as_newline();
+    /// assert!(w.is_some());
+    /// let w = pieces[1].as_newline();
+    /// assert!(w.is_none());
+    /// ```
+    pub fn as_newline(&self) -> Option<SyntaxTriviaPieceNewline<L>> {
+        match &self.trivia {
+            TriviaPiece::Newline(_) => Some(SyntaxTriviaPieceNewline(self.clone())),
+            _ => None,
+        }
+    }
+
     /// Cast this trivia piece to [SyntaxTriviaPieceWhitespace].
     ///
     /// ```
@@ -204,8 +231,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     /// let mut node = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT,|builder| {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
-    ///         "\n\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+    ///         "\t /**/let \t\t",
+    ///         &[TriviaPiece::Whitespace(2), TriviaPiece::Comments(4, false)],
     ///         &[TriviaPiece::Whitespace(3)],
     ///     );
     /// });


### PR DESCRIPTION
## Summary

This reimplements the formatting of comments from Rome Classic on the new CST model, where comments are attached as either leading or trailing trivias on tokens instead or leading / inner / trailing comments on nodes.

In general this means for a document to be formatted correctly the formatter needs to see every token in the input: this is enforced by the formatter now being stateful and storing a set of all printed comments and tokens and checking all the input tokens were actually processed in debug mode. To help with this I introduced the `format_or_create_token` and `format_replaced_token` to help formatters handle optional tokens or replace an input token with a custom representation while retaining all the attached comments respectively.

I also introduced a `format_delimited_group` specifically to handle constructs of `<opening token> <indent group> <closing tokens>` as the trailing comment of the opening token and the leading comment of the closing token both need to be pushed inside the indent group while the tokens themselves are not. It ended up being quite verbose as many formatters handle this slightly differently so maybe I could introduce shortcut methods for the common cases like `format_delimited_block_indent` or `format_delimited_soft_indent`.

Finally, I changed the semantics of `space_token` and `hard_line_break` for accommodate for individual node formatters not knowing whether and where comments are printed. These were previously implemented as "print a space or newline character unconditionally" but now are interpreted by the printer as "the previous and next element should be separated by a whitespace / newline". Functionally this means multiple consecutive occurrences of these tokens will only print once: newlines are only printed if the "insertion cursor" is not already on an empty line, and spaces are printed if the cursor is not preceded by a whitespace (space or newline). Possible additional tokens to supplement this would be `empty_line()` (force the previous and next element to be separated by an empty line) and `align(column)` (force the printer to insert enough spaces for the next element to be printed on the given column)
