### PR TITLE
feat(rslint_parser): add an error diagnostic to for loops initializer

### DIFF
--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -980,10 +980,32 @@ fn parse_variable_declaration(
 				}
 			}
 			if let Some(initializer) = initializer {
-				// Initializers are disallowed in strict mode for `for..in`
-				// and `for..of`, except for `for(var ... in ...)`
+				// Initializers are disallowed for `for..in` and `for..of`,
+				// except for `for(var ... in ...)` in loose mode
+
+				// test for_in_initializer_loose_mode
+				// // SCRIPT
+				// for (var i = 0 in []) {}
+
+				// test_err for_in_and_of_initializer_loose_mode
+				// // SCRIPT
+				// for (let i = 0 in []) {}
+				// for (const i = 0 in []) {}
+				// for (var i = 0 of []) {}
+				// for (let i = 0 of []) {}
+				// for (const i = 0 of []) {}
+
+				// test_err for_in_and_of_initializer_strict_mode
+				// for (var i = 0 in []) {}
+				// for (let i = 0 in []) {}
+				// for (const i = 0 in []) {}
+				// for (var i = 0 of []) {}
+				// for (let i = 0 of []) {}
+				// for (const i = 0 of []) {}
+
 				let is_strict = StrictMode.is_supported(p);
 				let is_var = !context.is_let && context.is_const.is_none();
+
 				if is_strict || !is_in_for_in || !is_var {
 					let err = p
 						.err_builder(if is_in_for_in {

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.js
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.js
@@ -1,0 +1,6 @@
+// SCRIPT
+for (let i = 0 in []) {}
+for (const i = 0 in []) {}
+for (var i = 0 of []) {}
+for (let i = 0 of []) {}
+for (const i = 0 of []) {}

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.rast
@@ -1,0 +1,341 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsForInStatement {
+            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@14..15 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: LET_KW@15..19 "let" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@19..21 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@23..25 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@25..28 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@28..29 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@29..30 "]" [] [],
+            },
+            r_paren_token: R_PAREN@30..32 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@32..33 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@33..34 "}" [] [],
+            },
+        },
+        JsForInStatement {
+            for_token: FOR_KW@34..39 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@39..40 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: CONST_KW@40..46 "const" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@46..48 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@48..50 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@50..52 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@52..55 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@55..56 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@56..57 "]" [] [],
+            },
+            r_paren_token: R_PAREN@57..59 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@59..60 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@60..61 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@61..66 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@66..67 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: VAR_KW@67..71 "var" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@71..73 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@73..75 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@75..77 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@77..80 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@80..81 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@81..82 "]" [] [],
+            },
+            r_paren_token: R_PAREN@82..84 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@84..85 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@85..86 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@86..91 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@91..92 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: LET_KW@92..96 "let" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@96..98 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@98..100 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@100..102 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@102..105 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@105..106 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@106..107 "]" [] [],
+            },
+            r_paren_token: R_PAREN@107..109 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@109..110 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@110..111 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@111..116 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@116..117 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: CONST_KW@117..123 "const" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@123..125 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@125..127 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@127..129 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@129..132 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@132..133 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@133..134 "]" [] [],
+            },
+            r_paren_token: R_PAREN@134..136 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@136..137 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@137..138 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@138..139 "" [Whitespace("\n")] [],
+}
+
+0: JS_SCRIPT@0..139
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..138
+    0: JS_FOR_IN_STATEMENT@0..34
+      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@14..15 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@15..25
+        0: LET_KW@15..19 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@19..25
+          0: JS_IDENTIFIER_BINDING@19..21
+            0: IDENT@19..21 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@21..25
+            0: EQ@21..23 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@23..25
+              0: JS_NUMBER_LITERAL@23..25 "0" [] [Whitespace(" ")]
+      3: IN_KW@25..28 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@28..30
+        0: L_BRACK@28..29 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@29..29
+        2: R_BRACK@29..30 "]" [] []
+      5: R_PAREN@30..32 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@32..34
+        0: L_CURLY@32..33 "{" [] []
+        1: JS_STATEMENT_LIST@33..33
+        2: R_CURLY@33..34 "}" [] []
+    1: JS_FOR_IN_STATEMENT@34..61
+      0: FOR_KW@34..39 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@39..40 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@40..52
+        0: CONST_KW@40..46 "const" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@46..52
+          0: JS_IDENTIFIER_BINDING@46..48
+            0: IDENT@46..48 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@48..52
+            0: EQ@48..50 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@50..52
+              0: JS_NUMBER_LITERAL@50..52 "0" [] [Whitespace(" ")]
+      3: IN_KW@52..55 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@55..57
+        0: L_BRACK@55..56 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@56..56
+        2: R_BRACK@56..57 "]" [] []
+      5: R_PAREN@57..59 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@59..61
+        0: L_CURLY@59..60 "{" [] []
+        1: JS_STATEMENT_LIST@60..60
+        2: R_CURLY@60..61 "}" [] []
+    2: JS_FOR_OF_STATEMENT@61..86
+      0: FOR_KW@61..66 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@66..67 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@67..77
+        0: VAR_KW@67..71 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@71..77
+          0: JS_IDENTIFIER_BINDING@71..73
+            0: IDENT@71..73 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@73..77
+            0: EQ@73..75 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@75..77
+              0: JS_NUMBER_LITERAL@75..77 "0" [] [Whitespace(" ")]
+      4: OF_KW@77..80 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@80..82
+        0: L_BRACK@80..81 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@81..81
+        2: R_BRACK@81..82 "]" [] []
+      6: R_PAREN@82..84 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@84..86
+        0: L_CURLY@84..85 "{" [] []
+        1: JS_STATEMENT_LIST@85..85
+        2: R_CURLY@85..86 "}" [] []
+    3: JS_FOR_OF_STATEMENT@86..111
+      0: FOR_KW@86..91 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@91..92 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@92..102
+        0: LET_KW@92..96 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@96..102
+          0: JS_IDENTIFIER_BINDING@96..98
+            0: IDENT@96..98 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@98..102
+            0: EQ@98..100 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@100..102
+              0: JS_NUMBER_LITERAL@100..102 "0" [] [Whitespace(" ")]
+      4: OF_KW@102..105 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@105..107
+        0: L_BRACK@105..106 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@106..106
+        2: R_BRACK@106..107 "]" [] []
+      6: R_PAREN@107..109 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@109..111
+        0: L_CURLY@109..110 "{" [] []
+        1: JS_STATEMENT_LIST@110..110
+        2: R_CURLY@110..111 "}" [] []
+    4: JS_FOR_OF_STATEMENT@111..138
+      0: FOR_KW@111..116 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@116..117 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@117..129
+        0: CONST_KW@117..123 "const" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@123..129
+          0: JS_IDENTIFIER_BINDING@123..125
+            0: IDENT@123..125 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@125..129
+            0: EQ@125..127 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@127..129
+              0: JS_NUMBER_LITERAL@127..129 "0" [] [Whitespace(" ")]
+      4: OF_KW@129..132 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@132..134
+        0: L_BRACK@132..133 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@133..133
+        2: R_BRACK@133..134 "]" [] []
+      6: R_PAREN@134..136 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@136..138
+        0: L_CURLY@136..137 "{" [] []
+        1: JS_STATEMENT_LIST@137..137
+        2: R_CURLY@137..138 "}" [] []
+  3: EOF@138..139 "" [Whitespace("\n")] []
+--
+error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_loose_mode.js:2:12
+  │
+2 │ for (let i = 0 in []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_loose_mode.js:3:14
+  │
+3 │ for (const i = 0 in []) {}
+  │              ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_loose_mode.js:4:12
+  │
+4 │ for (var i = 0 of []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_loose_mode.js:5:12
+  │
+5 │ for (let i = 0 of []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_loose_mode.js:6:14
+  │
+6 │ for (const i = 0 of []) {}
+  │              ^^^
+
+--
+// SCRIPT
+for (let i = 0 in []) {}
+for (const i = 0 in []) {}
+for (var i = 0 of []) {}
+for (let i = 0 of []) {}
+for (const i = 0 of []) {}

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.js
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.js
@@ -1,0 +1,6 @@
+for (var i = 0 in []) {}
+for (let i = 0 in []) {}
+for (const i = 0 in []) {}
+for (var i = 0 of []) {}
+for (let i = 0 of []) {}
+for (const i = 0 of []) {}

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.rast
@@ -1,0 +1,404 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsForInStatement {
+            for_token: FOR_KW@0..4 "for" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@4..5 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: VAR_KW@5..9 "var" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@9..11 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@11..13 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@13..15 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@15..18 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@18..19 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@19..20 "]" [] [],
+            },
+            r_paren_token: R_PAREN@20..22 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@22..23 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@23..24 "}" [] [],
+            },
+        },
+        JsForInStatement {
+            for_token: FOR_KW@24..29 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@29..30 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: LET_KW@30..34 "let" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@34..36 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@36..38 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@38..40 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@40..43 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@43..44 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@44..45 "]" [] [],
+            },
+            r_paren_token: R_PAREN@45..47 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@47..48 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@48..49 "}" [] [],
+            },
+        },
+        JsForInStatement {
+            for_token: FOR_KW@49..54 "for" [Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@54..55 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: CONST_KW@55..61 "const" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@61..63 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@63..65 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@65..67 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@67..70 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@70..71 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@71..72 "]" [] [],
+            },
+            r_paren_token: R_PAREN@72..74 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@74..75 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@75..76 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@76..81 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@81..82 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: VAR_KW@82..86 "var" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@86..88 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@88..90 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@90..92 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@92..95 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@95..96 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@96..97 "]" [] [],
+            },
+            r_paren_token: R_PAREN@97..99 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@99..100 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@100..101 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@101..106 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@106..107 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: LET_KW@107..111 "let" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@111..113 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@113..115 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@115..117 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@117..120 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@120..121 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@121..122 "]" [] [],
+            },
+            r_paren_token: R_PAREN@122..124 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@124..125 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@125..126 "}" [] [],
+            },
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@126..131 "for" [Whitespace("\n")] [Whitespace(" ")],
+            await_token: missing (optional),
+            l_paren_token: L_PAREN@131..132 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: CONST_KW@132..138 "const" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@138..140 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@140..142 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@142..144 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            of_token: OF_KW@144..147 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@147..148 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@148..149 "]" [] [],
+            },
+            r_paren_token: R_PAREN@149..151 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@151..152 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@152..153 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@153..154 "" [Whitespace("\n")] [],
+}
+
+0: JS_MODULE@0..154
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..153
+    0: JS_FOR_IN_STATEMENT@0..24
+      0: FOR_KW@0..4 "for" [] [Whitespace(" ")]
+      1: L_PAREN@4..5 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@5..15
+        0: VAR_KW@5..9 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@9..15
+          0: JS_IDENTIFIER_BINDING@9..11
+            0: IDENT@9..11 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@11..15
+            0: EQ@11..13 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@13..15
+              0: JS_NUMBER_LITERAL@13..15 "0" [] [Whitespace(" ")]
+      3: IN_KW@15..18 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@18..20
+        0: L_BRACK@18..19 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@19..19
+        2: R_BRACK@19..20 "]" [] []
+      5: R_PAREN@20..22 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@22..24
+        0: L_CURLY@22..23 "{" [] []
+        1: JS_STATEMENT_LIST@23..23
+        2: R_CURLY@23..24 "}" [] []
+    1: JS_FOR_IN_STATEMENT@24..49
+      0: FOR_KW@24..29 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@29..30 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@30..40
+        0: LET_KW@30..34 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@34..40
+          0: JS_IDENTIFIER_BINDING@34..36
+            0: IDENT@34..36 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@36..40
+            0: EQ@36..38 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@38..40
+              0: JS_NUMBER_LITERAL@38..40 "0" [] [Whitespace(" ")]
+      3: IN_KW@40..43 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@43..45
+        0: L_BRACK@43..44 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@44..44
+        2: R_BRACK@44..45 "]" [] []
+      5: R_PAREN@45..47 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@47..49
+        0: L_CURLY@47..48 "{" [] []
+        1: JS_STATEMENT_LIST@48..48
+        2: R_CURLY@48..49 "}" [] []
+    2: JS_FOR_IN_STATEMENT@49..76
+      0: FOR_KW@49..54 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@54..55 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@55..67
+        0: CONST_KW@55..61 "const" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@61..67
+          0: JS_IDENTIFIER_BINDING@61..63
+            0: IDENT@61..63 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@63..67
+            0: EQ@63..65 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@65..67
+              0: JS_NUMBER_LITERAL@65..67 "0" [] [Whitespace(" ")]
+      3: IN_KW@67..70 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@70..72
+        0: L_BRACK@70..71 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@71..71
+        2: R_BRACK@71..72 "]" [] []
+      5: R_PAREN@72..74 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@74..76
+        0: L_CURLY@74..75 "{" [] []
+        1: JS_STATEMENT_LIST@75..75
+        2: R_CURLY@75..76 "}" [] []
+    3: JS_FOR_OF_STATEMENT@76..101
+      0: FOR_KW@76..81 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@81..82 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@82..92
+        0: VAR_KW@82..86 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@86..92
+          0: JS_IDENTIFIER_BINDING@86..88
+            0: IDENT@86..88 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@88..92
+            0: EQ@88..90 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@90..92
+              0: JS_NUMBER_LITERAL@90..92 "0" [] [Whitespace(" ")]
+      4: OF_KW@92..95 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@95..97
+        0: L_BRACK@95..96 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@96..96
+        2: R_BRACK@96..97 "]" [] []
+      6: R_PAREN@97..99 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@99..101
+        0: L_CURLY@99..100 "{" [] []
+        1: JS_STATEMENT_LIST@100..100
+        2: R_CURLY@100..101 "}" [] []
+    4: JS_FOR_OF_STATEMENT@101..126
+      0: FOR_KW@101..106 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@106..107 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@107..117
+        0: LET_KW@107..111 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@111..117
+          0: JS_IDENTIFIER_BINDING@111..113
+            0: IDENT@111..113 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@113..117
+            0: EQ@113..115 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@115..117
+              0: JS_NUMBER_LITERAL@115..117 "0" [] [Whitespace(" ")]
+      4: OF_KW@117..120 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@120..122
+        0: L_BRACK@120..121 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@121..121
+        2: R_BRACK@121..122 "]" [] []
+      6: R_PAREN@122..124 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@124..126
+        0: L_CURLY@124..125 "{" [] []
+        1: JS_STATEMENT_LIST@125..125
+        2: R_CURLY@125..126 "}" [] []
+    5: JS_FOR_OF_STATEMENT@126..153
+      0: FOR_KW@126..131 "for" [Whitespace("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: L_PAREN@131..132 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@132..144
+        0: CONST_KW@132..138 "const" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@138..144
+          0: JS_IDENTIFIER_BINDING@138..140
+            0: IDENT@138..140 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@140..144
+            0: EQ@140..142 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@142..144
+              0: JS_NUMBER_LITERAL@142..144 "0" [] [Whitespace(" ")]
+      4: OF_KW@144..147 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@147..149
+        0: L_BRACK@147..148 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@148..148
+        2: R_BRACK@148..149 "]" [] []
+      6: R_PAREN@149..151 ")" [] [Whitespace(" ")]
+      7: JS_BLOCK_STATEMENT@151..153
+        0: L_CURLY@151..152 "{" [] []
+        1: JS_STATEMENT_LIST@152..152
+        2: R_CURLY@152..153 "}" [] []
+  3: EOF@153..154 "" [Whitespace("\n")] []
+--
+error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:1:12
+  │
+1 │ for (var i = 0 in []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:2:12
+  │
+2 │ for (let i = 0 in []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:3:14
+  │
+3 │ for (const i = 0 in []) {}
+  │              ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:4:12
+  │
+4 │ for (var i = 0 of []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:5:12
+  │
+5 │ for (let i = 0 of []) {}
+  │            ^^^
+
+--
+error[SyntaxError]: `for..of` statement declarators cannot have an initializer expression
+  ┌─ for_in_and_of_initializer_strict_mode.js:6:14
+  │
+6 │ for (const i = 0 of []) {}
+  │              ^^^
+
+--
+for (var i = 0 in []) {}
+for (let i = 0 in []) {}
+for (const i = 0 in []) {}
+for (var i = 0 of []) {}
+for (let i = 0 of []) {}
+for (const i = 0 of []) {}

--- a/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.js
+++ b/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.js
@@ -1,0 +1,2 @@
+// SCRIPT
+for (var i = 0 in []) {}

--- a/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.rast
@@ -1,0 +1,69 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsForInStatement {
+            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@14..15 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: VAR_KW@15..19 "var" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@19..21 "i" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: JsInitializerClause {
+                        eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@23..25 "0" [] [Whitespace(" ")],
+                        },
+                    },
+                },
+            },
+            in_token: IN_KW@25..28 "in" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@28..29 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@29..30 "]" [] [],
+            },
+            r_paren_token: R_PAREN@30..32 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@32..33 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@33..34 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@34..35 "" [Whitespace("\n")] [],
+}
+
+0: JS_SCRIPT@0..35
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..34
+    0: JS_FOR_IN_STATEMENT@0..34
+      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      1: L_PAREN@14..15 "(" [] []
+      2: JS_FOR_VARIABLE_DECLARATION@15..25
+        0: VAR_KW@15..19 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@19..25
+          0: JS_IDENTIFIER_BINDING@19..21
+            0: IDENT@19..21 "i" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: JS_INITIALIZER_CLAUSE@21..25
+            0: EQ@21..23 "=" [] [Whitespace(" ")]
+            1: JS_NUMBER_LITERAL_EXPRESSION@23..25
+              0: JS_NUMBER_LITERAL@23..25 "0" [] [Whitespace(" ")]
+      3: IN_KW@25..28 "in" [] [Whitespace(" ")]
+      4: JS_ARRAY_EXPRESSION@28..30
+        0: L_BRACK@28..29 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@29..29
+        2: R_BRACK@29..30 "]" [] []
+      5: R_PAREN@30..32 ")" [] [Whitespace(" ")]
+      6: JS_BLOCK_STATEMENT@32..34
+        0: L_CURLY@32..33 "{" [] []
+        1: JS_STATEMENT_LIST@33..33
+        2: R_CURLY@33..34 "}" [] []
+  3: EOF@34..35 "" [Whitespace("\n")] []


### PR DESCRIPTION
## Summary

~`for..in` and `for..of` loops declarators are not allowed to have an initializer in strict mode except in `for(var ... in ...)` statements~

Edit: While writing the test cases I realized my wording was wrong (although the code is correct): initializers are never allowed in strict mode, and loose mode only allows `for(var ... in ...)` but none of the others