### PR TITLE
feat(rslint_lexer): add d flag to regex

### DIFF
--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -988,25 +988,25 @@ impl<'src> Lexer<'src> {
 							let next = self.next_bounded().copied();
 							let chr_start = self.cur;
 							match next {
-							   Some(b'g') => {
-								   if g && diagnostic.is_none() {
+								Some(b'g') => {
+									if g && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('g'))
-								   }
-								   g = true;
-							   },
-							   Some(b'i') => {
+									}
+									g = true;
+								},
+								Some(b'i') => {
 									if i && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('i'))
 									}
 									i = true;
-							   },
-							   Some(b'm') => {
+								},
+								Some(b'm') => {
 									if m && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('m'))
 									}
 									m = true;
-							   },
-							   Some(b's') => {
+								},
+								Some(b's') => {
 									if s && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('s'))
 									}
@@ -1017,14 +1017,14 @@ impl<'src> Lexer<'src> {
 										diagnostic = Some(self.flag_err('u'))
 									}
 									u = true;
-							   },
-							   Some(b'y') => {
+								},
+								Some(b'y') => {
 									if y && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('y'))
 									}
 									y = true;
 								},
-							   Some(b'd') => {
+								Some(b'd') => {
 									if d && diagnostic.is_none() {
 										diagnostic = Some(self.flag_err('d'))
 									}

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -982,7 +982,7 @@ impl<'src> Lexer<'src> {
 				Some(b']') => in_class = false,
 				Some(b'/') => {
 					if !in_class {
-						let (mut g, mut i, mut m, mut s, mut u, mut y) = (false, false, false, false, false, false);
+						let (mut g, mut i, mut m, mut s, mut u, mut y, mut d) = (false, false, false, false, false, false, false);
 
 						unwind_loop! {
 							let next = self.next_bounded().copied();
@@ -1023,6 +1023,12 @@ impl<'src> Lexer<'src> {
 										diagnostic = Some(self.flag_err('y'))
 									}
 									y = true;
+								},
+							   Some(b'd') => {
+									if d && diagnostic.is_none() {
+										diagnostic = Some(self.flag_err('d'))
+									}
+									d = true;
 								},
 								Some(_) if self.cur_ident_part().is_some() => {
 									if diagnostic.is_none() {


### PR DESCRIPTION

## Summary
This PR adds the d flag to regex, explanation of the d flag can be found here:
https://github.com/tc39/proposal-regexp-match-indices#why-use-d-for-the-regexp-flag


## Test Plan
Local run:
| Test result | `main` count | This PR count | Difference |
| :---------: | :----------: | :-----------: | :--------: |
| Total | 44951 | 44951 | 0 |
| Passed | 42892 | 42907 | ✅ ⏫ **+15** |
| Failed | 2058 | 2043 | ✅ ⏬ **-15** |
| Panics | 1 | 1 | 0 |
| Coverage | 95.42% | 95.45% | **+0.03%** |

<details><summary><b>:tada: Fixed (15):</b></summary>

```
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-element.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-matched.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-non-unicode-match.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-properties.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-unicode-match.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-unicode-property-names.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array-unmatched.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-array.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-groups-object-undefined.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-groups-object-unmatched.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-groups-object.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-groups-properties.js
xtask/src/coverage/test262/test/built-ins/RegExp/match-indices/indices-property.js
xtask/src/coverage/test262/test/built-ins/RegExp/prototype/flags/this-val-regexp.js
xtask/src/coverage/test262/test/built-ins/RegExp/prototype/hasIndices/this-val-regexp.js
```
</details>
