### PR TITLE
feat(rslint_parser): Avoid cloning parser state

### DIFF
--- a/crates/rslint_parser/src/lib.rs
+++ b/crates/rslint_parser/src/lib.rs
@@ -313,8 +313,8 @@ pub enum JsSyntaxFeature {
 impl SyntaxFeature for JsSyntaxFeature {
 	fn is_supported(&self, p: &Parser) -> bool {
 		match self {
-			JsSyntaxFeature::SloppyMode => p.state.strict.is_none(),
-			JsSyntaxFeature::StrictMode => p.state.strict.is_some(),
+			JsSyntaxFeature::SloppyMode => p.state.strict().is_none(),
+			JsSyntaxFeature::StrictMode => p.state.strict().is_some(),
 			JsSyntaxFeature::TypeScript => p.syntax.file_kind == FileKind::TypeScript,
 		}
 	}

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -138,23 +138,11 @@ pub struct Parser<'t> {
 impl<'t> Parser<'t> {
 	/// Make a new parser
 	pub fn new(tokens: TokenSource<'t>, file_id: usize, syntax: Syntax) -> Parser<'t> {
-		// TODO(RDambrosio016): Does TypeScript imply Module/Strict?
-		let strict = if syntax.file_kind == FileKind::Module {
-			Some(StrictMode::Module)
-		} else {
-			None
-		};
-		let state = ParserState {
-			is_module: syntax.file_kind == FileKind::Module,
-			strict,
-			..ParserState::default()
-		};
-
 		Parser {
 			file_id,
 			tokens,
 			events: vec![],
-			state,
+			state: ParserState::new(syntax),
 			syntax,
 			errors: vec![],
 		}
@@ -471,6 +459,11 @@ impl<'t> Parser<'t> {
 			.map(|x| usize::from(x.range(self).end()))
 			.unwrap_or_default();
 		start..end
+	}
+
+	/// Whether the code we are parsing is a module
+	pub fn is_module(&self) -> bool {
+		self.syntax.file_kind == FileKind::Module
 	}
 }
 

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -1,5 +1,6 @@
+use crate::{FileKind, Parser, Syntax};
 use std::collections::HashMap;
-use std::ops::Range;
+use std::ops::{Deref, DerefMut, Range};
 
 /// State kept by the parser while parsing.
 /// It is required for things such as strict mode or async functions
@@ -9,32 +10,30 @@ pub struct ParserState {
 	/// inside an expression.
 	///
 	/// Also applies for object patterns
-	pub allow_object_expr: bool,
+	allow_object_expr: bool,
 	/// Whether `in` should be counted in a binary expression
 	/// this is for `for...in` statements to prevent ambiguity.
-	pub include_in: bool,
+	include_in: bool,
 	/// Whether the parser is in an iteration statement and `continue` is allowed.
-	pub continue_allowed: bool,
+	continue_allowed: bool,
 	/// Whether the parser is in an iteration or switch statement and
 	/// `break` is allowed.
-	pub break_allowed: bool,
+	break_allowed: bool,
 	/// A list of labels for labelled statements used to report undefined label errors
 	/// for break and continue, as well as duplicate labels
 	pub labels: HashMap<String, Range<usize>>,
 	/// Whether the parser is in a generator function like `function* a() {}`
-	pub in_generator: bool,
+	in_generator: bool,
 	/// Whether the parser is inside of a function
-	pub in_function: bool,
+	in_function: bool,
 	/// Whatever the parser is inside of a constructor
-	pub in_constructor: bool,
+	in_constructor: bool,
 	/// Whether we potentially are in a place to parse an arrow expression
-	pub potential_arrow_start: bool,
+	potential_arrow_start: bool,
 	/// Whether we are in an async function
-	pub in_async: bool,
+	in_async: bool,
 	/// Whether we are in strict mode code
-	pub strict: Option<StrictMode>,
-	/// Whether the code we are parsing is a module
-	pub is_module: bool,
+	strict: Option<StrictMode>,
 	/// The exported default item, used for checking duplicate defaults
 	pub default_item: Option<Range<usize>>,
 	/// If set, the parser reports bindings with identical names. The option stores the name of the
@@ -42,11 +41,9 @@ pub struct ParserState {
 	pub duplicate_binding_parent: Option<&'static str>,
 	pub name_map: HashMap<String, Range<usize>>,
 	/// Whether the parser is in a conditional expr (ternary expr)
-	pub in_cond_expr: bool,
-	pub in_case_cond: bool,
+	in_cond_expr: bool,
 	pub(crate) no_recovery: bool,
-	pub in_declare: bool,
-	pub in_binding_list_for_signature: bool,
+	in_binding_list_for_signature: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -70,15 +67,471 @@ impl Default for ParserState {
 			potential_arrow_start: false,
 			in_async: false,
 			strict: None,
-			is_module: false,
 			default_item: None,
 			name_map: HashMap::with_capacity(3),
 			duplicate_binding_parent: None,
 			in_cond_expr: false,
-			in_case_cond: false,
 			no_recovery: false,
-			in_declare: false,
 			in_binding_list_for_signature: false,
 		}
+	}
+}
+
+impl ParserState {
+	pub fn new(syntax: Syntax) -> Self {
+		// TODO(RDambrosio016): Does TypeScript imply Module/Strict?
+		let strict = if syntax.file_kind == FileKind::Module {
+			Some(StrictMode::Module)
+		} else {
+			None
+		};
+
+		Self {
+			strict,
+			..ParserState::default()
+		}
+	}
+
+	pub fn in_function(&self) -> bool {
+		self.in_function
+	}
+
+	pub fn in_generator(&self) -> bool {
+		self.in_generator
+	}
+
+	pub fn in_async(&self) -> bool {
+		self.in_async
+	}
+
+	pub fn in_constructor(&self) -> bool {
+		self.in_constructor
+	}
+
+	pub fn continue_allowed(&self) -> bool {
+		self.continue_allowed
+	}
+	pub fn break_allowed(&self) -> bool {
+		self.break_allowed
+	}
+
+	pub fn include_in(&self) -> bool {
+		self.include_in
+	}
+
+	pub fn in_condition_expression(&self) -> bool {
+		self.in_cond_expr
+	}
+
+	pub fn potential_arrow_start(&self) -> bool {
+		self.potential_arrow_start
+	}
+
+	pub fn allow_object_expression(&self) -> bool {
+		self.allow_object_expr
+	}
+
+	pub fn strict(&self) -> Option<&StrictMode> {
+		self.strict.as_ref()
+	}
+
+	pub fn in_binding_list_for_signature(&self) -> bool {
+		self.in_binding_list_for_signature
+	}
+}
+
+impl<'t> Parser<'t> {
+	/// Changes the state of the parser applying the passed in `modifier`. Reverts the
+	/// state changes when the state guard goes out of scope.
+	pub fn with_state<'p, C: ChangeParserState>(
+		&'p mut self,
+		change: C,
+	) -> ParserStateGuard<'p, 't, C> {
+		let snapshot = change.apply(&mut self.state);
+		ParserStateGuard::new(self, snapshot)
+	}
+}
+
+/// Reverts state changes to their previous value when it goes out of scope.
+/// Can be used like a regular parser.
+pub struct ParserStateGuard<'parser, 't, C>
+where
+	C: ChangeParserState,
+{
+	snapshot: C::Snapshot,
+	inner: &'parser mut Parser<'t>,
+}
+
+impl<'parser, 't, C: ChangeParserState> ParserStateGuard<'parser, 't, C> {
+	fn new(parser: &'parser mut Parser<'t>, snapshot: C::Snapshot) -> Self {
+		Self {
+			snapshot,
+			inner: parser,
+		}
+	}
+}
+
+impl<'parser, 't, C: ChangeParserState> Drop for ParserStateGuard<'parser, 't, C> {
+	fn drop(&mut self) {
+		let snapshot = std::mem::take(&mut self.snapshot);
+
+		C::restore(&mut self.inner.state, snapshot);
+	}
+}
+
+impl<'parser, 't, C: ChangeParserState> Deref for ParserStateGuard<'parser, 't, C> {
+	type Target = Parser<'t>;
+
+	fn deref(&self) -> &Self::Target {
+		self.inner
+	}
+}
+
+impl<'parser, 't, C: ChangeParserState> DerefMut for ParserStateGuard<'parser, 't, C> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		self.inner
+	}
+}
+
+/// Implements a specific modification to the parser state that can later be reverted.
+pub trait ChangeParserState {
+	type Snapshot: Default;
+
+	/// Applies the change to the passed in state and returns snapshot that allows restoring the previous state.
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot;
+
+	/// Restores the state to its previous value
+	fn restore(state: &mut ParserState, value: Self::Snapshot);
+
+	/// Allows composing two changes.
+	/// The returned change first applies this modifier and then `other`.
+	fn and<O>(self, other: O) -> ComposedParserStateChange<Self, O>
+	where
+		Self: Sized,
+		O: ChangeParserState,
+	{
+		ComposedParserStateChange::new(self, other)
+	}
+}
+
+#[derive(Debug, Default)]
+pub struct ComposedSnapshot<A, B>
+where
+	A: Default,
+	B: Default,
+{
+	a: A,
+	b: B,
+}
+
+#[derive(Debug)]
+pub struct ComposedParserStateChange<A, B> {
+	a: A,
+	b: B,
+}
+
+impl<A, B> ComposedParserStateChange<A, B>
+where
+	A: ChangeParserState,
+	B: ChangeParserState,
+{
+	pub fn new(a: A, b: B) -> Self {
+		Self { a, b }
+	}
+}
+
+impl<A, B> ChangeParserState for ComposedParserStateChange<A, B>
+where
+	A: ChangeParserState,
+	B: ChangeParserState,
+{
+	type Snapshot = ComposedSnapshot<A::Snapshot, B::Snapshot>;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		ComposedSnapshot {
+			a: self.a.apply(state),
+			b: self.b.apply(state),
+		}
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		B::restore(state, value.b);
+		A::restore(state, value.a);
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InGeneratorSnapshot(bool);
+
+/// Changes the [ParserState] `in_generator` field
+#[derive(Debug)]
+pub struct InGenerator(bool);
+
+impl InGenerator {
+	pub fn new(in_generator: bool) -> Self {
+		Self(in_generator)
+	}
+}
+
+impl ChangeParserState for InGenerator {
+	type Snapshot = InGeneratorSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InGeneratorSnapshot(std::mem::replace(&mut state.in_generator, self.0))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_generator = value.0
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InFunctionSnapshot(bool);
+
+/// Sets the [ParserState] `in_function` state to true
+#[derive(Debug)]
+pub struct InFunction;
+
+impl ChangeParserState for InFunction {
+	type Snapshot = InFunctionSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InFunctionSnapshot(std::mem::replace(&mut state.in_function, true))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_function = value.0
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InAsyncSnapshot(bool);
+
+/// Changes the `ParserState] `in_async` flag
+#[derive(Debug)]
+pub struct InAsync(bool);
+
+impl InAsync {
+	pub fn new(in_async: bool) -> Self {
+		Self(in_async)
+	}
+}
+
+impl ChangeParserState for InAsync {
+	type Snapshot = InAsyncSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InAsyncSnapshot(std::mem::replace(&mut state.in_async, self.0))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_async = value.0;
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InConstructorSnapshot(bool);
+
+/// Sets the [ParserState] `in_constructor` field to true
+pub struct InConstructor(bool);
+
+impl InConstructor {
+	pub fn new(in_constructor: bool) -> Self {
+		Self(in_constructor)
+	}
+}
+
+impl ChangeParserState for InConstructor {
+	type Snapshot = InConstructorSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InConstructorSnapshot(std::mem::replace(&mut state.in_constructor, self.0))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_constructor = value.0;
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct BreakAllowedSnapshot(bool);
+
+/// Sets the [ParserState] `break_allowed` field to true
+pub struct BreakAllowed;
+
+impl ChangeParserState for BreakAllowed {
+	type Snapshot = BreakAllowedSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		BreakAllowedSnapshot(std::mem::replace(&mut state.break_allowed, true))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.break_allowed = value.0;
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct ContinueAllowedSnapshot(bool);
+
+/// Sets the [ParserState] `continue_allowed` field to true
+pub struct ContinueAllowed;
+
+impl ChangeParserState for ContinueAllowed {
+	type Snapshot = ContinueAllowedSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		ContinueAllowedSnapshot(std::mem::replace(&mut state.continue_allowed, true))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.continue_allowed = value.0;
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SeenLabelsSnapshot(HashMap<String, Range<usize>>);
+
+/// Resets the [ParserState] `labels` field to an empty map
+pub struct NewLabelsScope;
+
+impl ChangeParserState for NewLabelsScope {
+	type Snapshot = SeenLabelsSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		SeenLabelsSnapshot(std::mem::take(&mut state.labels))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.labels = value.0
+	}
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct ExcludeInSnapshot(bool);
+
+/// Sets the [ParserState] `include_in` state to `false`
+pub struct ExcludeIn;
+
+impl ChangeParserState for ExcludeIn {
+	type Snapshot = ExcludeInSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		ExcludeInSnapshot(std::mem::replace(&mut state.include_in, false))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.include_in = value.0;
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InConditionExpressionSnapshot(bool);
+
+/// Sets the [ParserState] `in_cond_expr` state to `true`
+pub struct InConditionExpression;
+
+impl ChangeParserState for InConditionExpression {
+	type Snapshot = InConditionExpressionSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InConditionExpressionSnapshot(std::mem::replace(&mut state.in_cond_expr, true))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_cond_expr = value.0;
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PotentialArrowStartSnapshot(bool);
+
+/// Changes the [ParserState] `potential_arrow_expr` field
+pub struct PotentialArrowStart(bool);
+
+impl PotentialArrowStart {
+	pub fn new(potential_arrow_start: bool) -> Self {
+		Self(potential_arrow_start)
+	}
+}
+
+impl ChangeParserState for PotentialArrowStart {
+	type Snapshot = PotentialArrowStartSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		PotentialArrowStartSnapshot(std::mem::replace(&mut state.potential_arrow_start, self.0))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.potential_arrow_start = value.0;
+	}
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct AllowObjectExpressionSnapshot(bool);
+
+/// Sets the [ParserState] `allow_object_expr` field
+pub struct AllowObjectExpression(bool);
+
+impl AllowObjectExpression {
+	pub fn new(allow_object_expr: bool) -> Self {
+		Self(allow_object_expr)
+	}
+}
+
+impl ChangeParserState for AllowObjectExpression {
+	type Snapshot = AllowObjectExpressionSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		AllowObjectExpressionSnapshot(std::mem::replace(&mut state.allow_object_expr, self.0))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.allow_object_expr = value.0;
+	}
+}
+
+#[derive(Default, Debug)]
+pub struct EnableStrictModeSnapshot(Option<StrictMode>);
+
+/// Enables strict mode
+pub struct EnableStrictMode(StrictMode);
+
+impl EnableStrictMode {
+	pub fn new(mode: StrictMode) -> Self {
+		Self(mode)
+	}
+}
+
+impl ChangeParserState for EnableStrictMode {
+	type Snapshot = EnableStrictModeSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		EnableStrictModeSnapshot(std::mem::replace(&mut state.strict, Some(self.0)))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.strict = value.0
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InBindingListForSignatureSnapshot(bool);
+
+/// Sets [ParserState] `in_binding_list_for_signature` to true
+pub struct InBindingListForSignature;
+
+impl ChangeParserState for InBindingListForSignature {
+	type Snapshot = InBindingListForSignatureSnapshot;
+
+	fn apply(self, state: &mut ParserState) -> Self::Snapshot {
+		InBindingListForSignatureSnapshot(std::mem::replace(
+			&mut state.in_binding_list_for_signature,
+			true,
+		))
+	}
+
+	fn restore(state: &mut ParserState, value: Self::Snapshot) {
+		state.in_binding_list_for_signature = value.0;
 	}
 }

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -49,7 +49,7 @@ pub struct ParserState {
 	pub in_binding_list_for_signature: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum StrictMode {
 	Module,
 	Explicit(Range<usize>),

--- a/crates/rslint_parser/src/syntax/binding.rs
+++ b/crates/rslint_parser/src/syntax/binding.rs
@@ -15,7 +15,9 @@ use rslint_errors::Span;
 pub(crate) fn parse_binding_pattern(p: &mut Parser) -> ParsedSyntax {
 	match p.cur() {
 		T!['['] => ArrayBindingPattern.parse_array_pattern(p),
-		T!['{'] if p.state.allow_object_expr => ObjectBindingPattern.parse_object_pattern(p),
+		T!['{'] if p.state.allow_object_expression() => {
+			ObjectBindingPattern.parse_object_pattern(p)
+		}
 		T![ident] | T![yield] | T![await] => parse_identifier_binding(p),
 		_ => Absent,
 	}

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -856,13 +856,13 @@ fn parse_constructor_class_member_body(p: &mut Parser, member_marker: Marker) ->
 	}
 
 	let last_in_constructor = std::mem::replace(&mut p.state.in_constructor, true);
-	let last_in_generator = std::mem::replace(&mut p.state.in_generator, true);
+	let last_in_function = std::mem::replace(&mut p.state.in_function, true);
 
 	parse_block_impl(p, JS_FUNCTION_BODY)
 		.or_add_diagnostic(p, js_parse_error::expected_class_method_body);
 
 	p.state.in_constructor = last_in_constructor;
-	p.state.in_generator = last_in_generator;
+	p.state.in_function = last_in_function;
 
 	// FIXME(RDambrosio016): if there is no body we need to issue errors for any assign patterns
 

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1,7 +1,7 @@
 use crate::parser::{ParsedSyntax, ParserProgress, RecoveryResult};
 use crate::state::{
-	AllowObjectExpression, EnableStrictMode, InAsync, InConstructor, InFunction, InGenerator,
-	ChangeParserState,
+	AllowObjectExpression, ChangeParserState, EnableStrictMode, InAsync, InConstructor, InFunction,
+	InGenerator,
 };
 use crate::syntax::binding::parse_binding;
 use crate::syntax::decl::{parse_formal_param_pat, parse_parameter_list, parse_parameters_list};
@@ -401,6 +401,8 @@ fn parse_class_member_impl(
 		&& !p.has_linebreak_before_n(1)
 	{
 		let async_range = p.cur_tok().range();
+		p.bump_remap(T![async]);
+		let in_generator = p.eat(T![*]);
 
 		if p.cur_src() == "constructor" {
 			let err = p
@@ -417,9 +419,6 @@ fn parse_class_member_impl(
 
 			p.error(err);
 		}
-
-		p.bump_remap(T![async]);
-		let in_generator = p.eat(T![*]);
 
 		let method = {
 			let p = &mut *p.with_state(

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -49,8 +49,7 @@ pub(super) fn parse_parameters_list(
 	let mut first = true;
 	let has_l_paren = p.expect(T!['(']);
 
-	{
-		let p = &mut *p.with_state(AllowObjectExpression::new(has_l_paren));
+	p.with_state(AllowObjectExpression(has_l_paren), |p| {
 		let parameters_list = p.start();
 		let mut progress = ParserProgress::default();
 
@@ -160,17 +159,17 @@ pub(super) fn parse_parameters_list(
 		}
 
 		parameters_list.complete(p, list_kind);
-	}
+	});
 
 	p.expect(T![')']);
 }
 
 pub(super) fn parse_arrow_body(p: &mut Parser) -> ParsedSyntax {
-	let p = &mut *p.with_state(InFunction);
-
-	if p.at(T!['{']) {
-		function_body(p)
-	} else {
-		parse_expr_or_assignment(p)
-	}
+	p.with_state(InFunction(true), |p| {
+		if p.at(T!['{']) {
+			function_body(p)
+		} else {
+			parse_expr_or_assignment(p)
+		}
+	})
 }

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -6,6 +6,7 @@ use super::typescript::*;
 #[allow(deprecated)]
 use crate::parser::ParsedSyntax::{Absent, Present};
 use crate::parser::ParserProgress;
+use crate::state::{AllowObjectExpression, InFunction};
 use crate::syntax::binding::parse_binding_pattern_with_optional_default;
 use crate::syntax::function::function_body;
 use crate::syntax::js_parse_error;
@@ -46,129 +47,130 @@ pub(super) fn parse_parameters_list(
 	list_kind: JsSyntaxKind,
 ) {
 	let mut first = true;
+	let has_l_paren = p.expect(T!['(']);
 
-	p.state.allow_object_expr = p.expect(T!['(']);
+	{
+		let p = &mut *p.with_state(AllowObjectExpression::new(has_l_paren));
+		let parameters_list = p.start();
+		let mut progress = ParserProgress::default();
 
-	let parameters_list = p.start();
-	let mut progress = ParserProgress::default();
+		while !p.at(EOF) && !p.at(T![')']) {
+			progress.assert_progressing(p);
 
-	while !p.at(EOF) && !p.at(T![')']) {
-		progress.assert_progressing(p);
-
-		if first {
-			first = false;
-		} else {
-			p.expect(T![,]);
-		}
-
-		if p.at(T![')']) {
-			break;
-		}
-
-		if p.at(T![...]) {
-			let m = p.start();
-			p.bump_any();
-			parse_binding_pattern(p).or_add_diagnostic(p, expected_binding);
-
-			// TODO #1725 Review error handling and recovery
-			// rest patterns cannot be optional: `...foo?: number[]`
-			if p.at(T![?]) {
-				let err = p
-					.err_builder("rest patterns cannot be optional")
-					.primary(p.cur_tok().range(), "");
-
-				p.error(err);
-				let m = p.start();
-				p.bump_any();
-				m.complete(p, JS_UNKNOWN_BINDING);
+			if first {
+				first = false;
+			} else {
+				p.expect(T![,]);
 			}
 
-			// type annotation `...foo: number[]`
-			if p.eat(T![:]) {
-				let complete = ts_type(p);
-				if let Some(mut res) = complete {
-					res.err_if_not_ts(p, "type annotations can only be used in TypeScript files");
-				}
-			}
-
-			if p.at(T![=]) {
-				let start = p.cur_tok().start();
-				let m = p.start();
-				p.bump_any();
-
-				let end = parse_expr_or_assignment(&mut *p)
-					.ok()
-					.map(|marker| usize::from(marker.range(p).end()))
-					.unwrap_or_else(|| p.cur_tok().start());
-
-				let err = p
-					.err_builder("rest elements may not have default initializers")
-					.primary(start..end, "");
-
-				p.error(err);
-				m.complete(p, JS_UNKNOWN);
-			}
-
-			m.complete(p, JS_REST_PARAMETER);
-
-			// FIXME: this should be handled better, we should keep trying to parse params but issue an error for each one
-			// which would allow for better recovery from `foo, ...bar, foo`
-			if p.at(T![,]) {
-				let m = p.start();
-				let range = p.cur_tok().range();
-				p.bump_any();
-				m.complete(p, JS_UNKNOWN);
-				let err = p
-					.err_builder("rest elements may not have trailing commas")
-					.primary(range, "");
-
-				p.error(err);
-			}
-		} else {
-			// test_err formal_params_no_binding_element
-			// function foo(true) {}
-
-			// test_err formal_params_invalid
-			// function (a++, c) {}
-			let recovered_result = parse_param(p).or_recover(
-				p,
-				&ParseRecovery::new(
-					JS_UNKNOWN_BINDING,
-					token_set![
-						T![ident],
-						T![await],
-						T![yield],
-						T![,],
-						T!['['],
-						T![...],
-						T![')'],
-					],
-				)
-				.enable_recovery_on_line_break(),
-				js_parse_error::expected_parameter,
-			);
-
-			if recovered_result.is_err() {
+			if p.at(T![')']) {
 				break;
 			}
+
+			if p.at(T![...]) {
+				let m = p.start();
+				p.bump_any();
+				parse_binding_pattern(p).or_add_diagnostic(p, expected_binding);
+
+				// TODO #1725 Review error handling and recovery
+				// rest patterns cannot be optional: `...foo?: number[]`
+				if p.at(T![?]) {
+					let err = p
+						.err_builder("rest patterns cannot be optional")
+						.primary(p.cur_tok().range(), "");
+
+					p.error(err);
+					let m = p.start();
+					p.bump_any();
+					m.complete(p, JS_UNKNOWN_BINDING);
+				}
+
+				// type annotation `...foo: number[]`
+				if p.eat(T![:]) {
+					let complete = ts_type(p);
+					if let Some(mut res) = complete {
+						res.err_if_not_ts(
+							p,
+							"type annotations can only be used in TypeScript files",
+						);
+					}
+				}
+
+				if p.at(T![=]) {
+					let start = p.cur_tok().start();
+					let m = p.start();
+					p.bump_any();
+
+					let end = parse_expr_or_assignment(&mut *p)
+						.ok()
+						.map(|marker| usize::from(marker.range(p).end()))
+						.unwrap_or_else(|| p.cur_tok().start());
+
+					let err = p
+						.err_builder("rest elements may not have default initializers")
+						.primary(start..end, "");
+
+					p.error(err);
+					m.complete(p, JS_UNKNOWN);
+				}
+
+				m.complete(p, JS_REST_PARAMETER);
+
+				// FIXME: this should be handled better, we should keep trying to parse params but issue an error for each one
+				// which would allow for better recovery from `foo, ...bar, foo`
+				if p.at(T![,]) {
+					let m = p.start();
+					let range = p.cur_tok().range();
+					p.bump_any();
+					m.complete(p, JS_UNKNOWN);
+					let err = p
+						.err_builder("rest elements may not have trailing commas")
+						.primary(range, "");
+
+					p.error(err);
+				}
+			} else {
+				// test_err formal_params_no_binding_element
+				// function foo(true) {}
+
+				// test_err formal_params_invalid
+				// function (a++, c) {}
+				let recovered_result = parse_param(p).or_recover(
+					p,
+					&ParseRecovery::new(
+						JS_UNKNOWN_BINDING,
+						token_set![
+							T![ident],
+							T![await],
+							T![yield],
+							T![,],
+							T!['['],
+							T![...],
+							T![')'],
+						],
+					)
+					.enable_recovery_on_line_break(),
+					js_parse_error::expected_parameter,
+				);
+
+				if recovered_result.is_err() {
+					break;
+				}
+			}
 		}
+
+		parameters_list.complete(p, list_kind);
 	}
 
-	parameters_list.complete(p, list_kind);
-	p.state.allow_object_expr = true;
 	p.expect(T![')']);
 }
 
 pub(super) fn parse_arrow_body(p: &mut Parser) -> ParsedSyntax {
-	let last_in_function = std::mem::replace(&mut p.state.in_function, true);
+	let p = &mut *p.with_state(InFunction);
 
-	let result = if p.at(T!['{']) {
+	if p.at(T!['{']) {
 		function_body(p)
 	} else {
 		parse_expr_or_assignment(p)
-	};
-
-	p.state.in_function = last_in_function;
-
-	result
+	}
 }

--- a/crates/rslint_parser/src/syntax/decl.rs
+++ b/crates/rslint_parser/src/syntax/decl.rs
@@ -160,13 +160,15 @@ pub(super) fn parse_parameters_list(
 }
 
 pub(super) fn parse_arrow_body(p: &mut Parser) -> ParsedSyntax {
-	let mut guard = p.with_state(ParserState {
-		in_function: true,
-		..p.state.clone()
-	});
-	if guard.at(T!['{']) {
-		function_body(&mut *guard)
+	let last_in_function = std::mem::replace(&mut p.state.in_function, true);
+
+	let result = if p.at(T!['{']) {
+		function_body(p)
 	} else {
-		parse_expr_or_assignment(&mut *guard)
-	}
+		parse_expr_or_assignment(p)
+	};
+
+	p.state.in_function = last_in_function;
+
+	result
 }

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -1,6 +1,6 @@
 use crate::parser::ParsedSyntax;
 use crate::state::{
-	InAsync, InConstructor, InFunction, InGenerator, NewLabelsScope, ChangeParserState,
+	ChangeParserState, InAsync, InConstructor, InFunction, InGenerator, NewLabelsScope,
 };
 use crate::syntax::binding::parse_binding;
 use crate::syntax::decl::parse_parameter_list;

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -9,7 +9,6 @@ use crate::ParsedSyntax::{Absent, Present};
 use crate::{Marker, Parser, SyntaxFeature};
 use rslint_syntax::JsSyntaxKind::*;
 use rslint_syntax::{JsSyntaxKind, T};
-use std::collections::HashMap;
 
 /// A function declaration, this could be async and or a generator. This takes a marker
 /// because you need to first advance over async or start a marker and feed it in.
@@ -113,7 +112,7 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax
 	let last_in_function = std::mem::replace(&mut p.state.in_function, true);
 	let last_in_async = std::mem::replace(&mut p.state.in_async, in_async);
 	let last_in_generator = std::mem::replace(&mut p.state.in_generator, in_generator);
-	let last_labels = std::mem::replace(&mut p.state.labels, HashMap::new());
+	let last_labels = std::mem::take(&mut p.state.labels);
 
 	let id = parse_binding(p);
 

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -756,7 +756,7 @@ fn parse_export_default_clause(p: &mut Parser) -> ParsedSyntax {
 		// export default (class {})
 		// export default a + b;
 		// export default (function a() {})
-		if let Some(range) = p.state.default_item.as_ref().filter(|_| p.state.is_module) {
+		if let Some(range) = p.state.default_item.as_ref().filter(|_| p.is_module()) {
 			let err = p
 				.err_builder("Illegal duplicate default export declarations")
 				.secondary(

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -2,7 +2,7 @@
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
 use crate::parser::ParsedSyntax::{Absent, Present};
 use crate::parser::{ParsedSyntax, RecoveryResult};
-use crate::state::{AllowObjectExpression, InAsync, InFunction, InGenerator, ChangeParserState};
+use crate::state::{AllowObjectExpression, ChangeParserState, InAsync, InFunction, InGenerator};
 use crate::syntax::decl::{parse_formal_param_pat, parse_parameter_list};
 use crate::syntax::expr::{is_at_name, parse_expr_or_assignment, parse_expression};
 use crate::syntax::function::{
@@ -349,8 +349,7 @@ fn parse_method_object_member(p: &mut Parser) -> ParsedSyntax {
 	let in_generator = p.eat(T![*]);
 	parse_object_member_name(p).or_add_diagnostic(p, js_parse_error::expected_object_member_name);
 
-	let p =
-		&mut *p.with_state(InGenerator::new(in_generator).and(InAsync::new(is_async)));
+	let p = &mut *p.with_state(InGenerator::new(in_generator).and(InAsync::new(is_async)));
 
 	parse_method_object_member_body(p);
 

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -25,7 +25,9 @@ pub fn parse(p: &mut Parser) -> CompletedMarker {
 		FileKind::Module | FileKind::TypeScript => parse_module_body(p, m),
 	};
 
-	p.state.strict = last_strict;
+	if let Some(last_strict) = last_strict {
+		p.state.strict = last_strict;
+	}
 
 	result
 }

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -15,7 +15,7 @@ pub fn parse(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
 	p.eat(JS_SHEBANG);
 
-	let old_parser_state = directives(p);
+	let last_strict = directives(p);
 
 	let result = match p.syntax.file_kind {
 		FileKind::Script => {
@@ -25,9 +25,7 @@ pub fn parse(p: &mut Parser) -> CompletedMarker {
 		FileKind::Module | FileKind::TypeScript => parse_module_body(p, m),
 	};
 
-	if let Some(old_parser_state) = old_parser_state {
-		p.state = old_parser_state;
-	}
+	p.state.strict = last_strict;
 
 	result
 }

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -3,6 +3,7 @@
 use super::expr::parse_name;
 use super::stmt::{parse_statements, semi};
 use super::typescript::*;
+use crate::state::{EnableStrictMode, ChangeParserState};
 use crate::syntax::js_parse_error;
 use crate::syntax::module::parse_module_body;
 use crate::syntax::stmt::directives;
@@ -15,7 +16,7 @@ pub fn parse(p: &mut Parser) -> CompletedMarker {
 	let m = p.start();
 	p.eat(JS_SHEBANG);
 
-	let last_strict = directives(p);
+	let strict_snapshot = directives(p);
 
 	let result = match p.syntax.file_kind {
 		FileKind::Script => {
@@ -25,8 +26,8 @@ pub fn parse(p: &mut Parser) -> CompletedMarker {
 		FileKind::Module | FileKind::TypeScript => parse_module_body(p, m),
 	};
 
-	if let Some(last_strict) = last_strict {
-		p.state.strict = last_strict;
+	if let Some(strict_snapshot) = strict_snapshot {
+		EnableStrictMode::restore(&mut p.state, strict_snapshot);
 	}
 
 	result

--- a/crates/rslint_parser/src/syntax/program.rs
+++ b/crates/rslint_parser/src/syntax/program.rs
@@ -3,7 +3,7 @@
 use super::expr::parse_name;
 use super::stmt::{parse_statements, semi};
 use super::typescript::*;
-use crate::state::{EnableStrictMode, ChangeParserState};
+use crate::state::{ChangeParserState, EnableStrictMode};
 use crate::syntax::js_parse_error;
 use crate::syntax::module::parse_module_body;
 use crate::syntax::stmt::directives;

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -25,7 +25,6 @@ use crate::SyntaxFeature;
 use crate::{JsSyntaxKind::*, *};
 use rome_rowan::SyntaxKind;
 use rslint_errors::Span;
-use std::collections::HashMap;
 
 pub const STMT_RECOVERY_SET: TokenSet = token_set![
 	L_CURLY,
@@ -979,7 +978,7 @@ fn parse_variable_declaration(
 
 		let type_annotation = maybe_ts_type_annotation(p);
 
-		let last_name_map = std::mem::replace(&mut p.state.name_map, HashMap::default());
+		let last_name_map = std::mem::take(&mut p.state.name_map);
 		let duplicate_binding_parent = p.state.duplicate_binding_parent.take();
 
 		let initializer = parse_initializer_clause(p).ok();

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -5,6 +5,7 @@ use super::expr::{parse_expr_or_assignment, parse_lhs_expr, parse_literal_expres
 use crate::parser::ParserProgress;
 #[allow(deprecated)]
 use crate::parser::SingleTokenParseRecovery;
+use crate::state::InBindingListForSignature;
 use crate::syntax::binding::parse_binding;
 use crate::syntax::expr::{is_at_name, parse_any_name};
 use crate::syntax::js_parse_error;
@@ -257,10 +258,10 @@ pub fn ts_signature_member(p: &mut Parser, construct_sig: bool) -> Option<Comple
 		no_recover!(p, ts_type_params(p));
 	}
 
-	let last_in_binding_list_for_signature =
-		std::mem::replace(&mut p.state.in_binding_list_for_signature, true);
-	parse_parameter_list(p).ok();
-	p.state.in_binding_list_for_signature = last_in_binding_list_for_signature;
+	{
+		let p = &mut *p.with_state(InBindingListForSignature);
+		parse_parameter_list(p).ok();
+	}
 
 	if p.at(T![:]) {
 		no_recover!(p, ts_type_or_type_predicate_ann(p, T![:]));

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -258,10 +258,8 @@ pub fn ts_signature_member(p: &mut Parser, construct_sig: bool) -> Option<Comple
 		no_recover!(p, ts_type_params(p));
 	}
 
-	{
-		let p = &mut *p.with_state(InBindingListForSignature);
-		parse_parameter_list(p).ok();
-	}
+	p.with_state(InBindingListForSignature(true), parse_parameter_list)
+		.ok();
 
 	if p.at(T![:]) {
 		no_recover!(p, ts_type_or_type_predicate_ann(p, T![:]));


### PR DESCRIPTION
## Summary

The parser has a neat `with_state` function that takes a snapshot of the parser state and restores the state to its previous state when it goes out of scope. However, the downside is that it copies the state at least twice, once inside the `with_state` function and once in the call-site, when constructing the new state which results in a serious performance penalty. 

This PR introduces a new `ChangeParserState` trait that allows making specific changes to the `ParserState` that can later be undone, only keeping a copy of the data they changed (and need to be restored later). Ideally, these changes would have semantic names. However, this PR re-uses the name of the fields. 

I hope to be able to reduce a lot of the boilerplate by introducing generic fields, for example if we're inside a function, constructor, async, etc... that then can all be changed with a single `ChangeParserState` implementation.




## Performance

The parse time (excluding tree sink and lexing) or across all libs improves by 25-33%, in some cases even close to 50%

* jquery.min.js: 3.244868ms -> 2.395019ms
* vue.global.prod.js: 6.825166ms -> 3.757078ms
* react.production.min.js: 246.53µs -> 191.09µs
* react-dom.production.min.js: 4.974296ms -> 3.006538ms
* compiler.js: 12.915072ms -> 9.110865ms
* dojo.js: 784.669µs -> 617.38µs
* d3.min.js: 11.771383ms -> 8.440315ms
* pixi.min.js: 12.437823ms -> 10.148374ms
* three.min.js:  19.487128ms -> 11.145823ms
* tex-chtml-full.js: 29.200492ms  -> 21.564177ms

## Test Plan

Verified that coverage doesn't change.
