### PR TITLE
removing token_offset_pair and tokens_after_linebreaks

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -30,16 +30,16 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum TriviaPiece {
-	Whitespace(usize),
-	Comments(usize),
+	Whitespace(u32),
+	Comments(u32),
 }
 
 impl TriviaPiece {
 	#[inline]
 	pub fn text_len(&self) -> TextSize {
 		match self {
-			TriviaPiece::Whitespace(n) => (*n as u32).into(),
-			TriviaPiece::Comments(n) => (*n as u32).into(),
+			TriviaPiece::Whitespace(n) => (*n).into(),
+			TriviaPiece::Comments(n) => (*n).into(),
 		}
 	}
 }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -18,8 +18,8 @@ use crate::{
 #[allow(clippy::box_collection)]
 pub enum GreenTokenTrivia {
 	None,
-	Whitespace(usize),
-	Comments(usize),
+	Whitespace(u32),
+	Comments(u32),
 	Many(Box<Vec<TriviaPiece>>),
 }
 
@@ -291,13 +291,13 @@ mod tests {
 	}
 
 	#[quickcheck]
-	fn whitespace_and_comments_text_len(len: usize) {
+	fn whitespace_and_comments_text_len(len: u32) {
 		assert_eq!(
-			TextSize::from(len as u32),
+			TextSize::from(len),
 			GreenTokenTrivia::Whitespace(len).text_len()
 		);
 		assert_eq!(
-			TextSize::from(len as u32),
+			TextSize::from(len),
 			GreenTokenTrivia::Comments(len).text_len()
 		);
 	}
@@ -305,7 +305,7 @@ mod tests {
 	#[test]
 	fn many_text_len_dont_panic() {
 		let trivia = GreenTokenTrivia::Many(Box::new(vec![
-			TriviaPiece::Whitespace(usize::MAX),
+			TriviaPiece::Whitespace(u32::MAX),
 			TriviaPiece::Comments(1),
 		]));
 		assert_eq!(TextSize::from(u32::MAX), trivia.text_len());
@@ -315,7 +315,7 @@ mod tests {
 	fn many_text_len(lengths: Vec<u32>) {
 		let trivia: Vec<_> = lengths
 			.iter()
-			.map(|x| TriviaPiece::Whitespace(*x as usize))
+			.map(|x| TriviaPiece::Whitespace(*x))
 			.collect();
 		let trivia = GreenTokenTrivia::Many(Box::new(trivia));
 

--- a/crates/rslint_lexer/src/highlight.rs
+++ b/crates/rslint_lexer/src/highlight.rs
@@ -64,7 +64,8 @@ impl<'s> Highlighter<'s> {
 	}
 
 	fn src(&self) -> &'s str {
-		&self.source[self.cur_idx..self.cur_idx + self.tokens.get(self.cur).unwrap().len]
+		let end = self.cur_idx + self.tokens.get(self.cur).unwrap().len as usize;
+		&self.source[self.cur_idx..end]
 	}
 }
 
@@ -133,7 +134,7 @@ impl<'s> Iterator for Highlighter<'s> {
 		};
 
 		let string = self.src();
-		self.cur_idx += self.tokens.get(self.cur).unwrap().len;
+		self.cur_idx += self.tokens.get(self.cur).unwrap().len as usize;
 		self.cur += 1;
 		Some(color.paint(string))
 	}

--- a/crates/rslint_lexer/src/state.rs
+++ b/crates/rslint_lexer/src/state.rs
@@ -7,6 +7,7 @@ pub(crate) struct LexerState {
 	pub(crate) prev: Option<JsSyntaxKind>,
 	pub(crate) had_linebreak: bool,
 	pub(crate) ctx: Vec<Context>,
+	pub(crate) after_newline: bool,
 }
 
 impl LexerState {
@@ -16,6 +17,7 @@ impl LexerState {
 			prev: None,
 			had_linebreak: false,
 			ctx: vec![Context::BraceStmt],
+			after_newline: false
 		}
 	}
 

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -38,7 +38,9 @@ macro_rules! assert_lex {
                 tokens[idx].0.kind,
             );
 
-            new_str.push_str($src.get(tok_idx..(tok_idx + tokens[idx].0.len)).unwrap());
+            let tok_start = tok_idx as usize;
+			let tok_end = tok_idx as usize + tokens[idx].0.len as usize;
+            new_str.push_str($src.get(tok_start..tok_end).unwrap());
             tok_idx += tokens[idx].0.len;
 
             idx += 1;
@@ -75,7 +77,9 @@ fn losslessness(string: String) -> bool {
 	let mut idx = 0;
 
 	for token in tokens {
-		new_str.push_str(string.get(idx..(idx + token.len)).unwrap());
+		let start = idx as usize;
+		let end = idx as usize + token.len as usize;
+		new_str.push_str(string.get(start..end).unwrap());
 		idx += token.len;
 	}
 

--- a/crates/rslint_lexer/src/token.rs
+++ b/crates/rslint_lexer/src/token.rs
@@ -7,20 +7,53 @@ use crate::JsSyntaxKind;
 pub struct Token {
 	/// The kind of token this is.
 	pub kind: JsSyntaxKind,
+	/// Indicates if there is a newline between this token and the previous non-trivia token.
+	pub after_newline: bool,
+	/// Offset from the start of the file, in bytes.
+	pub offset: u32,
 	/// How long the token is in bytes. For tokens with escape sequences
 	/// like strings with `\uXXXX` escapes, the length is the raw length, not considering the char backed by the escape.
-	pub len: usize,
+	pub len: u32,
 }
 
 impl Token {
 	/// Create a new token which has an exact length of 1.
-	pub fn single(kind: JsSyntaxKind) -> Self {
-		Self { kind, len: 1 }
+	pub fn single(kind: JsSyntaxKind, offset: usize) -> Self {
+		Self {
+			kind,
+			len: 1,
+			offset: offset as u32,
+			after_newline: false,
+		}
 	}
 
 	/// Create a new token which has a specific length.
 	pub fn new(kind: JsSyntaxKind, len: usize) -> Self {
-		Self { kind, len }
+		Self {
+			kind,
+			len: len as u32,
+			offset: 0,
+			after_newline: false,
+		}
+	}
+
+	/// Range from the start of the file, in bytes.
+	#[inline(always)]
+	pub fn range(&self) -> std::ops::Range<usize> {
+		let end = self.offset as usize + self.len as usize;
+		(self.offset as usize)..end
+	}
+
+	/// Same as [Token::range()].start.
+	#[inline(always)]
+	pub fn start(&self) -> usize {
+		self.offset as usize
+	}
+
+	/// Same as [Token::range()].end.
+	#[inline(always)]
+	pub fn end(&self) -> usize {
+		self.offset as usize + self.len as usize
 	}
 }
 

--- a/crates/rslint_parser/src/lib.rs
+++ b/crates/rslint_parser/src/lib.rs
@@ -104,23 +104,6 @@ pub use crate::ParsedSyntax::{Absent, Present};
 use rslint_errors::Diagnostic;
 use std::ops::Range;
 
-/// Abstracted token for `TokenSource`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Token {
-	/// What kind of token it is
-	pub kind: JsSyntaxKind,
-	/// The range (in byte indices) of the token
-	pub range: Range<usize>,
-	/// How long the token is
-	pub len: TextSize,
-}
-
-impl From<Token> for Range<usize> {
-	fn from(token: Token) -> Self {
-		token.range
-	}
-}
-
 /// An abstraction for syntax tree implementations
 pub trait TreeSink {
 	/// Adds new token to the current branch.

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -92,7 +92,7 @@ impl<'a> LosslessTreeSink<'a> {
 				self.tokens[self.token_pos..self.token_pos + token_count as usize]
 					.iter()
 					.map(|x| x.len)
-					.sum::<usize>()
+					.sum()
 			}) as u32,
 		);
 

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -40,7 +40,7 @@ impl<'a> TreeSink for LossyTreeSink<'a> {
 			self.tokens[self.token_pos..self.token_pos + amount as usize]
 				.iter()
 				.map(|x| x.len)
-				.sum::<usize>() as u32,
+				.sum::<u32>()
 		);
 
 		self.do_tokens(kind, len, amount)
@@ -104,7 +104,7 @@ impl<'a> LossyTreeSink<'a> {
 	///
 	/// # Panics
 	/// Panics if the token start does not line up to a token's start index or is out of bounds
-	pub fn with_offset(text: &'a str, tokens: &'a [Token], token_start: usize) -> Self {
+	pub fn with_offset(text: &'a str, tokens: &'a [Token], token_start: u32) -> Self {
 		let mut len = 0;
 		for (idx, tok) in tokens.iter().enumerate() {
 			if len == token_start {
@@ -212,7 +212,7 @@ impl<'a> LossyTreeSink<'a> {
 			length += len;
 
 			let current_trivia = match token.kind {
-				JsSyntaxKind::WHITESPACE => continue,
+				JsSyntaxKind::WHITESPACE | JsSyntaxKind::NEWLINE => continue,
 				JsSyntaxKind::COMMENT => TriviaPiece::Comments(token.len),
 				_ => unreachable!("Not Trivia"),
 			};

--- a/crates/rslint_parser/src/parser/parsed_syntax.rs
+++ b/crates/rslint_parser/src/parser/parsed_syntax.rs
@@ -127,7 +127,7 @@ impl ParsedSyntax {
 		match self {
 			Present(syntax) => Some(syntax),
 			Absent => {
-				let diagnostic = error_builder(p, p.cur_tok().range);
+				let diagnostic = error_builder(p, p.cur_tok().range());
 				p.error(diagnostic);
 				None
 			}
@@ -144,7 +144,7 @@ impl ParsedSyntax {
 		match self {
 			Present(completed) => completed.precede(p),
 			Absent => {
-				let diagnostic = error_builder(p, p.cur_tok().range);
+				let diagnostic = error_builder(p, p.cur_tok().range());
 				p.error(diagnostic);
 				p.start()
 			}
@@ -187,7 +187,7 @@ impl ParsedSyntax {
 				}
 
 				Err(recovery_error) => {
-					let diagnostic = error_builder(p, p.cur_tok().range);
+					let diagnostic = error_builder(p, p.cur_tok().range());
 					p.error(diagnostic);
 					Err(recovery_error)
 				}

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -74,12 +74,12 @@ fn parse_class(p: &mut Parser, kind: ClassKind) -> ParsedSyntax {
 	}
 	let mut class_is_valid = true;
 	let m = p.start();
-	let class_token_range = p.cur_tok().range;
+	let class_token_range = p.cur_tok().range();
 	p.expect(T![class]);
 
 	// class bodies are implicitly strict
 	let mut guard = p.with_state(ParserState {
-		strict: Some(StrictMode::Class(p.cur_tok().range)),
+		strict: Some(StrictMode::Class(p.cur_tok().range())),
 		..p.state.clone()
 	});
 
@@ -112,7 +112,7 @@ fn parse_class(p: &mut Parser, kind: ClassKind) -> ParsedSyntax {
 			if kind == ClassKind::Statement && !guard.state.in_default {
 				let err = guard
 					.err_builder("class declarations must have a name")
-					.primary(class_token_range.start..guard.cur_tok().range.start, "");
+					.primary(class_token_range.start..guard.cur_tok().start(), "");
 
 				guard.error(err);
 			}
@@ -155,7 +155,7 @@ fn implements_clause(p: &mut Parser) -> ParsedSyntax {
 	let mut is_valid = true;
 	let implements_clause = p.start();
 
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	p.bump_remap(T![implements]);
 
 	let list = p.start();
@@ -174,7 +174,7 @@ fn implements_clause(p: &mut Parser) -> ParsedSyntax {
 	let mut progress = ParserProgress::default();
 	while p.cur_src() == "implements" {
 		progress.assert_progressing(p);
-		let start = p.cur_tok().range.start;
+		let start = p.cur_tok().start();
 		p.bump_any();
 		let elems = ts_heritage_clause(&mut *p, false);
 
@@ -319,7 +319,7 @@ fn parse_class_member_impl(
 	member_marker: Marker,
 	modifiers: ClassMemberModifiers,
 ) -> ParsedSyntax {
-	let generator_range = p.cur_tok().range;
+	let generator_range = p.cur_tok().range();
 	let checkpoint = p.checkpoint();
 
 	// Seems like we're at a generator method
@@ -358,7 +358,7 @@ fn parse_class_member_impl(
 		&& !is_at_method_class_member(p, 1)
 		&& !p.has_linebreak_before_n(1)
 	{
-		let async_range = p.cur_tok().range;
+		let async_range = p.cur_tok().range();
 		p.bump_remap(T![async]);
 		let in_generator = p.eat(T![*]);
 
@@ -657,10 +657,10 @@ fn parse_property_class_member_body(p: &mut Parser, member_marker: Marker) -> Pa
 	let optional_token = optional_member_token(p);
 	let mut property_is_valid = optional_token.is_ok();
 
-	let range = p.cur_tok().range;
+	let range = p.cur_tok().range();
 	if p.eat(T![!]) {
 		if let Ok(Some(optional_token)) = optional_token {
-			let range = p.cur_tok().range;
+			let range = p.cur_tok().range();
 
 			let error = p
 				.err_builder("class properties cannot be both optional and definite")
@@ -694,7 +694,7 @@ fn parse_property_class_member_body(p: &mut Parser, member_marker: Marker) -> Pa
 
 		let err = p
 			.err_builder("expected a semicolon for a class property, but found none")
-			.primary(start..p.cur_tok().range.start, "");
+			.primary(start..p.cur_tok().start(), "");
 
 		p.error(err);
 	}
@@ -710,7 +710,7 @@ fn parse_property_class_member_body(p: &mut Parser, member_marker: Marker) -> Pa
 /// Eats the ? token for optional member. Emits an error if this isn't typescript
 fn optional_member_token(p: &mut Parser) -> Result<Option<Range<usize>>, ()> {
 	if p.eat(T![?]) {
-		let range = p.cur_tok().range;
+		let range = p.cur_tok().range();
 		p.bump_any();
 
 		// test_err optional_member
@@ -909,7 +909,7 @@ fn parse_access_modifier(p: &mut Parser) -> Option<Range<usize>> {
 		_ => return None,
 	};
 
-	let range = p.cur_tok().range;
+	let range = p.cur_tok().range();
 	p.bump_remap(kind);
 	Some(range)
 }
@@ -1047,7 +1047,7 @@ fn parse_modifier(p: &mut Parser) -> Option<Modifier> {
 		return None;
 	}
 
-	let range = p.cur_tok().range;
+	let range = p.cur_tok().range();
 
 	let (modifier_kind, kw_kind) = match p.cur_src() {
 		"declare" => (ModifierKind::Declare, DECLARE_KW),

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -75,7 +75,7 @@ pub(super) fn parse_parameters_list(
 			if p.at(T![?]) {
 				let err = p
 					.err_builder("rest patterns cannot be optional")
-					.primary(p.cur_tok().range, "");
+					.primary(p.cur_tok().range(), "");
 
 				p.error(err);
 				let m = p.start();
@@ -92,14 +92,14 @@ pub(super) fn parse_parameters_list(
 			}
 
 			if p.at(T![=]) {
-				let start = p.cur_tok().range.start;
+				let start = p.cur_tok().start();
 				let m = p.start();
 				p.bump_any();
 
 				let end = parse_expr_or_assignment(&mut *p)
 					.ok()
 					.map(|marker| usize::from(marker.range(p).end()))
-					.unwrap_or_else(|| p.cur_tok().range.start);
+					.unwrap_or_else(|| p.cur_tok().start());
 
 				let err = p
 					.err_builder("rest elements may not have default initializers")
@@ -115,7 +115,7 @@ pub(super) fn parse_parameters_list(
 			// which would allow for better recovery from `foo, ...bar, foo`
 			if p.at(T![,]) {
 				let m = p.start();
-				let range = p.cur_tok().range;
+				let range = p.cur_tok().range();
 				p.bump_any();
 				m.complete(p, JS_UNKNOWN);
 				let err = p

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -370,8 +370,8 @@ fn parse_binary_or_logical_expression_recursive(
 	// This is a hack to allow us to effectively recover from `foo + / bar`
 	let right = if get_precedence(p.cur()).is_some() && !p.at_ts(token_set![T![-], T![+], T![<]]) {
 		let err = p.err_builder(&format!("Expected an expression for the right hand side of a `{}`, but found an operator instead", p.token_src(&op_tok)))
-            .secondary(op_tok.range, "This operator requires a right hand side value")
-            .primary(p.cur_tok().range, "But this operator was encountered instead");
+            .secondary(op_tok.range(), "This operator requires a right hand side value")
+            .primary(p.cur_tok().range(), "But this operator was encountered instead");
 
 		p.error(err);
 
@@ -745,7 +745,7 @@ fn parse_arguments(p: &mut Parser) -> ParsedSyntax {
 fn parse_paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> ParsedSyntax {
 	let m = p.start();
 	let checkpoint = p.checkpoint();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 
 	p.expect(T!['(']);
 	let mut spread_range = None;
@@ -785,7 +785,7 @@ fn parse_paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> ParsedSyntax
 						temp.expect(T![')']);
 					} else {
 						let err = temp.err_builder(&format!("expect a closing parenthesis after a spread element, but instead found `{}`", temp.cur_src()))
-                    .primary(temp.cur_tok().range, "");
+                    .primary(temp.cur_tok().range(), "");
 
 						#[allow(deprecated)]
 						SingleTokenParseRecovery::with_error(EXPR_RECOVERY_SET, JS_UNKNOWN, err)
@@ -847,7 +847,7 @@ fn parse_paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> ParsedSyntax
 		if !can_be_arrow && !p.at(T![:]) {
 			let err = p
 				.err_builder("Unexpected token `=>`")
-				.primary(p.cur_tok().range, "an arrow expression is not allowed here");
+				.primary(p.cur_tok().range(), "an arrow expression is not allowed here");
 
 			p.error(err);
 		} else {
@@ -885,7 +885,7 @@ fn parse_paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> ParsedSyntax
 	if is_empty {
 		let err = p
 			.err_builder("grouping expressions cannot be empty")
-			.primary(start..p.cur_tok().range.start, "");
+			.primary(start..p.cur_tok().start(), "");
 
 		p.error(err);
 		return Present(m.complete(p, JS_PARENTHESIZED_EXPRESSION));
@@ -1080,14 +1080,14 @@ fn parse_primary_expression(p: &mut Parser) -> ParsedSyntax {
 							"Expected `meta` following an import keyword, but found `{}`",
 							p.token_src(&p.cur_tok())
 						))
-						.primary(p.cur_tok().range, "");
+						.primary(p.cur_tok().range(), "");
 
 					p.err_and_bump(err, JS_UNKNOWN);
 					m.complete(p, IMPORT_META)
 				} else {
 					let err = p
 						.err_builder("Expected `meta` following an import keyword, but found none")
-						.primary(p.cur_tok().range, "");
+						.primary(p.cur_tok().range(), "");
 
 					p.error(err);
 					m.complete(p, JS_UNKNOWN)
@@ -1168,15 +1168,15 @@ pub(super) fn parse_identifier(p: &mut Parser, kind: JsSyntaxKind) -> ParsedSynt
 			let error = match name {
 				"await" if p.state.in_async => Some(
 					p.err_builder("Illegal use of `await` as an identifier in an async context")
-						.primary(p.cur_tok().range, ""),
+						.primary(p.cur_tok().range(), ""),
 				),
 				"await" if p.syntax.file_kind == FileKind::Module => Some(
 					p.err_builder("Illegal use of `await` as an identifier inside of a module")
-						.primary(p.cur_tok().range, ""),
+						.primary(p.cur_tok().range(), ""),
 				),
 				"yield" if p.state.in_generator => Some(
 					p.err_builder("Illegal use of `yield` as an identifier in generator function")
-						.primary(p.cur_tok().range, ""),
+						.primary(p.cur_tok().range(), ""),
 				),
 
 				"yield" | "let" | "public" | "protected" | "private" | "package" | "implements"
@@ -1188,12 +1188,12 @@ pub(super) fn parse_identifier(p: &mut Parser, kind: JsSyntaxKind) -> ParsedSynt
 							"Illegal use of reserved keyword `{}` as an identifier in strict mode",
 							name
 						))
-						.primary(p.cur_tok().range, ""),
+						.primary(p.cur_tok().range(), ""),
 					)
 				}
 				_ if p.cur() == T![enum] => Some(
 					p.err_builder("Illegal use of reserved keyword `enum` as an identifier")
-						.primary(p.cur_tok().range, ""),
+						.primary(p.cur_tok().range(), ""),
 				),
 				_ => None,
 			};

--- a/crates/rslint_parser/src/syntax/js_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/js_parse_error.rs
@@ -147,7 +147,7 @@ pub(crate) fn expected_local_name_for_default_import(
 	range: Range<usize>,
 ) -> Diagnostic {
 	p.err_builder("`default` imports must be aliased")
-		.primary(p.cur_tok().range, "`default` used here")
+		.primary(p.cur_tok().range(), "`default` used here")
 		.secondary(
 			range.end..range.end,
 			"add the `as` keyword followed by an identifier name here",

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -78,7 +78,7 @@ pub(crate) fn parse_import(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	let import = p.start();
 	p.bump_any();
 
@@ -96,7 +96,7 @@ pub(crate) fn parse_import(p: &mut Parser) -> ParsedSyntax {
 	p.state.duplicate_binding_parent = None;
 	p.state.name_map.clear();
 
-	let end = p.cur_tok().range.start;
+	let end = p.cur_tok().start();
 
 	semi(p, start..end);
 
@@ -272,7 +272,7 @@ fn parse_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
 	let m = p.start();
 
 	if p.cur_src() == "as" && p.nth_src(1) != "as" {
-		p.error(expected_export_name_after_as_keyword(p, p.cur_tok().range));
+		p.error(expected_export_name_after_as_keyword(p, p.cur_tok().range()));
 	} else if p.nth_src(1) == "as" {
 		parse_export_name(p).or_add_diagnostic(p, expected_export_name);
 	} else {
@@ -288,7 +288,7 @@ fn parse_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
 
 fn parse_shorthand_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
 	if p.at(T![default]) {
-		p.error(expected_local_name_for_default_import(p, p.cur_tok().range));
+		p.error(expected_local_name_for_default_import(p, p.cur_tok().range()));
 
 		let shorthand = p.start();
 		let binding = p.start();
@@ -383,7 +383,7 @@ fn parse_import_assertion_entry(
 	seen_assertion_keys: &mut HashMap<String, Range<usize>>,
 ) -> ParsedSyntax {
 	let m = p.start();
-	let key_range = p.cur_tok().range;
+	let key_range = p.cur_tok().range();
 
 	let key = match p.cur() {
 		JS_STRING_LITERAL => Some(p.cur_src().trim_matches(&['\'', '"'][..])),
@@ -402,7 +402,7 @@ fn parse_import_assertion_entry(
 		}
 		T![:] => {
 			p.error(
-				expected_any(&["identifier", "string literal"], p.cur_tok().range).to_diagnostic(p),
+				expected_any(&["identifier", "string literal"], p.cur_tok().range()).to_diagnostic(p),
 			);
 		}
 		_ => {

--- a/crates/rslint_parser/src/syntax/pattern.rs
+++ b/crates/rslint_parser/src/syntax/pattern.rs
@@ -120,7 +120,7 @@ pub(crate) trait ParseArrayPattern<P: ParseWithDefaultPattern> {
 		}
 
 		let m = p.start();
-		let rest_end = p.cur_tok().range.end;
+		let rest_end = p.cur_tok().end();
 		p.bump(T![...]);
 
 		let with_default = self.pattern_with_default();
@@ -161,7 +161,7 @@ pub(crate) trait ParseObjectPattern {
 
 			if p.at(T![,]) {
 				// missing element
-				p.error(Self::expected_property_pattern_error(p, p.cur_tok().range));
+				p.error(Self::expected_property_pattern_error(p, p.cur_tok().range()));
 				p.bump_any(); // bump ,
 				continue;
 			}
@@ -227,7 +227,7 @@ fn validate_rest_pattern(
 	if p.at(T![=]) {
 		let rest_range = rest.range(p);
 		let rest_marker = rest.undo_completion(p);
-		let default_start = p.cur_tok().range.start;
+		let default_start = p.cur_tok().start();
 		let kind = rest.kind();
 		p.bump(T![=]);
 
@@ -237,7 +237,7 @@ fn validate_rest_pattern(
 		p.error(
 			p.err_builder("rest element cannot have a default")
 				.primary(
-					default_start..p.cur_tok().range.start,
+					default_start..p.cur_tok().start(),
 					"Remove the default value here",
 				)
 				.secondary(rest_range, "Rest element"),
@@ -249,7 +249,7 @@ fn validate_rest_pattern(
 	} else if p.at(T![,]) && p.nth_at(1, end_token) {
 		p.error(
 			p.err_builder("rest element may not have a trailing comma")
-				.primary(p.cur_tok().range, "Remove the trailing comma here")
+				.primary(p.cur_tok().range(), "Remove the trailing comma here")
 				.secondary(rest.range(p), "Rest element"),
 		);
 		rest.change_to_unknown(p);

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -62,7 +62,7 @@ fn named_export_specifier(p: &mut Parser) -> CompletedMarker {
 // test export
 // export { foo } from "bla";
 pub fn export_decl(p: &mut Parser) -> CompletedMarker {
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	let m = p.start();
 	p.expect(T![export]);
 
@@ -93,7 +93,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 	macro_rules! err_if_declare {
 		($p:expr, $declare:expr, $msg:literal) => {
 			if $declare {
-				let range = $p.cur_tok().range;
+				let range = $p.cur_tok().range();
 				$p.bump_remap(T![declare]);
 				let err = $p.err_builder($msg).primary(range, "");
 
@@ -125,7 +125,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 			);
 			p.bump_any();
 			parse_expression(p).or_add_diagnostic(p, js_parse_error::expected_expression);
-			semi(p, start..p.cur_tok().range.start);
+			semi(p, start..p.cur_tok().start());
 			let mut complete = m.complete(p, TS_EXPORT_ASSIGNMENT);
 			complete.err_if_not_ts(
 				p,
@@ -143,7 +143,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 			if p.cur_src() != "namespace" {
 				let err = p
 					.err_builder("expected `namespace`, but found none")
-					.primary(p.cur_tok().range, "");
+					.primary(p.cur_tok().range(), "");
 
 				p.error(err);
 			} else {
@@ -152,7 +152,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 
 			// TODO(RDambrosio016): verify, is identifier_name correct here or should it just be ident?
 			parse_name(p).or_add_diagnostic(p, js_parse_error::expected_identifier);
-			semi(p, start..p.cur_tok().range.start);
+			semi(p, start..p.cur_tok().start());
 			let mut complete = m.complete(p, TS_NAMESPACE_EXPORT_DECL);
 			complete.err_if_not_ts(
 				p,
@@ -171,7 +171,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 			let m = p.start();
 			let err = p
 				.err_builder("declare modifiers can only be used in TypeScript files")
-				.primary(p.cur_tok().range, "");
+				.primary(p.cur_tok().range(), "");
 
 			p.error(err);
 			p.bump_any();
@@ -212,7 +212,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 			if !p.typescript() {
 				let err = p
 					.err_builder("`abstract` modifiers can only be used in TypeScript files")
-					.primary(p.cur_tok().range, "");
+					.primary(p.cur_tok().range(), "");
 
 				p.error(err);
 				let m = p.start();
@@ -258,7 +258,7 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 			export_default = true;
 		} else {
 			parse_expr_or_assignment(p).or_add_diagnostic(p, js_parse_error::expected_expression);
-			semi(p, start..p.cur_tok().range.start);
+			semi(p, start..p.cur_tok().start());
 			return m.complete(p, EXPORT_DEFAULT_EXPR);
 		}
 	}
@@ -328,13 +328,13 @@ pub fn export_decl(p: &mut Parser) -> CompletedMarker {
 		if p.cur_src() == "from" {
 			from_clause_and_semi(p, start);
 		} else {
-			semi(p, start..p.cur_tok().range.start);
+			semi(p, start..p.cur_tok().start());
 			if export_default || exports_ns {
 				let err = p
 					.err_builder(
 						"`export default` and `export as` declarations must have a `from` clause",
 					)
-					.primary(start..p.cur_tok().range.start, "");
+					.primary(start..p.cur_tok().start(), "");
 
 				p.error(err);
 			}
@@ -349,11 +349,11 @@ fn from_clause_and_semi(p: &mut Parser, start: usize) {
 	debug_assert_eq!(p.cur_src(), "from");
 	p.bump_remap(T![from]);
 	p.expect(JS_STRING_LITERAL);
-	semi(p, start..p.cur_tok().range.start);
+	semi(p, start..p.cur_tok().start());
 }
 
 pub fn ts_import_equals_decl(p: &mut Parser, m: Marker) -> CompletedMarker {
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	parse_name(p).or_add_diagnostic(p, js_parse_error::expected_identifier);
 	p.expect(T![=]);
 
@@ -362,7 +362,7 @@ pub fn ts_import_equals_decl(p: &mut Parser, m: Marker) -> CompletedMarker {
 	} else {
 		ts_entity_name(p, None, false);
 	}
-	semi(p, start..p.cur_tok().range.start);
+	semi(p, start..p.cur_tok().start());
 	m.complete(p, TS_IMPORT_EQUALS_DECL)
 }
 
@@ -371,7 +371,7 @@ pub fn ts_external_module_ref(p: &mut Parser) -> CompletedMarker {
 	if p.cur_src() != "require" {
 		let err = p
 			.err_builder("expected `require` for an external module reference, but found none")
-			.primary(p.cur_tok().range, "");
+			.primary(p.cur_tok().range(), "");
 
 		p.error(err);
 	} else {

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -71,7 +71,7 @@ pub fn semi(p: &mut Parser, err_range: Range<usize>) -> bool {
 				"Expected a semicolon or an implicit semicolon after a statement, but found none",
 			)
 			.primary(
-				p.cur_tok().range,
+				p.cur_tok().range(),
 				"An explicit or implicit semicolon is expected here...",
 			)
 			.secondary(err_range, "...Which is required to end this statement");
@@ -267,13 +267,13 @@ fn parse_labeled_statement(p: &mut Parser) -> ParsedSyntax {
 // public = 4;
 // implements = 5;
 fn parse_expression_statement(p: &mut Parser) -> ParsedSyntax {
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 
 	let expr = parse_expression_or_recover_to_next_statement(p, false);
 
 	if let Ok(expr) = expr {
 		let m = expr.precede(p);
-		semi(p, start..p.cur_tok().range.end);
+		semi(p, start..p.cur_tok().end());
 		Present(m.complete(p, JS_EXPRESSION_STATEMENT))
 	} else {
 		Absent
@@ -296,7 +296,7 @@ pub fn parse_debugger_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let range = p.cur_tok().range;
+	let range = p.cur_tok().range();
 	p.bump_any(); // debugger keyword
 	semi(p, range);
 	Present(m.complete(p, JS_DEBUGGER_STATEMENT))
@@ -315,17 +315,17 @@ pub fn parse_throw_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	p.bump_any(); // throw keyword
 	if p.has_linebreak_before_n(0) {
 		let mut err = p
 			.err_builder(
 				"Linebreaks between a throw statement and the error to be thrown are not allowed",
 			)
-			.primary(p.cur_tok().range, "A linebreak is not allowed here");
+			.primary(p.cur_tok().range(), "A linebreak is not allowed here");
 
 		if is_at_expression(p) {
-			err = err.secondary(p.cur_tok().range, "Help: did you mean to throw this?");
+			err = err.secondary(p.cur_tok().range(), "Help: did you mean to throw this?");
 		}
 
 		p.error(err);
@@ -333,7 +333,7 @@ pub fn parse_throw_statement(p: &mut Parser) -> ParsedSyntax {
 		parse_expression_or_recover_to_next_statement(p, false).ok();
 	}
 
-	semi(p, start..p.cur_tok().range.end);
+	semi(p, start..p.cur_tok().end());
 	Present(m.complete(p, JS_THROW_STATEMENT))
 }
 
@@ -357,19 +357,19 @@ pub fn parse_break_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let start = p.cur_tok().range;
+	let start = p.cur_tok().range();
 	p.bump_any(); // break keyword
 	let end = if !p.has_linebreak_before_n(0) && p.at(T![ident]) {
 		let label_token = p.cur_tok();
 		p.bump_any();
 		check_label_use(p, &label_token);
 
-		label_token.range.end
+		label_token.end()
 	} else {
 		start.end
 	};
 
-	semi(p, start.start..p.cur_tok().range.end);
+	semi(p, start.start..p.cur_tok().end());
 
 	if !p.state.break_allowed && p.state.labels.is_empty() {
 		let err = p
@@ -403,7 +403,7 @@ pub fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let start = p.cur_tok().range;
+	let start = p.cur_tok().range();
 	p.bump_any(); // continue keyword
 
 	let end = if !p.has_linebreak_before_n(0) && p.at(T![ident]) {
@@ -411,12 +411,12 @@ pub fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
 		p.bump_any();
 		check_label_use(p, &label_token);
 
-		label_token.range.end
+		label_token.end()
 	} else {
 		start.end
 	};
 
-	semi(p, start.start..p.cur_tok().range.end);
+	semi(p, start.start..p.cur_tok().end());
 
 	if !p.state.break_allowed && p.state.labels.is_empty() {
 		let err = p
@@ -445,13 +445,13 @@ pub fn parse_return_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	p.bump_any(); // return keyword
 	if !p.has_linebreak_before_n(0) {
 		parse_expression(p).ok();
 	}
 
-	semi(p, start..p.cur_tok().range.end);
+	semi(p, start..p.cur_tok().end());
 	let mut complete = m.complete(p, JS_RETURN_STATEMENT);
 
 	if !p.state.in_function && !p.syntax.global_return {
@@ -551,7 +551,7 @@ impl ParseNodeList for DirectivesList {
 			}
 
 			let mut new_state = p.state.clone();
-			new_state.strict(p, directive_token.range);
+			new_state.strict(p, directive_token.range());
 			p.state = new_state;
 		}
 
@@ -766,14 +766,14 @@ pub fn variable_declaration_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err var_decl_err
 	// var a =;
 	// const a = 5 let b = 5;
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 
 	let declaration =
 		parse_variable_declaration_list(p, VariableDeclarationParent::VariableStatement)
 			.or_add_diagnostic(p, js_parse_error::expected_variable);
 	if let Some(declaration) = declaration {
 		let m = declaration.precede(p);
-		semi(p, start..p.cur_tok().range.start);
+		semi(p, start..p.cur_tok().start());
 		Present(m.complete(p, JS_VARIABLE_STATEMENT))
 	} else {
 		Absent
@@ -818,7 +818,7 @@ fn parse_variable_declarations(
 	match p.cur() {
 		T![var] => p.bump_any(),
 		T![const] => {
-			context.is_const = Some(p.cur_tok().range);
+			context.is_const = Some(p.cur_tok().range());
 			p.bump_any()
 		}
 		T![ident] if p.cur_src() == "let" => {
@@ -942,7 +942,7 @@ fn parse_variable_declaration(
 	id.map(|id| {
 		let m = id.precede(p);
 
-		let cur = p.cur_tok().range;
+		let cur = p.cur_tok().range();
 		let opt = p.eat(T![!]);
 		if opt && !p.typescript() {
 			let err = p
@@ -1037,7 +1037,7 @@ pub fn parse_do_statement(p: &mut Parser) -> ParsedSyntax {
 		return Absent;
 	}
 	let m = p.start();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	p.bump_any(); // do keyword
 
 	{
@@ -1051,7 +1051,7 @@ pub fn parse_do_statement(p: &mut Parser) -> ParsedSyntax {
 
 	p.expect(T![while]);
 	parenthesized_expression(p);
-	let end_range = p.cur_tok().range.end;
+	let end_range = p.cur_tok().end();
 	semi(p, start..end_range);
 	Present(m.complete(p, JS_DO_WHILE_STATEMENT))
 }
@@ -1212,7 +1212,7 @@ pub fn parse_for_statement(p: &mut Parser) -> ParsedSyntax {
 
 	let mut await_range = None;
 	if p.at(T![await]) {
-		await_range = Some(p.cur_tok().range);
+		await_range = Some(p.cur_tok().range());
 		p.bump_any();
 	}
 
@@ -1481,7 +1481,7 @@ fn parse_catch_declaration(p: &mut Parser) -> ParsedSyntax {
 			Some(pattern_node) => pattern_node.precede(p),
 			_ => p.start(),
 		};
-		let start = p.cur_tok().range.start;
+		let start = p.cur_tok().start();
 		p.bump_any();
 		let ty = ts_type(p);
 		if !matches!(
@@ -1498,7 +1498,7 @@ fn parse_catch_declaration(p: &mut Parser) -> ParsedSyntax {
 
 		let end = ty
 			.map(|x| usize::from(x.range(p).end()))
-			.unwrap_or(p.cur_tok().range.start);
+			.unwrap_or(p.cur_tok().start());
 		error_marker.complete(
 			p,
 			pattern_kind

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -59,7 +59,7 @@ pub fn ts_modifier(p: &mut Parser, modifiers: &[&'static str]) -> Option<Range<u
 		return None;
 	}
 
-	let range = p.cur_tok().range;
+	let range = p.cur_tok().range();
 
 	if p.has_linebreak_before_n(1)
 		|| token_set![T!['('], T![')'], T![:], T![=], T![?]].contains(p.nth(1))
@@ -81,13 +81,13 @@ pub(crate) fn maybe_ts_type_annotation(p: &mut Parser) -> Option<Range<usize>> {
 	if p.at(T![:]) {
 		let m = p.start();
 
-		let start = p.cur_tok().range.start;
+		let start = p.cur_tok().start();
 		p.bump_any();
 		let compl = ts_type(p);
 
 		let end = compl
 			.map(|x| usize::from(x.range(p).end()))
-			.unwrap_or_else(|| p.cur_tok().range.start);
+			.unwrap_or_else(|| p.cur_tok().start());
 
 		if !p.typescript() {
 			let err = p
@@ -176,7 +176,7 @@ pub(crate) fn ts_declare(p: &mut Parser) -> Option<CompletedMarker> {
 pub(crate) fn ts_decl(p: &mut Parser) -> Option<CompletedMarker> {
 	if p.cur_src() == "abstract" {
 		let m = p.start();
-		let range = p.cur_tok().range;
+		let range = p.cur_tok().range();
 		p.bump_remap(T![abstract]);
 		if !p.at(T![class]) {
 			let err = p.err_builder("abstract modifiers can only be applied to classes, methods, or property definitions")
@@ -230,7 +230,7 @@ pub fn ts_type_alias_decl(p: &mut Parser) -> Option<CompletedMarker> {
 	let t = p.checkpoint();
 
 	let m = p.start();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	p.bump_any();
 	let identifier = parse_name(p).or_add_diagnostic(p, js_parse_error::expected_identifier);
 
@@ -241,7 +241,7 @@ pub fn ts_type_alias_decl(p: &mut Parser) -> Option<CompletedMarker> {
 		no_recover!(p, ts_type_params(p));
 	}
 
-	let end = p.cur_tok().range.end;
+	let end = p.cur_tok().end();
 
 	if p.expect_no_recover(T![=]).is_none() {
 		m.abandon(p);
@@ -290,21 +290,21 @@ pub fn ts_ambient_external_module_decl(
 	check_for_module: bool,
 ) -> Option<CompletedMarker> {
 	let m = p.start();
-	let start = p.cur_tok().range.start;
+	let start = p.cur_tok().start();
 	if check_for_module && p.cur_src() != "module" {
 		let err = p
 			.err_builder(&format!(
 				"expected keyword `module`, but instead found `{}`",
 				p.cur_src()
 			))
-			.primary(p.cur_tok().range, "");
+			.primary(p.cur_tok().range(), "");
 
 		p.error(err);
 	} else if check_for_module {
 		p.bump_remap(T![module]);
 	}
 
-	let end = p.cur_tok().range.end;
+	let end = p.cur_tok().end();
 	if p.cur_src() == "global" {
 		p.bump_any();
 	} else {
@@ -335,7 +335,7 @@ pub fn ts_interface(p: &mut Parser) -> Option<CompletedMarker> {
 				"expected keyword `interface`, but instead found `{}`",
 				p.cur_src()
 			))
-			.primary(p.cur_tok().range, "");
+			.primary(p.cur_tok().range(), "");
 
 		p.error(err);
 	} else {
@@ -348,7 +348,7 @@ pub fn ts_interface(p: &mut Parser) -> Option<CompletedMarker> {
 				"`{}` cannot be used as the name of an interface",
 				p.cur_src()
 			))
-			.primary(p.cur_tok().range, "")
+			.primary(p.cur_tok().range(), "")
 			.footer_note(format!("`{}` is already reserved as a type", p.cur_src()));
 
 		p.error(err);
@@ -609,7 +609,7 @@ pub fn ts_enum(p: &mut Parser) -> CompletedMarker {
 		{
 			let err = p
 				.err_builder("expected an identifier or string for an enum variant, but found none")
-				.primary(p.cur_tok().range, "");
+				.primary(p.cur_tok().range(), "");
 
 			#[allow(deprecated)]
 			SingleTokenParseRecovery::with_error(
@@ -902,7 +902,7 @@ pub fn ts_tuple(p: &mut Parser) -> Option<CompletedMarker> {
 	while !p.at(EOF) && !p.at(T![']']) {
 		progress.assert_progressing(p);
 		let m = p.start();
-		let rest_range = p.cur_tok().range;
+		let rest_range = p.cur_tok().range();
 		let rest = p.eat(T![...]);
 		let name = if crate::at_ident_name!(p)
 			&& !DISALLOWED_TYPE_NAMES.contains(&p.cur_src())
@@ -914,7 +914,7 @@ pub fn ts_tuple(p: &mut Parser) -> Option<CompletedMarker> {
 			false
 		};
 
-		let opt_range = p.cur_tok().range;
+		let opt_range = p.cur_tok().range();
 		let is_opt = name && p.eat(T![?]);
 		if name {
 			p.expect(T![:]);
@@ -1067,7 +1067,7 @@ pub fn ts_non_array_type(p: &mut Parser) -> Option<CompletedMarker> {
 		_ => {
 			let err = p
 				.err_builder("expected a type")
-				.primary(p.cur_tok().range, "");
+				.primary(p.cur_tok().range(), "");
 
 			#[allow(deprecated)]
 			SingleTokenParseRecovery::with_error(
@@ -1115,7 +1115,7 @@ pub fn ts_type_args(p: &mut Parser) -> Option<CompletedMarker> {
 			first = false;
 		} else if p.at(T![,]) && p.nth_at(1, T![>]) {
 			let m = p.start();
-			let range = p.cur_tok().range;
+			let range = p.cur_tok().range();
 			p.bump_any();
 			m.complete(p, JS_UNKNOWN);
 			let err = p
@@ -1208,7 +1208,7 @@ fn type_param(p: &mut Parser) -> Option<CompletedMarker> {
 		m.abandon(p);
 		let err = p
 			.err_builder("expected a type parameter, but found none")
-			.primary(p.cur_tok().range, "");
+			.primary(p.cur_tok().range(), "");
 
 		#[allow(deprecated)]
 		SingleTokenParseRecovery::with_error(
@@ -1252,7 +1252,7 @@ pub fn ts_type_query(p: &mut Parser) -> Option<CompletedMarker> {
 pub fn ts_mapped_type(p: &mut Parser) -> Option<CompletedMarker> {
 	let m = p.start();
 	p.expect_no_recover(T!['{'])?;
-	let tok = p.cur_tok().range;
+	let tok = p.cur_tok().range();
 	let _m = p.start();
 	if p.eat(T![+]) || p.eat(T![-]) {
 		if p.cur_src() != "readonly" {
@@ -1281,7 +1281,7 @@ pub fn ts_mapped_type(p: &mut Parser) -> Option<CompletedMarker> {
 	if p.cur_src() != "in" {
 		let err = p
 			.err_builder("expected `in` after a mapped type parameter name")
-			.primary(p.cur_tok().range, "");
+			.primary(p.cur_tok().range(), "");
 
 		p.error(err);
 	} else {
@@ -1294,7 +1294,7 @@ pub fn ts_mapped_type(p: &mut Parser) -> Option<CompletedMarker> {
 	}
 	p.expect_no_recover(T![']'])?;
 	param.complete(p, TS_MAPPED_TYPE_PARAM);
-	let tok = p.cur_tok().range;
+	let tok = p.cur_tok().range();
 	if p.eat(T![+]) || p.eat(T![-]) {
 		if !p.at(T![?]) {
 			// TODO: Im not sure of the proper terminology for this, someone should clarify this error
@@ -1457,7 +1457,7 @@ pub fn ts_type_name(
 			"expected a TypeScript type name, but instead found `{}`",
 			p.cur_src()
 		))
-		.primary(p.cur_tok().range, "");
+		.primary(p.cur_tok().range(), "");
 
 	#[allow(deprecated)]
 	SingleTokenParseRecovery::with_error(set, JS_UNKNOWN, err).recover(p);

--- a/crates/rslint_parser/src/syntax/util.rs
+++ b/crates/rslint_parser/src/syntax/util.rs
@@ -1,6 +1,7 @@
 //! General utility functions for parsing and error checking.
 
-use crate::{Parser, Token};
+use crate::Parser;
+use rslint_lexer::Token;
 use rslint_syntax::{JsSyntaxKind, T};
 
 /// Check if the use of a statement label is valid and the label is defined.
@@ -14,8 +15,7 @@ pub(crate) fn check_label_use(p: &mut Parser, label: &Token) {
 	if p.state.labels.get(name).is_none() {
 		let err = p
 			.err_builder(&format!("Use of undefined statement label `{}`", name))
-			.primary(&label.range, "This label is used, but it is never defined");
-
+			.primary(label.range(), "This label is used, but it is never defined");
 		p.error(err);
 	}
 }
@@ -47,14 +47,14 @@ pub(crate) fn expect_keyword(p: &mut Parser, keyword_name: &str, kind: JsSyntaxK
 				"expected `{}` but instead the file ends",
 				keyword_name
 			))
-			.primary(p.cur_tok().range, "the file ends here")
+			.primary(p.cur_tok().range(), "the file ends here")
 		} else {
 			p.err_builder(&format!(
 				"expected `{}` but instead found `{}`",
 				keyword_name,
 				p.cur_src()
 			))
-			.primary(p.cur_tok().range, "unexpected")
+			.primary(p.cur_tok().range(), "unexpected")
 		};
 
 		p.error(err);

--- a/crates/rslint_parser/src/token_source.rs
+++ b/crates/rslint_parser/src/token_source.rs
@@ -1,164 +1,131 @@
-use crate::{JsSyntaxKind::EOF, TextRange, TextSize, Token};
-use rslint_lexer::is_linebreak;
-use std::collections::HashSet;
+use crate::JsSyntaxKind::EOF;
 use std::iter::FusedIterator;
 
 /// The source of tokens for the parser
 pub struct TokenSource<'t> {
 	source: &'t str,
-	/// Hashset of offsets for tokens which occur after a linebreak.
-	/// This is required for things such as ASI and postfix expressions
-	tokens_after_linebreaks: HashSet<TextSize>,
 
-	/// A vector of tokens and their offset from the start.
-	token_offset_pairs: Vec<(rslint_lexer::Token, TextSize)>,
 	/// A list of the tokens including whitespace.
 	pub raw_tokens: &'t [rslint_lexer::Token],
 
-	/// Current token and position
-	cur: (Token, usize),
-}
-
-fn mk_token(pos: usize, token_offset_pairs: &[(rslint_lexer::Token, TextSize)]) -> Token {
-	let kind = match token_offset_pairs.get(pos) {
-		Some((token, _)) => token.kind,
-		None => EOF,
-	};
-	let range = token_offset_pairs
-		.get(pos)
-		.map(|x| {
-			let start: usize = x.1.into();
-			let end = start + x.0.len;
-			start..end
-		})
-		.unwrap_or_else(|| {
-			token_offset_pairs
-				.last()
-				.map(|x| {
-					let start: usize = x.1.into();
-					let end = start + x.0.len;
-					start..end
-				})
-				.unwrap_or(0..0)
-		});
-
-	Token {
-		kind,
-		range: range.to_owned(),
-		len: TextSize::from(range.len() as u32),
-	}
+	/// Current token index at raw_tokens.
+	cur: usize,
 }
 
 impl<'t> TokenSource<'t> {
-	/// Generate input from tokens(except comments and whitespace).
-	///
-	/// # Panics
-	/// This method will panic in case the source and raw tokens do not match
-	/// as it relies on the source code for checking if trivia contains linebreaks
+	/// Creates a new [TokenSource] and set its
+	/// [TokenSource::cur] to the first non-trivia
+	/// token from [raw_tokens]
 	pub fn new(source: &'t str, raw_tokens: &'t [rslint_lexer::Token]) -> TokenSource<'t> {
-		let mut tokens_after_linebreaks = HashSet::new();
-		let mut token_offset_pairs = Vec::with_capacity(raw_tokens.len() / 2);
-
-		let mut len: TextSize = 0.into();
-		let mut has_linebreak = false;
-
-		for token in raw_tokens {
-			if token.kind.is_trivia() {
-				let src = source
-					.get(len.into()..(usize::from(len) + token.len))
-					.expect("src and tokens do not match");
-				if !has_linebreak && src.chars().any(is_linebreak) {
-					has_linebreak = true;
-				}
-			} else {
-				if has_linebreak {
-					tokens_after_linebreaks.insert(len);
-					has_linebreak = false;
-				}
-				token_offset_pairs.push((*token, len));
-			};
-
-			len += TextSize::from(token.len as u32);
+		let mut pos = 0usize;
+		while raw_tokens[pos].kind.is_trivia() {
+			pos += 1;
 		}
-
-		let first = mk_token(0, token_offset_pairs.as_slice());
 		TokenSource {
 			source,
-			token_offset_pairs,
-			cur: (first, 0),
-			tokens_after_linebreaks,
+			cur: pos,
 			raw_tokens,
 		}
 	}
 
-	/// Rewind the current position to a former position.
-	pub fn rewind(&mut self, pos: usize) {
-		self.cur = (mk_token(pos, &self.token_offset_pairs), pos);
-	}
-
-	pub fn last_tok(&self) -> Option<Token> {
-		if self.cur.1 == 0 {
+	#[inline(always)]
+	fn next_non_trivia(&self, pos: usize, dir: isize) -> Option<usize> {
+		let mut pos = pos as isize + dir;
+		if (pos < 0) || ((pos as usize) >= self.raw_tokens.len()) {
 			return None;
 		}
-		Some(mk_token(self.cur.1 - 1, &self.token_offset_pairs))
+		while self.raw_tokens[pos as usize].kind.is_trivia() {
+			pos += dir;
+			if (pos < 0) || ((pos as usize) >= self.raw_tokens.len()) {
+				return None;
+			}
+		}
+		Some(pos as usize)
 	}
 
-	pub fn current(&self) -> Token {
-		self.cur.0.to_owned()
+	#[inline(always)]
+	fn raw_lookahead_nth(&self, n: usize) -> usize {
+		let mut idx = self.cur;
+		for _ in 0..n {
+			idx = self.next_non_trivia(idx, 1).unwrap();
+		}
+		idx
 	}
 
+	/// Rewind the current position to a former position.
+	#[inline(always)]
+	pub fn rewind(&mut self, pos: usize) {
+		self.cur = pos;
+	}
+
+	#[inline(always)]
+	pub fn last_tok(&self) -> Option<&rslint_lexer::Token> {
+		self.next_non_trivia(self.cur, -1)
+			.and_then(|idx| self.raw_tokens.get(idx))
+	}
+
+	#[inline(always)]
+	pub fn current(&self) -> &rslint_lexer::Token {
+		&self.raw_tokens[self.cur]
+	}
+
+	#[inline(always)]
 	pub fn source(&self) -> &str {
 		self.source
 	}
 
-	pub fn lookahead_nth(&self, n: usize) -> Token {
-		mk_token(self.cur.1 + n, &self.token_offset_pairs)
+	#[inline(always)]
+	pub fn lookahead_nth(&self, n: usize) -> &'t rslint_lexer::Token {
+		let idx = self.raw_lookahead_nth(n);
+		&self.raw_tokens[idx]
 	}
 
+	#[inline(always)]
 	pub fn bump(&mut self) {
-		if self.cur.0.kind == EOF {
+		if self.current().kind == EOF {
 			return;
 		}
 
-		let pos = self.cur.1 + 1;
-		self.cur = (mk_token(pos, &self.token_offset_pairs), pos);
+		self.cur = self
+			.next_non_trivia(self.cur, 1)
+			.unwrap_or(self.raw_tokens.len() - 1);
 	}
 
+	#[inline(always)]
 	pub fn is_keyword(&self, kw: &str) -> bool {
-		self.token_offset_pairs
-			.get(self.cur.1)
-			.map(|(token, offset)| {
-				&self.source[TextRange::at(*offset, TextSize::from(token.len as u32))] == kw
-			})
-			.unwrap_or(false)
+		let range = self.current().range();
+		&self.source[range] == kw
 	}
 
+	#[inline(always)]
 	pub fn had_linebreak_before_nth(&self, n: usize) -> bool {
-		if let Some(i) = self.token_offset_pairs.get(self.cur.1 + n) {
-			self.tokens_after_linebreaks.contains(&i.1)
-		} else {
-			false
-		}
+		self.lookahead_nth(n).after_newline
 	}
 
+	#[inline(always)]
 	pub fn cur_pos(&self) -> usize {
-		self.token_offset_pairs[self.cur.1].1.into()
+		self.current().offset as usize
 	}
 
+	#[inline(always)]
 	pub fn cur_token_idx(&self) -> usize {
-		self.cur.1
+		self.cur
 	}
 
 	pub fn size_hint(&self) -> usize {
-		self.token_offset_pairs.len()
+		self.raw_tokens.len()
 	}
 }
 
 impl Iterator for TokenSource<'_> {
-	type Item = Token;
+	type Item = rslint_lexer::Token;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let cur = self.cur.0.clone();
+		while self.current().kind.is_trivia() {
+			self.bump();
+		}
+
+		let cur = self.current().to_owned();
 		if cur.kind != EOF {
 			self.bump();
 			Some(cur)


### PR DESCRIPTION
see: https://github.com/rome/tools/issues/1901

With the newly created tokens (NEWLINE, MULTILINE_COMMENT), we can completely remove tokens_after_linebreaks. The lexer will know when a non-trivia token is after a newline. We can attach this info in the Token struct and completely avoid creating and searching this HashSet.

We can also improve the lexer by already calculating the token offset and remove token_offset_pair. Avoiding a whole iteration when creating the Parser.