### PR TITLE
using DebugDropBomb

### DIFF
--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -9,7 +9,7 @@ mod parse_recovery;
 mod parsed_syntax;
 pub(crate) mod single_token_parse_recovery;
 
-use drop_bomb::DropBomb;
+use drop_bomb::DebugDropBomb;
 use rslint_errors::Diagnostic;
 use rslint_lexer::Token;
 use rslint_syntax::JsSyntaxKind::EOF;
@@ -484,7 +484,7 @@ pub struct Marker {
 	pub start: usize,
 	pub old_start: u32,
 	pub(crate) child_idx: Option<usize>,
-	bomb: DropBomb,
+	bomb: DebugDropBomb,
 }
 
 impl Marker {
@@ -494,7 +494,7 @@ impl Marker {
 			start,
 			old_start: pos,
 			child_idx: None,
-			bomb: DropBomb::new("Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent."),
+			bomb: DebugDropBomb::new("Marker must either be `completed` or `abandoned` to avoid that children are implicitly attached to a markers parent."),
 		}
 	}
 


### PR DESCRIPTION
@MichaReiser  pointed out that ```drop_bomb``` already compiles to nothing on release; but only if we use the ```DebugDropBomb```

Before
```
ttps://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
                        time:   [13.214 ms 13.346 ms 13.483 ms]
https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
                        time:   [76.430 ms 77.113 ms 77.814 ms]
```


After
```
https://cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js
                        time:   [13.318 ms 13.412 ms 13.521 ms]
https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
                        time:   [71.329 ms 71.884 ms 72.578 ms]
```

Summary
```
jquery.min.js,Total Time,15.8501ms,tokenization,1.2743ms,parsing,7.3124ms,tree_sink,7.2634ms
vue.global.prod.js,Total Time,21.6517ms,tokenization,1.8166ms,parsing,9.9708ms,tree_sink,9.8643ms
react.production.min.js,Total Time,963.7µs,tokenization,81µs,parsing,403.7µs,tree_sink,479µs
react-dom.production.min.js,Total Time,18.6554ms,tokenization,1.7162ms,parsing,7.699ms,tree_sink,9.2402ms
compiler.js,Total Time,84.122ms,tokenization,9.3408ms,parsing,32.802ms,tree_sink,41.9792ms
dojo.js,Total Time,3.5862ms,tokenization,464.6µs,parsing,1.1646ms,tree_sink,1.957ms
pixi.min.js,Total Time,51.3571ms,tokenization,4.7786ms,parsing,21.2089ms,tree_sink,25.3696ms
three.min.js,Total Time,72.282ms,tokenization,5.9013ms,parsing,34.8234ms,tree_sink,31.5573ms
tex-chtml-full.js,Total Time,117.0081ms,tokenization,15.6527ms,parsing,42.311ms,tree_sink,59.0444ms
```
