### PR TITLE
fix(git): force LF line endings for test cases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+crates/rslint_parser/test_data/**/*.js text eol=lf


### PR DESCRIPTION
## Summary

This forces all the auto-generated test cases to be checked out by Git with LF line endings. The default autocrlf behavior of Git on Windows makes it create those files with CRLF line endings on the disk which messes up both with the generation script (which creates those files with LF line endings so they all get marked as changed) and the rast snapshots (as all the "\n" whitespace tokens get changed into "\r\n")
