### PR TITLE
NEWLINE and MULTILINE_COMMENT tokens on the trivia api

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -30,8 +30,8 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum TriviaPiece {
-	Newline(u32), // length
-	Whitespace(u32), // length
+	Newline(u32),        // length
+	Whitespace(u32),     // length
 	Comments(u32, bool), // length, has_newline
 }
 

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -108,8 +108,8 @@ impl<L: Language> SyntaxTriviaPieceComments<L> {
 /// builder.token_with_trivia(
 ///     RawSyntaxKind(1),
 ///     "\n\t /**/let \t\t",
-///     vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-///     vec![TriviaPiece::Whitespace(3)],
+///     &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+///     &[TriviaPiece::Whitespace(3)],
 /// );
 /// });
 ///
@@ -136,8 +136,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t /**/let \t\t",
-	///         vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -162,8 +162,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t /**/let \t\t",
-	///         vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -184,8 +184,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t /**/let \t\t",
-	///         vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -205,8 +205,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t /**/let \t\t",
-	///         vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -232,8 +232,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t /**/let \t\t",
-	///         vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -423,8 +423,8 @@ impl<L: Language> SyntaxTrivia<L> {
 	/// builder.token_with_trivia(
 	///     RawLanguageKind::LET_TOKEN,
 	///     "\n\t /**/let \t\t",
-	///     vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-	///     vec![TriviaPiece::Whitespace(3)],
+	///     &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+	///     &[TriviaPiece::Whitespace(3)],
 	/// );
 	/// });
 	/// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -474,15 +474,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// assert_eq!("\n\t let \t\ta; \t\t", node.text());
@@ -502,15 +502,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// assert_eq!("let \t\ta;", node.text_trimmed());
@@ -528,15 +528,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let range = node.text_range();
@@ -558,15 +558,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let range = node.text_trimmed_range();
@@ -586,15 +586,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let trivia = node.first_leading_trivia();
@@ -621,15 +621,15 @@ impl<L: Language> SyntaxNode<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::SEMICOLON_TOKEN,
 	///         "; \t\t",
-	///         vec![],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// });
 	/// let trivia = node.last_trailing_trivia();
@@ -838,8 +838,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("\n\t let \t\t", token.text());
@@ -857,8 +857,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("let", token.text_trimmed());
@@ -913,8 +913,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!("\n\t ", token.leading_trivia().text());
@@ -936,8 +936,8 @@ impl<L: Language> SyntaxToken<L> {
 	///     builder.token_with_trivia(
 	///         RawLanguageKind::LET_TOKEN,
 	///         "\n\t let \t\t",
-	///         vec![TriviaPiece::Whitespace(3)],
-	///         vec![TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
+	///         &[TriviaPiece::Whitespace(3)],
 	///     );
 	/// }).first_token().unwrap();
 	/// assert_eq!(" \t\t", token.trailing_trivia().text());
@@ -1527,8 +1527,8 @@ mod tests {
 		builder.token_with_trivia(
 			RawLanguageKind::LET_TOKEN,
 			"\n\t let \t\t",
-			vec![TriviaPiece::Whitespace(3)],
-			vec![TriviaPiece::Whitespace(3)],
+			&[TriviaPiece::Whitespace(3)],
+			&[TriviaPiece::Whitespace(3)],
 		);
 		builder.finish_node();
 
@@ -1556,27 +1556,27 @@ mod tests {
 		builder.token_with_trivia(
 			RawLanguageKind::LET_TOKEN,
 			"\n\t let \t\t",
-			vec![TriviaPiece::Whitespace(3)],
-			vec![TriviaPiece::Whitespace(3)],
+			&[TriviaPiece::Whitespace(3)],
+			&[TriviaPiece::Whitespace(3)],
 		);
 		builder.token_with_trivia(
 			RawLanguageKind::LET_TOKEN,
 			"a ",
-			vec![TriviaPiece::Whitespace(0)],
-			vec![TriviaPiece::Whitespace(1)],
+			&[TriviaPiece::Whitespace(0)],
+			&[TriviaPiece::Whitespace(1)],
 		);
 		builder.token_with_trivia(
 			RawLanguageKind::EQUAL_TOKEN,
 			"\n=\n",
-			vec![TriviaPiece::Whitespace(1)],
-			vec![TriviaPiece::Whitespace(1)],
+			&[TriviaPiece::Whitespace(1)],
+			&[TriviaPiece::Whitespace(1)],
 		);
 		builder.token(RawLanguageKind::NUMBER_TOKEN, "1");
 		builder.token_with_trivia(
 			RawLanguageKind::SEMICOLON_TOKEN,
 			";\t\t",
-			vec![],
-			vec![TriviaPiece::Whitespace(2)],
+			&[],
+			&[TriviaPiece::Whitespace(2)],
 		);
 		builder.finish_node();
 
@@ -1644,8 +1644,8 @@ mod tests {
 			builder.token_with_trivia(
 				RawLanguageKind::LET_TOKEN,
 				"\n\t /**/let \t\t",
-				vec![TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-				vec![TriviaPiece::Whitespace(3)],
+				&[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
+				&[TriviaPiece::Whitespace(3)],
 			);
 		});
 		let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -147,15 +147,15 @@ impl NodeCache {
 	}
 
 	pub(crate) fn token(&mut self, kind: RawSyntaxKind, text: &str) -> (u64, GreenToken) {
-		self.token_with_trivia(kind, text, Vec::new(), Vec::new())
+		self.token_with_trivia(kind, text, &[], &[])
 	}
 
 	pub(crate) fn token_with_trivia(
 		&mut self,
 		kind: RawSyntaxKind,
 		text: &str,
-		leading: Vec<TriviaPiece>,
-		trailing: Vec<TriviaPiece>,
+		leading: &[TriviaPiece],
+		trailing: &[TriviaPiece],
 	) -> (u64, GreenToken) {
 		let hash = token_hash_of(kind, text);
 

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -55,7 +55,9 @@ impl From<Vec<TriviaPiece>> for GreenTokenTrivia {
 		match trivias.as_slice() {
 			[] => GreenTokenTrivia::None,
 			[TriviaPiece::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
-			[TriviaPiece::Comments(len, has_newline)] => GreenTokenTrivia::Comments(*len, *has_newline),
+			[TriviaPiece::Comments(len, has_newline)] => {
+				GreenTokenTrivia::Comments(*len, *has_newline)
+			}
 			_ => GreenTokenTrivia::Many(Box::new(trivias)),
 		}
 	}

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -50,15 +50,15 @@ impl GreenTokenTrivia {
 	}
 }
 
-impl From<Vec<TriviaPiece>> for GreenTokenTrivia {
-	fn from(trivias: Vec<TriviaPiece>) -> Self {
-		match trivias.as_slice() {
+impl From<&[TriviaPiece]> for GreenTokenTrivia {
+	fn from(trivias: &[TriviaPiece]) -> Self {
+		match trivias {
 			[] => GreenTokenTrivia::None,
 			[TriviaPiece::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
 			[TriviaPiece::Comments(len, has_newline)] => {
 				GreenTokenTrivia::Comments(*len, *has_newline)
 			}
-			_ => GreenTokenTrivia::Many(Box::new(trivias)),
+			_ => GreenTokenTrivia::Many(Box::new(trivias.to_vec())),
 		}
 	}
 }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -19,7 +19,7 @@ use crate::{
 pub enum GreenTokenTrivia {
 	None,
 	Whitespace(u32),
-	Comments(u32, bool),
+	Comment(u32, bool),
 	Many(Box<Vec<TriviaPiece>>),
 }
 
@@ -28,7 +28,7 @@ impl GreenTokenTrivia {
 		match self {
 			GreenTokenTrivia::None => 0.into(),
 			GreenTokenTrivia::Whitespace(len) => (*len as u32).into(),
-			GreenTokenTrivia::Comments(len, _) => (*len as u32).into(),
+			GreenTokenTrivia::Comment(len, _) => (*len as u32).into(),
 			GreenTokenTrivia::Many(v) => {
 				let r = v.iter().fold(Some(TextSize::of("")), |len, trivia| {
 					len.and_then(|x| x.checked_add(trivia.text_len()))
@@ -43,7 +43,7 @@ impl GreenTokenTrivia {
 	pub(crate) fn get_piece(&self, index: usize) -> Option<TriviaPiece> {
 		match self {
 			GreenTokenTrivia::Whitespace(l) if index == 0 => Some(TriviaPiece::Whitespace(*l)),
-			GreenTokenTrivia::Comments(l, h) if index == 0 => Some(TriviaPiece::Comments(*l, *h)),
+			GreenTokenTrivia::Comment(l, h) if index == 0 => Some(TriviaPiece::Comments(*l, *h)),
 			GreenTokenTrivia::Many(v) => v.get(index).copied(),
 			_ => None,
 		}
@@ -56,7 +56,7 @@ impl From<&[TriviaPiece]> for GreenTokenTrivia {
 			[] => GreenTokenTrivia::None,
 			[TriviaPiece::Whitespace(len)] => GreenTokenTrivia::Whitespace(*len),
 			[TriviaPiece::Comments(len, has_newline)] => {
-				GreenTokenTrivia::Comments(*len, *has_newline)
+				GreenTokenTrivia::Comment(*len, *has_newline)
 			}
 			_ => GreenTokenTrivia::Many(Box::new(trivias.to_vec())),
 		}
@@ -300,7 +300,7 @@ mod tests {
 		);
 		assert_eq!(
 			TextSize::from(len),
-			GreenTokenTrivia::Comments(len, false).text_len()
+			GreenTokenTrivia::Comment(len, false).text_len()
 		);
 	}
 

--- a/crates/rome_rowan/src/tree_builder.rs
+++ b/crates/rome_rowan/src/tree_builder.rs
@@ -77,8 +77,8 @@ impl<L: Language, S: SyntaxFactory<Kind = L::Kind>> TreeBuilder<'_, L, S> {
 		&mut self,
 		kind: L::Kind,
 		text: &str,
-		leading: Vec<TriviaPiece>,
-		trailing: Vec<TriviaPiece>,
+		leading: &[TriviaPiece],
+		trailing: &[TriviaPiece],
 	) {
 		let (hash, token) = self
 			.cache

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -133,7 +133,8 @@ impl<'a> LosslessTreeSink<'a> {
 
 			let current_trivia = match token.kind {
 				NEWLINE | WHITESPACE => TriviaPiece::Whitespace(token.len),
-				COMMENT | MULTILINE_COMMENT => TriviaPiece::Comments(token.len),
+				COMMENT => TriviaPiece::Comments(token.len, false),
+				MULTILINE_COMMENT => TriviaPiece::Comments(token.len, true),
 				_ => unreachable!("Not Trivia"),
 			};
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -19,7 +19,7 @@ pub struct LosslessTreeSink<'a> {
 	inner: SyntaxTreeBuilder,
 	/// Signal that the sink must generate an EOF token when its finishing. See [LosslessTreeSink::finish] for more details.
 	needs_eof: bool,
-	trivia: Vec<TriviaPiece>
+	trivia: Vec<TriviaPiece>,
 }
 
 impl<'a> TreeSink for LosslessTreeSink<'a> {
@@ -62,7 +62,7 @@ impl<'a> LosslessTreeSink<'a> {
 			inner: SyntaxTreeBuilder::default(),
 			errors: vec![],
 			needs_eof: true,
-			trivia: Vec::with_capacity(128)
+			trivia: Vec::with_capacity(128),
 		}
 	}
 
@@ -87,7 +87,6 @@ impl<'a> LosslessTreeSink<'a> {
 		// Every trivia up to the token (including line breaks) will be the leading trivia
 		self.trivia.clear();
 		let (leading_range, leading_end) = self.get_trivia(false);
-		let leading_end = if leading_end == 0 { 0 } else { leading_end - 1 };
 
 		let len = TextSize::from(
 			(if token_count == 1 {
@@ -139,7 +138,8 @@ impl<'a> LosslessTreeSink<'a> {
 			length += len;
 
 			let current_trivia = match token.kind {
-				NEWLINE | WHITESPACE => TriviaPiece::Whitespace(token.len),
+				NEWLINE => TriviaPiece::Newline(token.len),
+				WHITESPACE => TriviaPiece::Whitespace(token.len),
 				COMMENT => TriviaPiece::Comments(token.len, false),
 				MULTILINE_COMMENT => TriviaPiece::Comments(token.len, true),
 				_ => unreachable!("Not Trivia"),

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -188,7 +188,7 @@ impl<'a> LossyTreeSink<'a> {
 		let range = leading_range.cover(token_range).cover(trailing_range);
 		let text = &self.text[range];
 
-		self.inner.token_with_trivia(kind, text, leading, trailing);
+		self.inner.token_with_trivia(kind, text, &leading, &trailing);
 	}
 
 	fn get_trivia(&mut self, break_on_newline: bool) -> (TextRange, Vec<TriviaPiece>) {

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -213,7 +213,8 @@ impl<'a> LossyTreeSink<'a> {
 
 			let current_trivia = match token.kind {
 				JsSyntaxKind::WHITESPACE | JsSyntaxKind::NEWLINE => continue,
-				JsSyntaxKind::COMMENT => TriviaPiece::Comments(token.len),
+				JsSyntaxKind::COMMENT => TriviaPiece::Comments(token.len, false),
+				JsSyntaxKind::MULTILINE_COMMENT => TriviaPiece::Comments(token.len, true),
 				_ => unreachable!("Not Trivia"),
 			};
 

--- a/crates/rslint_parser/src/lossy_tree_sink.rs
+++ b/crates/rslint_parser/src/lossy_tree_sink.rs
@@ -188,7 +188,8 @@ impl<'a> LossyTreeSink<'a> {
 		let range = leading_range.cover(token_range).cover(trailing_range);
 		let text = &self.text[range];
 
-		self.inner.token_with_trivia(kind, text, &leading, &trailing);
+		self.inner
+			.token_with_trivia(kind, text, &leading, &trailing);
 	}
 
 	fn get_trivia(&mut self, break_on_newline: bool) -> (TextRange, Vec<TriviaPiece>) {

--- a/crates/rslint_parser/test_data/inline/err/array_assignment_target_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/array_assignment_target_err.rast
@@ -37,7 +37,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@20..22 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@20..22 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsIdentifierAssignment {
                             name_token: IDENT@22..23 "a" [] [],
@@ -71,7 +71,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@45..47 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@45..47 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsAssignmentWithDefault {
                             pattern: JsIdentifierAssignment {
@@ -103,7 +103,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@70..72 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@70..72 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsComputedMemberAssignment {
                             object: JsArrayExpression {
@@ -146,7 +146,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@89..91 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@89..91 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsIdentifierAssignment {
                             name_token: IDENT@91..92 "a" [] [],
@@ -171,7 +171,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@100..101 "" [Whitespace("\n")] [],
+    eof_token: EOF@100..101 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..101
@@ -202,7 +202,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@20..45
       0: JS_ASSIGNMENT_EXPRESSION@20..44
         0: JS_ARRAY_ASSIGNMENT_PATTERN@20..38
-          0: L_BRACK@20..22 "[" [Whitespace("\n")] []
+          0: L_BRACK@20..22 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@22..36
             0: JS_IDENTIFIER_ASSIGNMENT@22..23
               0: IDENT@22..23 "a" [] []
@@ -224,7 +224,7 @@ JsModule {
     2: JS_EXPRESSION_STATEMENT@45..70
       0: JS_ASSIGNMENT_EXPRESSION@45..69
         0: JS_ARRAY_ASSIGNMENT_PATTERN@45..63
-          0: L_BRACK@45..47 "[" [Whitespace("\n")] []
+          0: L_BRACK@45..47 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@47..61
             0: JS_ASSIGNMENT_WITH_DEFAULT@47..51
               0: JS_IDENTIFIER_ASSIGNMENT@47..49
@@ -246,7 +246,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@70..89
       0: JS_ASSIGNMENT_EXPRESSION@70..88
         0: JS_ARRAY_ASSIGNMENT_PATTERN@70..82
-          0: L_BRACK@70..72 "[" [Whitespace("\n")] []
+          0: L_BRACK@70..72 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@72..81
             0: JS_COMPUTED_MEMBER_ASSIGNMENT@72..81
               0: JS_ARRAY_EXPRESSION@72..78
@@ -274,7 +274,7 @@ JsModule {
     4: JS_EXPRESSION_STATEMENT@89..100
       0: JS_ASSIGNMENT_EXPRESSION@89..100
         0: JS_ARRAY_ASSIGNMENT_PATTERN@89..97
-          0: L_BRACK@89..91 "[" [Whitespace("\n")] []
+          0: L_BRACK@89..91 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@91..95
             0: JS_IDENTIFIER_ASSIGNMENT@91..92
               0: IDENT@91..92 "a" [] []
@@ -288,7 +288,7 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@99..100
             0: IDENT@99..100 "c" [] []
       1: (empty)
-  3: EOF@100..101 "" [Whitespace("\n")] []
+  3: EOF@100..101 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `,` but instead found `a`
   ┌─ array_assignment_target_err.js:1:4

--- a/crates/rslint_parser/test_data/inline/err/array_assignment_target_rest_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/array_assignment_target_rest_err.rast
@@ -29,7 +29,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@14..16 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@14..16 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@16..18 "[" [] [Whitespace(" ")],
@@ -60,7 +60,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@42..44 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@42..44 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@44..46 "[" [] [Whitespace(" ")],
@@ -92,7 +92,7 @@ JsModule {
             semicolon_token: SEMICOLON@78..79 ";" [] [],
         },
     ],
-    eof_token: EOF@79..80 "" [Whitespace("\n")] [],
+    eof_token: EOF@79..80 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..80
@@ -118,7 +118,7 @@ JsModule {
       1: SEMICOLON@13..14 ";" [] []
     1: JS_EXPRESSION_STATEMENT@14..42
       0: JS_PARENTHESIZED_EXPRESSION@14..41
-        0: L_PAREN@14..16 "(" [Whitespace("\n")] []
+        0: L_PAREN@14..16 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@16..40
           0: JS_ARRAY_ASSIGNMENT_PATTERN@16..37
             0: L_BRACK@16..18 "[" [] [Whitespace(" ")]
@@ -138,7 +138,7 @@ JsModule {
       1: SEMICOLON@41..42 ";" [] []
     2: JS_EXPRESSION_STATEMENT@42..79
       0: JS_PARENTHESIZED_EXPRESSION@42..78
-        0: L_PAREN@42..44 "(" [Whitespace("\n")] []
+        0: L_PAREN@42..44 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@44..77
           0: JS_ARRAY_ASSIGNMENT_PATTERN@44..74
             0: L_BRACK@44..46 "[" [] [Whitespace(" ")]
@@ -157,7 +157,7 @@ JsModule {
               0: IDENT@76..77 "a" [] []
         2: R_PAREN@77..78 ")" [] []
       1: SEMICOLON@78..79 ";" [] []
-  3: EOF@79..80 "" [Whitespace("\n")] []
+  3: EOF@79..80 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, or an assignment target but instead found ''
   ┌─ array_assignment_target_rest_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/array_binding_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/array_binding_err.rast
@@ -45,7 +45,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@19..24 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@19..24 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -86,7 +86,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -125,7 +125,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@72..77 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@72..77 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -160,7 +160,7 @@ JsModule {
             semicolon_token: SEMICOLON@87..88 ";" [] [],
         },
     ],
-    eof_token: EOF@88..89 "" [Whitespace("\n")] [],
+    eof_token: EOF@88..89 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..89
@@ -197,7 +197,7 @@ JsModule {
       1: SEMICOLON@18..19 ";" [] []
     1: JS_VARIABLE_STATEMENT@19..46
       0: JS_VARIABLE_DECLARATIONS@19..45
-        0: LET_KW@19..24 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@19..24 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@24..45
           0: JS_VARIABLE_DECLARATION@24..45
             0: JS_ARRAY_BINDING_PATTERN@24..37
@@ -225,7 +225,7 @@ JsModule {
       1: SEMICOLON@45..46 ";" [] []
     2: JS_VARIABLE_STATEMENT@46..72
       0: JS_VARIABLE_DECLARATIONS@46..71
-        0: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@51..71
           0: JS_VARIABLE_DECLARATION@51..71
             0: JS_ARRAY_BINDING_PATTERN@51..63
@@ -250,7 +250,7 @@ JsModule {
       1: SEMICOLON@71..72 ";" [] []
     3: JS_VARIABLE_STATEMENT@72..88
       0: JS_VARIABLE_DECLARATIONS@72..87
-        0: LET_KW@72..77 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@72..77 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@77..87
           0: JS_VARIABLE_DECLARATION@77..87
             0: JS_ARRAY_BINDING_PATTERN@77..87
@@ -273,7 +273,7 @@ JsModule {
             2: (empty)
             3: (empty)
       1: SEMICOLON@87..88 ";" [] []
-  3: EOF@88..89 "" [Whitespace("\n")] []
+  3: EOF@88..89 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `,` but instead found `b`
   ┌─ array_binding_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/array_binding_rest_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/array_binding_rest_err.rast
@@ -34,7 +34,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -70,7 +70,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -107,7 +107,7 @@ JsModule {
             semicolon_token: SEMICOLON@84..85 ";" [] [],
         },
     ],
-    eof_token: EOF@85..86 "" [Whitespace("\n")] [],
+    eof_token: EOF@85..86 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..86
@@ -136,7 +136,7 @@ JsModule {
       1: SEMICOLON@15..16 ";" [] []
     1: JS_VARIABLE_STATEMENT@16..46
       0: JS_VARIABLE_DECLARATIONS@16..45
-        0: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@21..45
           0: JS_VARIABLE_DECLARATION@21..45
             0: JS_ARRAY_BINDING_PATTERN@21..42
@@ -159,7 +159,7 @@ JsModule {
       1: SEMICOLON@45..46 ";" [] []
     2: JS_VARIABLE_STATEMENT@46..85
       0: JS_VARIABLE_DECLARATIONS@46..84
-        0: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@51..84
           0: JS_VARIABLE_DECLARATION@51..84
             0: JS_ARRAY_BINDING_PATTERN@51..81
@@ -181,7 +181,7 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@83..84
                   0: IDENT@83..84 "a" [] []
       1: SEMICOLON@84..85 ";" [] []
-  3: EOF@85..86 "" [Whitespace("\n")] []
+  3: EOF@85..86 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, an array pattern, or an object pattern but instead found ''
   ┌─ array_binding_rest_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/assign_expr_left.rast
+++ b/crates/rslint_parser/test_data/inline/err/assign_expr_left.rast
@@ -27,7 +27,7 @@ JsModule {
             semicolon_token: SEMICOLON@8..9 ";" [] [],
         },
     ],
-    eof_token: EOF@9..10 "" [Whitespace("\n")] [],
+    eof_token: EOF@9..10 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..10
@@ -49,7 +49,7 @@ JsModule {
       0: R_PAREN@7..8 ")" [] []
     2: JS_EMPTY_STATEMENT@8..9
       0: SEMICOLON@8..9 ";" [] []
-  3: EOF@9..10 "" [Whitespace("\n")] []
+  3: EOF@9..10 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ assign_expr_left.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/assign_expr_right.rast
+++ b/crates/rslint_parser/test_data/inline/err/assign_expr_right.rast
@@ -17,7 +17,7 @@ JsModule {
             semicolon_token: SEMICOLON@8..9 ";" [] [],
         },
     ],
-    eof_token: EOF@9..10 "" [Whitespace("\n")] [],
+    eof_token: EOF@9..10 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..10
@@ -34,7 +34,7 @@ JsModule {
           2: (empty)
         2: R_PAREN@7..8 ")" [] []
       1: SEMICOLON@8..9 ";" [] []
-  3: EOF@9..10 "" [Whitespace("\n")] []
+  3: EOF@9..10 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression, or an assignment but instead found ')'
   ┌─ assign_expr_right.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_arrow_expr_await_parameter.rast
@@ -38,7 +38,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@25..26 "" [Whitespace("\n")] [],
+    eof_token: EOF@25..26 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..26
@@ -69,7 +69,7 @@ JsModule {
                   2: JS_STATEMENT_LIST@24..24
                   3: R_CURLY@24..25 "}" [] []
       1: (empty)
-  3: EOF@25..26 "" [Whitespace("\n")] []
+  3: EOF@25..26 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of `await` as an identifier in an async context
   ┌─ async_arrow_expr_await_parameter.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -33,7 +33,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@11..16 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@11..16 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: PLUS@16..18 "+" [] [Whitespace(" ")],
@@ -50,7 +50,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsUnaryExpression {
-                    operator: BANG@22..24 "!" [Whitespace("\n")] [],
+                    operator: BANG@22..24 "!" [Newline("\n")] [],
                     argument: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@24..28 "foo" [] [Whitespace(" ")],
@@ -67,7 +67,7 @@ JsModule {
             semicolon_token: SEMICOLON@33..34 ";" [] [],
         },
     ],
-    eof_token: EOF@34..35 "" [Whitespace("\n")] [],
+    eof_token: EOF@34..35 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..35
@@ -96,7 +96,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@11..21
         0: JS_IDENTIFIER_EXPRESSION@11..16
           0: JS_REFERENCE_IDENTIFIER@11..16
-            0: IDENT@11..16 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@11..16 "foo" [Newline("\n")] [Whitespace(" ")]
         1: PLUS@16..18 "+" [] [Whitespace(" ")]
         2: JS_BINARY_EXPRESSION@18..21
           0: (empty)
@@ -107,7 +107,7 @@ JsModule {
     2: JS_EXPRESSION_STATEMENT@22..34
       0: JS_BINARY_EXPRESSION@22..33
         0: JS_UNARY_EXPRESSION@22..28
-          0: BANG@22..24 "!" [Whitespace("\n")] []
+          0: BANG@22..24 "!" [Newline("\n")] []
           1: JS_IDENTIFIER_EXPRESSION@24..28
             0: JS_REFERENCE_IDENTIFIER@24..28
               0: IDENT@24..28 "foo" [] [Whitespace(" ")]
@@ -116,7 +116,7 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@30..33
             0: IDENT@30..33 "bar" [] []
       1: SEMICOLON@33..34 ";" [] []
-  3: EOF@34..35 "" [Whitespace("\n")] []
+  3: EOF@34..35 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found ')'
   ┌─ binary_expressions_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid.rast
@@ -48,7 +48,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@30..40 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@30..40 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: STAR@40..41 "*" [] [],
             id: JsIdentifierBinding {
                 name_token: IDENT@41..44 "foo" [] [],
@@ -66,7 +66,7 @@ JsModule {
                 statements: JsStatementList [
                     JsVariableStatement {
                         declarations: JsVariableDeclarations {
-                            kind: LET_KW@48..56 "let" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")],
+                            kind: LET_KW@48..56 "let" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
                             items: JsVariableDeclarationList [
                                 JsVariableDeclaration {
                                     id: JsUnknownBinding {
@@ -88,12 +88,12 @@ JsModule {
                         semicolon_token: SEMICOLON@65..66 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@66..68 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@66..68 "}" [Newline("\n")] [],
             },
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@68..73 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@68..73 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsUnknownBinding {
@@ -116,7 +116,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@82..87 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@82..87 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsUnknownBinding {
@@ -139,7 +139,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@95..102 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@95..102 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsUnknownBinding {
@@ -162,7 +162,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@110..115 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@110..115 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -188,7 +188,7 @@ JsModule {
             semicolon_token: SEMICOLON@119..120 ";" [] [],
         },
     ],
-    eof_token: EOF@120..121 "" [Whitespace("\n")] [],
+    eof_token: EOF@120..121 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..121
@@ -227,7 +227,7 @@ JsModule {
       1: (empty)
     1: JS_FUNCTION_STATEMENT@30..68
       0: (empty)
-      1: FUNCTION_KW@30..40 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@30..40 "function" [Newline("\n")] [Whitespace(" ")]
       2: STAR@40..41 "*" [] []
       3: JS_IDENTIFIER_BINDING@41..44
         0: IDENT@41..44 "foo" [] []
@@ -243,7 +243,7 @@ JsModule {
         2: JS_STATEMENT_LIST@48..66
           0: JS_VARIABLE_STATEMENT@48..66
             0: JS_VARIABLE_DECLARATIONS@48..65
-              0: LET_KW@48..56 "let" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")]
+              0: LET_KW@48..56 "let" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")]
               1: JS_VARIABLE_DECLARATION_LIST@56..65
                 0: JS_VARIABLE_DECLARATION@56..65
                   0: JS_UNKNOWN_BINDING@56..62
@@ -255,10 +255,10 @@ JsModule {
                     1: JS_NUMBER_LITERAL_EXPRESSION@64..65
                       0: JS_NUMBER_LITERAL@64..65 "5" [] []
             1: SEMICOLON@65..66 ";" [] []
-        3: R_CURLY@66..68 "}" [Whitespace("\n")] []
+        3: R_CURLY@66..68 "}" [Newline("\n")] []
     2: JS_VARIABLE_STATEMENT@68..82
       0: JS_VARIABLE_DECLARATIONS@68..81
-        0: LET_KW@68..73 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@68..73 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@73..81
           0: JS_VARIABLE_DECLARATION@73..81
             0: JS_UNKNOWN_BINDING@73..78
@@ -272,7 +272,7 @@ JsModule {
       1: SEMICOLON@81..82 ";" [] []
     3: JS_VARIABLE_STATEMENT@82..95
       0: JS_VARIABLE_DECLARATIONS@82..94
-        0: LET_KW@82..87 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@82..87 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@87..94
           0: JS_VARIABLE_DECLARATION@87..94
             0: JS_UNKNOWN_BINDING@87..91
@@ -286,7 +286,7 @@ JsModule {
       1: SEMICOLON@94..95 ";" [] []
     4: JS_VARIABLE_STATEMENT@95..110
       0: JS_VARIABLE_DECLARATIONS@95..109
-        0: CONST_KW@95..102 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@95..102 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@102..109
           0: JS_VARIABLE_DECLARATION@102..109
             0: JS_UNKNOWN_BINDING@102..106
@@ -300,7 +300,7 @@ JsModule {
       1: SEMICOLON@109..110 ";" [] []
     5: JS_VARIABLE_STATEMENT@110..120
       0: JS_VARIABLE_DECLARATIONS@110..119
-        0: LET_KW@110..115 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@110..115 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@115..119
           0: JS_VARIABLE_DECLARATION@115..116
             0: JS_IDENTIFIER_BINDING@115..116
@@ -316,7 +316,7 @@ JsModule {
             2: (empty)
             3: (empty)
       1: SEMICOLON@119..120 ";" [] []
-  3: EOF@120..121 "" [Whitespace("\n")] []
+  3: EOF@120..121 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of `await` as an identifier in an async context
   ┌─ binding_identifier_invalid.js:1:19

--- a/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid_script.rast
+++ b/crates/rslint_parser/test_data/inline/err/binding_identifier_invalid_script.rast
@@ -4,7 +4,7 @@ JsScript {
     statements: JsStatementList [
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@0..14 "let" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@0..14 "let" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsUnknownBinding {
@@ -27,7 +27,7 @@ JsScript {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@22..29 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@22..29 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsUnknownBinding {
@@ -49,7 +49,7 @@ JsScript {
             semicolon_token: SEMICOLON@36..37 ";" [] [],
         },
     ],
-    eof_token: EOF@37..38 "" [Whitespace("\n")] [],
+    eof_token: EOF@37..38 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..38
@@ -58,7 +58,7 @@ JsScript {
   2: JS_STATEMENT_LIST@0..37
     0: JS_VARIABLE_STATEMENT@0..22
       0: JS_VARIABLE_DECLARATIONS@0..21
-        0: LET_KW@0..14 "let" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@0..14 "let" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@14..21
           0: JS_VARIABLE_DECLARATION@14..21
             0: JS_UNKNOWN_BINDING@14..18
@@ -72,7 +72,7 @@ JsScript {
       1: SEMICOLON@21..22 ";" [] []
     1: JS_VARIABLE_STATEMENT@22..37
       0: JS_VARIABLE_DECLARATIONS@22..36
-        0: CONST_KW@22..29 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@22..29 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@29..36
           0: JS_VARIABLE_DECLARATION@29..36
             0: JS_UNKNOWN_BINDING@29..33
@@ -84,7 +84,7 @@ JsScript {
               1: JS_NUMBER_LITERAL_EXPRESSION@35..36
                 0: JS_NUMBER_LITERAL@35..36 "5" [] []
       1: SEMICOLON@36..37 ";" [] []
-  3: EOF@37..38 "" [Whitespace("\n")] []
+  3: EOF@37..38 "" [Newline("\n")] []
 --
 error[SyntaxError]: `let` cannot be declared as a variable name inside of a `let` declaration
   ┌─ binding_identifier_invalid_script.js:2:5

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -25,7 +25,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -45,7 +45,7 @@ JsModule {
       6: R_CURLY@9..10 "}" [] []
     1: JS_UNKNOWN_STATEMENT@10..11
       0: R_CURLY@10..11 "}" [] []
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a property , a method, a getter, or a setter but instead found '{'
   ┌─ block_stmt_in_class.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/bracket_expr_err.rast
@@ -20,7 +20,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@5..9 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: QUESTIONDOT@9..11 "?." [] [],
@@ -34,7 +34,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@13..17 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@13..17 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: missing (optional),
@@ -45,7 +45,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@18..19 "" [Whitespace("\n")] [],
+    eof_token: EOF@18..19 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..19
@@ -66,7 +66,7 @@ JsModule {
       0: JS_COMPUTED_MEMBER_EXPRESSION@5..13
         0: JS_IDENTIFIER_EXPRESSION@5..9
           0: JS_REFERENCE_IDENTIFIER@5..9
-            0: IDENT@5..9 "foo" [Whitespace("\n")] []
+            0: IDENT@5..9 "foo" [Newline("\n")] []
         1: QUESTIONDOT@9..11 "?." [] []
         2: L_BRACK@11..12 "[" [] []
         3: (empty)
@@ -76,13 +76,13 @@ JsModule {
       0: JS_COMPUTED_MEMBER_EXPRESSION@13..18
         0: JS_IDENTIFIER_EXPRESSION@13..17
           0: JS_REFERENCE_IDENTIFIER@13..17
-            0: IDENT@13..17 "foo" [Whitespace("\n")] []
+            0: IDENT@13..17 "foo" [Newline("\n")] []
         1: (empty)
         2: L_BRACK@17..18 "[" [] []
         3: (empty)
         4: (empty)
       1: (empty)
-  3: EOF@18..19 "" [Whitespace("\n")] []
+  3: EOF@18..19 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found ']'
   ┌─ bracket_expr_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/break_stmt.rast
@@ -31,7 +31,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@25..32 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@25..32 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@32..33 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@33..37 "true" [] [],
@@ -41,16 +41,16 @@ JsModule {
                 l_curly_token: L_CURLY@39..40 "{" [] [],
                 statements: JsStatementList [
                     JsBreakStatement {
-                        break_token: BREAK_KW@40..49 "break" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                        break_token: BREAK_KW@40..49 "break" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                         label_token: IDENT@49..52 "foo" [] [],
                         semicolon_token: SEMICOLON@52..53 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@53..55 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@53..55 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@55..56 "" [Whitespace("\n")] [],
+    eof_token: EOF@55..56 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..56
@@ -78,7 +78,7 @@ JsModule {
             1: SEMICOLON@22..24 ";" [] [Whitespace(" ")]
         3: R_CURLY@24..25 "}" [] []
     1: JS_WHILE_STATEMENT@25..55
-      0: WHILE_KW@25..32 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@25..32 "while" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@32..33 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@33..37
         0: TRUE_KW@33..37 "true" [] []
@@ -87,11 +87,11 @@ JsModule {
         0: L_CURLY@39..40 "{" [] []
         1: JS_STATEMENT_LIST@40..53
           0: JS_BREAK_STATEMENT@40..53
-            0: BREAK_KW@40..49 "break" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+            0: BREAK_KW@40..49 "break" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
             1: IDENT@49..52 "foo" [] []
             2: SEMICOLON@52..53 ";" [] []
-        2: R_CURLY@53..55 "}" [Whitespace("\n")] []
-  3: EOF@55..56 "" [Whitespace("\n")] []
+        2: R_CURLY@53..55 "}" [Newline("\n")] []
+  3: EOF@55..56 "" [Newline("\n")] []
 --
 error[SyntaxError]: Invalid break not inside of a switch, loop, or labelled statement
   ┌─ break_stmt.js:1:18

--- a/crates/rslint_parser/test_data/inline/err/class_constructor_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_constructor_parameter.rast
@@ -43,7 +43,7 @@ JsModule {
             r_curly_token: R_CURLY@38..39 "}" [] [],
         },
     ],
-    eof_token: EOF@39..40 "" [Whitespace("\n")] [],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..40
@@ -80,7 +80,7 @@ JsModule {
             2: JS_STATEMENT_LIST@36..36
             3: R_CURLY@36..38 "}" [] [Whitespace(" ")]
       6: R_CURLY@38..39 "}" [] []
-  3: EOF@39..40 "" [Whitespace("\n")] []
+  3: EOF@39..40 "" [Newline("\n")] []
 --
 error[SyntaxError]: accessibility modifiers for a parameter inside a constructor can only be used in TypeScript files
   ┌─ class_constructor_parameter.js:1:23

--- a/crates/rslint_parser/test_data/inline/err/class_constructor_parameter_readonly.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_constructor_parameter_readonly.rast
@@ -43,7 +43,7 @@ JsModule {
             r_curly_token: R_CURLY@37..38 "}" [] [],
         },
     ],
-    eof_token: EOF@38..39 "" [Whitespace("\n")] [],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..39
@@ -80,7 +80,7 @@ JsModule {
             2: JS_STATEMENT_LIST@35..35
             3: R_CURLY@35..37 "}" [] [Whitespace(" ")]
       6: R_CURLY@37..38 "}" [] []
-  3: EOF@38..39 "" [Whitespace("\n")] []
+  3: EOF@38..39 "" [Newline("\n")] []
 --
 error[SyntaxError]: readonly modifiers for a parameter inside a constructor can only be used in TypeScript files
   ┌─ class_constructor_parameter_readonly.js:1:23

--- a/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_err.rast
@@ -12,7 +12,7 @@ JsModule {
             r_curly_token: R_CURLY@7..8 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@8..15 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@8..15 "class" [Newline("\n")] [Whitespace(" ")],
             id: missing (required),
             extends_clause: JsExtendsClause {
                 extends_token: EXTENDS_KW@15..23 "extends" [] [Whitespace(" ")],
@@ -28,7 +28,7 @@ JsModule {
             r_curly_token: R_CURLY@28..29 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@29..36 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@29..36 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@36..40 "foo" [] [Whitespace(" ")],
             },
@@ -56,7 +56,7 @@ JsModule {
             r_curly_token: R_CURLY@49..50 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@50..57 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@50..57 "class" [Newline("\n")] [Whitespace(" ")],
             id: missing (required),
             extends_clause: JsExtendsClause {
                 extends_token: EXTENDS_KW@57..65 "extends" [] [Whitespace(" ")],
@@ -72,7 +72,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@67..68 "" [Whitespace("\n")] [],
+    eof_token: EOF@67..68 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..68
@@ -88,7 +88,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@7..7
       6: R_CURLY@7..8 "}" [] []
     1: JS_CLASS_STATEMENT@8..29
-      0: CLASS_KW@8..15 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@8..15 "class" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: JS_EXTENDS_CLAUSE@15..27
         0: EXTENDS_KW@15..23 "extends" [] [Whitespace(" ")]
@@ -100,7 +100,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@28..28
       6: R_CURLY@28..29 "}" [] []
     2: JS_CLASS_STATEMENT@29..50
-      0: CLASS_KW@29..36 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@29..36 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@36..40
         0: IDENT@36..40 "foo" [] [Whitespace(" ")]
       2: (empty)
@@ -123,7 +123,7 @@ JsModule {
             3: R_CURLY@47..49 "}" [] [Whitespace(" ")]
       6: R_CURLY@49..50 "}" [] []
     3: JS_CLASS_STATEMENT@50..67
-      0: CLASS_KW@50..57 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@50..57 "class" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: JS_EXTENDS_CLAUSE@57..67
         0: EXTENDS_KW@57..65 "extends" [] [Whitespace(" ")]
@@ -135,7 +135,7 @@ JsModule {
       4: (empty)
       5: JS_CLASS_MEMBER_LIST@67..67
       6: (empty)
-  3: EOF@67..68 "" [Whitespace("\n")] []
+  3: EOF@67..68 "" [Newline("\n")] []
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ class_decl_err.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/class_decl_no_id.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_decl_no_id.rast
@@ -13,7 +13,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                CLASS_KW@8..15 "class" [Whitespace("\n")] [Whitespace(" ")],
+                CLASS_KW@8..15 "class" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         IMPLEMENTS_KW@15..26 "implements" [] [Whitespace(" ")],
@@ -33,7 +33,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@30..31 "" [Whitespace("\n")] [],
+    eof_token: EOF@30..31 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..31
@@ -49,7 +49,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@7..7
       6: R_CURLY@7..8 "}" [] []
     1: JS_UNKNOWN_STATEMENT@8..30
-      0: CLASS_KW@8..15 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@8..15 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@15..28
         0: IMPLEMENTS_KW@15..26 "implements" [] [Whitespace(" ")]
         1: TS_TYPE_LIST@26..28
@@ -60,7 +60,7 @@ JsModule {
       2: L_CURLY@28..29 "{" [] []
       3: JS_CLASS_MEMBER_LIST@29..29
       4: R_CURLY@29..30 "}" [] []
-  3: EOF@30..31 "" [Whitespace("\n")] []
+  3: EOF@30..31 "" [Newline("\n")] []
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ class_decl_no_id.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/class_declare_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_declare_member.rast
@@ -23,7 +23,7 @@ JsModule {
             r_curly_token: R_CURLY@22..23 "}" [] [],
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -43,7 +43,7 @@ JsModule {
           1: JS_LITERAL_MEMBER_NAME@18..22
             0: IDENT@18..22 "foo" [] [Whitespace(" ")]
       6: R_CURLY@22..23 "}" [] []
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []
 --
 error[SyntaxError]: `declare` modifier can only be used in TypeScript files
   ┌─ class_declare_member.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/class_declare_method.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_declare_method.rast
@@ -34,7 +34,7 @@ JsModule {
             r_curly_token: R_CURLY@26..27 "}" [] [],
         },
     ],
-    eof_token: EOF@27..28 "" [Whitespace("\n")] [],
+    eof_token: EOF@27..28 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..28
@@ -63,7 +63,7 @@ JsModule {
             2: JS_STATEMENT_LIST@24..24
             3: R_CURLY@24..26 "}" [] [Whitespace(" ")]
       6: R_CURLY@26..27 "}" [] []
-  3: EOF@27..28 "" [Whitespace("\n")] []
+  3: EOF@27..28 "" [Newline("\n")] []
 --
 error[SyntaxError]: `declare` modifier can only be used in TypeScript files
   ┌─ class_declare_method.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/class_extends_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_extends_err.rast
@@ -35,7 +35,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                CLASS_KW@34..41 "class" [Whitespace("\n")] [Whitespace(" ")],
+                CLASS_KW@34..41 "class" [Newline("\n")] [Whitespace(" ")],
                 JsIdentifierBinding {
                     name_token: IDENT@41..43 "A" [] [Whitespace(" ")],
                 },
@@ -65,7 +65,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@62..63 "" [Whitespace("\n")] [],
+    eof_token: EOF@62..63 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..63
@@ -90,7 +90,7 @@ JsModule {
       4: JS_CLASS_MEMBER_LIST@33..33
       5: R_CURLY@33..34 "}" [] []
     1: JS_UNKNOWN_STATEMENT@34..62
-      0: CLASS_KW@34..41 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@34..41 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@41..43
         0: IDENT@41..43 "A" [] [Whitespace(" ")]
       2: JS_UNKNOWN@43..60
@@ -106,7 +106,7 @@ JsModule {
       3: L_CURLY@60..61 "{" [] []
       4: JS_CLASS_MEMBER_LIST@61..61
       5: R_CURLY@61..62 "}" [] []
-  3: EOF@62..63 "" [Whitespace("\n")] []
+  3: EOF@62..63 "" [Newline("\n")] []
 --
 error[SyntaxError]: classes cannot extend multiple classes
   ┌─ class_extends_err.js:1:29

--- a/crates/rslint_parser/test_data/inline/err/class_implements.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_implements.rast
@@ -27,7 +27,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -48,7 +48,7 @@ JsModule {
       3: L_CURLY@21..22 "{" [] []
       4: JS_CLASS_MEMBER_LIST@22..22
       5: R_CURLY@22..23 "}" [] []
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []
 --
 error[SyntaxError]: classes can only implement interfaces in TypeScript files
   ┌─ class_implements.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/class_invalid_modifiers.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_invalid_modifiers.rast
@@ -34,7 +34,7 @@ JsModule {
             r_curly_token: R_CURLY@26..27 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@27..34 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@27..34 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@34..36 "B" [] [Whitespace(" ")],
             },
@@ -66,7 +66,7 @@ JsModule {
             r_curly_token: R_CURLY@61..62 "}" [] [],
         },
     ],
-    eof_token: EOF@62..63 "" [Whitespace("\n")] [],
+    eof_token: EOF@62..63 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..63
@@ -96,7 +96,7 @@ JsModule {
             3: R_CURLY@24..26 "}" [] [Whitespace(" ")]
       6: R_CURLY@26..27 "}" [] []
     1: JS_CLASS_STATEMENT@27..62
-      0: CLASS_KW@27..34 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@27..34 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@34..36
         0: IDENT@34..36 "B" [] [Whitespace(" ")]
       2: (empty)
@@ -118,7 +118,7 @@ JsModule {
             2: JS_STATEMENT_LIST@59..59
             3: R_CURLY@59..61 "}" [] [Whitespace(" ")]
       6: R_CURLY@61..62 "}" [] []
-  3: EOF@62..63 "" [Whitespace("\n")] []
+  3: EOF@62..63 "" [Newline("\n")] []
 --
 error[SyntaxError]: `public` modifier can only be used in TypeScript files
   ┌─ class_invalid_modifiers.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/class_member_bang.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_member_bang.rast
@@ -24,7 +24,7 @@ JsModule {
             r_curly_token: R_CURLY@16..17 "}" [] [],
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -45,7 +45,7 @@ JsModule {
           1: BANG@13..14 "!" [] []
           2: SEMICOLON@14..16 ";" [] [Whitespace(" ")]
       6: R_CURLY@16..17 "}" [] []
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []
 --
 error[SyntaxError]: definite assignment assertions can only be used in TypeScript files
   ┌─ class_member_bang.js:1:14

--- a/crates/rslint_parser/test_data/inline/err/class_member_method_body.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_member_method_body.rast
@@ -41,7 +41,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@16..17 "" [Whitespace("\n")] [],
+    eof_token: EOF@16..17 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..17
@@ -77,7 +77,7 @@ JsModule {
           8: (empty)
           9: (empty)
       6: (empty)
-  3: EOF@16..17 "" [Whitespace("\n")] []
+  3: EOF@16..17 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a class method body but instead found ''
   ┌─ class_member_method_body.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/class_member_method_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_member_method_parameters.rast
@@ -57,7 +57,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@20..21 "" [Whitespace("\n")] [],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..21
@@ -104,7 +104,7 @@ JsModule {
           8: (empty)
           9: (empty)
       6: (empty)
-  3: EOF@20..21 "" [Whitespace("\n")] []
+  3: EOF@20..21 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `,` but instead found `{`
   ┌─ class_member_method_parameters.js:1:17

--- a/crates/rslint_parser/test_data/inline/err/class_member_modifier.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_member_modifier.rast
@@ -24,7 +24,7 @@ JsModule {
             r_curly_token: R_CURLY@24..25 "}" [] [],
         },
     ],
-    eof_token: EOF@25..26 "" [Whitespace("\n")] [],
+    eof_token: EOF@25..26 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..26
@@ -45,7 +45,7 @@ JsModule {
             0: IDENT@19..22 "foo" [] []
           2: SEMICOLON@22..24 ";" [] [Whitespace(" ")]
       6: R_CURLY@24..25 "}" [] []
-  3: EOF@25..26 "" [Whitespace("\n")] []
+  3: EOF@25..26 "" [Newline("\n")] []
 --
 error[SyntaxError]: `abstract` modifier can only be used in TypeScript files
   ┌─ class_member_modifier.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/class_property_initializer.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_property_initializer.rast
@@ -33,7 +33,7 @@ JsModule {
             r_curly_token: R_CURLY@20..21 "}" [] [],
         },
     ],
-    eof_token: EOF@21..22 "" [Whitespace("\n")] [],
+    eof_token: EOF@21..22 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..22
@@ -64,7 +64,7 @@ JsModule {
             1: (empty)
           10: SEMICOLON@18..20 ";" [] [Whitespace(" ")]
       6: R_CURLY@20..21 "}" [] []
-  3: EOF@21..22 "" [Whitespace("\n")] []
+  3: EOF@21..22 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression, or an assignment but instead found ';'
   ┌─ class_property_initializer.js:1:19

--- a/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/conditional_expr_err.rast
@@ -28,7 +28,7 @@ JsModule {
             expression: JsConditionalExpression {
                 test: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@13..18 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@13..18 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 question_mark_token: QUESTION@18..20 "?" [] [Whitespace(" ")],
@@ -64,7 +64,7 @@ JsModule {
             expression: JsConditionalExpression {
                 test: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@39..44 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@39..44 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 question_mark_token: QUESTION@44..46 "?" [] [Whitespace(" ")],
@@ -79,7 +79,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@51..52 "" [Whitespace("\n")] [],
+    eof_token: EOF@51..52 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..52
@@ -104,7 +104,7 @@ JsModule {
       0: JS_CONDITIONAL_EXPRESSION@13..39
         0: JS_IDENTIFIER_EXPRESSION@13..18
           0: JS_REFERENCE_IDENTIFIER@13..18
-            0: IDENT@13..18 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@13..18 "foo" [Newline("\n")] [Whitespace(" ")]
         1: QUESTION@18..20 "?" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@20..24
           0: JS_REFERENCE_IDENTIFIER@20..24
@@ -127,7 +127,7 @@ JsModule {
       0: JS_CONDITIONAL_EXPRESSION@39..51
         0: JS_IDENTIFIER_EXPRESSION@39..44
           0: JS_REFERENCE_IDENTIFIER@39..44
-            0: IDENT@39..44 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@39..44 "foo" [Newline("\n")] [Whitespace(" ")]
         1: QUESTION@44..46 "?" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@46..50
           0: JS_REFERENCE_IDENTIFIER@46..50
@@ -135,7 +135,7 @@ JsModule {
         3: COLON@50..51 ":" [] []
         4: (empty)
       1: (empty)
-  3: EOF@51..52 "" [Whitespace("\n")] []
+  3: EOF@51..52 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `baz`
   ┌─ conditional_expr_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/continue_stmt.rast
@@ -31,7 +31,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@28..35 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@28..35 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@35..36 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@36..40 "true" [] [],
@@ -41,16 +41,16 @@ JsModule {
                 l_curly_token: L_CURLY@42..43 "{" [] [],
                 statements: JsStatementList [
                     JsContinueStatement {
-                        continue_token: CONTINUE_KW@43..55 "continue" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                        continue_token: CONTINUE_KW@43..55 "continue" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                         label_token: IDENT@55..58 "foo" [] [],
                         semicolon_token: SEMICOLON@58..59 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@59..61 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@59..61 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@61..62 "" [Whitespace("\n")] [],
+    eof_token: EOF@61..62 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..62
@@ -78,7 +78,7 @@ JsModule {
             1: SEMICOLON@25..27 ";" [] [Whitespace(" ")]
         3: R_CURLY@27..28 "}" [] []
     1: JS_WHILE_STATEMENT@28..61
-      0: WHILE_KW@28..35 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@28..35 "while" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@35..36 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@36..40
         0: TRUE_KW@36..40 "true" [] []
@@ -87,11 +87,11 @@ JsModule {
         0: L_CURLY@42..43 "{" [] []
         1: JS_STATEMENT_LIST@43..59
           0: JS_CONTINUE_STATEMENT@43..59
-            0: CONTINUE_KW@43..55 "continue" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+            0: CONTINUE_KW@43..55 "continue" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
             1: IDENT@55..58 "foo" [] []
             2: SEMICOLON@58..59 ";" [] []
-        2: R_CURLY@59..61 "}" [Whitespace("\n")] []
-  3: EOF@61..62 "" [Whitespace("\n")] []
+        2: R_CURLY@59..61 "}" [Newline("\n")] []
+  3: EOF@61..62 "" [Newline("\n")] []
 --
 error[SyntaxError]: Invalid continue not inside of a loop
   ┌─ continue_stmt.js:1:18

--- a/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/err/debugger_stmt.rast
@@ -21,7 +21,7 @@ JsModule {
                 directives: JsDirectiveList [],
                 statements: JsStatementList [
                     JsDebuggerStatement {
-                        debugger_token: DEBUGGER_KW@16..27 "debugger" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        debugger_token: DEBUGGER_KW@16..27 "debugger" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         semicolon_token: missing (optional),
                     },
                     JsBlockStatement {
@@ -29,7 +29,7 @@ JsModule {
                         statements: JsStatementList [
                             JsVariableStatement {
                                 declarations: JsVariableDeclarations {
-                                    kind: VAR_KW@28..35 "var" [Whitespace("\n"), Whitespace("\t\t")] [Whitespace(" ")],
+                                    kind: VAR_KW@28..35 "var" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
                                     items: JsVariableDeclarationList [
                                         JsVariableDeclaration {
                                             id: JsIdentifierBinding {
@@ -49,14 +49,14 @@ JsModule {
                                 semicolon_token: SEMICOLON@54..55 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@55..58 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@55..58 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 ],
-                r_curly_token: R_CURLY@58..60 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@58..60 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@60..61 "" [Whitespace("\n")] [],
+    eof_token: EOF@60..61 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..61
@@ -80,14 +80,14 @@ JsModule {
         1: JS_DIRECTIVE_LIST@16..16
         2: JS_STATEMENT_LIST@16..58
           0: JS_DEBUGGER_STATEMENT@16..27
-            0: DEBUGGER_KW@16..27 "debugger" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            0: DEBUGGER_KW@16..27 "debugger" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
             1: (empty)
           1: JS_BLOCK_STATEMENT@27..58
             0: L_CURLY@27..28 "{" [] []
             1: JS_STATEMENT_LIST@28..55
               0: JS_VARIABLE_STATEMENT@28..55
                 0: JS_VARIABLE_DECLARATIONS@28..54
-                  0: VAR_KW@28..35 "var" [Whitespace("\n"), Whitespace("\t\t")] [Whitespace(" ")]
+                  0: VAR_KW@28..35 "var" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
                   1: JS_VARIABLE_DECLARATION_LIST@35..54
                     0: JS_VARIABLE_DECLARATION@35..54
                       0: JS_IDENTIFIER_BINDING@35..45
@@ -99,9 +99,9 @@ JsModule {
                         1: JS_STRING_LITERAL_EXPRESSION@47..54
                           0: JS_STRING_LITERAL@47..54 "\"lorem\"" [] []
                 1: SEMICOLON@54..55 ";" [] []
-            2: R_CURLY@55..58 "}" [Whitespace("\n"), Whitespace("\t")] []
-        3: R_CURLY@58..60 "}" [Whitespace("\n")] []
-  3: EOF@60..61 "" [Whitespace("\n")] []
+            2: R_CURLY@55..58 "}" [Newline("\n"), Whitespace("\t")] []
+        3: R_CURLY@58..60 "}" [Newline("\n")] []
+  3: EOF@60..61 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ debugger_stmt.js:2:11

--- a/crates/rslint_parser/test_data/inline/err/directives_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/directives_err.rast
@@ -4,7 +4,7 @@ JsScript {
     statements: JsStatementList [
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@19..23 "test" [] [],
@@ -20,14 +20,14 @@ JsScript {
                 l_curly_token: L_CURLY@26..27 "{" [] [],
                 directives: JsDirectiveList [
                     JsDirective {
-                        value_token: JS_STRING_LITERAL@27..41 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                        value_token: JS_STRING_LITERAL@27..41 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                         semicolon_token: SEMICOLON@41..42 ";" [] [],
                     },
                 ],
                 statements: JsStatementList [
                     JsFunctionStatement {
                         async_token: missing (optional),
-                        function_token: FUNCTION_KW@42..53 "function" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        function_token: FUNCTION_KW@42..53 "function" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         star_token: missing (optional),
                         id: JsIdentifierBinding {
                             name_token: IDENT@53..60 "inner_a" [] [],
@@ -43,17 +43,17 @@ JsScript {
                             l_curly_token: L_CURLY@63..64 "{" [] [],
                             directives: JsDirectiveList [
                                 JsDirective {
-                                    value_token: JS_STRING_LITERAL@64..79 "\"use strict\"" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                    value_token: JS_STRING_LITERAL@64..79 "\"use strict\"" [Newline("\n"), Whitespace("\t\t")] [],
                                     semicolon_token: SEMICOLON@79..80 ";" [] [],
                                 },
                             ],
                             statements: JsStatementList [],
-                            r_curly_token: R_CURLY@80..83 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                            r_curly_token: R_CURLY@80..83 "}" [Newline("\n"), Whitespace("\t")] [],
                         },
                     },
                     JsFunctionStatement {
                         async_token: missing (optional),
-                        function_token: FUNCTION_KW@83..94 "function" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        function_token: FUNCTION_KW@83..94 "function" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         star_token: missing (optional),
                         id: JsIdentifierBinding {
                             name_token: IDENT@94..101 "inner_b" [] [],
@@ -71,7 +71,7 @@ JsScript {
                             statements: JsStatementList [
                                 JsFunctionStatement {
                                     async_token: missing (optional),
-                                    function_token: FUNCTION_KW@105..117 "function" [Whitespace("\n"), Whitespace("\t\t")] [Whitespace(" ")],
+                                    function_token: FUNCTION_KW@105..117 "function" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")],
                                     star_token: missing (optional),
                                     id: JsIdentifierBinding {
                                         name_token: IDENT@117..128 "inner_inner" [] [],
@@ -87,24 +87,24 @@ JsScript {
                                         l_curly_token: L_CURLY@131..132 "{" [] [],
                                         directives: JsDirectiveList [
                                             JsDirective {
-                                                value_token: JS_STRING_LITERAL@132..148 "\"use strict\"" [Whitespace("\n"), Whitespace("\t\t\t")] [],
+                                                value_token: JS_STRING_LITERAL@132..148 "\"use strict\"" [Newline("\n"), Whitespace("\t\t\t")] [],
                                                 semicolon_token: SEMICOLON@148..149 ";" [] [],
                                             },
                                         ],
                                         statements: JsStatementList [],
-                                        r_curly_token: R_CURLY@149..153 "}" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                        r_curly_token: R_CURLY@149..153 "}" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
                                 },
                             ],
-                            r_curly_token: R_CURLY@153..156 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                            r_curly_token: R_CURLY@153..156 "}" [Newline("\n"), Whitespace("\t")] [],
                         },
                     },
                 ],
-                r_curly_token: R_CURLY@156..158 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@156..158 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@158..159 "" [Whitespace("\n")] [],
+    eof_token: EOF@158..159 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..159
@@ -113,7 +113,7 @@ JsScript {
   2: JS_STATEMENT_LIST@0..158
     0: JS_FUNCTION_STATEMENT@0..158
       0: (empty)
-      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@19..23
         0: IDENT@19..23 "test" [] []
@@ -127,12 +127,12 @@ JsScript {
         0: L_CURLY@26..27 "{" [] []
         1: JS_DIRECTIVE_LIST@27..42
           0: JS_DIRECTIVE@27..42
-            0: JS_STRING_LITERAL@27..41 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@27..41 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
             1: SEMICOLON@41..42 ";" [] []
         2: JS_STATEMENT_LIST@42..156
           0: JS_FUNCTION_STATEMENT@42..83
             0: (empty)
-            1: FUNCTION_KW@42..53 "function" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: FUNCTION_KW@42..53 "function" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
             2: (empty)
             3: JS_IDENTIFIER_BINDING@53..60
               0: IDENT@53..60 "inner_a" [] []
@@ -146,13 +146,13 @@ JsScript {
               0: L_CURLY@63..64 "{" [] []
               1: JS_DIRECTIVE_LIST@64..80
                 0: JS_DIRECTIVE@64..80
-                  0: JS_STRING_LITERAL@64..79 "\"use strict\"" [Whitespace("\n"), Whitespace("\t\t")] []
+                  0: JS_STRING_LITERAL@64..79 "\"use strict\"" [Newline("\n"), Whitespace("\t\t")] []
                   1: SEMICOLON@79..80 ";" [] []
               2: JS_STATEMENT_LIST@80..80
-              3: R_CURLY@80..83 "}" [Whitespace("\n"), Whitespace("\t")] []
+              3: R_CURLY@80..83 "}" [Newline("\n"), Whitespace("\t")] []
           1: JS_FUNCTION_STATEMENT@83..156
             0: (empty)
-            1: FUNCTION_KW@83..94 "function" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: FUNCTION_KW@83..94 "function" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
             2: (empty)
             3: JS_IDENTIFIER_BINDING@94..101
               0: IDENT@94..101 "inner_b" [] []
@@ -168,7 +168,7 @@ JsScript {
               2: JS_STATEMENT_LIST@105..153
                 0: JS_FUNCTION_STATEMENT@105..153
                   0: (empty)
-                  1: FUNCTION_KW@105..117 "function" [Whitespace("\n"), Whitespace("\t\t")] [Whitespace(" ")]
+                  1: FUNCTION_KW@105..117 "function" [Newline("\n"), Whitespace("\t\t")] [Whitespace(" ")]
                   2: (empty)
                   3: JS_IDENTIFIER_BINDING@117..128
                     0: IDENT@117..128 "inner_inner" [] []
@@ -182,13 +182,13 @@ JsScript {
                     0: L_CURLY@131..132 "{" [] []
                     1: JS_DIRECTIVE_LIST@132..149
                       0: JS_DIRECTIVE@132..149
-                        0: JS_STRING_LITERAL@132..148 "\"use strict\"" [Whitespace("\n"), Whitespace("\t\t\t")] []
+                        0: JS_STRING_LITERAL@132..148 "\"use strict\"" [Newline("\n"), Whitespace("\t\t\t")] []
                         1: SEMICOLON@148..149 ";" [] []
                     2: JS_STATEMENT_LIST@149..149
-                    3: R_CURLY@149..153 "}" [Whitespace("\n"), Whitespace("\t\t")] []
-              3: R_CURLY@153..156 "}" [Whitespace("\n"), Whitespace("\t")] []
-        3: R_CURLY@156..158 "}" [Whitespace("\n")] []
-  3: EOF@158..159 "" [Whitespace("\n")] []
+                    3: R_CURLY@149..153 "}" [Newline("\n"), Whitespace("\t\t")] []
+              3: R_CURLY@153..156 "}" [Newline("\n"), Whitespace("\t")] []
+        3: R_CURLY@156..158 "}" [Newline("\n")] []
+  3: EOF@158..159 "" [Newline("\n")] []
 --
 warning[SyntaxError]: Redundant strict mode declaration
   ┌─ directives_err.js:3:2

--- a/crates/rslint_parser/test_data/inline/err/do_while_no_continue_break.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_no_continue_break.rast
@@ -39,7 +39,7 @@ JsModule {
             ],
         },
         JsDoWhileStatement {
-            do_token: DO_KW@23..27 "do" [Whitespace("\n")] [Whitespace(" ")],
+            do_token: DO_KW@23..27 "do" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@27..29 "{" [] [Whitespace(" ")],
                 statements: JsStatementList [],
@@ -75,7 +75,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@47..48 "" [Whitespace("\n")] [],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..48
@@ -106,7 +106,7 @@ JsModule {
     4: JS_UNKNOWN_STATEMENT@22..23
       0: R_PAREN@22..23 ")" [] []
     5: JS_DO_WHILE_STATEMENT@23..31
-      0: DO_KW@23..27 "do" [Whitespace("\n")] [Whitespace(" ")]
+      0: DO_KW@23..27 "do" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@27..31
         0: L_CURLY@27..29 "{" [] [Whitespace(" ")]
         1: JS_STATEMENT_LIST@29..29
@@ -128,7 +128,7 @@ JsModule {
       0: BREAK_KW@41..46 "break" [] []
     9: JS_UNKNOWN_STATEMENT@46..47
       0: R_PAREN@46..47 ")" [] []
-  3: EOF@47..48 "" [Whitespace("\n")] []
+  3: EOF@47..48 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `WHILE_KW` but instead found `break`
   ┌─ do_while_no_continue_break.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/do_while_stmt_err.rast
@@ -12,14 +12,14 @@ JsModule {
                 },
                 r_paren_token: R_PAREN@14..15 ")" [] [],
                 body: JsDoWhileStatement {
-                    do_token: DO_KW@15..19 "do" [Whitespace("\n")] [Whitespace(" ")],
+                    do_token: DO_KW@15..19 "do" [Newline("\n")] [Whitespace(" ")],
                     body: JsWhileStatement {
                         while_token: WHILE_KW@19..25 "while" [] [Whitespace(" ")],
                         l_paren_token: L_PAREN@25..26 "(" [] [],
                         test: missing (required),
                         r_paren_token: R_PAREN@26..27 ")" [] [],
                         body: JsDoWhileStatement {
-                            do_token: DO_KW@27..31 "do" [Whitespace("\n")] [Whitespace(" ")],
+                            do_token: DO_KW@27..31 "do" [Newline("\n")] [Whitespace(" ")],
                             body: JsWhileStatement {
                                 while_token: WHILE_KW@31..37 "while" [] [Whitespace(" ")],
                                 l_paren_token: missing (required),
@@ -50,7 +50,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@41..42 "" [Whitespace("\n")] [],
+    eof_token: EOF@41..42 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..42
@@ -66,14 +66,14 @@ JsModule {
           0: TRUE_KW@10..14 "true" [] []
         3: R_PAREN@14..15 ")" [] []
         4: JS_DO_WHILE_STATEMENT@15..41
-          0: DO_KW@15..19 "do" [Whitespace("\n")] [Whitespace(" ")]
+          0: DO_KW@15..19 "do" [Newline("\n")] [Whitespace(" ")]
           1: JS_WHILE_STATEMENT@19..41
             0: WHILE_KW@19..25 "while" [] [Whitespace(" ")]
             1: L_PAREN@25..26 "(" [] []
             2: (empty)
             3: R_PAREN@26..27 ")" [] []
             4: JS_DO_WHILE_STATEMENT@27..41
-              0: DO_KW@27..31 "do" [Whitespace("\n")] [Whitespace(" ")]
+              0: DO_KW@27..31 "do" [Newline("\n")] [Whitespace(" ")]
               1: JS_WHILE_STATEMENT@31..41
                 0: WHILE_KW@31..37 "while" [] [Whitespace(" ")]
                 1: (empty)
@@ -96,7 +96,7 @@ JsModule {
       4: (empty)
       5: (empty)
       6: (empty)
-  3: EOF@41..42 "" [Whitespace("\n")] []
+  3: EOF@41..42 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found ')'
   ┌─ do_while_stmt_err.js:2:11

--- a/crates/rslint_parser/test_data/inline/err/double_label.rast
+++ b/crates/rslint_parser/test_data/inline/err/double_label.rast
@@ -9,13 +9,13 @@ JsModule {
                 l_curly_token: L_CURLY@8..9 "{" [] [],
                 statements: JsStatementList [
                     JsLabeledStatement {
-                        label_token: IDENT@9..17 "label2" [Whitespace("\n"), Whitespace("\t")] [],
+                        label_token: IDENT@9..17 "label2" [Newline("\n"), Whitespace("\t")] [],
                         colon_token: COLON@17..19 ":" [] [Whitespace(" ")],
                         body: JsBlockStatement {
                             l_curly_token: L_CURLY@19..20 "{" [] [],
                             statements: JsStatementList [
                                 JsLabeledStatement {
-                                    label_token: IDENT@20..29 "label1" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                    label_token: IDENT@20..29 "label1" [Newline("\n"), Whitespace("\t\t")] [],
                                     colon_token: COLON@29..31 ":" [] [Whitespace(" ")],
                                     body: JsBlockStatement {
                                         l_curly_token: L_CURLY@31..32 "{" [] [],
@@ -24,15 +24,15 @@ JsModule {
                                     },
                                 },
                             ],
-                            r_curly_token: R_CURLY@33..36 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                            r_curly_token: R_CURLY@33..36 "}" [Newline("\n"), Whitespace("\t")] [],
                         },
                     },
                 ],
-                r_curly_token: R_CURLY@36..38 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@36..38 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@38..39 "" [Whitespace("\n")] [],
+    eof_token: EOF@38..39 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..39
@@ -46,21 +46,21 @@ JsModule {
         0: L_CURLY@8..9 "{" [] []
         1: JS_STATEMENT_LIST@9..36
           0: JS_LABELED_STATEMENT@9..36
-            0: IDENT@9..17 "label2" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@9..17 "label2" [Newline("\n"), Whitespace("\t")] []
             1: COLON@17..19 ":" [] [Whitespace(" ")]
             2: JS_BLOCK_STATEMENT@19..36
               0: L_CURLY@19..20 "{" [] []
               1: JS_STATEMENT_LIST@20..33
                 0: JS_LABELED_STATEMENT@20..33
-                  0: IDENT@20..29 "label1" [Whitespace("\n"), Whitespace("\t\t")] []
+                  0: IDENT@20..29 "label1" [Newline("\n"), Whitespace("\t\t")] []
                   1: COLON@29..31 ":" [] [Whitespace(" ")]
                   2: JS_BLOCK_STATEMENT@31..33
                     0: L_CURLY@31..32 "{" [] []
                     1: JS_STATEMENT_LIST@32..32
                     2: R_CURLY@32..33 "}" [] []
-              2: R_CURLY@33..36 "}" [Whitespace("\n"), Whitespace("\t")] []
-        2: R_CURLY@36..38 "}" [Whitespace("\n")] []
-  3: EOF@38..39 "" [Whitespace("\n")] []
+              2: R_CURLY@33..36 "}" [Newline("\n"), Whitespace("\t")] []
+        2: R_CURLY@36..38 "}" [Newline("\n")] []
+  3: EOF@38..39 "" [Newline("\n")] []
 --
 error[SyntaxError]: Duplicate statement labels are not allowed
   ┌─ double_label.js:3:3

--- a/crates/rslint_parser/test_data/inline/err/export_as_identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_as_identifier_err.rast
@@ -21,7 +21,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@15..16 "" [Whitespace("\n")] [],
+    eof_token: EOF@15..16 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..16
@@ -41,7 +41,7 @@ JsModule {
               0: IDENT@12..14 "c" [] [Whitespace(" ")]
         2: R_CURLY@14..15 "}" [] []
         3: (empty)
-  3: EOF@15..16 "" [Whitespace("\n")] []
+  3: EOF@15..16 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a string literal, or an identifier but instead found 'as'
   ┌─ export_as_identifier_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_decl_not_top_level.rast
@@ -7,7 +7,7 @@ JsModule {
             statements: JsStatementList [
                 JsUnknownStatement {
                     items: [
-                        EXPORT_KW@1..10 "export" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                        EXPORT_KW@1..10 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsExportNamedFromClause {
                             l_curly_token: L_CURLY@10..12 "{" [] [Whitespace(" ")],
                             specifiers: JsExportNamedFromSpecifierList [
@@ -30,10 +30,10 @@ JsModule {
                     ],
                 },
             ],
-            r_curly_token: R_CURLY@31..33 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@31..33 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@33..34 "" [Whitespace("\n")] [],
+    eof_token: EOF@33..34 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..34
@@ -44,7 +44,7 @@ JsModule {
       0: L_CURLY@0..1 "{" [] []
       1: JS_STATEMENT_LIST@1..31
         0: JS_UNKNOWN_STATEMENT@1..31
-          0: EXPORT_KW@1..10 "export" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          0: EXPORT_KW@1..10 "export" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           1: JS_EXPORT_NAMED_FROM_CLAUSE@10..31
             0: L_CURLY@10..12 "{" [] [Whitespace(" ")]
             1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@12..17
@@ -59,8 +59,8 @@ JsModule {
               0: JS_STRING_LITERAL@24..30 "\"life\"" [] []
             5: (empty)
             6: SEMICOLON@30..31 ";" [] []
-      2: R_CURLY@31..33 "}" [Whitespace("\n")] []
-  3: EOF@33..34 "" [Whitespace("\n")] []
+      2: R_CURLY@31..33 "}" [Newline("\n")] []
+  3: EOF@33..34 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ export_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/export_default_expression_clause_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_default_expression_clause_err.rast
@@ -24,7 +24,7 @@ JsModule {
             semicolon_token: SEMICOLON@19..20 ";" [] [],
         },
     ],
-    eof_token: EOF@20..21 "" [Whitespace("\n")] [],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..21
@@ -44,7 +44,7 @@ JsModule {
       1: IDENT@18..19 "b" [] []
     2: JS_EMPTY_STATEMENT@19..20
       0: SEMICOLON@19..20 ";" [] []
-  3: EOF@20..21 "" [Whitespace("\n")] []
+  3: EOF@20..21 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ export_default_expression_clause_err.js:1:17

--- a/crates/rslint_parser/test_data/inline/err/export_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_err.rast
@@ -7,7 +7,7 @@ JsModule {
             export_clause: missing (required),
         },
     ],
-    eof_token: EOF@6..7 "" [Whitespace("\n")] [],
+    eof_token: EOF@6..7 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..7
@@ -17,7 +17,7 @@ JsModule {
     0: JS_EXPORT@0..6
       0: EXPORT_KW@0..6 "export" [] []
       1: (empty)
-  3: EOF@6..7 "" [Whitespace("\n")] []
+  3: EOF@6..7 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a class, a function, or a variable declaration but instead found ''
   ┌─ export_err.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/export_from_clause_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_from_clause_err.rast
@@ -14,7 +14,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@9..17 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: STAR@17..19 "*" [] [Whitespace(" ")],
                 export_as: missing (optional),
@@ -31,7 +31,7 @@ JsModule {
             semicolon_token: SEMICOLON@25..26 ";" [] [],
         },
         JsExport {
-            export_token: EXPORT_KW@26..34 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: missing (required),
                 export_as: JsExportAsClause {
@@ -49,7 +49,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@49..57 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: missing (required),
                 export_as: missing (optional),
@@ -62,7 +62,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@69..70 "" [Whitespace("\n")] [],
+    eof_token: EOF@69..70 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..70
@@ -79,7 +79,7 @@ JsModule {
         4: (empty)
         5: SEMICOLON@8..9 ";" [] []
     1: JS_EXPORT@9..24
-      0: EXPORT_KW@9..17 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@9..17 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@17..24
         0: STAR@17..19 "*" [] [Whitespace(" ")]
         1: (empty)
@@ -92,7 +92,7 @@ JsModule {
         0: JS_NUMBER_LITERAL@24..25 "5" [] []
       1: SEMICOLON@25..26 ";" [] []
     3: JS_EXPORT@26..49
-      0: EXPORT_KW@26..34 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@34..49
         0: (empty)
         1: JS_EXPORT_AS_CLAUSE@34..42
@@ -105,7 +105,7 @@ JsModule {
         4: (empty)
         5: SEMICOLON@48..49 ";" [] []
     4: JS_EXPORT@49..69
-      0: EXPORT_KW@49..57 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@49..57 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@57..69
         0: (empty)
         1: (empty)
@@ -114,7 +114,7 @@ JsModule {
           0: JS_STRING_LITERAL@62..68 "\"test\"" [] []
         4: (empty)
         5: SEMICOLON@68..69 ";" [] []
-  3: EOF@69..70 "" [Whitespace("\n")] []
+  3: EOF@69..70 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `from` but instead found `;`
   ┌─ export_from_clause_err.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/export_named_clause_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_named_clause_err.rast
@@ -27,7 +27,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@26..34 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         L_CURLY@34..36 "{" [] [Whitespace(" ")],
@@ -49,7 +49,7 @@ JsModule {
             ],
         },
         JsExport {
-            export_token: EXPORT_KW@47..55 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@55..57 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -68,7 +68,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@64..72 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         L_CURLY@72..74 "{" [] [Whitespace(" ")],
@@ -96,7 +96,7 @@ JsModule {
             ],
         },
         JsExport {
-            export_token: EXPORT_KW@83..91 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@83..91 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@91..93 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -126,7 +126,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@101..102 "" [Whitespace("\n")] [],
+    eof_token: EOF@101..102 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..102
@@ -145,7 +145,7 @@ JsModule {
         2: R_CURLY@24..25 "}" [] []
         3: SEMICOLON@25..26 ";" [] []
     1: JS_UNKNOWN_STATEMENT@26..47
-      0: EXPORT_KW@26..34 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@26..34 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@34..47
         0: L_CURLY@34..36 "{" [] [Whitespace(" ")]
         1: JS_UNKNOWN@36..45
@@ -156,7 +156,7 @@ JsModule {
         2: R_CURLY@45..46 "}" [] []
         3: SEMICOLON@46..47 ";" [] []
     2: JS_EXPORT@47..64
-      0: EXPORT_KW@47..55 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@55..64
         0: L_CURLY@55..57 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@57..62
@@ -169,7 +169,7 @@ JsModule {
         2: R_CURLY@62..63 "}" [] []
         3: SEMICOLON@63..64 ";" [] []
     3: JS_UNKNOWN_STATEMENT@64..83
-      0: EXPORT_KW@64..72 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@64..72 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@72..83
         0: L_CURLY@72..74 "{" [] [Whitespace(" ")]
         1: JS_UNKNOWN@74..81
@@ -184,7 +184,7 @@ JsModule {
         2: R_CURLY@81..82 "}" [] []
         3: SEMICOLON@82..83 ";" [] []
     4: JS_EXPORT@83..101
-      0: EXPORT_KW@83..91 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@83..91 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@91..101
         0: L_CURLY@91..93 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@93..99
@@ -204,7 +204,7 @@ JsModule {
               0: IDENT@97..99 "c" [] [Whitespace(" ")]
         2: R_CURLY@99..100 "}" [] []
         3: SEMICOLON@100..101 ";" [] []
-  3: EOF@101..102 "" [Whitespace("\n")] []
+  3: EOF@101..102 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an export name but instead found 'default as "b"'
   ┌─ export_named_clause_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/export_named_from_clause_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_named_from_clause_err.rast
@@ -34,7 +34,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@27..35 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@27..35 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         L_CURLY@35..37 "{" [] [Whitespace(" ")],
@@ -68,7 +68,7 @@ JsModule {
             ],
         },
         JsExport {
-            export_token: EXPORT_KW@57..65 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@57..65 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@65..67 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -107,7 +107,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@86..94 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         L_CURLY@94..96 "{" [] [Whitespace(" ")],
@@ -133,7 +133,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@116..117 "" [Whitespace("\n")] [],
+    eof_token: EOF@116..117 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..117
@@ -163,7 +163,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@26..27 ";" [] []
     1: JS_UNKNOWN_STATEMENT@27..57
-      0: EXPORT_KW@27..35 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@27..35 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@35..57
         0: L_CURLY@35..37 "{" [] [Whitespace(" ")]
         1: JS_UNKNOWN@37..44
@@ -182,7 +182,7 @@ JsModule {
           0: JS_STRING_LITERAL@51..56 "\"mod\"" [] []
         5: SEMICOLON@56..57 ";" [] []
     2: JS_EXPORT@57..86
-      0: EXPORT_KW@57..65 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@57..65 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@65..86
         0: L_CURLY@65..67 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@67..73
@@ -210,7 +210,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@85..86 ";" [] []
     3: JS_UNKNOWN_STATEMENT@86..116
-      0: EXPORT_KW@86..94 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@94..116
         0: L_CURLY@94..96 "{" [] [Whitespace(" ")]
         1: JS_UNKNOWN@96..103
@@ -223,7 +223,7 @@ JsModule {
         4: JS_MODULE_SOURCE@110..115
           0: JS_STRING_LITERAL@110..115 "\"mod\"" [] []
         5: SEMICOLON@115..116 ";" [] []
-  3: EOF@116..117 "" [Whitespace("\n")] []
+  3: EOF@116..117 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `,` but instead found `b`
   ┌─ export_named_from_clause_err.js:1:13

--- a/crates/rslint_parser/test_data/inline/err/export_variable_clause_error.rast
+++ b/crates/rslint_parser/test_data/inline/err/export_variable_clause_error.rast
@@ -25,7 +25,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@16..24 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportVariableClause {
                 declarations: JsVariableDeclarations {
                     kind: CONST_KW@24..30 "const" [] [Whitespace(" ")],
@@ -44,7 +44,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@32..40 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportVariableClause {
                 declarations: JsVariableDeclarations {
                     kind: LET_KW@40..44 "let" [] [Whitespace(" ")],
@@ -74,7 +74,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@49..50 "" [Whitespace("\n")] [],
+    eof_token: EOF@49..50 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..50
@@ -97,7 +97,7 @@ JsModule {
                 1: (empty)
         1: SEMICOLON@15..16 ";" [] []
     1: JS_EXPORT@16..32
-      0: EXPORT_KW@16..24 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@16..24 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_VARIABLE_CLAUSE@24..32
         0: JS_VARIABLE_DECLARATIONS@24..31
           0: CONST_KW@24..30 "const" [] [Whitespace(" ")]
@@ -110,7 +110,7 @@ JsModule {
               3: (empty)
         1: SEMICOLON@31..32 ";" [] []
     2: JS_EXPORT@32..49
-      0: EXPORT_KW@32..40 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@32..40 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_VARIABLE_CLAUSE@40..49
         0: JS_VARIABLE_DECLARATIONS@40..48
           0: LET_KW@40..44 "let" [] [Whitespace(" ")]
@@ -129,7 +129,7 @@ JsModule {
               2: (empty)
               3: (empty)
         1: SEMICOLON@48..49 ";" [] []
-  3: EOF@49..50 "" [Whitespace("\n")] []
+  3: EOF@49..50 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression, or an assignment but instead found ';'
   ┌─ export_variable_clause_error.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_loose_mode.rast
@@ -3,7 +3,7 @@ JsScript {
     directives: JsDirectiveList [],
     statements: JsStatementList [
         JsForInStatement {
-            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@14..15 "(" [] [],
             initializer: JsForVariableDeclaration {
                 kind_token: LET_KW@15..19 "let" [] [Whitespace(" ")],
@@ -35,7 +35,7 @@ JsScript {
             },
         },
         JsForInStatement {
-            for_token: FOR_KW@34..39 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@34..39 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@39..40 "(" [] [],
             initializer: JsForVariableDeclaration {
                 kind_token: CONST_KW@40..46 "const" [] [Whitespace(" ")],
@@ -67,7 +67,7 @@ JsScript {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@61..66 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@61..66 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@66..67 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -100,7 +100,7 @@ JsScript {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@86..91 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@86..91 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@91..92 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -133,7 +133,7 @@ JsScript {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@111..116 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@111..116 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@116..117 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -166,7 +166,7 @@ JsScript {
             },
         },
     ],
-    eof_token: EOF@138..139 "" [Whitespace("\n")] [],
+    eof_token: EOF@138..139 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..139
@@ -174,7 +174,7 @@ JsScript {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_STATEMENT_LIST@0..138
     0: JS_FOR_IN_STATEMENT@0..34
-      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@14..15 "(" [] []
       2: JS_FOR_VARIABLE_DECLARATION@15..25
         0: LET_KW@15..19 "let" [] [Whitespace(" ")]
@@ -198,7 +198,7 @@ JsScript {
         1: JS_STATEMENT_LIST@33..33
         2: R_CURLY@33..34 "}" [] []
     1: JS_FOR_IN_STATEMENT@34..61
-      0: FOR_KW@34..39 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@34..39 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@39..40 "(" [] []
       2: JS_FOR_VARIABLE_DECLARATION@40..52
         0: CONST_KW@40..46 "const" [] [Whitespace(" ")]
@@ -222,7 +222,7 @@ JsScript {
         1: JS_STATEMENT_LIST@60..60
         2: R_CURLY@60..61 "}" [] []
     2: JS_FOR_OF_STATEMENT@61..86
-      0: FOR_KW@61..66 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@61..66 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@66..67 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@67..77
@@ -247,7 +247,7 @@ JsScript {
         1: JS_STATEMENT_LIST@85..85
         2: R_CURLY@85..86 "}" [] []
     3: JS_FOR_OF_STATEMENT@86..111
-      0: FOR_KW@86..91 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@86..91 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@91..92 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@92..102
@@ -272,7 +272,7 @@ JsScript {
         1: JS_STATEMENT_LIST@110..110
         2: R_CURLY@110..111 "}" [] []
     4: JS_FOR_OF_STATEMENT@111..138
-      0: FOR_KW@111..116 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@111..116 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@116..117 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@117..129
@@ -296,7 +296,7 @@ JsScript {
         0: L_CURLY@136..137 "{" [] []
         1: JS_STATEMENT_LIST@137..137
         2: R_CURLY@137..138 "}" [] []
-  3: EOF@138..139 "" [Whitespace("\n")] []
+  3: EOF@138..139 "" [Newline("\n")] []
 --
 error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
   ┌─ for_in_and_of_initializer_loose_mode.js:2:12

--- a/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_in_and_of_initializer_strict_mode.rast
@@ -35,7 +35,7 @@ JsModule {
             },
         },
         JsForInStatement {
-            for_token: FOR_KW@24..29 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@24..29 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@29..30 "(" [] [],
             initializer: JsForVariableDeclaration {
                 kind_token: LET_KW@30..34 "let" [] [Whitespace(" ")],
@@ -67,7 +67,7 @@ JsModule {
             },
         },
         JsForInStatement {
-            for_token: FOR_KW@49..54 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@49..54 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@54..55 "(" [] [],
             initializer: JsForVariableDeclaration {
                 kind_token: CONST_KW@55..61 "const" [] [Whitespace(" ")],
@@ -99,7 +99,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@76..81 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@76..81 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@81..82 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -132,7 +132,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@101..106 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@101..106 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@106..107 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -165,7 +165,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@126..131 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@126..131 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@131..132 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -198,7 +198,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@153..154 "" [Whitespace("\n")] [],
+    eof_token: EOF@153..154 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..154
@@ -230,7 +230,7 @@ JsModule {
         1: JS_STATEMENT_LIST@23..23
         2: R_CURLY@23..24 "}" [] []
     1: JS_FOR_IN_STATEMENT@24..49
-      0: FOR_KW@24..29 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@24..29 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@29..30 "(" [] []
       2: JS_FOR_VARIABLE_DECLARATION@30..40
         0: LET_KW@30..34 "let" [] [Whitespace(" ")]
@@ -254,7 +254,7 @@ JsModule {
         1: JS_STATEMENT_LIST@48..48
         2: R_CURLY@48..49 "}" [] []
     2: JS_FOR_IN_STATEMENT@49..76
-      0: FOR_KW@49..54 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@49..54 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@54..55 "(" [] []
       2: JS_FOR_VARIABLE_DECLARATION@55..67
         0: CONST_KW@55..61 "const" [] [Whitespace(" ")]
@@ -278,7 +278,7 @@ JsModule {
         1: JS_STATEMENT_LIST@75..75
         2: R_CURLY@75..76 "}" [] []
     3: JS_FOR_OF_STATEMENT@76..101
-      0: FOR_KW@76..81 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@76..81 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@81..82 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@82..92
@@ -303,7 +303,7 @@ JsModule {
         1: JS_STATEMENT_LIST@100..100
         2: R_CURLY@100..101 "}" [] []
     4: JS_FOR_OF_STATEMENT@101..126
-      0: FOR_KW@101..106 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@101..106 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@106..107 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@107..117
@@ -328,7 +328,7 @@ JsModule {
         1: JS_STATEMENT_LIST@125..125
         2: R_CURLY@125..126 "}" [] []
     5: JS_FOR_OF_STATEMENT@126..153
-      0: FOR_KW@126..131 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@126..131 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@131..132 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@132..144
@@ -352,7 +352,7 @@ JsModule {
         0: L_CURLY@151..152 "{" [] []
         1: JS_STATEMENT_LIST@152..152
         2: R_CURLY@152..153 "}" [] []
-  3: EOF@153..154 "" [Whitespace("\n")] []
+  3: EOF@153..154 "" [Newline("\n")] []
 --
 error[SyntaxError]: `for..in` statement declarators cannot have an initializer expression
   ┌─ for_in_and_of_initializer_strict_mode.js:1:12

--- a/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/for_stmt_err.rast
@@ -16,7 +16,7 @@ JsModule {
             },
             r_paren_token: missing (required),
             body: JsForStatement {
-                for_token: FOR_KW@9..14 "for" [Whitespace("\n")] [Whitespace(" ")],
+                for_token: FOR_KW@9..14 "for" [Newline("\n")] [Whitespace(" ")],
                 l_paren_token: missing (required),
                 initializer: JsVariableDeclarations {
                     kind: LET_KW@14..18 "let" [] [Whitespace(" ")],
@@ -64,7 +64,7 @@ JsModule {
             },
         },
         JsForStatement {
-            for_token: FOR_KW@39..44 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@39..44 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             initializer: JsVariableDeclarations {
                 kind: LET_KW@44..48 "let" [] [Whitespace(" ")],
@@ -111,7 +111,7 @@ JsModule {
             },
         },
         JsForInStatement {
-            for_token: FOR_KW@69..74 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@69..74 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@74..75 "(" [] [],
             initializer: missing (required),
             in_token: IN_KW@75..78 "in" [] [Whitespace(" ")],
@@ -129,7 +129,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                FOR_KW@84..89 "for" [Whitespace("\n")] [Whitespace(" ")],
+                FOR_KW@84..89 "for" [Newline("\n")] [Whitespace(" ")],
                 L_PAREN@89..90 "(" [] [],
                 JsUnknown {
                     items: [
@@ -174,7 +174,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                FOR_KW@112..117 "for" [Whitespace("\n")] [Whitespace(" ")],
+                FOR_KW@112..117 "for" [Newline("\n")] [Whitespace(" ")],
                 AWAIT_KW@117..123 "await" [] [Whitespace(" ")],
                 L_PAREN@123..124 "(" [] [],
                 JsForVariableDeclaration {
@@ -204,7 +204,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                FOR_KW@139..144 "for" [Whitespace("\n")] [Whitespace(" ")],
+                FOR_KW@139..144 "for" [Newline("\n")] [Whitespace(" ")],
                 AWAIT_KW@144..150 "await" [] [Whitespace(" ")],
                 L_PAREN@150..151 "(" [] [],
                 JsVariableDeclarations {
@@ -253,7 +253,7 @@ JsModule {
             ],
         },
         JsForStatement {
-            for_token: FOR_KW@177..182 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@177..182 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@182..183 "(" [] [],
             initializer: JsVariableDeclarations {
                 kind: LET_KW@183..187 "let" [] [Whitespace(" ")],
@@ -286,7 +286,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@196..197 "" [Whitespace("\n")] [],
+    eof_token: EOF@196..197 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..197
@@ -306,7 +306,7 @@ JsModule {
         2: R_CURLY@8..9 "}" [] []
       7: (empty)
       8: JS_FOR_STATEMENT@9..39
-        0: FOR_KW@9..14 "for" [Whitespace("\n")] [Whitespace(" ")]
+        0: FOR_KW@9..14 "for" [Newline("\n")] [Whitespace(" ")]
         1: (empty)
         2: JS_VARIABLE_DECLARATIONS@14..23
           0: LET_KW@14..18 "let" [] [Whitespace(" ")]
@@ -339,7 +339,7 @@ JsModule {
           1: JS_STATEMENT_LIST@38..38
           2: R_CURLY@38..39 "}" [] []
     1: JS_FOR_STATEMENT@39..69
-      0: FOR_KW@39..44 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@39..44 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: JS_VARIABLE_DECLARATIONS@44..53
         0: LET_KW@44..48 "let" [] [Whitespace(" ")]
@@ -372,7 +372,7 @@ JsModule {
         1: JS_STATEMENT_LIST@68..68
         2: R_CURLY@68..69 "}" [] []
     2: JS_FOR_IN_STATEMENT@69..84
-      0: FOR_KW@69..74 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@69..74 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@74..75 "(" [] []
       2: (empty)
       3: IN_KW@75..78 "in" [] [Whitespace(" ")]
@@ -386,7 +386,7 @@ JsModule {
         1: JS_STATEMENT_LIST@83..83
         2: R_CURLY@83..84 "}" [] []
     3: JS_UNKNOWN_STATEMENT@84..112
-      0: FOR_KW@84..89 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@84..89 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@89..90 "(" [] []
       2: JS_UNKNOWN@90..103
         0: LET_KW@90..94 "let" [] [Whitespace(" ")]
@@ -417,7 +417,7 @@ JsModule {
         1: JS_STATEMENT_LIST@111..111
         2: R_CURLY@111..112 "}" [] []
     4: JS_UNKNOWN_STATEMENT@112..139
-      0: FOR_KW@112..117 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@112..117 "for" [Newline("\n")] [Whitespace(" ")]
       1: AWAIT_KW@117..123 "await" [] [Whitespace(" ")]
       2: L_PAREN@123..124 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@124..130
@@ -439,7 +439,7 @@ JsModule {
         1: JS_STATEMENT_LIST@138..138
         2: R_CURLY@138..139 "}" [] []
     5: JS_UNKNOWN_STATEMENT@139..177
-      0: FOR_KW@139..144 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@139..144 "for" [Newline("\n")] [Whitespace(" ")]
       1: AWAIT_KW@144..150 "await" [] [Whitespace(" ")]
       2: L_PAREN@150..151 "(" [] []
       3: JS_VARIABLE_DECLARATIONS@151..160
@@ -473,7 +473,7 @@ JsModule {
         1: JS_STATEMENT_LIST@176..176
         2: R_CURLY@176..177 "}" [] []
     6: JS_FOR_STATEMENT@177..196
-      0: FOR_KW@177..182 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@177..182 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@182..183 "(" [] []
       2: JS_VARIABLE_DECLARATIONS@183..190
         0: LET_KW@183..187 "let" [] [Whitespace(" ")]
@@ -497,7 +497,7 @@ JsModule {
         0: L_CURLY@194..195 "{" [] []
         1: JS_STATEMENT_LIST@195..195
         2: R_CURLY@195..196 "}" [] []
-  3: EOF@196..197 "" [Whitespace("\n")] []
+  3: EOF@196..197 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `'('` but instead found `;`
   ┌─ for_stmt_err.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_invalid.rast
@@ -44,7 +44,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@20..21 "" [Whitespace("\n")] [],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..21
@@ -81,7 +81,7 @@ JsModule {
         1: JS_DIRECTIVE_LIST@19..19
         2: JS_STATEMENT_LIST@19..19
         3: R_CURLY@19..20 "}" [] []
-  3: EOF@20..21 "" [Whitespace("\n")] []
+  3: EOF@20..21 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a name for the function in a function declaration, but found none
   ┌─ formal_params_invalid.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
+++ b/crates/rslint_parser/test_data/inline/err/formal_params_no_binding_element.rast
@@ -30,7 +30,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@21..22 "" [Whitespace("\n")] [],
+    eof_token: EOF@21..22 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..22
@@ -56,7 +56,7 @@ JsModule {
         1: JS_DIRECTIVE_LIST@20..20
         2: JS_STATEMENT_LIST@20..20
         3: R_CURLY@20..21 "}" [] []
-  3: EOF@21..22 "" [Whitespace("\n")] []
+  3: EOF@21..22 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a parameter but instead found 'true'
   ┌─ formal_params_no_binding_element.js:1:14

--- a/crates/rslint_parser/test_data/inline/err/function_broken.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_broken.rast
@@ -50,7 +50,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@25..26 "" [Whitespace("\n")] [],
+    eof_token: EOF@25..26 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..26
@@ -91,7 +91,7 @@ JsModule {
               2: (empty)
           2: (empty)
       2: (empty)
-  3: EOF@25..26 "" [Whitespace("\n")] []
+  3: EOF@25..26 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a function body but instead found ')'
   ┌─ function_broken.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_decl_err.rast
@@ -23,7 +23,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@13..23 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@13..23 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@23..27 "foo" [] [Whitespace(" ")],
@@ -40,7 +40,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@29..39 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@29..39 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: missing (required),
             type_parameters: missing (optional),
@@ -55,7 +55,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@41..51 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@41..51 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: STAR@51..52 "*" [] [],
             id: missing (required),
             type_parameters: missing (optional),
@@ -73,7 +73,7 @@ JsModule {
             },
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@57..64 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@57..64 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@64..72 "function" [] [],
             star_token: missing (optional),
             id: missing (required),
@@ -92,7 +92,7 @@ JsModule {
             },
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@77..84 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@77..84 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")],
             star_token: STAR@93..94 "*" [] [],
             id: missing (required),
@@ -112,7 +112,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@99..109 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@99..109 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: STAR@109..110 "*" [] [],
             id: JsIdentifierBinding {
                 name_token: IDENT@110..113 "foo" [] [],
@@ -136,7 +136,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@118..125 "yield" [Whitespace("\n")] [Whitespace(" ")],
+                            IDENT@118..125 "yield" [Newline("\n")] [Whitespace(" ")],
                         ],
                     },
                 ],
@@ -153,7 +153,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                FUNCTION_KW@129..139 "function" [Whitespace("\n")] [Whitespace(" ")],
+                FUNCTION_KW@129..139 "function" [Newline("\n")] [Whitespace(" ")],
                 JsIdentifierBinding {
                     name_token: IDENT@139..143 "test" [] [],
                 },
@@ -182,7 +182,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@156..166 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@156..166 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@166..169 "foo" [] [],
@@ -213,7 +213,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@179..189 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@179..189 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@189..192 "foo" [] [],
@@ -243,7 +243,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@202..203 "" [Whitespace("\n")] [],
+    eof_token: EOF@202..203 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..203
@@ -268,7 +268,7 @@ JsModule {
         3: R_CURLY@12..13 "}" [] []
     1: JS_FUNCTION_STATEMENT@13..29
       0: (empty)
-      1: FUNCTION_KW@13..23 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@13..23 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@23..27
         0: IDENT@23..27 "foo" [] [Whitespace(" ")]
@@ -282,7 +282,7 @@ JsModule {
         3: R_CURLY@28..29 "}" [] []
     2: JS_FUNCTION_STATEMENT@29..41
       0: (empty)
-      1: FUNCTION_KW@29..39 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@29..39 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: (empty)
       4: (empty)
@@ -295,7 +295,7 @@ JsModule {
         3: R_CURLY@40..41 "}" [] []
     3: JS_FUNCTION_STATEMENT@41..57
       0: (empty)
-      1: FUNCTION_KW@41..51 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@41..51 "function" [Newline("\n")] [Whitespace(" ")]
       2: STAR@51..52 "*" [] []
       3: (empty)
       4: (empty)
@@ -310,7 +310,7 @@ JsModule {
         2: JS_STATEMENT_LIST@56..56
         3: R_CURLY@56..57 "}" [] []
     4: JS_FUNCTION_STATEMENT@57..77
-      0: ASYNC_KW@57..64 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@57..64 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@64..72 "function" [] []
       2: (empty)
       3: (empty)
@@ -326,7 +326,7 @@ JsModule {
         2: JS_STATEMENT_LIST@76..76
         3: R_CURLY@76..77 "}" [] []
     5: JS_FUNCTION_STATEMENT@77..99
-      0: ASYNC_KW@77..84 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@77..84 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@84..93 "function" [] [Whitespace(" ")]
       2: STAR@93..94 "*" [] []
       3: (empty)
@@ -343,7 +343,7 @@ JsModule {
         3: R_CURLY@98..99 "}" [] []
     6: JS_FUNCTION_STATEMENT@99..118
       0: (empty)
-      1: FUNCTION_KW@99..109 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@99..109 "function" [Newline("\n")] [Whitespace(" ")]
       2: STAR@109..110 "*" [] []
       3: JS_IDENTIFIER_BINDING@110..113
         0: IDENT@110..113 "foo" [] []
@@ -361,7 +361,7 @@ JsModule {
     7: JS_EXPRESSION_STATEMENT@118..125
       0: JS_UNKNOWN_EXPRESSION@118..125
         0: JS_UNKNOWN@118..125
-          0: IDENT@118..125 "yield" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@118..125 "yield" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
     8: JS_EXPRESSION_STATEMENT@125..129
       0: JS_IDENTIFIER_EXPRESSION@125..128
@@ -369,7 +369,7 @@ JsModule {
           0: IDENT@125..128 "foo" [] []
       1: SEMICOLON@128..129 ";" [] []
     9: JS_UNKNOWN_STATEMENT@129..156
-      0: FUNCTION_KW@129..139 "function" [Whitespace("\n")] [Whitespace(" ")]
+      0: FUNCTION_KW@129..139 "function" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@139..143
         0: IDENT@139..143 "test" [] []
       2: JS_PARAMETERS@143..145
@@ -387,7 +387,7 @@ JsModule {
         3: R_CURLY@155..156 "}" [] []
     10: JS_FUNCTION_STATEMENT@156..179
       0: (empty)
-      1: FUNCTION_KW@156..166 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@156..166 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@166..169
         0: IDENT@166..169 "foo" [] []
@@ -409,7 +409,7 @@ JsModule {
         3: R_CURLY@178..179 "}" [] []
     11: JS_FUNCTION_STATEMENT@179..202
       0: (empty)
-      1: FUNCTION_KW@179..189 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@179..189 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@189..192
         0: IDENT@189..192 "foo" [] []
@@ -429,7 +429,7 @@ JsModule {
         1: JS_DIRECTIVE_LIST@201..201
         2: JS_STATEMENT_LIST@201..201
         3: R_CURLY@201..202 "}" [] []
-  3: EOF@202..203 "" [Whitespace("\n")] []
+  3: EOF@202..203 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a name for the function in a function declaration, but found none
   ┌─ function_decl_err.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/getter_class_no_body.rast
+++ b/crates/rslint_parser/test_data/inline/err/getter_class_no_body.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@15..22 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    get_token: GET_KW@15..22 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@22..25 "foo" [] [],
                     },
@@ -28,7 +28,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@27..28 "" [Whitespace("\n")] [],
+    eof_token: EOF@27..28 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..28
@@ -47,7 +47,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@15..22 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+          3: GET_KW@15..22 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@22..25
             0: IDENT@22..25 "foo" [] []
           5: L_PAREN@25..26 "(" [] []
@@ -55,7 +55,7 @@ JsModule {
           7: (empty)
           8: (empty)
       6: (empty)
-  3: EOF@27..28 "" [Whitespace("\n")] []
+  3: EOF@27..28 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a class method body but instead found ''
   ┌─ getter_class_no_body.js:3:1

--- a/crates/rslint_parser/test_data/inline/err/identifier.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier.rast
@@ -19,7 +19,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@6..12 "await" [Whitespace("\n")] [],
+                            IDENT@6..12 "await" [Newline("\n")] [],
                         ],
                     },
                 ],
@@ -27,7 +27,7 @@ JsModule {
             semicolon_token: SEMICOLON@12..13 ";" [] [],
         },
     ],
-    eof_token: EOF@13..14 "" [Whitespace("\n")] [],
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..14
@@ -42,9 +42,9 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@6..13
       0: JS_UNKNOWN_EXPRESSION@6..12
         0: JS_UNKNOWN@6..12
-          0: IDENT@6..12 "await" [Whitespace("\n")] []
+          0: IDENT@6..12 "await" [Newline("\n")] []
       1: SEMICOLON@12..13 ";" [] []
-  3: EOF@13..14 "" [Whitespace("\n")] []
+  3: EOF@13..14 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
   ┌─ identifier.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.rast
@@ -19,7 +19,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@6..12 "await" [Whitespace("\n")] [],
+                            IDENT@6..12 "await" [Newline("\n")] [],
                         ],
                     },
                 ],
@@ -27,7 +27,7 @@ JsModule {
             semicolon_token: SEMICOLON@12..13 ";" [] [],
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@13..20 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@13..20 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@20..29 "function" [] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
@@ -59,7 +59,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@43..52 "function" [Whitespace("\n")] [],
+            function_token: FUNCTION_KW@43..52 "function" [Newline("\n")] [],
             star_token: STAR@52..54 "*" [] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@54..58 "test" [] [],
@@ -93,7 +93,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@68..73 "enum" [Whitespace("\n")] [],
+                            IDENT@68..73 "enum" [Newline("\n")] [],
                         ],
                     },
                 ],
@@ -105,7 +105,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@74..85 "implements" [Whitespace("\n")] [],
+                            IDENT@74..85 "implements" [Newline("\n")] [],
                         ],
                     },
                 ],
@@ -117,7 +117,7 @@ JsModule {
                 items: [
                     JsUnknown {
                         items: [
-                            IDENT@86..96 "interface" [Whitespace("\n")] [],
+                            IDENT@86..96 "interface" [Newline("\n")] [],
                         ],
                     },
                 ],
@@ -125,7 +125,7 @@ JsModule {
             semicolon_token: SEMICOLON@96..97 ";" [] [],
         },
     ],
-    eof_token: EOF@97..98 "" [Whitespace("\n")] [],
+    eof_token: EOF@97..98 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..98
@@ -140,10 +140,10 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@6..13
       0: JS_UNKNOWN_EXPRESSION@6..12
         0: JS_UNKNOWN@6..12
-          0: IDENT@6..12 "await" [Whitespace("\n")] []
+          0: IDENT@6..12 "await" [Newline("\n")] []
       1: SEMICOLON@12..13 ";" [] []
     2: JS_FUNCTION_STATEMENT@13..43
-      0: ASYNC_KW@13..20 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@13..20 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@20..29 "function" [] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@29..33
@@ -166,7 +166,7 @@ JsModule {
         3: R_CURLY@42..43 "}" [] []
     3: JS_FUNCTION_STATEMENT@43..68
       0: (empty)
-      1: FUNCTION_KW@43..52 "function" [Whitespace("\n")] []
+      1: FUNCTION_KW@43..52 "function" [Newline("\n")] []
       2: STAR@52..54 "*" [] [Whitespace(" ")]
       3: JS_IDENTIFIER_BINDING@54..58
         0: IDENT@54..58 "test" [] []
@@ -189,19 +189,19 @@ JsModule {
     4: JS_EXPRESSION_STATEMENT@68..74
       0: JS_UNKNOWN_EXPRESSION@68..73
         0: JS_UNKNOWN@68..73
-          0: IDENT@68..73 "enum" [Whitespace("\n")] []
+          0: IDENT@68..73 "enum" [Newline("\n")] []
       1: SEMICOLON@73..74 ";" [] []
     5: JS_EXPRESSION_STATEMENT@74..86
       0: JS_UNKNOWN_EXPRESSION@74..85
         0: JS_UNKNOWN@74..85
-          0: IDENT@74..85 "implements" [Whitespace("\n")] []
+          0: IDENT@74..85 "implements" [Newline("\n")] []
       1: SEMICOLON@85..86 ";" [] []
     6: JS_EXPRESSION_STATEMENT@86..97
       0: JS_UNKNOWN_EXPRESSION@86..96
         0: JS_UNKNOWN@86..96
-          0: IDENT@86..96 "interface" [Whitespace("\n")] []
+          0: IDENT@86..96 "interface" [Newline("\n")] []
       1: SEMICOLON@96..97 ";" [] []
-  3: EOF@97..98 "" [Whitespace("\n")] []
+  3: EOF@97..98 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of reserved keyword `yield` as an identifier in strict mode
   ┌─ identifier_err.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/if_stmt_err.rast
@@ -20,7 +20,7 @@ JsModule {
             },
         },
         JsIfStatement {
-            if_token: IF_KW@17..21 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@17..21 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@21..22 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@22..26 "true" [] [],
@@ -30,7 +30,7 @@ JsModule {
             else_clause: JsElseClause {
                 else_token: ELSE_KW@28..32 "else" [] [],
                 alternate: JsIfStatement {
-                    if_token: IF_KW@32..36 "if" [Whitespace("\n")] [Whitespace(" ")],
+                    if_token: IF_KW@32..36 "if" [Newline("\n")] [Whitespace(" ")],
                     l_paren_token: missing (required),
                     test: missing (required),
                     r_paren_token: missing (required),
@@ -47,7 +47,7 @@ JsModule {
             },
         },
         JsIfStatement {
-            if_token: IF_KW@43..47 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@43..47 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@47..48 "(" [] [],
             test: missing (required),
             r_paren_token: R_PAREN@48..50 ")" [] [Whitespace(" ")],
@@ -66,7 +66,7 @@ JsModule {
             },
         },
         JsIfStatement {
-            if_token: IF_KW@60..64 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@60..64 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@64..65 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@65..69 "true" [] [],
@@ -89,7 +89,7 @@ JsModule {
             r_curly_token: R_CURLY@76..77 "}" [] [],
         },
     ],
-    eof_token: EOF@77..78 "" [Whitespace("\n")] [],
+    eof_token: EOF@77..78 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..78
@@ -110,7 +110,7 @@ JsModule {
           1: JS_STATEMENT_LIST@16..16
           2: R_CURLY@16..17 "}" [] []
     1: JS_IF_STATEMENT@17..43
-      0: IF_KW@17..21 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@17..21 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@21..22 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@22..26
         0: TRUE_KW@22..26 "true" [] []
@@ -119,7 +119,7 @@ JsModule {
       5: JS_ELSE_CLAUSE@28..43
         0: ELSE_KW@28..32 "else" [] []
         1: JS_IF_STATEMENT@32..43
-          0: IF_KW@32..36 "if" [Whitespace("\n")] [Whitespace(" ")]
+          0: IF_KW@32..36 "if" [Newline("\n")] [Whitespace(" ")]
           1: (empty)
           2: (empty)
           3: (empty)
@@ -131,7 +131,7 @@ JsModule {
               1: JS_STATEMENT_LIST@42..42
               2: R_CURLY@42..43 "}" [] []
     2: JS_IF_STATEMENT@43..60
-      0: IF_KW@43..47 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@43..47 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@47..48 "(" [] []
       2: (empty)
       3: R_PAREN@48..50 ")" [] [Whitespace(" ")]
@@ -146,7 +146,7 @@ JsModule {
           1: JS_STATEMENT_LIST@59..59
           2: R_CURLY@59..60 "}" [] []
     3: JS_IF_STATEMENT@60..70
-      0: IF_KW@60..64 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@60..64 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@64..65 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@65..69
         0: TRUE_KW@65..69 "true" [] []
@@ -162,7 +162,7 @@ JsModule {
       0: L_CURLY@75..76 "{" [] []
       1: JS_STATEMENT_LIST@76..76
       2: R_CURLY@76..77 "}" [] []
-  3: EOF@77..78 "" [Whitespace("\n")] []
+  3: EOF@77..78 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a statement but instead found 'else'
   ┌─ if_stmt_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/import_as_identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_as_identifier_err.rast
@@ -28,7 +28,7 @@ JsModule {
             semicolon_token: SEMICOLON@27..28 ";" [] [],
         },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..29
@@ -53,7 +53,7 @@ JsModule {
           0: JS_STRING_LITERAL@21..27 "\"test\"" [] []
         4: (empty)
       2: SEMICOLON@27..28 ";" [] []
-  3: EOF@28..29 "" [Whitespace("\n")] []
+  3: EOF@28..29 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a string literal, or an identifier but instead found 'as'
   ┌─ import_as_identifier_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
@@ -30,7 +30,7 @@ JsModule {
             semicolon_token: SEMICOLON@36..37 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@37..45 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@45..51 "\"foo\"" [] [Whitespace(" ")],
@@ -67,7 +67,7 @@ JsModule {
             semicolon_token: SEMICOLON@79..80 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@80..88 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@80..88 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -99,7 +99,7 @@ JsModule {
             semicolon_token: SEMICOLON@119..120 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@120..128 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@120..128 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@128..133 "\"foo\"" [] [],
@@ -111,7 +111,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@133..141 "assert" [Whitespace("\n")] [Whitespace(" ")],
+                    value_token: IDENT@133..141 "assert" [Newline("\n")] [Whitespace(" ")],
                 },
             },
             semicolon_token: missing (optional),
@@ -133,7 +133,7 @@ JsModule {
             r_curly_token: R_CURLY@156..157 "}" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@157..165 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@157..165 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@165..169 "foo" [] [Whitespace(" ")],
@@ -174,7 +174,7 @@ JsModule {
             semicolon_token: SEMICOLON@238..239 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@239..247 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@239..247 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@247..251 "\"x\"" [] [Whitespace(" ")],
@@ -189,7 +189,7 @@ JsModule {
             semicolon_token: SEMICOLON@257..258 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@258..266 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@258..266 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@266..270 "foo" [] [Whitespace(" ")],
@@ -238,7 +238,7 @@ JsModule {
             semicolon_token: SEMICOLON@337..338 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@338..346 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@338..346 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -266,7 +266,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@372..373 "" [Whitespace("\n")] [],
+    eof_token: EOF@372..373 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..373
@@ -294,7 +294,7 @@ JsModule {
           3: R_CURLY@35..36 "}" [] []
       2: SEMICOLON@36..37 ";" [] []
     1: JS_IMPORT@37..51
-      0: IMPORT_KW@37..45 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@45..51
         0: JS_MODULE_SOURCE@45..51
           0: JS_STRING_LITERAL@45..51 "\"foo\"" [] [Whitespace(" ")]
@@ -319,7 +319,7 @@ JsModule {
     4: JS_EMPTY_STATEMENT@79..80
       0: SEMICOLON@79..80 ";" [] []
     5: JS_IMPORT@80..120
-      0: IMPORT_KW@80..88 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@80..88 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@88..119
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@88..96
@@ -342,7 +342,7 @@ JsModule {
           3: R_CURLY@118..119 "}" [] []
       2: SEMICOLON@119..120 ";" [] []
     6: JS_IMPORT@120..133
-      0: IMPORT_KW@120..128 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@120..128 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@128..133
         0: JS_MODULE_SOURCE@128..133
           0: JS_STRING_LITERAL@128..133 "\"foo\"" [] []
@@ -351,7 +351,7 @@ JsModule {
     7: JS_EXPRESSION_STATEMENT@133..141
       0: JS_IDENTIFIER_EXPRESSION@133..141
         0: JS_REFERENCE_IDENTIFIER@133..141
-          0: IDENT@133..141 "assert" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@133..141 "assert" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
     8: JS_BLOCK_STATEMENT@141..157
       0: L_CURLY@141..143 "{" [] [Whitespace(" ")]
@@ -365,7 +365,7 @@ JsModule {
             1: (empty)
       2: R_CURLY@156..157 "}" [] []
     9: JS_IMPORT@157..239
-      0: IMPORT_KW@157..165 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@157..165 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@165..238
         0: JS_IDENTIFIER_BINDING@165..169
           0: IDENT@165..169 "foo" [] [Whitespace(" ")]
@@ -393,7 +393,7 @@ JsModule {
           3: R_CURLY@237..238 "}" [] []
       2: SEMICOLON@238..239 ";" [] []
     10: JS_IMPORT@239..258
-      0: IMPORT_KW@239..247 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@239..247 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@247..257
         0: JS_MODULE_SOURCE@247..251
           0: JS_STRING_LITERAL@247..251 "\"x\"" [] [Whitespace(" ")]
@@ -404,7 +404,7 @@ JsModule {
           3: (empty)
       2: SEMICOLON@257..258 ";" [] []
     11: JS_IMPORT@258..338
-      0: IMPORT_KW@258..266 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@258..266 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@266..337
         0: JS_IDENTIFIER_BINDING@266..270
           0: IDENT@266..270 "foo" [] [Whitespace(" ")]
@@ -440,7 +440,7 @@ JsModule {
           3: R_CURLY@336..337 "}" [] []
       2: SEMICOLON@337..338 ";" [] []
     12: JS_IMPORT@338..372
-      0: IMPORT_KW@338..346 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@338..346 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@346..372
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@346..352
@@ -459,7 +459,7 @@ JsModule {
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@372..372
           3: (empty)
       2: (empty)
-  3: EOF@372..373 "" [Whitespace("\n")] []
+  3: EOF@372..373 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `,`
   ┌─ import_assertion_err.js:1:27

--- a/crates/rslint_parser/test_data/inline/err/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call.rast
@@ -1,0 +1,38 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsImportCallExpression {
+                import_token: IMPORT_KW@0..6 "import" [] [],
+                l_paren_token: L_PAREN@6..7 "(" [] [],
+                argument: missing (required),
+                r_paren_token: R_PAREN@7..8 ")" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@8..9 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..9
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..8
+    0: JS_EXPRESSION_STATEMENT@0..8
+      0: JS_IMPORT_CALL_EXPRESSION@0..8
+        0: IMPORT_KW@0..6 "import" [] []
+        1: L_PAREN@6..7 "(" [] []
+        2: (empty)
+        3: R_PAREN@7..8 ")" [] []
+      1: (empty)
+  3: EOF@8..9 "" [Newline("\n")] []
+--
+error[SyntaxError]: expected an expression, or an assignment but instead found ')'
+  ┌─ import_call.js:1:8
+  │
+1 │ import()
+  │        ^ Expected an expression, or an assignment here
+
+--
+import()

--- a/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_call_no_arg.rast
@@ -1,0 +1,93 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                        },
+                        excl_token: missing (optional),
+                        type_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsImportCallExpression {
+                                import_token: IMPORT_KW@8..14 "import" [] [],
+                                l_paren_token: L_PAREN@14..15 "(" [] [],
+                                argument: missing (required),
+                                r_paren_token: R_PAREN@15..16 ")" [] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@16..17 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsCallExpression {
+                callee: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@17..21 "foo" [Newline("\n")] [],
+                    },
+                },
+                optional_chain_token_token: missing (optional),
+                type_args: missing (optional),
+                arguments: JsCallArguments {
+                    l_paren_token: L_PAREN@21..22 "(" [] [],
+                    args: JsCallArgumentList [],
+                    r_paren_token: R_PAREN@22..23 ")" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@23..24 ";" [] [],
+        },
+    ],
+    eof_token: EOF@24..25 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..25
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..24
+    0: JS_VARIABLE_STATEMENT@0..17
+      0: JS_VARIABLE_DECLARATIONS@0..16
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@4..16
+          0: JS_VARIABLE_DECLARATION@4..16
+            0: JS_IDENTIFIER_BINDING@4..6
+              0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: (empty)
+            3: JS_INITIALIZER_CLAUSE@6..16
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: JS_IMPORT_CALL_EXPRESSION@8..16
+                0: IMPORT_KW@8..14 "import" [] []
+                1: L_PAREN@14..15 "(" [] []
+                2: (empty)
+                3: R_PAREN@15..16 ")" [] []
+      1: SEMICOLON@16..17 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@17..24
+      0: JS_CALL_EXPRESSION@17..23
+        0: JS_IDENTIFIER_EXPRESSION@17..21
+          0: JS_REFERENCE_IDENTIFIER@17..21
+            0: IDENT@17..21 "foo" [Newline("\n")] []
+        1: (empty)
+        2: (empty)
+        3: JS_CALL_ARGUMENTS@21..23
+          0: L_PAREN@21..22 "(" [] []
+          1: JS_CALL_ARGUMENT_LIST@22..22
+          2: R_PAREN@22..23 ")" [] []
+      1: SEMICOLON@23..24 ";" [] []
+  3: EOF@24..25 "" [Newline("\n")] []
+--
+error[SyntaxError]: expected an expression, or an assignment but instead found ')'
+  ┌─ import_call_no_arg.js:1:16
+  │
+1 │ let a = import();
+  │                ^ Expected an expression, or an assignment here
+
+--
+let a = import();
+foo();

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -7,7 +7,7 @@ JsModule {
             statements: JsStatementList [
                 JsUnknownStatement {
                     items: [
-                        IMPORT_KW@1..10 "import" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                        IMPORT_KW@1..10 "import" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsImportDefaultClause {
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@10..14 "foo" [] [Whitespace(" ")],
@@ -22,10 +22,10 @@ JsModule {
                     ],
                 },
             ],
-            r_curly_token: R_CURLY@25..27 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@25..27 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@27..28 "" [Whitespace("\n")] [],
+    eof_token: EOF@27..28 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..28
@@ -36,7 +36,7 @@ JsModule {
       0: L_CURLY@0..1 "{" [] []
       1: JS_STATEMENT_LIST@1..25
         0: JS_UNKNOWN_STATEMENT@1..25
-          0: IMPORT_KW@1..10 "import" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          0: IMPORT_KW@1..10 "import" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           1: JS_IMPORT_DEFAULT_CLAUSE@10..24
             0: JS_IDENTIFIER_BINDING@10..14
               0: IDENT@10..14 "foo" [] [Whitespace(" ")]
@@ -45,8 +45,8 @@ JsModule {
               0: JS_STRING_LITERAL@19..24 "\"bar\"" [] []
             3: (empty)
           2: SEMICOLON@24..25 ";" [] []
-      2: R_CURLY@25..27 "}" [Whitespace("\n")] []
-  3: EOF@27..28 "" [Whitespace("\n")] []
+      2: R_CURLY@25..27 "}" [Newline("\n")] []
+  3: EOF@27..28 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal use of an import declaration not at the top level
   ┌─ import_decl_not_top_level.js:2:2

--- a/crates/rslint_parser/test_data/inline/err/import_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_err.rast
@@ -8,7 +8,7 @@ JsModule {
             semicolon_token: SEMICOLON@6..7 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@7..15 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@7..15 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamespaceClause {
                 star_token: STAR@15..16 "*" [] [],
                 as_token: missing (required),
@@ -20,7 +20,7 @@ JsModule {
             semicolon_token: SEMICOLON@16..17 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@17..25 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@17..25 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamespaceClause {
                 star_token: STAR@25..27 "*" [] [Whitespace(" ")],
                 as_token: AS_KW@27..30 "as" [] [Whitespace(" ")],
@@ -75,7 +75,7 @@ JsModule {
             semicolon_token: SEMICOLON@50..51 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@51..59 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@51..59 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -111,7 +111,7 @@ JsModule {
             semicolon_token: SEMICOLON@80..81 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@81..89 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@81..89 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -142,7 +142,7 @@ JsModule {
             semicolon_token: SEMICOLON@106..107 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@107..115 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@107..115 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -167,7 +167,7 @@ JsModule {
             semicolon_token: SEMICOLON@135..136 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@136..144 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@136..144 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -190,7 +190,7 @@ JsModule {
             semicolon_token: SEMICOLON@160..161 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@161..169 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@161..169 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -215,7 +215,7 @@ JsModule {
             semicolon_token: SEMICOLON@186..187 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@187..195 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@187..195 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: missing (required),
             semicolon_token: missing (optional),
         },
@@ -240,7 +240,7 @@ JsModule {
             semicolon_token: SEMICOLON@205..206 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@206..214 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@206..214 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@214..216 "a" [] [Whitespace(" ")],
@@ -258,7 +258,7 @@ JsModule {
             semicolon_token: SEMICOLON@222..223 ";" [] [],
         },
     ],
-    eof_token: EOF@223..224 "" [Whitespace("\n")] [],
+    eof_token: EOF@223..224 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..224
@@ -270,7 +270,7 @@ JsModule {
       1: (empty)
       2: SEMICOLON@6..7 ";" [] []
     1: JS_IMPORT@7..17
-      0: IMPORT_KW@7..15 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@7..15 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMESPACE_CLAUSE@15..16
         0: STAR@15..16 "*" [] []
         1: (empty)
@@ -280,7 +280,7 @@ JsModule {
         5: (empty)
       2: SEMICOLON@16..17 ";" [] []
     2: JS_IMPORT@17..31
-      0: IMPORT_KW@17..25 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@17..25 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMESPACE_CLAUSE@25..31
         0: STAR@25..27 "*" [] [Whitespace(" ")]
         1: AS_KW@27..30 "as" [] [Whitespace(" ")]
@@ -316,7 +316,7 @@ JsModule {
         0: JS_STRING_LITERAL@47..50 "\"c\"" [] []
       1: SEMICOLON@50..51 ";" [] []
     7: JS_IMPORT@51..81
-      0: IMPORT_KW@51..59 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@51..59 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@59..80
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@59..72
@@ -340,7 +340,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@80..81 ";" [] []
     8: JS_IMPORT@81..107
-      0: IMPORT_KW@81..89 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@81..89 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@89..106
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@89..98
@@ -360,7 +360,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@106..107 ";" [] []
     9: JS_IMPORT@107..136
-      0: IMPORT_KW@107..115 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@107..115 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@115..135
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@115..127
@@ -376,7 +376,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@135..136 ";" [] []
     10: JS_IMPORT@136..161
-      0: IMPORT_KW@136..144 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@136..144 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@144..160
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@144..152
@@ -391,7 +391,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@160..161 ";" [] []
     11: JS_IMPORT@161..187
-      0: IMPORT_KW@161..169 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@161..169 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@169..186
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@169..178
@@ -409,7 +409,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@186..187 ";" [] []
     12: JS_IMPORT@187..195
-      0: IMPORT_KW@187..195 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@187..195 "import" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
     13: JS_EXPRESSION_STATEMENT@195..197
@@ -426,7 +426,7 @@ JsModule {
         0: JS_STRING_LITERAL@202..205 "\"c\"" [] []
       1: SEMICOLON@205..206 ";" [] []
     16: JS_IMPORT@206..221
-      0: IMPORT_KW@206..214 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@206..214 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@214..221
         0: JS_IDENTIFIER_BINDING@214..216
           0: IDENT@214..216 "a" [] [Whitespace(" ")]
@@ -438,7 +438,7 @@ JsModule {
       0: JS_NUMBER_LITERAL_EXPRESSION@221..222
         0: JS_NUMBER_LITERAL@221..222 "4" [] []
       1: SEMICOLON@222..223 ";" [] []
-  3: EOF@223..224 "" [Whitespace("\n")] []
+  3: EOF@223..224 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a default import, a namespace import, or a named import but instead found ';'
   ┌─ import_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/import_invalid_args.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_invalid_args.rast
@@ -15,7 +15,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsImportCallExpression {
-                import_token: IMPORT_KW@8..15 "import" [Whitespace("\n")] [],
+                import_token: IMPORT_KW@8..15 "import" [Newline("\n")] [],
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@15..16 "(" [] [],
                     args: JsCallArgumentList [],
@@ -38,7 +38,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsImportCallExpression {
-                import_token: IMPORT_KW@27..34 "import" [Whitespace("\n")] [],
+                import_token: IMPORT_KW@27..34 "import" [Newline("\n")] [],
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@34..35 "(" [] [],
                     args: JsCallArgumentList [
@@ -84,7 +84,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@78..79 "" [Whitespace("\n")] [],
+    eof_token: EOF@78..79 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..79
@@ -101,7 +101,7 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@8..16
       0: JS_IMPORT_CALL_EXPRESSION@8..16
-        0: IMPORT_KW@8..15 "import" [Whitespace("\n")] []
+        0: IMPORT_KW@8..15 "import" [Newline("\n")] []
         1: JS_CALL_ARGUMENTS@15..16
           0: L_PAREN@15..16 "(" [] []
           1: JS_CALL_ARGUMENT_LIST@16..16
@@ -117,7 +117,7 @@ JsModule {
       1: (empty)
     3: JS_EXPRESSION_STATEMENT@27..78
       0: JS_IMPORT_CALL_EXPRESSION@27..78
-        0: IMPORT_KW@27..34 "import" [Whitespace("\n")] []
+        0: IMPORT_KW@27..34 "import" [Newline("\n")] []
         1: JS_CALL_ARGUMENTS@34..78
           0: L_PAREN@34..35 "(" [] []
           1: JS_CALL_ARGUMENT_LIST@35..77
@@ -147,7 +147,7 @@ JsModule {
               0: JS_STRING_LITERAL@72..77 "\"bar\"" [] []
           2: R_PAREN@77..78 ")" [] []
       1: (empty)
-  3: EOF@78..79 "" [Whitespace("\n")] []
+  3: EOF@78..79 "" [Newline("\n")] []
 --
 error[SyntaxError]: `import()` requires exactly one or two arguments. 
   ┌─ import_invalid_args.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_no_meta.rast
@@ -19,7 +19,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsUnknownExpression {
                 items: [
-                    IMPORT_KW@10..17 "import" [Whitespace("\n")] [],
+                    IMPORT_KW@10..17 "import" [Newline("\n")] [],
                     DOT@17..18 "." [] [],
                     JsUnknown {
                         items: [
@@ -31,7 +31,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -47,12 +47,12 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@10..23
       0: JS_UNKNOWN_EXPRESSION@10..23
-        0: IMPORT_KW@10..17 "import" [Whitespace("\n")] []
+        0: IMPORT_KW@10..17 "import" [Newline("\n")] []
         1: DOT@17..18 "." [] []
         2: JS_UNKNOWN@18..23
           0: IDENT@18..23 "metaa" [] []
       1: (empty)
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected `meta` following an import keyword, but found `foo`
   ┌─ import_no_meta.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -35,7 +35,7 @@ JsModule {
             expression: JsCallExpression {
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@8..12 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token_token: missing (optional),
@@ -66,7 +66,7 @@ JsModule {
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
-                            name_token: IDENT@20..25 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                            name_token: IDENT@20..25 "foo" [Newline("\n")] [Whitespace(" ")],
                         },
                         excl_token: missing (optional),
                         type_annotation: missing (optional),
@@ -95,7 +95,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@30..31 "" [Whitespace("\n")] [],
+    eof_token: EOF@30..31 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..31
@@ -125,7 +125,7 @@ JsModule {
       0: JS_CALL_EXPRESSION@8..17
         0: JS_IDENTIFIER_EXPRESSION@8..12
           0: JS_REFERENCE_IDENTIFIER@8..12
-            0: IDENT@8..12 "foo" [Whitespace("\n")] []
+            0: IDENT@8..12 "foo" [Newline("\n")] []
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@12..17
@@ -146,7 +146,7 @@ JsModule {
         1: JS_VARIABLE_DECLARATION_LIST@20..25
           0: JS_VARIABLE_DECLARATION@20..25
             0: JS_IDENTIFIER_BINDING@20..25
-              0: IDENT@20..25 "foo" [Whitespace("\n")] [Whitespace(" ")]
+              0: IDENT@20..25 "foo" [Newline("\n")] [Whitespace(" ")]
             1: (empty)
             2: (empty)
             3: (empty)
@@ -162,7 +162,7 @@ JsModule {
               0: IDENT@28..29 "b" [] []
         2: R_PAREN@29..30 ")" [] []
       1: (empty)
-  3: EOF@30..31 "" [Whitespace("\n")] []
+  3: EOF@30..31 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `')'` but instead found `;`
   ┌─ invalid_arg_list.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/invalid_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_assignment_target.rast
@@ -22,7 +22,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsParenthesizedAssignment {
-                    l_paren_token: L_PAREN@8..10 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@8..10 "(" [Newline("\n")] [],
                     assignment: JsUnknownAssignment {
                         items: [
                             PLUS2@10..12 "++" [] [],
@@ -44,7 +44,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@19..21 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@19..21 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsIdentifierAssignment {
                         name_token: IDENT@21..23 "a" [] [Whitespace(" ")],
@@ -66,7 +66,7 @@ JsModule {
                     items: [
                         JsIdentifierExpression {
                             name: JsReferenceIdentifier {
-                                value_token: IDENT@27..29 "a" [Whitespace("\n")] [],
+                                value_token: IDENT@27..29 "a" [Newline("\n")] [],
                             },
                         },
                         QUESTIONDOT@29..31 "?." [] [],
@@ -90,7 +90,7 @@ JsModule {
                     items: [
                         JsIdentifierExpression {
                             name: JsReferenceIdentifier {
-                                value_token: IDENT@37..39 "a" [Whitespace("\n")] [],
+                                value_token: IDENT@37..39 "a" [Newline("\n")] [],
                             },
                         },
                         QUESTIONDOT@39..41 "?." [] [],
@@ -113,7 +113,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsParenthesizedAssignment {
-                    l_paren_token: L_PAREN@51..53 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@51..53 "(" [Newline("\n")] [],
                     assignment: JsUnknownAssignment {
                         items: [
                             JsIdentifierExpression {
@@ -136,7 +136,7 @@ JsModule {
             semicolon_token: SEMICOLON@61..62 ";" [] [],
         },
     ],
-    eof_token: EOF@62..63 "" [Whitespace("\n")] [],
+    eof_token: EOF@62..63 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..63
@@ -156,7 +156,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@8..19
       0: JS_ASSIGNMENT_EXPRESSION@8..18
         0: JS_PARENTHESIZED_ASSIGNMENT@8..15
-          0: L_PAREN@8..10 "(" [Whitespace("\n")] []
+          0: L_PAREN@8..10 "(" [Newline("\n")] []
           1: JS_UNKNOWN_ASSIGNMENT@10..13
             0: PLUS2@10..12 "++" [] []
             1: JS_IDENTIFIER_ASSIGNMENT@12..13
@@ -169,7 +169,7 @@ JsModule {
       1: SEMICOLON@18..19 ";" [] []
     2: JS_EXPRESSION_STATEMENT@19..27
       0: JS_PARENTHESIZED_EXPRESSION@19..26
-        0: L_PAREN@19..21 "(" [Whitespace("\n")] []
+        0: L_PAREN@19..21 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@21..26
           0: JS_IDENTIFIER_ASSIGNMENT@21..23
             0: IDENT@21..23 "a" [] [Whitespace(" ")]
@@ -184,7 +184,7 @@ JsModule {
         0: JS_UNKNOWN_ASSIGNMENT@27..33
           0: JS_IDENTIFIER_EXPRESSION@27..29
             0: JS_REFERENCE_IDENTIFIER@27..29
-              0: IDENT@27..29 "a" [Whitespace("\n")] []
+              0: IDENT@27..29 "a" [Newline("\n")] []
           1: QUESTIONDOT@29..31 "?." [] []
           2: JS_NAME@31..33
             0: IDENT@31..33 "b" [] [Whitespace(" ")]
@@ -198,7 +198,7 @@ JsModule {
         0: JS_UNKNOWN_ASSIGNMENT@37..47
           0: JS_IDENTIFIER_EXPRESSION@37..39
             0: JS_REFERENCE_IDENTIFIER@37..39
-              0: IDENT@37..39 "a" [Whitespace("\n")] []
+              0: IDENT@37..39 "a" [Newline("\n")] []
           1: QUESTIONDOT@39..41 "?." [] []
           2: L_BRACK@41..42 "[" [] []
           3: JS_STRING_LITERAL_EXPRESSION@42..45
@@ -212,7 +212,7 @@ JsModule {
     5: JS_EXPRESSION_STATEMENT@51..62
       0: JS_ASSIGNMENT_EXPRESSION@51..61
         0: JS_PARENTHESIZED_ASSIGNMENT@51..58
-          0: L_PAREN@51..53 "(" [Whitespace("\n")] []
+          0: L_PAREN@51..53 "(" [Newline("\n")] []
           1: JS_UNKNOWN_ASSIGNMENT@53..56
             0: JS_IDENTIFIER_EXPRESSION@53..55
               0: JS_REFERENCE_IDENTIFIER@53..55
@@ -224,7 +224,7 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@60..61
             0: IDENT@60..61 "b" [] []
       1: SEMICOLON@61..62 ";" [] []
-  3: EOF@62..63 "" [Whitespace("\n")] []
+  3: EOF@62..63 "" [Newline("\n")] []
 --
 error[SyntaxError]: Invalid assignment to `++a`
   ┌─ invalid_assignment_target.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_method_recover.rast
@@ -16,7 +16,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsComputedMemberName {
-                        l_brack_token: L_BRACK@7..11 "[" [Whitespace("\n"), Whitespace("  ")] [],
+                        l_brack_token: L_BRACK@7..11 "[" [Newline("\n"), Whitespace("  ")] [],
                         expression: JsBinaryExpression {
                             left: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@11..13 "1" [] [Whitespace(" ")],
@@ -49,7 +49,7 @@ JsModule {
                                 statements: JsStatementList [
                                     JsVariableStatement {
                                         declarations: JsVariableDeclarations {
-                                            kind: LET_KW@27..36 "let" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                            kind: LET_KW@27..36 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                             items: JsVariableDeclarationList [
                                                 JsVariableDeclaration {
                                                     id: JsIdentifierBinding {
@@ -67,20 +67,20 @@ JsModule {
                                         semicolon_token: SEMICOLON@38..39 ";" [] [],
                                     },
                                 ],
-                                r_curly_token: R_CURLY@39..43 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                r_curly_token: R_CURLY@39..43 "}" [Newline("\n"), Whitespace("  ")] [],
                             },
                         },
                     },
                     semicolon_token: SEMICOLON@43..44 ";" [] [],
                 },
             ],
-            r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@44..46 "}" [Newline("\n")] [],
         },
         JsEmptyStatement {
             semicolon_token: SEMICOLON@46..47 ";" [] [],
         },
     ],
-    eof_token: EOF@47..48 "" [Whitespace("\n")] [],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..48
@@ -101,7 +101,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_COMPUTED_MEMBER_NAME@7..18
-            0: L_BRACK@7..11 "[" [Whitespace("\n"), Whitespace("  ")] []
+            0: L_BRACK@7..11 "[" [Newline("\n"), Whitespace("  ")] []
             1: JS_BINARY_EXPRESSION@11..16
               0: JS_NUMBER_LITERAL_EXPRESSION@11..13
                 0: JS_NUMBER_LITERAL@11..13 "1" [] [Whitespace(" ")]
@@ -129,7 +129,7 @@ JsModule {
                 2: JS_STATEMENT_LIST@27..39
                   0: JS_VARIABLE_STATEMENT@27..39
                     0: JS_VARIABLE_DECLARATIONS@27..38
-                      0: LET_KW@27..36 "let" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                      0: LET_KW@27..36 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                       1: JS_VARIABLE_DECLARATION_LIST@36..38
                         0: JS_VARIABLE_DECLARATION@36..38
                           0: JS_IDENTIFIER_BINDING@36..37
@@ -140,12 +140,12 @@ JsModule {
                             0: EQ@37..38 "=" [] []
                             1: (empty)
                     1: SEMICOLON@38..39 ";" [] []
-                3: R_CURLY@39..43 "}" [Whitespace("\n"), Whitespace("  ")] []
+                3: R_CURLY@39..43 "}" [Newline("\n"), Whitespace("  ")] []
           10: SEMICOLON@43..44 ";" [] []
-      6: R_CURLY@44..46 "}" [Whitespace("\n")] []
+      6: R_CURLY@44..46 "}" [Newline("\n")] []
     1: JS_EMPTY_STATEMENT@46..47
       0: SEMICOLON@46..47 ";" [] []
-  3: EOF@47..48 "" [Whitespace("\n")] []
+  3: EOF@47..48 "" [Newline("\n")] []
 --
 error[SyntaxError]: class declarations must have a name
   ┌─ invalid_method_recover.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
@@ -23,7 +23,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsLogicalExpression {
                 left: JsUnaryExpression {
-                    operator: BANG@11..13 "!" [Whitespace("\n")] [],
+                    operator: BANG@11..13 "!" [Newline("\n")] [],
                     argument: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@13..17 "foo" [] [Whitespace(" ")],
@@ -43,7 +43,7 @@ JsModule {
             expression: JsCallExpression {
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@24..28 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@24..28 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token_token: missing (optional),
@@ -67,7 +67,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@36..37 "" [Whitespace("\n")] [],
+    eof_token: EOF@36..37 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..37
@@ -89,7 +89,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@11..24
       0: JS_LOGICAL_EXPRESSION@11..23
         0: JS_UNARY_EXPRESSION@11..17
-          0: BANG@11..13 "!" [Whitespace("\n")] []
+          0: BANG@11..13 "!" [Newline("\n")] []
           1: JS_IDENTIFIER_EXPRESSION@13..17
             0: JS_REFERENCE_IDENTIFIER@13..17
               0: IDENT@13..17 "foo" [] [Whitespace(" ")]
@@ -102,7 +102,7 @@ JsModule {
       0: JS_CALL_EXPRESSION@24..36
         0: JS_IDENTIFIER_EXPRESSION@24..28
           0: JS_REFERENCE_IDENTIFIER@24..28
-            0: IDENT@24..28 "foo" [Whitespace("\n")] []
+            0: IDENT@24..28 "foo" [Newline("\n")] []
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@28..36
@@ -116,7 +116,7 @@ JsModule {
               2: (empty)
           2: R_PAREN@35..36 ")" [] []
       1: (empty)
-  3: EOF@36..37 "" [Whitespace("\n")] []
+  3: EOF@36..37 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected an expression for the right hand side of a `??`, but found an operator instead
   ┌─ logical_expressions_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/method_getter_err.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@11..17 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    get_token: GET_KW@11..17 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     name: missing (required),
                     l_paren_token: missing (required),
                     r_paren_token: missing (required),
@@ -28,10 +28,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@19..21 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@19..21 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@21..22 "" [Whitespace("\n")] [],
+    eof_token: EOF@21..22 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..22
@@ -50,7 +50,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@11..17 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          3: GET_KW@11..17 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           4: (empty)
           5: (empty)
           6: (empty)
@@ -60,8 +60,8 @@ JsModule {
             1: JS_DIRECTIVE_LIST@18..18
             2: JS_STATEMENT_LIST@18..18
             3: R_CURLY@18..19 "}" [] []
-      6: R_CURLY@19..21 "}" [Whitespace("\n")] []
-  3: EOF@21..22 "" [Whitespace("\n")] []
+      6: R_CURLY@19..21 "}" [Newline("\n")] []
+  3: EOF@21..22 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, a string literal, a number literal, a private field name, or a computed name but instead found '{'
   ┌─ method_getter_err.js:2:6

--- a/crates/rslint_parser/test_data/inline/err/multiple_default_exports_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/multiple_default_exports_err.rast
@@ -24,7 +24,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@25..33 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@25..33 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         DEFAULT_KW@33..41 "default" [] [Whitespace(" ")],
@@ -48,7 +48,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                EXPORT_KW@47..55 "export" [Whitespace("\n")] [Whitespace(" ")],
+                EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")],
                 JsUnknown {
                     items: [
                         DEFAULT_KW@55..63 "default" [] [Whitespace(" ")],
@@ -82,7 +82,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@80..81 "" [Whitespace("\n")] [],
+    eof_token: EOF@80..81 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..81
@@ -106,7 +106,7 @@ JsModule {
           2: R_PAREN@24..25 ")" [] []
         2: (empty)
     1: JS_UNKNOWN_STATEMENT@25..47
-      0: EXPORT_KW@25..33 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@25..33 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@33..47
         0: DEFAULT_KW@33..41 "default" [] [Whitespace(" ")]
         1: JS_BINARY_EXPRESSION@41..46
@@ -119,7 +119,7 @@ JsModule {
               0: IDENT@45..46 "b" [] []
         2: SEMICOLON@46..47 ";" [] []
     2: JS_UNKNOWN_STATEMENT@47..80
-      0: EXPORT_KW@47..55 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@47..55 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_UNKNOWN@55..80
         0: DEFAULT_KW@55..63 "default" [] [Whitespace(" ")]
         1: JS_PARENTHESIZED_EXPRESSION@63..80
@@ -142,7 +142,7 @@ JsModule {
               2: JS_STATEMENT_LIST@78..78
               3: R_CURLY@78..79 "}" [] []
           2: R_PAREN@79..80 ")" [] []
-  3: EOF@80..81 "" [Whitespace("\n")] []
+  3: EOF@80..81 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal duplicate default export declarations
   ┌─ multiple_default_exports_err.js:2:8

--- a/crates/rslint_parser/test_data/inline/err/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/err/new_exprs.rast
@@ -12,7 +12,7 @@ JsModule {
             semicolon_token: SEMICOLON@3..4 ";" [] [],
         },
     ],
-    eof_token: EOF@4..5 "" [Whitespace("\n")] [],
+    eof_token: EOF@4..5 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..5
@@ -26,7 +26,7 @@ JsModule {
         2: (empty)
         3: (empty)
       1: SEMICOLON@3..4 ";" [] []
-  3: EOF@4..5 "" [Whitespace("\n")] []
+  3: EOF@4..5 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found ';'
   ┌─ new_exprs.js:1:4

--- a/crates/rslint_parser/test_data/inline/err/object_binding_pattern.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_binding_pattern.rast
@@ -56,7 +56,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@30..35 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -100,7 +100,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@62..67 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@62..67 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -153,7 +153,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@94..99 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@94..99 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -195,7 +195,7 @@ JsModule {
             semicolon_token: SEMICOLON@123..124 ";" [] [],
         },
     ],
-    eof_token: EOF@124..125 "" [Whitespace("\n")] [],
+    eof_token: EOF@124..125 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..125
@@ -239,7 +239,7 @@ JsModule {
       0: SEMICOLON@29..30 ";" [] []
     4: JS_VARIABLE_STATEMENT@30..62
       0: JS_VARIABLE_DECLARATIONS@30..61
-        0: LET_KW@30..35 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@30..35 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@35..61
           0: JS_VARIABLE_DECLARATION@35..61
             0: JS_OBJECT_BINDING_PATTERN@35..44
@@ -267,7 +267,7 @@ JsModule {
       1: SEMICOLON@61..62 ";" [] []
     5: JS_VARIABLE_STATEMENT@62..94
       0: JS_VARIABLE_DECLARATIONS@62..93
-        0: LET_KW@62..67 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@62..67 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@67..93
           0: JS_VARIABLE_DECLARATION@67..93
             0: JS_OBJECT_BINDING_PATTERN@67..76
@@ -304,7 +304,7 @@ JsModule {
       1: SEMICOLON@93..94 ";" [] []
     6: JS_VARIABLE_STATEMENT@94..124
       0: JS_VARIABLE_DECLARATIONS@94..123
-        0: LET_KW@94..99 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@94..99 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@99..123
           0: JS_VARIABLE_DECLARATION@99..123
             0: JS_OBJECT_BINDING_PATTERN@99..119
@@ -333,7 +333,7 @@ JsModule {
                 1: JS_OBJECT_MEMBER_LIST@122..122
                 2: R_CURLY@122..123 "}" [] []
       1: SEMICOLON@123..124 ";" [] []
-  3: EOF@124..125 "" [Whitespace("\n")] []
+  3: EOF@124..125 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `}`
   ┌─ object_binding_pattern.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/object_expr_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_err.rast
@@ -35,7 +35,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@15..20 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -69,7 +69,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@35..36 "" [Whitespace("\n")] [],
+    eof_token: EOF@35..36 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..36
@@ -99,7 +99,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@15..35
       0: JS_VARIABLE_DECLARATIONS@15..35
-        0: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@15..20 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@20..35
           0: JS_VARIABLE_DECLARATION@20..35
             0: JS_IDENTIFIER_BINDING@20..22
@@ -120,7 +120,7 @@ JsModule {
                         0: IDENT@30..34 "bar" [] [Whitespace(" ")]
                 2: R_CURLY@34..35 "}" [] []
       1: (empty)
-  3: EOF@35..36 "" [Whitespace("\n")] []
+  3: EOF@35..36 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `bar`
   ┌─ object_expr_err.js:2:15

--- a/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_error_prop_name.rast
@@ -41,7 +41,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@26..31 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@26..31 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -74,7 +74,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@39..40 "" [Whitespace("\n")] [],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..40
@@ -105,7 +105,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@26..38
       0: JS_VARIABLE_DECLARATIONS@26..38
-        0: LET_KW@26..31 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@26..31 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@31..38
           0: JS_VARIABLE_DECLARATION@31..38
             0: JS_IDENTIFIER_BINDING@31..33
@@ -123,7 +123,7 @@ JsModule {
       1: (empty)
     2: JS_UNKNOWN_STATEMENT@38..39
       0: R_CURLY@38..39 "}" [] []
-  3: EOF@39..40 "" [Whitespace("\n")] []
+  3: EOF@39..40 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a property, a shorthand property, a getter, a setter, or a method but instead found '/: 6, /'
   ┌─ object_expr_error_prop_name.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_method.rast
@@ -40,7 +40,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@16..17 "" [Whitespace("\n")] [],
+    eof_token: EOF@16..17 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..17
@@ -71,7 +71,7 @@ JsModule {
                     0: R_PAREN@13..15 ")" [] [Whitespace(" ")]
                 2: R_CURLY@15..16 "}" [] []
       1: (empty)
-  3: EOF@16..17 "" [Whitespace("\n")] []
+  3: EOF@16..17 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `)`
   ┌─ object_expr_method.js:1:14

--- a/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_non_ident_literal_prop.rast
@@ -34,7 +34,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -62,7 +62,7 @@ JsModule {
                     2: (empty)
                 2: R_CURLY@10..11 "}" [] []
       1: (empty)
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `:` but instead found `}`
   ┌─ object_expr_non_ident_literal_prop.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_expr_setter.rast
@@ -18,7 +18,7 @@ JsModule {
                                 l_curly_token: L_CURLY@8..9 "{" [] [],
                                 members: JsObjectMemberList [
                                     JsSetterObjectMember {
-                                        set_token: SET_KW@9..15 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        set_token: SET_KW@9..15 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: IDENT@15..18 "foo" [] [],
                                         },
@@ -30,18 +30,18 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@22..34 "return" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@22..34 "return" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                     argument: JsNumberLiteralExpression {
                                                         value_token: JS_NUMBER_LITERAL@34..35 "5" [] [],
                                                     },
                                                     semicolon_token: SEMICOLON@35..36 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@36..39 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@36..39 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@39..41 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@39..41 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -50,7 +50,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@41..42 "" [Whitespace("\n")] [],
+    eof_token: EOF@41..42 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..42
@@ -72,7 +72,7 @@ JsModule {
                 0: L_CURLY@8..9 "{" [] []
                 1: JS_OBJECT_MEMBER_LIST@9..39
                   0: JS_SETTER_OBJECT_MEMBER@9..39
-                    0: SET_KW@9..15 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: SET_KW@9..15 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@15..18
                       0: IDENT@15..18 "foo" [] []
                     2: L_PAREN@18..19 "(" [] []
@@ -83,14 +83,14 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@22..22
                       2: JS_STATEMENT_LIST@22..36
                         0: JS_RETURN_STATEMENT@22..36
-                          0: RETURN_KW@22..34 "return" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                          0: RETURN_KW@22..34 "return" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                           1: JS_NUMBER_LITERAL_EXPRESSION@34..35
                             0: JS_NUMBER_LITERAL@34..35 "5" [] []
                           2: SEMICOLON@35..36 ";" [] []
-                      3: R_CURLY@36..39 "}" [Whitespace("\n"), Whitespace(" ")] []
-                2: R_CURLY@39..41 "}" [Whitespace("\n")] []
+                      3: R_CURLY@36..39 "}" [Newline("\n"), Whitespace(" ")] []
+                2: R_CURLY@39..41 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@41..42 "" [Whitespace("\n")] []
+  3: EOF@41..42 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a parameter but instead found ')'
   ┌─ object_expr_setter.js:2:10

--- a/crates/rslint_parser/test_data/inline/err/object_property_binding_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_property_binding_err.rast
@@ -45,7 +45,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@23..28 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -84,7 +84,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@51..56 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -121,7 +121,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@75..76 "" [Whitespace("\n")] [],
+    eof_token: EOF@75..76 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..76
@@ -159,7 +159,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@23..51
       0: JS_VARIABLE_DECLARATIONS@23..51
-        0: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@23..28 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@28..51
           0: JS_VARIABLE_DECLARATION@28..51
             0: JS_OBJECT_BINDING_PATTERN@28..47
@@ -186,7 +186,7 @@ JsModule {
       1: (empty)
     2: JS_VARIABLE_STATEMENT@51..75
       0: JS_VARIABLE_DECLARATIONS@51..75
-        0: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@51..56 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@56..75
           0: JS_VARIABLE_DECLARATION@56..75
             0: JS_OBJECT_BINDING_PATTERN@56..71
@@ -211,7 +211,7 @@ JsModule {
                 1: JS_OBJECT_MEMBER_LIST@74..74
                 2: R_CURLY@74..75 "}" [] []
       1: (empty)
-  3: EOF@75..76 "" [Whitespace("\n")] []
+  3: EOF@75..76 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, an array pattern, or an object pattern but instead found ','
   ┌─ object_property_binding_err.js:1:12

--- a/crates/rslint_parser/test_data/inline/err/object_shorthand_property_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/object_shorthand_property_err.rast
@@ -43,7 +43,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@15..20 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -78,7 +78,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@36..41 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -111,7 +111,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@52..53 "" [Whitespace("\n")] [],
+    eof_token: EOF@52..53 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..53
@@ -146,7 +146,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@15..36
       0: JS_VARIABLE_DECLARATIONS@15..36
-        0: LET_KW@15..20 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@15..20 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@20..36
           0: JS_VARIABLE_DECLARATION@20..36
             0: JS_OBJECT_BINDING_PATTERN@20..33
@@ -169,7 +169,7 @@ JsModule {
       1: (empty)
     2: JS_VARIABLE_STATEMENT@36..52
       0: JS_VARIABLE_DECLARATIONS@36..52
-        0: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@36..41 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@41..52
           0: JS_VARIABLE_DECLARATION@41..52
             0: JS_OBJECT_BINDING_PATTERN@41..49
@@ -190,7 +190,7 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@51..52
                   0: IDENT@51..52 "c" [] []
       1: (empty)
-  3: EOF@52..53 "" [Whitespace("\n")] []
+  3: EOF@52..53 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `,` but instead found `b`
   ┌─ object_shorthand_property_err.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/optional_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/optional_member.rast
@@ -24,7 +24,7 @@ JsModule {
             r_curly_token: R_CURLY@16..17 "}" [] [],
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -45,7 +45,7 @@ JsModule {
           1: QUESTION@13..14 "?" [] []
           2: SEMICOLON@14..16 ";" [] [Whitespace(" ")]
       6: R_CURLY@16..17 "}" [] []
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []
 --
 error[SyntaxError]: `?` modifiers can only be used in TypeScript files
   ┌─ optional_member.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rslint_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -34,7 +34,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsParameters {
-                        l_paren_token: L_PAREN@13..15 "(" [Whitespace("\n")] [],
+                        l_paren_token: L_PAREN@13..15 "(" [Newline("\n")] [],
                         items: JsParameterList [
                             JsParameter {
                                 binding: JsIdentifierBinding {
@@ -73,7 +73,7 @@ JsModule {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsParameters {
-                    l_paren_token: L_PAREN@27..29 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@27..29 "(" [Newline("\n")] [],
                     items: JsParameterList [
                         JsParameter {
                             binding: JsIdentifierBinding {
@@ -100,7 +100,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@37..38 "" [Whitespace("\n")] [],
+    eof_token: EOF@37..38 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..38
@@ -130,7 +130,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@13..20
       0: JS_UNKNOWN_EXPRESSION@13..20
         0: JS_PARAMETERS@13..18
-          0: L_PAREN@13..15 "(" [Whitespace("\n")] []
+          0: L_PAREN@13..15 "(" [Newline("\n")] []
           1: JS_PARAMETER_LIST@15..18
             0: JS_PARAMETER@15..16
               0: JS_IDENTIFIER_BINDING@15..16
@@ -156,7 +156,7 @@ JsModule {
         0: (empty)
         1: (empty)
         2: JS_PARAMETERS@27..35
-          0: L_PAREN@27..29 "(" [Whitespace("\n")] []
+          0: L_PAREN@27..29 "(" [Newline("\n")] []
           1: JS_PARAMETER_LIST@29..33
             0: JS_PARAMETER@29..30
               0: JS_IDENTIFIER_BINDING@29..30
@@ -174,7 +174,7 @@ JsModule {
         4: FAT_ARROW@35..37 "=>" [] []
         5: (empty)
       1: (empty)
-  3: EOF@37..38 "" [Whitespace("\n")] []
+  3: EOF@37..38 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a parameter but instead found '5 + 5'
   ┌─ paren_or_arrow_expr_invalid_params.js:1:2

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -51,7 +51,7 @@ JsModule {
             semicolon_token: SEMICOLON@16..17 ";" [] [],
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -82,7 +82,7 @@ JsModule {
           1: JS_CALL_ARGUMENT_LIST@15..15
           2: R_PAREN@15..16 ")" [] []
       1: SEMICOLON@16..17 ";" [] []
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []
 --
 error: unexpected token `\`
   ┌─ primary_expr_invalid_recovery.js:1:9

--- a/crates/rslint_parser/test_data/inline/err/property_assignment_target_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/property_assignment_target_err.rast
@@ -33,7 +33,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@12..14 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@12..14 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@14..15 "{" [] [],
@@ -65,7 +65,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@25..27 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@25..27 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@27..28 "{" [] [],
@@ -97,7 +97,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@44..46 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@44..46 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@46..47 "{" [] [],
@@ -127,7 +127,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@57..59 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@57..59 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@59..61 "{" [] [Whitespace(" ")],
@@ -160,7 +160,7 @@ JsModule {
             semicolon_token: SEMICOLON@72..73 ";" [] [],
         },
     ],
-    eof_token: EOF@73..74 "" [Whitespace("\n")] [],
+    eof_token: EOF@73..74 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..74
@@ -190,7 +190,7 @@ JsModule {
       1: SEMICOLON@11..12 ";" [] []
     1: JS_EXPRESSION_STATEMENT@12..25
       0: JS_PARENTHESIZED_EXPRESSION@12..24
-        0: L_PAREN@12..14 "(" [Whitespace("\n")] []
+        0: L_PAREN@12..14 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@14..23
           0: JS_OBJECT_ASSIGNMENT_PATTERN@14..19
             0: L_CURLY@14..15 "{" [] []
@@ -212,7 +212,7 @@ JsModule {
       1: SEMICOLON@24..25 ";" [] []
     2: JS_EXPRESSION_STATEMENT@25..44
       0: JS_PARENTHESIZED_EXPRESSION@25..43
-        0: L_PAREN@25..27 "(" [Whitespace("\n")] []
+        0: L_PAREN@25..27 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@27..42
           0: JS_OBJECT_ASSIGNMENT_PATTERN@27..38
             0: L_CURLY@27..28 "{" [] []
@@ -235,7 +235,7 @@ JsModule {
       1: SEMICOLON@43..44 ";" [] []
     3: JS_EXPRESSION_STATEMENT@44..57
       0: JS_PARENTHESIZED_EXPRESSION@44..56
-        0: L_PAREN@44..46 "(" [Whitespace("\n")] []
+        0: L_PAREN@44..46 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@46..55
           0: JS_OBJECT_ASSIGNMENT_PATTERN@46..51
             0: L_CURLY@46..47 "{" [] []
@@ -257,7 +257,7 @@ JsModule {
       1: SEMICOLON@56..57 ";" [] []
     4: JS_EXPRESSION_STATEMENT@57..73
       0: JS_PARENTHESIZED_EXPRESSION@57..72
-        0: L_PAREN@57..59 "(" [Whitespace("\n")] []
+        0: L_PAREN@57..59 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@59..71
           0: JS_OBJECT_ASSIGNMENT_PATTERN@59..67
             0: L_CURLY@59..61 "{" [] [Whitespace(" ")]
@@ -279,7 +279,7 @@ JsModule {
             2: R_CURLY@70..71 "}" [] []
         2: R_PAREN@71..72 ")" [] []
       1: SEMICOLON@72..73 ";" [] []
-  3: EOF@73..74 "" [Whitespace("\n")] []
+  3: EOF@73..74 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, a string literal, a number literal, or a computed property but instead found ':'
   ┌─ property_assignment_target_err.js:1:3

--- a/crates/rslint_parser/test_data/inline/err/rest_property_assignment_target_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/rest_property_assignment_target_err.rast
@@ -29,7 +29,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@14..16 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@14..16 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@16..18 "{" [] [Whitespace(" ")],
@@ -60,7 +60,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@42..44 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@42..44 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@44..46 "{" [] [Whitespace(" ")],
@@ -98,7 +98,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@60..62 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@60..62 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@62..64 "{" [] [Whitespace(" ")],
@@ -134,7 +134,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@97..99 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@97..99 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@99..101 "{" [] [Whitespace(" ")],
@@ -163,7 +163,7 @@ JsModule {
             semicolon_token: SEMICOLON@116..117 ";" [] [],
         },
     ],
-    eof_token: EOF@117..118 "" [Whitespace("\n")] [],
+    eof_token: EOF@117..118 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..118
@@ -189,7 +189,7 @@ JsModule {
       1: SEMICOLON@13..14 ";" [] []
     1: JS_EXPRESSION_STATEMENT@14..42
       0: JS_PARENTHESIZED_EXPRESSION@14..41
-        0: L_PAREN@14..16 "(" [Whitespace("\n")] []
+        0: L_PAREN@14..16 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@16..40
           0: JS_OBJECT_ASSIGNMENT_PATTERN@16..37
             0: L_CURLY@16..18 "{" [] [Whitespace(" ")]
@@ -209,7 +209,7 @@ JsModule {
       1: SEMICOLON@41..42 ";" [] []
     2: JS_EXPRESSION_STATEMENT@42..60
       0: JS_PARENTHESIZED_EXPRESSION@42..59
-        0: L_PAREN@42..44 "(" [Whitespace("\n")] []
+        0: L_PAREN@42..44 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@44..58
           0: JS_OBJECT_ASSIGNMENT_PATTERN@44..55
             0: L_CURLY@44..46 "{" [] [Whitespace(" ")]
@@ -233,7 +233,7 @@ JsModule {
       1: SEMICOLON@59..60 ";" [] []
     3: JS_EXPRESSION_STATEMENT@60..97
       0: JS_PARENTHESIZED_EXPRESSION@60..96
-        0: L_PAREN@60..62 "(" [Whitespace("\n")] []
+        0: L_PAREN@60..62 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@62..95
           0: JS_OBJECT_ASSIGNMENT_PATTERN@62..92
             0: L_CURLY@62..64 "{" [] [Whitespace(" ")]
@@ -256,7 +256,7 @@ JsModule {
       1: SEMICOLON@96..97 ";" [] []
     4: JS_EXPRESSION_STATEMENT@97..117
       0: JS_PARENTHESIZED_EXPRESSION@97..116
-        0: L_PAREN@97..99 "(" [Whitespace("\n")] []
+        0: L_PAREN@97..99 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@99..115
           0: JS_OBJECT_ASSIGNMENT_PATTERN@99..112
             0: L_CURLY@99..101 "{" [] [Whitespace(" ")]
@@ -273,7 +273,7 @@ JsModule {
               0: IDENT@114..115 "a" [] []
         2: R_PAREN@115..116 ")" [] []
       1: SEMICOLON@116..117 ";" [] []
-  3: EOF@117..118 "" [Whitespace("\n")] []
+  3: EOF@117..118 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, or an assignment target but instead found '}'
   ┌─ rest_property_assignment_target_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/rest_property_binding_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/rest_property_binding_err.rast
@@ -34,7 +34,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -70,7 +70,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -113,7 +113,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@66..71 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@66..71 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -154,7 +154,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@105..110 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@105..110 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -188,7 +188,7 @@ JsModule {
             semicolon_token: SEMICOLON@126..127 ";" [] [],
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@127..134 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@127..134 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@134..143 "function" [] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
@@ -207,7 +207,7 @@ JsModule {
                 statements: JsStatementList [
                     JsVariableStatement {
                         declarations: JsVariableDeclarations {
-                            kind: LET_KW@151..158 "let" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            kind: LET_KW@151..158 "let" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             items: JsVariableDeclarationList [
                                 JsVariableDeclaration {
                                     id: JsObjectBindingPattern {
@@ -240,11 +240,11 @@ JsModule {
                         semicolon_token: SEMICOLON@174..175 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@175..177 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@175..177 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@177..178 "" [Whitespace("\n")] [],
+    eof_token: EOF@177..178 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..178
@@ -273,7 +273,7 @@ JsModule {
       1: SEMICOLON@15..16 ";" [] []
     1: JS_VARIABLE_STATEMENT@16..46
       0: JS_VARIABLE_DECLARATIONS@16..45
-        0: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@21..45
           0: JS_VARIABLE_DECLARATION@21..45
             0: JS_OBJECT_BINDING_PATTERN@21..42
@@ -296,7 +296,7 @@ JsModule {
       1: SEMICOLON@45..46 ";" [] []
     2: JS_VARIABLE_STATEMENT@46..66
       0: JS_VARIABLE_DECLARATIONS@46..65
-        0: LET_KW@46..51 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@46..51 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@51..65
           0: JS_VARIABLE_DECLARATION@51..65
             0: JS_OBJECT_BINDING_PATTERN@51..62
@@ -323,7 +323,7 @@ JsModule {
       1: SEMICOLON@65..66 ";" [] []
     3: JS_VARIABLE_STATEMENT@66..105
       0: JS_VARIABLE_DECLARATIONS@66..104
-        0: LET_KW@66..71 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@66..71 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@71..104
           0: JS_VARIABLE_DECLARATION@71..104
             0: JS_OBJECT_BINDING_PATTERN@71..101
@@ -349,7 +349,7 @@ JsModule {
       1: SEMICOLON@104..105 ";" [] []
     4: JS_VARIABLE_STATEMENT@105..127
       0: JS_VARIABLE_DECLARATIONS@105..126
-        0: LET_KW@105..110 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@105..110 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@110..126
           0: JS_VARIABLE_DECLARATION@110..126
             0: JS_OBJECT_BINDING_PATTERN@110..123
@@ -370,7 +370,7 @@ JsModule {
                   0: IDENT@125..126 "a" [] []
       1: SEMICOLON@126..127 ";" [] []
     5: JS_FUNCTION_STATEMENT@127..177
-      0: ASYNC_KW@127..134 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@127..134 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@134..143 "function" [] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@143..147
@@ -387,7 +387,7 @@ JsModule {
         2: JS_STATEMENT_LIST@151..175
           0: JS_VARIABLE_STATEMENT@151..175
             0: JS_VARIABLE_DECLARATIONS@151..174
-              0: LET_KW@151..158 "let" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+              0: LET_KW@151..158 "let" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
               1: JS_VARIABLE_DECLARATION_LIST@158..174
                 0: JS_VARIABLE_DECLARATION@158..174
                   0: JS_OBJECT_BINDING_PATTERN@158..171
@@ -406,8 +406,8 @@ JsModule {
                       0: JS_REFERENCE_IDENTIFIER@173..174
                         0: IDENT@173..174 "a" [] []
             1: SEMICOLON@174..175 ";" [] []
-        3: R_CURLY@175..177 "}" [Whitespace("\n")] []
-  3: EOF@177..178 "" [Whitespace("\n")] []
+        3: R_CURLY@175..177 "}" [Newline("\n")] []
+  3: EOF@177..178 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier but instead found '}'
   ┌─ rest_property_binding_err.js:1:11

--- a/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/return_stmt_err.rast
@@ -10,7 +10,7 @@ JsModule {
         },
         JsUnknownStatement {
             items: [
-                RETURN_KW@7..15 "return" [Whitespace("\n")] [Whitespace(" ")],
+                RETURN_KW@7..15 "return" [Newline("\n")] [Whitespace(" ")],
                 JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@15..18 "foo" [] [],
@@ -20,7 +20,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@19..20 "" [Whitespace("\n")] [],
+    eof_token: EOF@19..20 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..20
@@ -31,12 +31,12 @@ JsModule {
       0: RETURN_KW@0..6 "return" [] []
       1: SEMICOLON@6..7 ";" [] []
     1: JS_UNKNOWN_STATEMENT@7..19
-      0: RETURN_KW@7..15 "return" [Whitespace("\n")] [Whitespace(" ")]
+      0: RETURN_KW@7..15 "return" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_EXPRESSION@15..18
         0: JS_REFERENCE_IDENTIFIER@15..18
           0: IDENT@15..18 "foo" [] []
       2: SEMICOLON@18..19 ";" [] []
-  3: EOF@19..20 "" [Whitespace("\n")] []
+  3: EOF@19..20 "" [Newline("\n")] []
 --
 error[SyntaxError]: Illegal return statement outside of a function
   ┌─ return_stmt_err.js:1:1

--- a/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/semicolons_err.rast
@@ -35,7 +35,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -63,7 +63,7 @@ JsModule {
         0: JS_REFERENCE_IDENTIFIER@20..23
           0: IDENT@20..23 "foo" [] []
       2: (empty)
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []
 --
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ semicolons_err.js:1:15

--- a/crates/rslint_parser/test_data/inline/err/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/err/sequence_expr.rast
@@ -25,7 +25,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@9..10 "" [Whitespace("\n")] [],
+    eof_token: EOF@9..10 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..10
@@ -46,7 +46,7 @@ JsModule {
     1: JS_UNKNOWN_STATEMENT@6..9
       0: COMMA@6..8 "," [] [Whitespace(" ")]
       1: JS_NUMBER_LITERAL@8..9 "4" [] []
-  3: EOF@9..10 "" [Whitespace("\n")] []
+  3: EOF@9..10 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found ','
   ┌─ sequence_expr.js:1:7

--- a/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/setter_class_member.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@15..22 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    set_token: SET_KW@15..22 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@22..25 "foo" [] [],
                     },
@@ -30,10 +30,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@30..32 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@30..32 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@32..33 "" [Whitespace("\n")] [],
+    eof_token: EOF@32..33 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..33
@@ -52,7 +52,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@15..22 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+          3: SET_KW@15..22 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@22..25
             0: IDENT@22..25 "foo" [] []
           5: L_PAREN@25..26 "(" [] []
@@ -63,8 +63,8 @@ JsModule {
             1: JS_DIRECTIVE_LIST@29..29
             2: JS_STATEMENT_LIST@29..29
             3: R_CURLY@29..30 "}" [] []
-      6: R_CURLY@30..32 "}" [Whitespace("\n")] []
-  3: EOF@32..33 "" [Whitespace("\n")] []
+      6: R_CURLY@30..32 "}" [Newline("\n")] []
+  3: EOF@32..33 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a parameter but instead found ')'
   ┌─ setter_class_member.js:2:11

--- a/crates/rslint_parser/test_data/inline/err/setter_class_no_body.rast
+++ b/crates/rslint_parser/test_data/inline/err/setter_class_no_body.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@15..22 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                    set_token: SET_KW@15..22 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@22..25 "foo" [] [],
                     },
@@ -34,7 +34,7 @@ JsModule {
             r_curly_token: missing (required),
         },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..29
@@ -53,7 +53,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@15..22 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+          3: SET_KW@15..22 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@22..25
             0: IDENT@22..25 "foo" [] []
           5: L_PAREN@25..26 "(" [] []
@@ -65,7 +65,7 @@ JsModule {
           7: R_PAREN@27..28 ")" [] []
           8: (empty)
       6: (empty)
-  3: EOF@28..29 "" [Whitespace("\n")] []
+  3: EOF@28..29 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected a class method body but instead found ''
   ┌─ setter_class_no_body.js:3:1

--- a/crates/rslint_parser/test_data/inline/err/spread.rast
+++ b/crates/rslint_parser/test_data/inline/err/spread.rast
@@ -16,7 +16,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@5..6 "" [Whitespace("\n")] [],
+    eof_token: EOF@5..6 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..6
@@ -32,7 +32,7 @@ JsModule {
             1: (empty)
         2: R_BRACK@4..5 "]" [] []
       1: (empty)
-  3: EOF@5..6 "" [Whitespace("\n")] []
+  3: EOF@5..6 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression, or an assignment but instead found ']'
   ┌─ spread.js:1:5

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -33,7 +33,7 @@ JsModule {
                     },
                     operator: DOT@12..13 "." [] [],
                     member: JsName {
-                        value_token: IDENT@13..17 "BAR" [Whitespace("\n")] [],
+                        value_token: IDENT@13..17 "BAR" [Newline("\n")] [],
                     },
                 },
                 l_tick_token: BACKTICK@17..18 "`" [] [],
@@ -78,7 +78,7 @@ JsModule {
             4: R_BRACK@11..12 "]" [] []
           1: DOT@12..13 "." [] []
           2: JS_NAME@13..17
-            0: IDENT@13..17 "BAR" [Whitespace("\n")] []
+            0: IDENT@13..17 "BAR" [Newline("\n")] []
         1: BACKTICK@17..18 "`" [] []
         2: TEMPLATE_ELEMENT_LIST@18..20
           0: TEMPLATE_CHUNK_ELEMENT@18..20

--- a/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
@@ -25,7 +25,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@22..28 "test" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@22..28 "test" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -42,7 +42,7 @@ JsModule {
                                 expression: JsCallExpression {
                                     callee: JsUnknownExpression {
                                         items: [
-                                            SUPER_KW@32..40 "super" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            SUPER_KW@32..40 "super" [Newline("\n"), Whitespace("\t\t")] [],
                                         ],
                                     },
                                     optional_chain_token_token: missing (optional),
@@ -60,7 +60,7 @@ JsModule {
                                     callee: JsStaticMemberExpression {
                                         object: JsUnknownExpression {
                                             items: [
-                                                SUPER_KW@43..51 "super" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                                SUPER_KW@43..51 "super" [Newline("\n"), Whitespace("\t\t")] [],
                                             ],
                                         },
                                         operator: QUESTIONDOT@51..53 "?." [] [],
@@ -79,17 +79,17 @@ JsModule {
                                 semicolon_token: SEMICOLON@59..60 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@60..63 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@60..63 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@63..65 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@63..65 "}" [Newline("\n")] [],
         },
         JsExpressionStatement {
             expression: JsCallExpression {
                 callee: JsUnknownExpression {
                     items: [
-                        SUPER_KW@65..71 "super" [Whitespace("\n")] [],
+                        SUPER_KW@65..71 "super" [Newline("\n")] [],
                     ],
                 },
                 optional_chain_token_token: missing (optional),
@@ -103,7 +103,7 @@ JsModule {
             semicolon_token: SEMICOLON@73..74 ";" [] [],
         },
     ],
-    eof_token: EOF@74..75 "" [Whitespace("\n")] [],
+    eof_token: EOF@74..75 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..75
@@ -129,7 +129,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@22..28
-            0: IDENT@22..28 "test" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@22..28 "test" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@28..31
             0: L_PAREN@28..29 "(" [] []
@@ -143,7 +143,7 @@ JsModule {
               0: JS_EXPRESSION_STATEMENT@32..43
                 0: JS_CALL_EXPRESSION@32..42
                   0: JS_UNKNOWN_EXPRESSION@32..40
-                    0: SUPER_KW@32..40 "super" [Whitespace("\n"), Whitespace("\t\t")] []
+                    0: SUPER_KW@32..40 "super" [Newline("\n"), Whitespace("\t\t")] []
                   1: (empty)
                   2: (empty)
                   3: JS_CALL_ARGUMENTS@40..42
@@ -155,7 +155,7 @@ JsModule {
                 0: JS_CALL_EXPRESSION@43..59
                   0: JS_STATIC_MEMBER_EXPRESSION@43..57
                     0: JS_UNKNOWN_EXPRESSION@43..51
-                      0: SUPER_KW@43..51 "super" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: SUPER_KW@43..51 "super" [Newline("\n"), Whitespace("\t\t")] []
                     1: QUESTIONDOT@51..53 "?." [] []
                     2: JS_NAME@53..57
                       0: IDENT@53..57 "test" [] []
@@ -166,12 +166,12 @@ JsModule {
                     1: JS_CALL_ARGUMENT_LIST@58..58
                     2: R_PAREN@58..59 ")" [] []
                 1: SEMICOLON@59..60 ";" [] []
-            3: R_CURLY@60..63 "}" [Whitespace("\n"), Whitespace("\t")] []
-      6: R_CURLY@63..65 "}" [Whitespace("\n")] []
+            3: R_CURLY@60..63 "}" [Newline("\n"), Whitespace("\t")] []
+      6: R_CURLY@63..65 "}" [Newline("\n")] []
     1: JS_EXPRESSION_STATEMENT@65..74
       0: JS_CALL_EXPRESSION@65..73
         0: JS_UNKNOWN_EXPRESSION@65..71
-          0: SUPER_KW@65..71 "super" [Whitespace("\n")] []
+          0: SUPER_KW@65..71 "super" [Newline("\n")] []
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@71..73
@@ -179,7 +179,7 @@ JsModule {
           1: JS_CALL_ARGUMENT_LIST@72..72
           2: R_PAREN@72..73 ")" [] []
       1: SEMICOLON@73..74 ";" [] []
-  3: EOF@74..75 "" [Whitespace("\n")] []
+  3: EOF@74..75 "" [Newline("\n")] []
 --
 error[SyntaxError]: `super` is only valid inside of a class constructor of a subclass.
   ┌─ super_expression_err.js:3:3

--- a/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/switch_stmt_err.rast
@@ -16,7 +16,7 @@ JsModule {
             r_curly_token: R_CURLY@12..13 "}" [] [],
         },
         JsSwitchStatement {
-            switch_token: SWITCH_KW@13..21 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            switch_token: SWITCH_KW@13..21 "switch" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             discriminant: missing (required),
             r_paren_token: missing (required),
@@ -25,7 +25,7 @@ JsModule {
             r_curly_token: R_CURLY@22..23 "}" [] [],
         },
         JsSwitchStatement {
-            switch_token: SWITCH_KW@23..31 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            switch_token: SWITCH_KW@23..31 "switch" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             discriminant: missing (required),
             r_paren_token: missing (required),
@@ -50,7 +50,7 @@ JsModule {
             r_curly_token: R_CURLY@43..44 "}" [] [],
         },
         JsSwitchStatement {
-            switch_token: SWITCH_KW@44..52 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            switch_token: SWITCH_KW@44..52 "switch" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             discriminant: missing (required),
             r_paren_token: missing (required),
@@ -90,7 +90,7 @@ JsModule {
             r_curly_token: R_CURLY@80..81 "}" [] [],
         },
         JsSwitchStatement {
-            switch_token: SWITCH_KW@81..89 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            switch_token: SWITCH_KW@81..89 "switch" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@89..90 "(" [] [],
             discriminant: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
@@ -101,7 +101,7 @@ JsModule {
             l_curly_token: L_CURLY@95..96 "{" [] [],
             cases: JsSwitchCaseList [
                 JsDefaultClause {
-                    default_token: DEFAULT_KW@96..105 "default" [Whitespace("\n"), Whitespace("\t")] [],
+                    default_token: DEFAULT_KW@96..105 "default" [Newline("\n"), Whitespace("\t")] [],
                     colon_token: COLON@105..107 ":" [] [Whitespace(" ")],
                     consequent: JsStatementList [
                         JsBlockStatement {
@@ -115,7 +115,7 @@ JsModule {
                     case_token: missing (required),
                     test: JsUnknownExpression {
                         items: [
-                            DEFAULT_KW@109..118 "default" [Whitespace("\n"), Whitespace("\t")] [],
+                            DEFAULT_KW@109..118 "default" [Newline("\n"), Whitespace("\t")] [],
                         ],
                     },
                     colon_token: COLON@118..120 ":" [] [Whitespace(" ")],
@@ -128,10 +128,10 @@ JsModule {
                     ],
                 },
             ],
-            r_curly_token: R_CURLY@122..124 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@122..124 "}" [Newline("\n")] [],
         },
         JsSwitchStatement {
-            switch_token: SWITCH_KW@124..132 "switch" [Whitespace("\n")] [Whitespace(" ")],
+            switch_token: SWITCH_KW@124..132 "switch" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@132..133 "(" [] [],
             discriminant: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
@@ -151,7 +151,7 @@ JsModule {
             r_curly_token: R_CURLY@147..148 "}" [] [],
         },
     ],
-    eof_token: EOF@148..149 "" [Whitespace("\n")] [],
+    eof_token: EOF@148..149 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..149
@@ -169,7 +169,7 @@ JsModule {
       5: JS_SWITCH_CASE_LIST@12..12
       6: R_CURLY@12..13 "}" [] []
     1: JS_SWITCH_STATEMENT@13..23
-      0: SWITCH_KW@13..21 "switch" [Whitespace("\n")] [Whitespace(" ")]
+      0: SWITCH_KW@13..21 "switch" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
       3: (empty)
@@ -177,7 +177,7 @@ JsModule {
       5: JS_SWITCH_CASE_LIST@22..22
       6: R_CURLY@22..23 "}" [] []
     2: JS_SWITCH_STATEMENT@23..44
-      0: SWITCH_KW@23..31 "switch" [Whitespace("\n")] [Whitespace(" ")]
+      0: SWITCH_KW@23..31 "switch" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
       3: (empty)
@@ -195,7 +195,7 @@ JsModule {
               3: JS_NUMBER_LITERAL@41..43 "0" [] [Whitespace(" ")]
       6: R_CURLY@43..44 "}" [] []
     3: JS_SWITCH_STATEMENT@44..81
-      0: SWITCH_KW@44..52 "switch" [Whitespace("\n")] [Whitespace(" ")]
+      0: SWITCH_KW@44..52 "switch" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
       3: (empty)
@@ -224,7 +224,7 @@ JsModule {
               2: R_CURLY@78..80 "}" [] [Whitespace(" ")]
       6: R_CURLY@80..81 "}" [] []
     4: JS_SWITCH_STATEMENT@81..124
-      0: SWITCH_KW@81..89 "switch" [Whitespace("\n")] [Whitespace(" ")]
+      0: SWITCH_KW@81..89 "switch" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@89..90 "(" [] []
       2: JS_IDENTIFIER_EXPRESSION@90..93
         0: JS_REFERENCE_IDENTIFIER@90..93
@@ -233,7 +233,7 @@ JsModule {
       4: L_CURLY@95..96 "{" [] []
       5: JS_SWITCH_CASE_LIST@96..122
         0: JS_DEFAULT_CLAUSE@96..109
-          0: DEFAULT_KW@96..105 "default" [Whitespace("\n"), Whitespace("\t")] []
+          0: DEFAULT_KW@96..105 "default" [Newline("\n"), Whitespace("\t")] []
           1: COLON@105..107 ":" [] [Whitespace(" ")]
           2: JS_STATEMENT_LIST@107..109
             0: JS_BLOCK_STATEMENT@107..109
@@ -243,16 +243,16 @@ JsModule {
         1: JS_CASE_CLAUSE@109..122
           0: (empty)
           1: JS_UNKNOWN_EXPRESSION@109..118
-            0: DEFAULT_KW@109..118 "default" [Whitespace("\n"), Whitespace("\t")] []
+            0: DEFAULT_KW@109..118 "default" [Newline("\n"), Whitespace("\t")] []
           2: COLON@118..120 ":" [] [Whitespace(" ")]
           3: JS_STATEMENT_LIST@120..122
             0: JS_BLOCK_STATEMENT@120..122
               0: L_CURLY@120..121 "{" [] []
               1: JS_STATEMENT_LIST@121..121
               2: R_CURLY@121..122 "}" [] []
-      6: R_CURLY@122..124 "}" [Whitespace("\n")] []
+      6: R_CURLY@122..124 "}" [Newline("\n")] []
     5: JS_SWITCH_STATEMENT@124..148
-      0: SWITCH_KW@124..132 "switch" [Whitespace("\n")] [Whitespace(" ")]
+      0: SWITCH_KW@124..132 "switch" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@132..133 "(" [] []
       2: JS_IDENTIFIER_EXPRESSION@133..136
         0: JS_REFERENCE_IDENTIFIER@133..136
@@ -266,7 +266,7 @@ JsModule {
           2: COLON@145..147 ":" [] [Whitespace(" ")]
           3: JS_STATEMENT_LIST@147..147
       6: R_CURLY@147..148 "}" [] []
-  3: EOF@148..149 "" [Whitespace("\n")] []
+  3: EOF@148..149 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `'('` but instead found `foo`
   ┌─ switch_stmt_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal.rast
@@ -36,7 +36,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -66,7 +66,7 @@ JsModule {
                     2: R_CURLY@15..16 "}" [] []
                 3: BACKTICK@16..17 "`" [] []
       1: (empty)
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found '}'
   ┌─ template_literal.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/throw_stmt_err.rast
@@ -9,7 +9,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsNewExpression {
-                new_token: NEW_KW@5..10 "new" [Whitespace("\n")] [Whitespace(" ")],
+                new_token: NEW_KW@5..10 "new" [Newline("\n")] [Whitespace(" ")],
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@10..15 "Error" [] [],
@@ -29,12 +29,12 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsThrowStatement {
-            throw_token: THROW_KW@27..33 "throw" [Whitespace("\n")] [],
+            throw_token: THROW_KW@27..33 "throw" [Newline("\n")] [],
             argument: missing (required),
             semicolon_token: SEMICOLON@33..34 ";" [] [],
         },
     ],
-    eof_token: EOF@34..35 "" [Whitespace("\n")] [],
+    eof_token: EOF@34..35 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..35
@@ -47,7 +47,7 @@ JsModule {
       2: (empty)
     1: JS_EXPRESSION_STATEMENT@5..27
       0: JS_NEW_EXPRESSION@5..27
-        0: NEW_KW@5..10 "new" [Whitespace("\n")] [Whitespace(" ")]
+        0: NEW_KW@5..10 "new" [Newline("\n")] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@10..15
           0: JS_REFERENCE_IDENTIFIER@10..15
             0: IDENT@10..15 "Error" [] []
@@ -60,10 +60,10 @@ JsModule {
           2: R_PAREN@26..27 ")" [] []
       1: (empty)
     2: JS_THROW_STATEMENT@27..34
-      0: THROW_KW@27..33 "throw" [Whitespace("\n")] []
+      0: THROW_KW@27..33 "throw" [Newline("\n")] []
       1: (empty)
       2: SEMICOLON@33..34 ";" [] []
-  3: EOF@34..35 "" [Whitespace("\n")] []
+  3: EOF@34..35 "" [Newline("\n")] []
 --
 error[SyntaxError]: Linebreaks between a throw statement and the error to be thrown are not allowed
   ┌─ throw_stmt_err.js:2:1

--- a/crates/rslint_parser/test_data/inline/err/unary_expr.rast
+++ b/crates/rslint_parser/test_data/inline/err/unary_expr.rast
@@ -11,20 +11,20 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: MINUS2@4..8 "--" [Whitespace("\n")] [Whitespace(" ")],
+                operator: MINUS2@4..8 "--" [Newline("\n")] [Whitespace(" ")],
                 operand: missing (required),
             },
             semicolon_token: SEMICOLON@8..9 ";" [] [],
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: MINUS@9..11 "-" [Whitespace("\n")] [],
+                operator: MINUS@9..11 "-" [Newline("\n")] [],
                 argument: missing (required),
             },
             semicolon_token: SEMICOLON@11..12 ";" [] [],
         },
     ],
-    eof_token: EOF@12..13 "" [Whitespace("\n")] [],
+    eof_token: EOF@12..13 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..13
@@ -38,15 +38,15 @@ JsModule {
       1: SEMICOLON@3..4 ";" [] []
     1: JS_EXPRESSION_STATEMENT@4..9
       0: JS_PRE_UPDATE_EXPRESSION@4..8
-        0: MINUS2@4..8 "--" [Whitespace("\n")] [Whitespace(" ")]
+        0: MINUS2@4..8 "--" [Newline("\n")] [Whitespace(" ")]
         1: (empty)
       1: SEMICOLON@8..9 ";" [] []
     2: JS_EXPRESSION_STATEMENT@9..12
       0: JS_UNARY_EXPRESSION@9..11
-        0: MINUS@9..11 "-" [Whitespace("\n")] []
+        0: MINUS@9..11 "-" [Newline("\n")] []
         1: (empty)
       1: SEMICOLON@11..12 ";" [] []
-  3: EOF@12..13 "" [Whitespace("\n")] []
+  3: EOF@12..13 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an identifier, or a member expression but instead found ';'
   ┌─ unary_expr.js:1:4

--- a/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
+++ b/crates/rslint_parser/test_data/inline/err/unterminated_unicode_codepoint.rast
@@ -34,7 +34,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -53,7 +53,7 @@ JsModule {
               1: JS_UNKNOWN@8..16
                 0: ERROR_TOKEN@8..16 "\"\\u{200\"" [] []
       1: SEMICOLON@16..17 ";" [] []
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []
 --
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
   ┌─ unterminated_unicode_codepoint.js:1:16

--- a/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/var_decl_err.rast
@@ -23,7 +23,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@8..15 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@8..15 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -64,7 +64,7 @@ JsModule {
             semicolon_token: SEMICOLON@30..31 ";" [] [],
         },
     ],
-    eof_token: EOF@31..32 "" [Whitespace("\n")] [],
+    eof_token: EOF@31..32 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..32
@@ -86,7 +86,7 @@ JsModule {
       1: SEMICOLON@7..8 ";" [] []
     1: JS_VARIABLE_STATEMENT@8..21
       0: JS_VARIABLE_DECLARATIONS@8..21
-        0: CONST_KW@8..15 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@8..15 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@15..21
           0: JS_VARIABLE_DECLARATION@15..21
             0: JS_IDENTIFIER_BINDING@15..17
@@ -112,7 +112,7 @@ JsModule {
               1: JS_NUMBER_LITERAL_EXPRESSION@29..30
                 0: JS_NUMBER_LITERAL@29..30 "5" [] []
       1: SEMICOLON@30..31 ";" [] []
-  3: EOF@31..32 "" [Whitespace("\n")] []
+  3: EOF@31..32 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression, or an assignment but instead found ';'
   ┌─ var_decl_err.js:1:8

--- a/crates/rslint_parser/test_data/inline/err/variable_declaration_statement_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/variable_declaration_statement_err.rast
@@ -57,7 +57,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@24..31 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@24..31 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -115,7 +115,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@55..62 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@55..62 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -131,7 +131,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@64..69 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@64..69 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -153,7 +153,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@73..80 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@73..80 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -177,7 +177,7 @@ JsModule {
             semicolon_token: SEMICOLON@85..86 ";" [] [],
         },
     ],
-    eof_token: EOF@86..87 "" [Whitespace("\n")] [],
+    eof_token: EOF@86..87 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..87
@@ -221,7 +221,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@24..55
       0: JS_VARIABLE_DECLARATIONS@24..55
-        0: CONST_KW@24..31 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@24..31 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@31..55
           0: JS_VARIABLE_DECLARATION@31..36
             0: JS_IDENTIFIER_BINDING@31..33
@@ -259,7 +259,7 @@ JsModule {
       1: (empty)
     2: JS_VARIABLE_STATEMENT@55..64
       0: JS_VARIABLE_DECLARATIONS@55..63
-        0: CONST_KW@55..62 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@55..62 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@62..63
           0: JS_VARIABLE_DECLARATION@62..63
             0: JS_IDENTIFIER_BINDING@62..63
@@ -270,7 +270,7 @@ JsModule {
       1: SEMICOLON@63..64 ";" [] []
     3: JS_VARIABLE_STATEMENT@64..73
       0: JS_VARIABLE_DECLARATIONS@64..72
-        0: LET_KW@64..69 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@64..69 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@69..72
           0: JS_VARIABLE_DECLARATION@69..72
             0: JS_ARRAY_BINDING_PATTERN@69..72
@@ -285,7 +285,7 @@ JsModule {
       1: SEMICOLON@72..73 ";" [] []
     4: JS_VARIABLE_STATEMENT@73..86
       0: JS_VARIABLE_DECLARATIONS@73..85
-        0: CONST_KW@73..80 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@73..80 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@80..85
           0: JS_VARIABLE_DECLARATION@80..85
             0: JS_OBJECT_BINDING_PATTERN@80..85
@@ -300,7 +300,7 @@ JsModule {
             2: (empty)
             3: (empty)
       1: SEMICOLON@85..86 ";" [] []
-  3: EOF@86..87 "" [Whitespace("\n")] []
+  3: EOF@86..87 "" [Newline("\n")] []
 --
 error[SyntaxError]: Declarations inside of a `let` declaration may not have duplicates
   ┌─ variable_declaration_statement_err.js:1:10

--- a/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/while_stmt_err.rast
@@ -16,7 +16,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@13..20 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@13..20 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             test: missing (required),
             r_paren_token: missing (required),
@@ -27,7 +27,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@22..29 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@22..29 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@29..30 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@30..35 "true" [] [Whitespace(" ")],
@@ -40,7 +40,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@37..44 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@37..44 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: missing (required),
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@44..48 "true" [] [],
@@ -54,7 +54,7 @@ JsModule {
             ],
         },
     ],
-    eof_token: EOF@51..52 "" [Whitespace("\n")] [],
+    eof_token: EOF@51..52 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..52
@@ -72,7 +72,7 @@ JsModule {
         1: JS_STATEMENT_LIST@12..12
         2: R_CURLY@12..13 "}" [] []
     1: JS_WHILE_STATEMENT@13..22
-      0: WHILE_KW@13..20 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@13..20 "while" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: (empty)
       3: (empty)
@@ -81,7 +81,7 @@ JsModule {
         1: JS_STATEMENT_LIST@21..21
         2: R_CURLY@21..22 "}" [] []
     2: JS_WHILE_STATEMENT@22..37
-      0: WHILE_KW@22..29 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@22..29 "while" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@29..30 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@30..35
         0: TRUE_KW@30..35 "true" [] [Whitespace(" ")]
@@ -91,7 +91,7 @@ JsModule {
         1: JS_STATEMENT_LIST@36..36
         2: R_CURLY@36..37 "}" [] []
     3: JS_WHILE_STATEMENT@37..50
-      0: WHILE_KW@37..44 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@37..44 "while" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: JS_BOOLEAN_LITERAL_EXPRESSION@44..48
         0: TRUE_KW@44..48 "true" [] []
@@ -99,7 +99,7 @@ JsModule {
       4: (empty)
     4: JS_UNKNOWN_STATEMENT@50..51
       0: R_CURLY@50..51 "}" [] []
-  3: EOF@51..52 "" [Whitespace("\n")] []
+  3: EOF@51..52 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected `'('` but instead found `true`
   ┌─ while_stmt_err.js:1:7

--- a/crates/rslint_parser/test_data/inline/ok/array_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_assignment_target.rast
@@ -29,7 +29,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@17..19 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@17..19 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsArrayHole,
                         COMMA@19..20 "," [] [],
@@ -62,7 +62,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@35..37 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@35..37 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsAssignmentWithDefault {
                             pattern: JsIdentifierAssignment {
@@ -121,7 +121,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@70..72 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@70..72 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsParenthesizedAssignment {
                             l_paren_token: L_PAREN@72..73 "(" [] [],
@@ -147,7 +147,7 @@ JsModule {
             semicolon_token: SEMICOLON@84..85 ";" [] [],
         },
     ],
-    eof_token: EOF@85..86 "" [Whitespace("\n")] [],
+    eof_token: EOF@85..86 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..86
@@ -173,7 +173,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@17..35
       0: JS_ASSIGNMENT_EXPRESSION@17..34
         0: JS_ARRAY_ASSIGNMENT_PATTERN@17..29
-          0: L_BRACK@17..19 "[" [Whitespace("\n")] []
+          0: L_BRACK@17..19 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@19..27
             0: JS_ARRAY_HOLE@19..19
             1: COMMA@19..20 "," [] []
@@ -198,7 +198,7 @@ JsModule {
     2: JS_EXPRESSION_STATEMENT@35..70
       0: JS_ASSIGNMENT_EXPRESSION@35..69
         0: JS_ARRAY_ASSIGNMENT_PATTERN@35..64
-          0: L_BRACK@35..37 "[" [Whitespace("\n")] []
+          0: L_BRACK@35..37 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@37..62
             0: JS_ASSIGNMENT_WITH_DEFAULT@37..47
               0: JS_IDENTIFIER_ASSIGNMENT@37..39
@@ -238,7 +238,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@70..85
       0: JS_ASSIGNMENT_EXPRESSION@70..84
         0: JS_ARRAY_ASSIGNMENT_PATTERN@70..79
-          0: L_BRACK@70..72 "[" [Whitespace("\n")] []
+          0: L_BRACK@70..72 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@72..77
             0: JS_PARENTHESIZED_ASSIGNMENT@72..77
               0: L_PAREN@72..73 "(" [] []
@@ -254,4 +254,4 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@81..84
             0: IDENT@81..84 "baz" [] []
       1: SEMICOLON@84..85 ";" [] []
-  3: EOF@85..86 "" [Whitespace("\n")] []
+  3: EOF@85..86 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/array_assignment_target_rest.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_assignment_target_rest.rast
@@ -31,7 +31,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@18..20 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@18..20 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@20..22 "[" [] [Whitespace(" ")],
@@ -62,7 +62,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@39..41 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@39..41 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@41..43 "[" [] [Whitespace(" ")],
@@ -97,7 +97,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@60..62 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@60..62 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@62..64 "[" [] [Whitespace(" ")],
@@ -144,7 +144,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@84..86 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@84..86 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@86..88 "[" [] [Whitespace(" ")],
@@ -194,7 +194,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@117..119 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@117..119 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@119..121 "[" [] [Whitespace(" ")],
@@ -231,7 +231,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@138..140 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@138..140 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsArrayAssignmentPattern {
                         l_brack_token: L_BRACK@140..142 "[" [] [Whitespace(" ")],
@@ -266,7 +266,7 @@ JsModule {
             semicolon_token: SEMICOLON@160..161 ";" [] [],
         },
     ],
-    eof_token: EOF@161..162 "" [Whitespace("\n")] [],
+    eof_token: EOF@161..162 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..162
@@ -293,7 +293,7 @@ JsModule {
       1: SEMICOLON@17..18 ";" [] []
     1: JS_EXPRESSION_STATEMENT@18..39
       0: JS_PARENTHESIZED_EXPRESSION@18..38
-        0: L_PAREN@18..20 "(" [Whitespace("\n")] []
+        0: L_PAREN@18..20 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@20..37
           0: JS_ARRAY_ASSIGNMENT_PATTERN@20..34
             0: L_BRACK@20..22 "[" [] [Whitespace(" ")]
@@ -314,7 +314,7 @@ JsModule {
       1: SEMICOLON@38..39 ";" [] []
     2: JS_EXPRESSION_STATEMENT@39..60
       0: JS_PARENTHESIZED_EXPRESSION@39..59
-        0: L_PAREN@39..41 "(" [Whitespace("\n")] []
+        0: L_PAREN@39..41 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@41..58
           0: JS_ARRAY_ASSIGNMENT_PATTERN@41..55
             0: L_BRACK@41..43 "[" [] [Whitespace(" ")]
@@ -337,7 +337,7 @@ JsModule {
       1: SEMICOLON@59..60 ";" [] []
     3: JS_EXPRESSION_STATEMENT@60..84
       0: JS_PARENTHESIZED_EXPRESSION@60..83
-        0: L_PAREN@60..62 "(" [Whitespace("\n")] []
+        0: L_PAREN@60..62 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@62..82
           0: JS_ARRAY_ASSIGNMENT_PATTERN@62..79
             0: L_BRACK@62..64 "[" [] [Whitespace(" ")]
@@ -369,7 +369,7 @@ JsModule {
       1: SEMICOLON@83..84 ";" [] []
     4: JS_EXPRESSION_STATEMENT@84..117
       0: JS_PARENTHESIZED_EXPRESSION@84..116
-        0: L_PAREN@84..86 "(" [Whitespace("\n")] []
+        0: L_PAREN@84..86 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@86..115
           0: JS_ARRAY_ASSIGNMENT_PATTERN@86..112
             0: L_BRACK@86..88 "[" [] [Whitespace(" ")]
@@ -403,7 +403,7 @@ JsModule {
       1: SEMICOLON@116..117 ";" [] []
     5: JS_EXPRESSION_STATEMENT@117..138
       0: JS_PARENTHESIZED_EXPRESSION@117..137
-        0: L_PAREN@117..119 "(" [Whitespace("\n")] []
+        0: L_PAREN@117..119 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@119..136
           0: JS_ARRAY_ASSIGNMENT_PATTERN@119..133
             0: L_BRACK@119..121 "[" [] [Whitespace(" ")]
@@ -428,7 +428,7 @@ JsModule {
       1: SEMICOLON@137..138 ";" [] []
     6: JS_EXPRESSION_STATEMENT@138..161
       0: JS_PARENTHESIZED_EXPRESSION@138..160
-        0: L_PAREN@138..140 "(" [Whitespace("\n")] []
+        0: L_PAREN@138..140 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@140..159
           0: JS_ARRAY_ASSIGNMENT_PATTERN@140..156
             0: L_BRACK@140..142 "[" [] [Whitespace(" ")]
@@ -450,4 +450,4 @@ JsModule {
               0: IDENT@158..159 "c" [] []
         2: R_PAREN@159..160 ")" [] []
       1: SEMICOLON@160..161 ";" [] []
-  3: EOF@161..162 "" [Whitespace("\n")] []
+  3: EOF@161..162 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/array_binding.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_binding.rast
@@ -25,7 +25,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@12..17 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@12..17 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -66,7 +66,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@33..38 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -106,7 +106,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@57..62 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@57..62 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -145,7 +145,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@85..90 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@85..90 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -183,7 +183,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@109..114 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@109..114 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -233,7 +233,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@137..138 "" [Whitespace("\n")] [],
+    eof_token: EOF@137..138 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..138
@@ -256,7 +256,7 @@ JsModule {
       1: SEMICOLON@11..12 ";" [] []
     1: JS_VARIABLE_STATEMENT@12..33
       0: JS_VARIABLE_DECLARATIONS@12..32
-        0: LET_KW@12..17 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@12..17 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@17..32
           0: JS_VARIABLE_DECLARATION@17..32
             0: JS_ARRAY_BINDING_PATTERN@17..24
@@ -284,7 +284,7 @@ JsModule {
       1: SEMICOLON@32..33 ";" [] []
     2: JS_VARIABLE_STATEMENT@33..57
       0: JS_VARIABLE_DECLARATIONS@33..56
-        0: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@33..38 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@38..56
           0: JS_VARIABLE_DECLARATION@38..56
             0: JS_ARRAY_BINDING_PATTERN@38..51
@@ -311,7 +311,7 @@ JsModule {
       1: SEMICOLON@56..57 ";" [] []
     3: JS_VARIABLE_STATEMENT@57..85
       0: JS_VARIABLE_DECLARATIONS@57..85
-        0: LET_KW@57..62 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@57..62 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@62..85
           0: JS_VARIABLE_DECLARATION@62..85
             0: JS_ARRAY_BINDING_PATTERN@62..81
@@ -338,7 +338,7 @@ JsModule {
       1: (empty)
     4: JS_VARIABLE_STATEMENT@85..109
       0: JS_VARIABLE_DECLARATIONS@85..109
-        0: LET_KW@85..90 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@85..90 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@90..109
           0: JS_VARIABLE_DECLARATION@90..109
             0: JS_ARRAY_BINDING_PATTERN@90..105
@@ -365,7 +365,7 @@ JsModule {
       1: (empty)
     5: JS_VARIABLE_STATEMENT@109..137
       0: JS_VARIABLE_DECLARATIONS@109..137
-        0: LET_KW@109..114 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@109..114 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@114..137
           0: JS_VARIABLE_DECLARATION@114..137
             0: JS_ARRAY_BINDING_PATTERN@114..133
@@ -398,4 +398,4 @@ JsModule {
                 1: JS_ARRAY_ELEMENT_LIST@136..136
                 2: R_BRACK@136..137 "]" [] []
       1: (empty)
-  3: EOF@137..138 "" [Whitespace("\n")] []
+  3: EOF@137..138 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/array_binding_rest.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_binding_rest.rast
@@ -36,7 +36,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@20..25 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@20..25 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -78,7 +78,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@43..48 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@43..48 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsArrayBindingPattern {
@@ -118,7 +118,7 @@ JsModule {
             semicolon_token: SEMICOLON@67..68 ";" [] [],
         },
     ],
-    eof_token: EOF@68..69 "" [Whitespace("\n")] [],
+    eof_token: EOF@68..69 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..69
@@ -148,7 +148,7 @@ JsModule {
       1: SEMICOLON@19..20 ";" [] []
     1: JS_VARIABLE_STATEMENT@20..43
       0: JS_VARIABLE_DECLARATIONS@20..42
-        0: LET_KW@20..25 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@20..25 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@25..42
           0: JS_VARIABLE_DECLARATION@25..42
             0: JS_ARRAY_BINDING_PATTERN@25..39
@@ -176,7 +176,7 @@ JsModule {
       1: SEMICOLON@42..43 ";" [] []
     2: JS_VARIABLE_STATEMENT@43..68
       0: JS_VARIABLE_DECLARATIONS@43..67
-        0: LET_KW@43..48 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@43..48 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@48..67
           0: JS_VARIABLE_DECLARATION@48..67
             0: JS_ARRAY_BINDING_PATTERN@48..64
@@ -201,4 +201,4 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@66..67
                   0: IDENT@66..67 "c" [] []
       1: SEMICOLON@67..68 ";" [] []
-  3: EOF@68..69 "" [Whitespace("\n")] []
+  3: EOF@68..69 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/array_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_expr.rast
@@ -24,7 +24,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrayExpression {
-                l_brack_token: L_BRACK@11..13 "[" [Whitespace("\n")] [],
+                l_brack_token: L_BRACK@11..13 "[" [Newline("\n")] [],
                 elements: JsArrayElementList [
                     JsIdentifierExpression {
                         name: JsReferenceIdentifier {
@@ -38,7 +38,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrayExpression {
-                l_brack_token: L_BRACK@18..20 "[" [Whitespace("\n")] [],
+                l_brack_token: L_BRACK@18..20 "[" [Newline("\n")] [],
                 elements: JsArrayElementList [
                     JsArrayHole,
                     COMMA@20..21 "," [] [],
@@ -54,7 +54,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrayExpression {
-                l_brack_token: L_BRACK@26..28 "[" [Whitespace("\n")] [],
+                l_brack_token: L_BRACK@26..28 "[" [Newline("\n")] [],
                 elements: JsArrayElementList [
                     JsIdentifierExpression {
                         name: JsReferenceIdentifier {
@@ -69,7 +69,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrayExpression {
-                l_brack_token: L_BRACK@34..36 "[" [Whitespace("\n")] [],
+                l_brack_token: L_BRACK@34..36 "[" [Newline("\n")] [],
                 elements: JsArrayElementList [
                     JsArrayHole,
                     COMMA@36..37 "," [] [],
@@ -100,7 +100,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrayExpression {
-                l_brack_token: L_BRACK@50..52 "[" [Whitespace("\n")] [],
+                l_brack_token: L_BRACK@50..52 "[" [Newline("\n")] [],
                 elements: JsArrayElementList [
                     JsSpread {
                         dotdotdot_token: DOT2@52..55 "..." [] [],
@@ -125,7 +125,7 @@ JsModule {
             semicolon_token: SEMICOLON@63..64 ";" [] [],
         },
     ],
-    eof_token: EOF@64..65 "" [Whitespace("\n")] [],
+    eof_token: EOF@64..65 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..65
@@ -147,7 +147,7 @@ JsModule {
       1: SEMICOLON@10..11 ";" [] []
     1: JS_EXPRESSION_STATEMENT@11..18
       0: JS_ARRAY_EXPRESSION@11..17
-        0: L_BRACK@11..13 "[" [Whitespace("\n")] []
+        0: L_BRACK@11..13 "[" [Newline("\n")] []
         1: JS_ARRAY_ELEMENT_LIST@13..16
           0: JS_IDENTIFIER_EXPRESSION@13..16
             0: JS_REFERENCE_IDENTIFIER@13..16
@@ -156,7 +156,7 @@ JsModule {
       1: SEMICOLON@17..18 ";" [] []
     2: JS_EXPRESSION_STATEMENT@18..26
       0: JS_ARRAY_EXPRESSION@18..25
-        0: L_BRACK@18..20 "[" [Whitespace("\n")] []
+        0: L_BRACK@18..20 "[" [Newline("\n")] []
         1: JS_ARRAY_ELEMENT_LIST@20..24
           0: JS_ARRAY_HOLE@20..20
           1: COMMA@20..21 "," [] []
@@ -167,7 +167,7 @@ JsModule {
       1: SEMICOLON@25..26 ";" [] []
     3: JS_EXPRESSION_STATEMENT@26..34
       0: JS_ARRAY_EXPRESSION@26..33
-        0: L_BRACK@26..28 "[" [Whitespace("\n")] []
+        0: L_BRACK@26..28 "[" [Newline("\n")] []
         1: JS_ARRAY_ELEMENT_LIST@28..32
           0: JS_IDENTIFIER_EXPRESSION@28..31
             0: JS_REFERENCE_IDENTIFIER@28..31
@@ -177,7 +177,7 @@ JsModule {
       1: SEMICOLON@33..34 ";" [] []
     4: JS_EXPRESSION_STATEMENT@34..50
       0: JS_ARRAY_EXPRESSION@34..49
-        0: L_BRACK@34..36 "[" [Whitespace("\n")] []
+        0: L_BRACK@34..36 "[" [Newline("\n")] []
         1: JS_ARRAY_ELEMENT_LIST@36..48
           0: JS_ARRAY_HOLE@36..36
           1: COMMA@36..37 "," [] []
@@ -203,7 +203,7 @@ JsModule {
       1: SEMICOLON@49..50 ";" [] []
     5: JS_EXPRESSION_STATEMENT@50..64
       0: JS_ARRAY_EXPRESSION@50..63
-        0: L_BRACK@50..52 "[" [Whitespace("\n")] []
+        0: L_BRACK@50..52 "[" [Newline("\n")] []
         1: JS_ARRAY_ELEMENT_LIST@52..62
           0: JS_SPREAD@52..56
             0: DOT2@52..55 "..." [] []
@@ -218,4 +218,4 @@ JsModule {
                 0: IDENT@61..62 "b" [] []
         2: R_BRACK@62..63 "]" [] []
       1: SEMICOLON@63..64 ";" [] []
-  3: EOF@64..65 "" [Whitespace("\n")] []
+  3: EOF@64..65 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_or_object_member_assignment.rast
@@ -13,7 +13,7 @@ JsModule {
                                     l_curly_token: L_CURLY@1..2 "{" [] [],
                                     members: JsObjectMemberList [
                                         JsGetterObjectMember {
-                                            get_token: GET_KW@2..9 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                            get_token: GET_KW@2..9 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                             name: JsLiteralMemberName {
                                                 value: IDENT@9..10 "y" [] [],
                                             },
@@ -25,7 +25,7 @@ JsModule {
                                                 directives: JsDirectiveList [],
                                                 statements: JsStatementList [
                                                     JsThrowStatement {
-                                                        throw_token: THROW_KW@14..25 "throw" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                        throw_token: THROW_KW@14..25 "throw" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                         argument: JsNewExpression {
                                                             new_token: NEW_KW@25..29 "new" [] [Whitespace(" ")],
                                                             callee: JsIdentifierExpression {
@@ -47,12 +47,12 @@ JsModule {
                                                         semicolon_token: SEMICOLON@81..82 ";" [] [],
                                                     },
                                                 ],
-                                                r_curly_token: R_CURLY@82..86 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                                r_curly_token: R_CURLY@82..86 "}" [Newline("\n"), Whitespace("  ")] [],
                                             },
                                         },
                                         COMMA@86..87 "," [] [],
                                         JsSetterObjectMember {
-                                            set_token: SET_KW@87..94 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                            set_token: SET_KW@87..94 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                             name: JsLiteralMemberName {
                                                 value: IDENT@94..95 "y" [] [],
                                             },
@@ -72,7 +72,7 @@ JsModule {
                                                     JsExpressionStatement {
                                                         expression: JsAssignmentExpression {
                                                             left: JsIdentifierAssignment {
-                                                                name_token: IDENT@102..116 "setValue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                                name_token: IDENT@102..116 "setValue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                             },
                                                             operator_token: EQ@116..118 "=" [] [Whitespace(" ")],
                                                             right: JsIdentifierExpression {
@@ -84,11 +84,11 @@ JsModule {
                                                         semicolon_token: SEMICOLON@121..122 ";" [] [],
                                                     },
                                                 ],
-                                                r_curly_token: R_CURLY@122..126 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                                r_curly_token: R_CURLY@122..126 "}" [Newline("\n"), Whitespace("  ")] [],
                                             },
                                         },
                                     ],
-                                    r_curly_token: R_CURLY@126..128 "}" [Whitespace("\n")] [],
+                                    r_curly_token: R_CURLY@126..128 "}" [Newline("\n")] [],
                                 },
                                 dot_token: DOT@128..129 "." [] [],
                                 member: JsName {
@@ -118,7 +118,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@144..146 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@144..146 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@146..148 "{" [] [Whitespace(" ")],
@@ -133,7 +133,7 @@ JsModule {
                                         l_curly_token: L_CURLY@151..152 "{" [] [],
                                         members: JsObjectMemberList [
                                             JsGetterObjectMember {
-                                                get_token: GET_KW@152..159 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                                get_token: GET_KW@152..159 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                                 name: JsLiteralMemberName {
                                                     value: IDENT@159..160 "y" [] [],
                                                 },
@@ -145,7 +145,7 @@ JsModule {
                                                     directives: JsDirectiveList [],
                                                     statements: JsStatementList [
                                                         JsThrowStatement {
-                                                            throw_token: THROW_KW@164..175 "throw" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                            throw_token: THROW_KW@164..175 "throw" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                             argument: JsNewExpression {
                                                                 new_token: NEW_KW@175..179 "new" [] [Whitespace(" ")],
                                                                 callee: JsIdentifierExpression {
@@ -167,12 +167,12 @@ JsModule {
                                                             semicolon_token: SEMICOLON@231..232 ";" [] [],
                                                         },
                                                     ],
-                                                    r_curly_token: R_CURLY@232..236 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                                    r_curly_token: R_CURLY@232..236 "}" [Newline("\n"), Whitespace("  ")] [],
                                                 },
                                             },
                                             COMMA@236..237 "," [] [],
                                             JsSetterObjectMember {
-                                                set_token: SET_KW@237..244 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                                set_token: SET_KW@237..244 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                                 name: JsLiteralMemberName {
                                                     value: IDENT@244..245 "y" [] [],
                                                 },
@@ -192,7 +192,7 @@ JsModule {
                                                         JsExpressionStatement {
                                                             expression: JsAssignmentExpression {
                                                                 left: JsIdentifierAssignment {
-                                                                    name_token: IDENT@252..266 "setValue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                                    name_token: IDENT@252..266 "setValue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                                 },
                                                                 operator_token: EQ@266..268 "=" [] [Whitespace(" ")],
                                                                 right: JsIdentifierExpression {
@@ -204,11 +204,11 @@ JsModule {
                                                             semicolon_token: SEMICOLON@271..272 ";" [] [],
                                                         },
                                                     ],
-                                                    r_curly_token: R_CURLY@272..276 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                                    r_curly_token: R_CURLY@272..276 "}" [Newline("\n"), Whitespace("  ")] [],
                                                 },
                                             },
                                         ],
-                                        r_curly_token: R_CURLY@276..278 "}" [Whitespace("\n")] [],
+                                        r_curly_token: R_CURLY@276..278 "}" [Newline("\n")] [],
                                     },
                                     dot_token: DOT@278..279 "." [] [],
                                     member: JsName {
@@ -247,7 +247,7 @@ JsModule {
             semicolon_token: SEMICOLON@300..301 ";" [] [],
         },
     ],
-    eof_token: EOF@301..302 "" [Whitespace("\n")] [],
+    eof_token: EOF@301..302 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..302
@@ -265,7 +265,7 @@ JsModule {
                   0: L_CURLY@1..2 "{" [] []
                   1: JS_OBJECT_MEMBER_LIST@2..126
                     0: JS_GETTER_OBJECT_MEMBER@2..86
-                      0: GET_KW@2..9 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                      0: GET_KW@2..9 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                       1: JS_LITERAL_MEMBER_NAME@9..10
                         0: IDENT@9..10 "y" [] []
                       2: L_PAREN@10..11 "(" [] []
@@ -276,7 +276,7 @@ JsModule {
                         1: JS_DIRECTIVE_LIST@14..14
                         2: JS_STATEMENT_LIST@14..82
                           0: JS_THROW_STATEMENT@14..82
-                            0: THROW_KW@14..25 "throw" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                            0: THROW_KW@14..25 "throw" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                             1: JS_NEW_EXPRESSION@25..81
                               0: NEW_KW@25..29 "new" [] [Whitespace(" ")]
                               1: JS_IDENTIFIER_EXPRESSION@29..41
@@ -290,10 +290,10 @@ JsModule {
                                     0: JS_STRING_LITERAL@42..80 "'The property should not be accessed.'" [] []
                                 2: R_PAREN@80..81 ")" [] []
                             2: SEMICOLON@81..82 ";" [] []
-                        3: R_CURLY@82..86 "}" [Whitespace("\n"), Whitespace("  ")] []
+                        3: R_CURLY@82..86 "}" [Newline("\n"), Whitespace("  ")] []
                     1: COMMA@86..87 "," [] []
                     2: JS_SETTER_OBJECT_MEMBER@87..126
-                      0: SET_KW@87..94 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                      0: SET_KW@87..94 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                       1: JS_LITERAL_MEMBER_NAME@94..95
                         0: IDENT@94..95 "y" [] []
                       2: L_PAREN@95..96 "(" [] []
@@ -310,14 +310,14 @@ JsModule {
                           0: JS_EXPRESSION_STATEMENT@102..122
                             0: JS_ASSIGNMENT_EXPRESSION@102..121
                               0: JS_IDENTIFIER_ASSIGNMENT@102..116
-                                0: IDENT@102..116 "setValue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                                0: IDENT@102..116 "setValue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                               1: EQ@116..118 "=" [] [Whitespace(" ")]
                               2: JS_IDENTIFIER_EXPRESSION@118..121
                                 0: JS_REFERENCE_IDENTIFIER@118..121
                                   0: IDENT@118..121 "val" [] []
                             1: SEMICOLON@121..122 ";" [] []
-                        3: R_CURLY@122..126 "}" [Whitespace("\n"), Whitespace("  ")] []
-                  2: R_CURLY@126..128 "}" [Whitespace("\n")] []
+                        3: R_CURLY@122..126 "}" [Newline("\n"), Whitespace("  ")] []
+                  2: R_CURLY@126..128 "}" [Newline("\n")] []
                 1: DOT@128..129 "." [] []
                 2: JS_NAME@129..131
                   0: IDENT@129..131 "y" [] [Whitespace(" ")]
@@ -335,7 +335,7 @@ JsModule {
       1: SEMICOLON@143..144 ";" [] []
     1: JS_EXPRESSION_STATEMENT@144..301
       0: JS_PARENTHESIZED_EXPRESSION@144..300
-        0: L_PAREN@144..146 "(" [Whitespace("\n")] []
+        0: L_PAREN@144..146 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@146..299
           0: JS_OBJECT_ASSIGNMENT_PATTERN@146..288
             0: L_CURLY@146..148 "{" [] [Whitespace(" ")]
@@ -349,7 +349,7 @@ JsModule {
                     0: L_CURLY@151..152 "{" [] []
                     1: JS_OBJECT_MEMBER_LIST@152..276
                       0: JS_GETTER_OBJECT_MEMBER@152..236
-                        0: GET_KW@152..159 "get" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                        0: GET_KW@152..159 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                         1: JS_LITERAL_MEMBER_NAME@159..160
                           0: IDENT@159..160 "y" [] []
                         2: L_PAREN@160..161 "(" [] []
@@ -360,7 +360,7 @@ JsModule {
                           1: JS_DIRECTIVE_LIST@164..164
                           2: JS_STATEMENT_LIST@164..232
                             0: JS_THROW_STATEMENT@164..232
-                              0: THROW_KW@164..175 "throw" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                              0: THROW_KW@164..175 "throw" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                               1: JS_NEW_EXPRESSION@175..231
                                 0: NEW_KW@175..179 "new" [] [Whitespace(" ")]
                                 1: JS_IDENTIFIER_EXPRESSION@179..191
@@ -374,10 +374,10 @@ JsModule {
                                       0: JS_STRING_LITERAL@192..230 "'The property should not be accessed.'" [] []
                                   2: R_PAREN@230..231 ")" [] []
                               2: SEMICOLON@231..232 ";" [] []
-                          3: R_CURLY@232..236 "}" [Whitespace("\n"), Whitespace("  ")] []
+                          3: R_CURLY@232..236 "}" [Newline("\n"), Whitespace("  ")] []
                       1: COMMA@236..237 "," [] []
                       2: JS_SETTER_OBJECT_MEMBER@237..276
-                        0: SET_KW@237..244 "set" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                        0: SET_KW@237..244 "set" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                         1: JS_LITERAL_MEMBER_NAME@244..245
                           0: IDENT@244..245 "y" [] []
                         2: L_PAREN@245..246 "(" [] []
@@ -394,14 +394,14 @@ JsModule {
                             0: JS_EXPRESSION_STATEMENT@252..272
                               0: JS_ASSIGNMENT_EXPRESSION@252..271
                                 0: JS_IDENTIFIER_ASSIGNMENT@252..266
-                                  0: IDENT@252..266 "setValue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                                  0: IDENT@252..266 "setValue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                                 1: EQ@266..268 "=" [] [Whitespace(" ")]
                                 2: JS_IDENTIFIER_EXPRESSION@268..271
                                   0: JS_REFERENCE_IDENTIFIER@268..271
                                     0: IDENT@268..271 "val" [] []
                               1: SEMICOLON@271..272 ";" [] []
-                          3: R_CURLY@272..276 "}" [Whitespace("\n"), Whitespace("  ")] []
-                    2: R_CURLY@276..278 "}" [Whitespace("\n")] []
+                          3: R_CURLY@272..276 "}" [Newline("\n"), Whitespace("  ")] []
+                    2: R_CURLY@276..278 "}" [Newline("\n")] []
                   1: DOT@278..279 "." [] []
                   2: JS_NAME@279..281
                     0: IDENT@279..281 "y" [] [Whitespace(" ")]
@@ -423,4 +423,4 @@ JsModule {
             2: R_CURLY@298..299 "}" [] []
         2: R_PAREN@299..300 ")" [] []
       1: SEMICOLON@300..301 ";" [] []
-  3: EOF@301..302 "" [Whitespace("\n")] []
+  3: EOF@301..302 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_expr_single_param.rast
@@ -7,7 +7,7 @@ JsScript {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsIdentifierBinding {
-                    name_token: IDENT@0..14 "foo" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@0..14 "foo" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
                 },
                 return_type: missing (optional),
                 fat_arrow_token: FAT_ARROW@14..17 "=>" [] [Whitespace(" ")],
@@ -25,7 +25,7 @@ JsScript {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsIdentifierBinding {
-                    name_token: IDENT@19..26 "yield" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@19..26 "yield" [Newline("\n")] [Whitespace(" ")],
                 },
                 return_type: missing (optional),
                 fat_arrow_token: FAT_ARROW@26..29 "=>" [] [Whitespace(" ")],
@@ -43,7 +43,7 @@ JsScript {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsIdentifierBinding {
-                    name_token: IDENT@31..38 "await" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@31..38 "await" [Newline("\n")] [Whitespace(" ")],
                 },
                 return_type: missing (optional),
                 fat_arrow_token: FAT_ARROW@38..41 "=>" [] [Whitespace(" ")],
@@ -61,12 +61,12 @@ JsScript {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsIdentifierBinding {
-                    name_token: IDENT@43..48 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@43..48 "foo" [Newline("\n")] [Whitespace(" ")],
                 },
                 return_type: missing (optional),
                 fat_arrow_token: FAT_ARROW@48..50 "=>" [] [],
                 body: JsFunctionBody {
-                    l_curly_token: L_CURLY@50..52 "{" [Whitespace("\n")] [],
+                    l_curly_token: L_CURLY@50..52 "{" [Newline("\n")] [],
                     directives: JsDirectiveList [],
                     statements: JsStatementList [],
                     r_curly_token: R_CURLY@52..53 "}" [] [],
@@ -75,7 +75,7 @@ JsScript {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@53..54 "" [Whitespace("\n")] [],
+    eof_token: EOF@53..54 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..54
@@ -87,7 +87,7 @@ JsScript {
         0: (empty)
         1: (empty)
         2: JS_IDENTIFIER_BINDING@0..14
-          0: IDENT@0..14 "foo" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@0..14 "foo" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@14..17 "=>" [] [Whitespace(" ")]
         5: JS_FUNCTION_BODY@17..19
@@ -101,7 +101,7 @@ JsScript {
         0: (empty)
         1: (empty)
         2: JS_IDENTIFIER_BINDING@19..26
-          0: IDENT@19..26 "yield" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@19..26 "yield" [Newline("\n")] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@26..29 "=>" [] [Whitespace(" ")]
         5: JS_FUNCTION_BODY@29..31
@@ -115,7 +115,7 @@ JsScript {
         0: (empty)
         1: (empty)
         2: JS_IDENTIFIER_BINDING@31..38
-          0: IDENT@31..38 "await" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@31..38 "await" [Newline("\n")] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@38..41 "=>" [] [Whitespace(" ")]
         5: JS_FUNCTION_BODY@41..43
@@ -129,13 +129,13 @@ JsScript {
         0: (empty)
         1: (empty)
         2: JS_IDENTIFIER_BINDING@43..48
-          0: IDENT@43..48 "foo" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@43..48 "foo" [Newline("\n")] [Whitespace(" ")]
         3: (empty)
         4: FAT_ARROW@48..50 "=>" [] []
         5: JS_FUNCTION_BODY@50..53
-          0: L_CURLY@50..52 "{" [Whitespace("\n")] []
+          0: L_CURLY@50..52 "{" [Newline("\n")] []
           1: JS_DIRECTIVE_LIST@52..52
           2: JS_STATEMENT_LIST@52..52
           3: R_CURLY@52..53 "}" [] []
       1: (empty)
-  3: EOF@53..54 "" [Whitespace("\n")] []
+  3: EOF@53..54 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assign_expr.rast
@@ -29,7 +29,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@21..26 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@21..26 "foo" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: MINUSEQ@26..29 "-=" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
@@ -42,7 +42,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@33..35 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@33..35 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsIdentifierAssignment {
                         name_token: IDENT@35..39 "foo" [] [Whitespace(" ")],
@@ -61,7 +61,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@46..48 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@46..48 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsIdentifierAssignment {
                             name_token: IDENT@48..51 "foo" [] [],
@@ -85,7 +85,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@64..66 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@64..66 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsIdentifierAssignment {
                             name_token: IDENT@66..69 "foo" [] [],
@@ -122,7 +122,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsArrayAssignmentPattern {
-                    l_brack_token: L_BRACK@103..105 "[" [Whitespace("\n")] [],
+                    l_brack_token: L_BRACK@103..105 "[" [Newline("\n")] [],
                     elements: JsArrayAssignmentPatternElementList [
                         JsArrayHole,
                         COMMA@105..106 "," [] [],
@@ -151,7 +151,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@123..125 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@123..125 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@125..127 "{" [] [Whitespace(" ")],
@@ -185,7 +185,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@144..146 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@144..146 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@146..148 "{" [] [Whitespace(" ")],
@@ -246,7 +246,7 @@ JsModule {
             semicolon_token: SEMICOLON@196..197 ";" [] [],
         },
     ],
-    eof_token: EOF@197..198 "" [Whitespace("\n")] [],
+    eof_token: EOF@197..198 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..198
@@ -272,7 +272,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@21..33
       0: JS_ASSIGNMENT_EXPRESSION@21..32
         0: JS_IDENTIFIER_ASSIGNMENT@21..26
-          0: IDENT@21..26 "foo" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@21..26 "foo" [Newline("\n")] [Whitespace(" ")]
         1: MINUSEQ@26..29 "-=" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@29..32
           0: JS_REFERENCE_IDENTIFIER@29..32
@@ -280,7 +280,7 @@ JsModule {
       1: SEMICOLON@32..33 ";" [] []
     2: JS_EXPRESSION_STATEMENT@33..46
       0: JS_PARENTHESIZED_EXPRESSION@33..45
-        0: L_PAREN@33..35 "(" [Whitespace("\n")] []
+        0: L_PAREN@33..35 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@35..44
           0: JS_IDENTIFIER_ASSIGNMENT@35..39
             0: IDENT@35..39 "foo" [] [Whitespace(" ")]
@@ -293,7 +293,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@46..64
       0: JS_ASSIGNMENT_EXPRESSION@46..63
         0: JS_ARRAY_ASSIGNMENT_PATTERN@46..58
-          0: L_BRACK@46..48 "[" [Whitespace("\n")] []
+          0: L_BRACK@46..48 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@48..56
             0: JS_IDENTIFIER_ASSIGNMENT@48..51
               0: IDENT@48..51 "foo" [] []
@@ -309,7 +309,7 @@ JsModule {
     4: JS_EXPRESSION_STATEMENT@64..103
       0: JS_ASSIGNMENT_EXPRESSION@64..102
         0: JS_ARRAY_ASSIGNMENT_PATTERN@64..97
-          0: L_BRACK@64..66 "[" [Whitespace("\n")] []
+          0: L_BRACK@64..66 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@66..95
             0: JS_IDENTIFIER_ASSIGNMENT@66..69
               0: IDENT@66..69 "foo" [] []
@@ -334,7 +334,7 @@ JsModule {
     5: JS_EXPRESSION_STATEMENT@103..123
       0: JS_ASSIGNMENT_EXPRESSION@103..122
         0: JS_ARRAY_ASSIGNMENT_PATTERN@103..117
-          0: L_BRACK@103..105 "[" [Whitespace("\n")] []
+          0: L_BRACK@103..105 "[" [Newline("\n")] []
           1: JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST@105..115
             0: JS_ARRAY_HOLE@105..105
             1: COMMA@105..106 "," [] []
@@ -355,7 +355,7 @@ JsModule {
       1: SEMICOLON@122..123 ";" [] []
     6: JS_EXPRESSION_STATEMENT@123..144
       0: JS_PARENTHESIZED_EXPRESSION@123..143
-        0: L_PAREN@123..125 "(" [Whitespace("\n")] []
+        0: L_PAREN@123..125 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@125..142
           0: JS_OBJECT_ASSIGNMENT_PATTERN@125..138
             0: L_CURLY@125..127 "{" [] [Whitespace(" ")]
@@ -379,7 +379,7 @@ JsModule {
       1: SEMICOLON@143..144 ";" [] []
     7: JS_EXPRESSION_STATEMENT@144..197
       0: JS_PARENTHESIZED_EXPRESSION@144..196
-        0: L_PAREN@144..146 "(" [Whitespace("\n")] []
+        0: L_PAREN@144..146 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@146..195
           0: JS_OBJECT_ASSIGNMENT_PATTERN@146..191
             0: L_CURLY@146..148 "{" [] [Whitespace(" ")]
@@ -420,4 +420,4 @@ JsModule {
             2: R_CURLY@194..195 "}" [] []
         2: R_PAREN@195..196 ")" [] []
       1: SEMICOLON@196..197 ";" [] []
-  3: EOF@197..198 "" [Whitespace("\n")] []
+  3: EOF@197..198 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assignment_target.rast
@@ -31,7 +31,7 @@ JsModule {
                 left: JsStaticMemberAssignment {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
-                            value_token: IDENT@21..23 "a" [Whitespace("\n")] [],
+                            value_token: IDENT@21..23 "a" [Newline("\n")] [],
                         },
                     },
                     dot_token: DOT@23..24 "." [] [],
@@ -50,7 +50,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@35..37 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@35..37 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsIdentifierAssignment {
                         name_token: IDENT@37..41 "foo" [] [Whitespace(" ")],
@@ -69,7 +69,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsParenthesizedAssignment {
-                    l_paren_token: L_PAREN@48..50 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@48..50 "(" [Newline("\n")] [],
                     assignment: JsParenthesizedAssignment {
                         l_paren_token: L_PAREN@50..51 "(" [] [],
                         assignment: JsParenthesizedAssignment {
@@ -97,7 +97,7 @@ JsModule {
                 left: JsComputedMemberAssignment {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
-                            value_token: IDENT@65..67 "a" [Whitespace("\n")] [],
+                            value_token: IDENT@65..67 "a" [Newline("\n")] [],
                         },
                     },
                     l_brack_token: L_BRACK@67..68 "[" [] [],
@@ -124,7 +124,7 @@ JsModule {
                                 callee: JsStaticMemberExpression {
                                     object: JsIdentifierExpression {
                                         name: JsReferenceIdentifier {
-                                            value_token: IDENT@82..84 "a" [Whitespace("\n")] [],
+                                            value_token: IDENT@82..84 "a" [Newline("\n")] [],
                                         },
                                     },
                                     operator: DOT@84..85 "." [] [],
@@ -170,7 +170,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsPreUpdateExpression {
-                    operator: PLUS2@111..114 "++" [Whitespace("\n")] [],
+                    operator: PLUS2@111..114 "++" [Newline("\n")] [],
                     operand: JsIdentifierAssignment {
                         name_token: IDENT@114..120 "count" [] [Whitespace(" ")],
                     },
@@ -187,7 +187,7 @@ JsModule {
                 left: JsComputedMemberAssignment {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
-                            value_token: IDENT@125..127 "a" [Whitespace("\n")] [],
+                            value_token: IDENT@125..127 "a" [Newline("\n")] [],
                         },
                     },
                     l_brack_token: L_BRACK@127..128 "[" [] [],
@@ -221,7 +221,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@148..149 "" [Whitespace("\n")] [],
+    eof_token: EOF@148..149 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..149
@@ -249,7 +249,7 @@ JsModule {
         0: JS_STATIC_MEMBER_ASSIGNMENT@21..28
           0: JS_IDENTIFIER_EXPRESSION@21..23
             0: JS_REFERENCE_IDENTIFIER@21..23
-              0: IDENT@21..23 "a" [Whitespace("\n")] []
+              0: IDENT@21..23 "a" [Newline("\n")] []
           1: DOT@23..24 "." [] []
           2: JS_NAME@24..28
             0: IDENT@24..28 "foo" [] [Whitespace(" ")]
@@ -260,7 +260,7 @@ JsModule {
       1: SEMICOLON@34..35 ";" [] []
     2: JS_EXPRESSION_STATEMENT@35..48
       0: JS_PARENTHESIZED_EXPRESSION@35..47
-        0: L_PAREN@35..37 "(" [Whitespace("\n")] []
+        0: L_PAREN@35..37 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@37..46
           0: JS_IDENTIFIER_ASSIGNMENT@37..41
             0: IDENT@37..41 "foo" [] [Whitespace(" ")]
@@ -273,7 +273,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@48..65
       0: JS_ASSIGNMENT_EXPRESSION@48..64
         0: JS_PARENTHESIZED_ASSIGNMENT@48..59
-          0: L_PAREN@48..50 "(" [Whitespace("\n")] []
+          0: L_PAREN@48..50 "(" [Newline("\n")] []
           1: JS_PARENTHESIZED_ASSIGNMENT@50..57
             0: L_PAREN@50..51 "(" [] []
             1: JS_PARENTHESIZED_ASSIGNMENT@51..56
@@ -293,7 +293,7 @@ JsModule {
         0: JS_COMPUTED_MEMBER_ASSIGNMENT@65..76
           0: JS_IDENTIFIER_EXPRESSION@65..67
             0: JS_REFERENCE_IDENTIFIER@65..67
-              0: IDENT@65..67 "a" [Whitespace("\n")] []
+              0: IDENT@65..67 "a" [Newline("\n")] []
           1: L_BRACK@67..68 "[" [] []
           2: JS_STRING_LITERAL_EXPRESSION@68..74
             0: JS_STRING_LITERAL@68..74 "\"test\"" [] []
@@ -312,7 +312,7 @@ JsModule {
                 0: JS_STATIC_MEMBER_EXPRESSION@82..89
                   0: JS_IDENTIFIER_EXPRESSION@82..84
                     0: JS_REFERENCE_IDENTIFIER@82..84
-                      0: IDENT@82..84 "a" [Whitespace("\n")] []
+                      0: IDENT@82..84 "a" [Newline("\n")] []
                   1: DOT@84..85 "." [] []
                   2: JS_NAME@85..89
                     0: IDENT@85..89 "call" [] []
@@ -342,7 +342,7 @@ JsModule {
     6: JS_EXPRESSION_STATEMENT@111..125
       0: JS_BINARY_EXPRESSION@111..125
         0: JS_PRE_UPDATE_EXPRESSION@111..120
-          0: PLUS2@111..114 "++" [Whitespace("\n")] []
+          0: PLUS2@111..114 "++" [Newline("\n")] []
           1: JS_IDENTIFIER_ASSIGNMENT@114..120
             0: IDENT@114..120 "count" [] [Whitespace(" ")]
         1: EQ3@120..124 "===" [] [Whitespace(" ")]
@@ -354,7 +354,7 @@ JsModule {
         0: JS_COMPUTED_MEMBER_ASSIGNMENT@125..133
           0: JS_IDENTIFIER_EXPRESSION@125..127
             0: JS_REFERENCE_IDENTIFIER@125..127
-              0: IDENT@125..127 "a" [Whitespace("\n")] []
+              0: IDENT@125..127 "a" [Newline("\n")] []
           1: L_BRACK@127..128 "[" [] []
           2: JS_STRING_LITERAL_EXPRESSION@128..131
             0: JS_STRING_LITERAL@128..131 "'b'" [] []
@@ -374,4 +374,4 @@ JsModule {
           2: JS_STRING_LITERAL_EXPRESSION@142..148
             0: JS_STRING_LITERAL@142..148 "\"test\"" [] []
       1: (empty)
-  3: EOF@148..149 "" [Whitespace("\n")] []
+  3: EOF@148..149 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_arrow_expr.rast
@@ -37,7 +37,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@23..28 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -80,7 +80,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsArrowFunctionExpression {
-                async_token: ASYNC_KW@49..56 "async" [Whitespace("\n")] [Whitespace(" ")],
+                async_token: ASYNC_KW@49..56 "async" [Newline("\n")] [Whitespace(" ")],
                 type_parameters: missing (optional),
                 parameters: JsParameters {
                     l_paren_token: L_PAREN@56..57 "(" [] [],
@@ -121,7 +121,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@81..82 "" [Whitespace("\n")] [],
+    eof_token: EOF@81..82 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..82
@@ -154,7 +154,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@23..49
       0: JS_VARIABLE_DECLARATIONS@23..49
-        0: LET_KW@23..28 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@23..28 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@28..49
           0: JS_VARIABLE_DECLARATION@28..49
             0: JS_IDENTIFIER_BINDING@28..30
@@ -185,7 +185,7 @@ JsModule {
       1: (empty)
     2: JS_EXPRESSION_STATEMENT@49..81
       0: JS_ARROW_FUNCTION_EXPRESSION@49..81
-        0: ASYNC_KW@49..56 "async" [Whitespace("\n")] [Whitespace(" ")]
+        0: ASYNC_KW@49..56 "async" [Newline("\n")] [Whitespace(" ")]
         1: (empty)
         2: JS_PARAMETERS@56..75
           0: L_PAREN@56..57 "(" [] []
@@ -213,4 +213,4 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@78..81
             0: IDENT@78..81 "foo" [] []
       1: (empty)
-  3: EOF@81..82 "" [Whitespace("\n")] []
+  3: EOF@81..82 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_function_expr.rast
@@ -41,7 +41,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@28..33 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -79,7 +79,7 @@ JsModule {
             semicolon_token: SEMICOLON@60..61 ";" [] [],
         },
     ],
-    eof_token: EOF@61..62 "" [Whitespace("\n")] [],
+    eof_token: EOF@61..62 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..62
@@ -116,7 +116,7 @@ JsModule {
       1: SEMICOLON@27..28 ";" [] []
     1: JS_VARIABLE_STATEMENT@28..61
       0: JS_VARIABLE_DECLARATIONS@28..60
-        0: LET_KW@28..33 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@28..33 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@33..60
           0: JS_VARIABLE_DECLARATION@33..60
             0: JS_IDENTIFIER_BINDING@33..35
@@ -143,4 +143,4 @@ JsModule {
                   2: JS_STATEMENT_LIST@59..59
                   3: R_CURLY@59..60 "}" [] []
       1: SEMICOLON@60..61 ";" [] []
-  3: EOF@61..62 "" [Whitespace("\n")] []
+  3: EOF@61..62 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/async_ident.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_ident.rast
@@ -26,7 +26,7 @@ JsModule {
             semicolon_token: SEMICOLON@13..14 ";" [] [],
         },
     ],
-    eof_token: EOF@14..15 "" [Whitespace("\n")] [],
+    eof_token: EOF@14..15 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..15
@@ -48,4 +48,4 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@8..13
                   0: IDENT@8..13 "async" [] []
       1: SEMICOLON@13..14 ";" [] []
-  3: EOF@14..15 "" [Whitespace("\n")] []
+  3: EOF@14..15 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@11..19 "async" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@11..19 "async" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@19..22 "foo" [] [],
@@ -38,7 +38,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@27..35 "async" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@27..35 "async" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     star_token: STAR@35..36 "*" [] [],
                     name: JsLiteralMemberName {
                         value: IDENT@36..39 "foo" [] [],
@@ -58,10 +58,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@44..46 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@44..46 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@46..47 "" [Whitespace("\n")] [],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..47
@@ -80,7 +80,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@11..19 "async" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          3: ASYNC_KW@11..19 "async" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@19..22
             0: IDENT@19..22 "foo" [] []
@@ -99,7 +99,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@27..35 "async" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          3: ASYNC_KW@27..35 "async" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           4: STAR@35..36 "*" [] []
           5: JS_LITERAL_MEMBER_NAME@36..39
             0: IDENT@36..39 "foo" [] []
@@ -114,5 +114,5 @@ JsModule {
             1: JS_DIRECTIVE_LIST@43..43
             2: JS_STATEMENT_LIST@43..43
             3: R_CURLY@43..44 "}" [] []
-      6: R_CURLY@44..46 "}" [Whitespace("\n")] []
-  3: EOF@46..47 "" [Whitespace("\n")] []
+      6: R_CURLY@44..46 "}" [Newline("\n")] []
+  3: EOF@46..47 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/await_expression.rast
@@ -22,7 +22,7 @@ JsModule {
                 statements: JsStatementList [
                     JsExpressionStatement {
                         expression: JsAwaitExpression {
-                            await_token: AWAIT_KW@23..31 "await" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            await_token: AWAIT_KW@23..31 "await" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                             argument: JsCallExpression {
                                 callee: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
@@ -43,7 +43,7 @@ JsModule {
                     JsExpressionStatement {
                         expression: JsBinaryExpression {
                             left: JsAwaitExpression {
-                                await_token: AWAIT_KW@39..47 "await" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                await_token: AWAIT_KW@39..47 "await" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                 argument: JsParenthesizedExpression {
                                     l_paren_token: L_PAREN@47..48 "(" [] [],
                                     expression: JsCallExpression {
@@ -85,11 +85,11 @@ JsModule {
                         semicolon_token: SEMICOLON@72..73 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@73..75 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@73..75 "}" [Newline("\n")] [],
             },
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@75..82 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@75..82 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@82..91 "function" [] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
@@ -107,18 +107,18 @@ JsModule {
                 directives: JsDirectiveList [],
                 statements: JsStatementList [
                     JsReturnStatement {
-                        return_token: RETURN_KW@100..109 "return" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        return_token: RETURN_KW@100..109 "return" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@109..110 "4" [] [],
                         },
                         semicolon_token: SEMICOLON@110..111 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@111..113 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@111..113 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@113..114 "" [Whitespace("\n")] [],
+    eof_token: EOF@113..114 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..114
@@ -143,7 +143,7 @@ JsModule {
         2: JS_STATEMENT_LIST@23..73
           0: JS_EXPRESSION_STATEMENT@23..39
             0: JS_AWAIT_EXPRESSION@23..38
-              0: AWAIT_KW@23..31 "await" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+              0: AWAIT_KW@23..31 "await" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
               1: JS_CALL_EXPRESSION@31..38
                 0: JS_IDENTIFIER_EXPRESSION@31..36
                   0: JS_REFERENCE_IDENTIFIER@31..36
@@ -158,7 +158,7 @@ JsModule {
           1: JS_EXPRESSION_STATEMENT@39..73
             0: JS_BINARY_EXPRESSION@39..72
               0: JS_AWAIT_EXPRESSION@39..57
-                0: AWAIT_KW@39..47 "await" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                0: AWAIT_KW@39..47 "await" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                 1: JS_PARENTHESIZED_EXPRESSION@47..57
                   0: L_PAREN@47..48 "(" [] []
                   1: JS_CALL_EXPRESSION@48..55
@@ -186,9 +186,9 @@ JsModule {
                     1: JS_CALL_ARGUMENT_LIST@71..71
                     2: R_PAREN@71..72 ")" [] []
             1: SEMICOLON@72..73 ";" [] []
-        3: R_CURLY@73..75 "}" [Whitespace("\n")] []
+        3: R_CURLY@73..75 "}" [Newline("\n")] []
     1: JS_FUNCTION_STATEMENT@75..113
-      0: ASYNC_KW@75..82 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@75..82 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@82..91 "function" [] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@91..96
@@ -204,9 +204,9 @@ JsModule {
         1: JS_DIRECTIVE_LIST@100..100
         2: JS_STATEMENT_LIST@100..111
           0: JS_RETURN_STATEMENT@100..111
-            0: RETURN_KW@100..109 "return" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            0: RETURN_KW@100..109 "return" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
             1: JS_NUMBER_LITERAL_EXPRESSION@109..110
               0: JS_NUMBER_LITERAL@109..110 "4" [] []
             2: SEMICOLON@110..111 ";" [] []
-        3: R_CURLY@111..113 "}" [Whitespace("\n")] []
-  3: EOF@113..114 "" [Whitespace("\n")] []
+        3: R_CURLY@111..113 "}" [Newline("\n")] []
+  3: EOF@113..114 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -17,7 +17,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsNumberLiteralExpression {
-                    value_token: JS_NUMBER_LITERAL@5..8 "6" [Whitespace("\n")] [Whitespace(" ")],
+                    value_token: JS_NUMBER_LITERAL@5..8 "6" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator: STAR2@8..11 "**" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
@@ -35,7 +35,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsNumberLiteralExpression {
-                    value_token: JS_NUMBER_LITERAL@17..20 "1" [Whitespace("\n")] [Whitespace(" ")],
+                    value_token: JS_NUMBER_LITERAL@17..20 "1" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator: PLUS@20..22 "+" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
@@ -51,7 +51,7 @@ JsModule {
                             optional_chain_token_token: missing (optional),
                             type_args: missing (optional),
                             arguments: JsCallArguments {
-                                l_paren_token: L_PAREN@27..29 "(" [Whitespace("\n")] [],
+                                l_paren_token: L_PAREN@27..29 "(" [Newline("\n")] [],
                                 args: JsCallArgumentList [
                                     JsBinaryExpression {
                                         left: JsNumberLiteralExpression {
@@ -78,7 +78,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsNumberLiteralExpression {
-                    value_token: JS_NUMBER_LITERAL@39..42 "1" [Whitespace("\n")] [Whitespace(" ")],
+                    value_token: JS_NUMBER_LITERAL@39..42 "1" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator: SLASH@42..44 "/" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -90,7 +90,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsNumberLiteralExpression {
-                    value_token: JS_NUMBER_LITERAL@45..49 "74" [Whitespace("\n")] [Whitespace(" ")],
+                    value_token: JS_NUMBER_LITERAL@45..49 "74" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator: IN_KW@49..52 "in" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
@@ -105,7 +105,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@55..60 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@55..60 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: INSTANCEOF_KW@60..71 "instanceof" [] [Whitespace(" ")],
@@ -121,7 +121,7 @@ JsModule {
             expression: JsLogicalExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@76..81 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@76..81 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: QUESTION2@81..84 "??" [] [Whitespace(" ")],
@@ -137,7 +137,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@87..90 "a" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@87..90 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: SHR@90..93 ">>" [] [Whitespace(" ")],
@@ -153,7 +153,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@94..97 "a" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@94..97 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: USHR@97..101 ">>>" [] [Whitespace(" ")],
@@ -170,7 +170,7 @@ JsModule {
                 left: JsBinaryExpression {
                     left: JsBinaryExpression {
                         left: JsNumberLiteralExpression {
-                            value_token: JS_NUMBER_LITERAL@102..105 "1" [Whitespace("\n")] [Whitespace(" ")],
+                            value_token: JS_NUMBER_LITERAL@102..105 "1" [Newline("\n")] [Whitespace(" ")],
                         },
                         operator: PLUS@105..107 "+" [] [Whitespace(" ")],
                         right: JsNumberLiteralExpression {
@@ -193,7 +193,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsBinaryExpression {
                     left: JsNumberLiteralExpression {
-                        value_token: JS_NUMBER_LITERAL@116..119 "5" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: JS_NUMBER_LITERAL@116..119 "5" [Newline("\n")] [Whitespace(" ")],
                     },
                     operator: PLUS@119..121 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
@@ -226,7 +226,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@139..140 "" [Whitespace("\n")] [],
+    eof_token: EOF@139..140 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..140
@@ -244,7 +244,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@5..17
       0: JS_BINARY_EXPRESSION@5..17
         0: JS_NUMBER_LITERAL_EXPRESSION@5..8
-          0: JS_NUMBER_LITERAL@5..8 "6" [Whitespace("\n")] [Whitespace(" ")]
+          0: JS_NUMBER_LITERAL@5..8 "6" [Newline("\n")] [Whitespace(" ")]
         1: STAR2@8..11 "**" [] [Whitespace(" ")]
         2: JS_BINARY_EXPRESSION@11..17
           0: JS_NUMBER_LITERAL_EXPRESSION@11..13
@@ -256,7 +256,7 @@ JsModule {
     2: JS_EXPRESSION_STATEMENT@17..39
       0: JS_BINARY_EXPRESSION@17..39
         0: JS_NUMBER_LITERAL_EXPRESSION@17..20
-          0: JS_NUMBER_LITERAL@17..20 "1" [Whitespace("\n")] [Whitespace(" ")]
+          0: JS_NUMBER_LITERAL@17..20 "1" [Newline("\n")] [Whitespace(" ")]
         1: PLUS@20..22 "+" [] [Whitespace(" ")]
         2: JS_BINARY_EXPRESSION@22..39
           0: JS_BINARY_EXPRESSION@22..36
@@ -269,7 +269,7 @@ JsModule {
               1: (empty)
               2: (empty)
               3: JS_CALL_ARGUMENTS@27..36
-                0: L_PAREN@27..29 "(" [Whitespace("\n")] []
+                0: L_PAREN@27..29 "(" [Newline("\n")] []
                 1: JS_CALL_ARGUMENT_LIST@29..34
                   0: JS_BINARY_EXPRESSION@29..34
                     0: JS_NUMBER_LITERAL_EXPRESSION@29..31
@@ -285,7 +285,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@39..45
       0: JS_BINARY_EXPRESSION@39..45
         0: JS_NUMBER_LITERAL_EXPRESSION@39..42
-          0: JS_NUMBER_LITERAL@39..42 "1" [Whitespace("\n")] [Whitespace(" ")]
+          0: JS_NUMBER_LITERAL@39..42 "1" [Newline("\n")] [Whitespace(" ")]
         1: SLASH@42..44 "/" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@44..45
           0: JS_NUMBER_LITERAL@44..45 "2" [] []
@@ -293,7 +293,7 @@ JsModule {
     4: JS_EXPRESSION_STATEMENT@45..55
       0: JS_BINARY_EXPRESSION@45..55
         0: JS_NUMBER_LITERAL_EXPRESSION@45..49
-          0: JS_NUMBER_LITERAL@45..49 "74" [Whitespace("\n")] [Whitespace(" ")]
+          0: JS_NUMBER_LITERAL@45..49 "74" [Newline("\n")] [Whitespace(" ")]
         1: IN_KW@49..52 "in" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@52..55
           0: JS_REFERENCE_IDENTIFIER@52..55
@@ -303,7 +303,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@55..76
         0: JS_IDENTIFIER_EXPRESSION@55..60
           0: JS_REFERENCE_IDENTIFIER@55..60
-            0: IDENT@55..60 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@55..60 "foo" [Newline("\n")] [Whitespace(" ")]
         1: INSTANCEOF_KW@60..71 "instanceof" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@71..76
           0: JS_REFERENCE_IDENTIFIER@71..76
@@ -313,7 +313,7 @@ JsModule {
       0: JS_LOGICAL_EXPRESSION@76..87
         0: JS_IDENTIFIER_EXPRESSION@76..81
           0: JS_REFERENCE_IDENTIFIER@76..81
-            0: IDENT@76..81 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@76..81 "foo" [Newline("\n")] [Whitespace(" ")]
         1: QUESTION2@81..84 "??" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@84..87
           0: JS_REFERENCE_IDENTIFIER@84..87
@@ -323,7 +323,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@87..94
         0: JS_IDENTIFIER_EXPRESSION@87..90
           0: JS_REFERENCE_IDENTIFIER@87..90
-            0: IDENT@87..90 "a" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@87..90 "a" [Newline("\n")] [Whitespace(" ")]
         1: SHR@90..93 ">>" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@93..94
           0: JS_REFERENCE_IDENTIFIER@93..94
@@ -333,7 +333,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@94..102
         0: JS_IDENTIFIER_EXPRESSION@94..97
           0: JS_REFERENCE_IDENTIFIER@94..97
-            0: IDENT@94..97 "a" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@94..97 "a" [Newline("\n")] [Whitespace(" ")]
         1: USHR@97..101 ">>>" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@101..102
           0: JS_REFERENCE_IDENTIFIER@101..102
@@ -344,7 +344,7 @@ JsModule {
         0: JS_BINARY_EXPRESSION@102..113
           0: JS_BINARY_EXPRESSION@102..109
             0: JS_NUMBER_LITERAL_EXPRESSION@102..105
-              0: JS_NUMBER_LITERAL@102..105 "1" [Whitespace("\n")] [Whitespace(" ")]
+              0: JS_NUMBER_LITERAL@102..105 "1" [Newline("\n")] [Whitespace(" ")]
             1: PLUS@105..107 "+" [] [Whitespace(" ")]
             2: JS_NUMBER_LITERAL_EXPRESSION@107..109
               0: JS_NUMBER_LITERAL@107..109 "1" [] [Whitespace(" ")]
@@ -359,7 +359,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@116..139
         0: JS_BINARY_EXPRESSION@116..123
           0: JS_NUMBER_LITERAL_EXPRESSION@116..119
-            0: JS_NUMBER_LITERAL@116..119 "5" [Whitespace("\n")] [Whitespace(" ")]
+            0: JS_NUMBER_LITERAL@116..119 "5" [Newline("\n")] [Whitespace(" ")]
           1: PLUS@119..121 "+" [] [Whitespace(" ")]
           2: JS_NUMBER_LITERAL_EXPRESSION@121..123
             0: JS_NUMBER_LITERAL@121..123 "6" [] [Whitespace(" ")]
@@ -379,4 +379,4 @@ JsModule {
             2: JS_NUMBER_LITERAL_EXPRESSION@138..139
               0: JS_NUMBER_LITERAL@138..139 "6" [] []
       1: (empty)
-  3: EOF@139..140 "" [Whitespace("\n")] []
+  3: EOF@139..140 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/block_stmt.rast
@@ -8,7 +8,7 @@ JsModule {
             r_curly_token: R_CURLY@1..2 "}" [] [],
         },
         JsBlockStatement {
-            l_curly_token: L_CURLY@2..4 "{" [Whitespace("\n")] [],
+            l_curly_token: L_CURLY@2..4 "{" [Newline("\n")] [],
             statements: JsStatementList [
                 JsBlockStatement {
                     l_curly_token: L_CURLY@4..5 "{" [] [],
@@ -31,7 +31,7 @@ JsModule {
             r_curly_token: R_CURLY@10..11 "}" [] [],
         },
         JsBlockStatement {
-            l_curly_token: L_CURLY@11..14 "{" [Whitespace("\n")] [Whitespace(" ")],
+            l_curly_token: L_CURLY@11..14 "{" [Newline("\n")] [Whitespace(" ")],
             statements: JsStatementList [
                 JsExpressionStatement {
                     expression: JsAssignmentExpression {
@@ -51,7 +51,7 @@ JsModule {
             r_curly_token: R_CURLY@25..26 "}" [] [],
         },
     ],
-    eof_token: EOF@26..27 "" [Whitespace("\n")] [],
+    eof_token: EOF@26..27 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..27
@@ -63,7 +63,7 @@ JsModule {
       1: JS_STATEMENT_LIST@1..1
       2: R_CURLY@1..2 "}" [] []
     1: JS_BLOCK_STATEMENT@2..11
-      0: L_CURLY@2..4 "{" [Whitespace("\n")] []
+      0: L_CURLY@2..4 "{" [Newline("\n")] []
       1: JS_STATEMENT_LIST@4..10
         0: JS_BLOCK_STATEMENT@4..10
           0: L_CURLY@4..5 "{" [] []
@@ -79,7 +79,7 @@ JsModule {
           2: R_CURLY@9..10 "}" [] []
       2: R_CURLY@10..11 "}" [] []
     2: JS_BLOCK_STATEMENT@11..26
-      0: L_CURLY@11..14 "{" [Whitespace("\n")] [Whitespace(" ")]
+      0: L_CURLY@11..14 "{" [Newline("\n")] [Whitespace(" ")]
       1: JS_STATEMENT_LIST@14..25
         0: JS_EXPRESSION_STATEMENT@14..25
           0: JS_ASSIGNMENT_EXPRESSION@14..23
@@ -91,4 +91,4 @@ JsModule {
                 0: IDENT@20..23 "bar" [] []
           1: SEMICOLON@23..25 ";" [] [Whitespace(" ")]
       2: R_CURLY@25..26 "}" [] []
-  3: EOF@26..27 "" [Whitespace("\n")] []
+  3: EOF@26..27 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/break_stmt.rast
@@ -13,31 +13,31 @@ JsModule {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
                 statements: JsStatementList [
                     JsBreakStatement {
-                        break_token: BREAK_KW@14..22 "break" [Whitespace("\n"), Whitespace("  ")] [],
+                        break_token: BREAK_KW@14..22 "break" [Newline("\n"), Whitespace("  ")] [],
                         label_token: missing (optional),
                         semicolon_token: SEMICOLON@22..23 ";" [] [],
                     },
                     JsLabeledStatement {
-                        label_token: IDENT@23..28 "foo" [Whitespace("\n"), Whitespace("\t")] [],
+                        label_token: IDENT@23..28 "foo" [Newline("\n"), Whitespace("\t")] [],
                         colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
                         body: JsBlockStatement {
                             l_curly_token: L_CURLY@30..31 "{" [] [],
                             statements: JsStatementList [
                                 JsBreakStatement {
-                                    break_token: BREAK_KW@31..41 "break" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")],
+                                    break_token: BREAK_KW@31..41 "break" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
                                     label_token: IDENT@41..44 "foo" [] [],
                                     semicolon_token: SEMICOLON@44..45 ";" [] [],
                                 },
                             ],
-                            r_curly_token: R_CURLY@45..48 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                            r_curly_token: R_CURLY@45..48 "}" [Newline("\n"), Whitespace("\t")] [],
                         },
                     },
                 ],
-                r_curly_token: R_CURLY@48..50 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@48..50 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@50..51 "" [Whitespace("\n")] [],
+    eof_token: EOF@50..51 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..51
@@ -54,19 +54,19 @@ JsModule {
         0: L_CURLY@13..14 "{" [] []
         1: JS_STATEMENT_LIST@14..48
           0: JS_BREAK_STATEMENT@14..23
-            0: BREAK_KW@14..22 "break" [Whitespace("\n"), Whitespace("  ")] []
+            0: BREAK_KW@14..22 "break" [Newline("\n"), Whitespace("  ")] []
             1: (empty)
             2: SEMICOLON@22..23 ";" [] []
           1: JS_LABELED_STATEMENT@23..48
-            0: IDENT@23..28 "foo" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@23..28 "foo" [Newline("\n"), Whitespace("\t")] []
             1: COLON@28..30 ":" [] [Whitespace(" ")]
             2: JS_BLOCK_STATEMENT@30..48
               0: L_CURLY@30..31 "{" [] []
               1: JS_STATEMENT_LIST@31..45
                 0: JS_BREAK_STATEMENT@31..45
-                  0: BREAK_KW@31..41 "break" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")]
+                  0: BREAK_KW@31..41 "break" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")]
                   1: IDENT@41..44 "foo" [] []
                   2: SEMICOLON@44..45 ";" [] []
-              2: R_CURLY@45..48 "}" [Whitespace("\n"), Whitespace("\t")] []
-        2: R_CURLY@48..50 "}" [Whitespace("\n")] []
-  3: EOF@50..51 "" [Whitespace("\n")] []
+              2: R_CURLY@45..48 "}" [Newline("\n"), Whitespace("\t")] []
+        2: R_CURLY@48..50 "}" [Newline("\n")] []
+  3: EOF@50..51 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_declaration.rast
@@ -14,7 +14,7 @@ JsModule {
             r_curly_token: R_CURLY@11..12 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@12..19 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@19..23 "foo" [] [Whitespace(" ")],
             },
@@ -32,7 +32,7 @@ JsModule {
             r_curly_token: R_CURLY@36..37 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@37..44 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@44..48 "foo" [] [Whitespace(" ")],
             },
@@ -56,7 +56,7 @@ JsModule {
             r_curly_token: R_CURLY@65..66 "}" [] [],
         },
     ],
-    eof_token: EOF@66..67 "" [Whitespace("\n")] [],
+    eof_token: EOF@66..67 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..67
@@ -73,7 +73,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@11..11
       6: R_CURLY@11..12 "}" [] []
     1: JS_CLASS_STATEMENT@12..37
-      0: CLASS_KW@12..19 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@12..19 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@19..23
         0: IDENT@19..23 "foo" [] [Whitespace(" ")]
       2: JS_EXTENDS_CLAUSE@23..35
@@ -86,7 +86,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@36..36
       6: R_CURLY@36..37 "}" [] []
     2: JS_CLASS_STATEMENT@37..66
-      0: CLASS_KW@37..44 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@37..44 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@44..48
         0: IDENT@44..48 "foo" [] [Whitespace(" ")]
       2: JS_EXTENDS_CLAUSE@48..64
@@ -102,4 +102,4 @@ JsModule {
       4: L_CURLY@64..65 "{" [] []
       5: JS_CLASS_MEMBER_LIST@65..65
       6: R_CURLY@65..66 "}" [] []
-  3: EOF@66..67 "" [Whitespace("\n")] []
+  3: EOF@66..67 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_declare.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_declare.rast
@@ -38,7 +38,7 @@ JsModule {
             r_curly_token: R_CURLY@23..24 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@24..31 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@24..31 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@31..33 "B" [] [Whitespace(" ")],
             },
@@ -72,7 +72,7 @@ JsModule {
             r_curly_token: R_CURLY@49..50 "}" [] [],
         },
     ],
-    eof_token: EOF@50..51 "" [Whitespace("\n")] [],
+    eof_token: EOF@50..51 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..51
@@ -108,7 +108,7 @@ JsModule {
             3: R_CURLY@21..23 "}" [] [Whitespace(" ")]
       6: R_CURLY@23..24 "}" [] []
     1: JS_CLASS_STATEMENT@24..50
-      0: CLASS_KW@24..31 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@24..31 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@31..33
         0: IDENT@31..33 "B" [] [Whitespace(" ")]
       2: (empty)
@@ -133,4 +133,4 @@ JsModule {
                 0: IDENT@45..49 "foo" [] [Whitespace(" ")]
           10: (empty)
       6: R_CURLY@49..50 "}" [] []
-  3: EOF@50..51 "" [Whitespace("\n")] []
+  3: EOF@50..51 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_empty_element.rast
@@ -75,7 +75,7 @@ JsModule {
             r_curly_token: R_CURLY@39..40 "}" [] [],
         },
     ],
-    eof_token: EOF@40..41 "" [Whitespace("\n")] [],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..41
@@ -134,4 +134,4 @@ JsModule {
         14: JS_EMPTY_CLASS_MEMBER@38..39
           0: SEMICOLON@38..39 ";" [] []
       6: R_CURLY@39..40 "}" [] []
-  3: EOF@40..41 "" [Whitespace("\n")] []
+  3: EOF@40..41 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -31,7 +31,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@17..22 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -53,7 +53,7 @@ JsModule {
                                     JsConstructorClassMember {
                                         access_modifier: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: IDENT@37..50 "constructor" [Whitespace("\n"), Whitespace(" ")] [],
+                                            value: IDENT@37..50 "constructor" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                         type_parameters: missing (optional),
                                         parameters: JsConstructorParameters {
@@ -69,7 +69,7 @@ JsModule {
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@55..57 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@55..57 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -81,7 +81,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@57..61 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@57..61 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: missing (optional),
@@ -100,7 +100,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@71..72 "" [Whitespace("\n")] [],
+    eof_token: EOF@71..72 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..72
@@ -129,7 +129,7 @@ JsModule {
       1: SEMICOLON@16..17 ";" [] []
     1: JS_VARIABLE_STATEMENT@17..57
       0: JS_VARIABLE_DECLARATIONS@17..57
-        0: LET_KW@17..22 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@17..22 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@22..57
           0: JS_VARIABLE_DECLARATION@22..57
             0: JS_IDENTIFIER_BINDING@22..24
@@ -149,7 +149,7 @@ JsModule {
                   0: JS_CONSTRUCTOR_CLASS_MEMBER@37..55
                     0: (empty)
                     1: JS_LITERAL_MEMBER_NAME@37..50
-                      0: IDENT@37..50 "constructor" [Whitespace("\n"), Whitespace(" ")] []
+                      0: IDENT@37..50 "constructor" [Newline("\n"), Whitespace(" ")] []
                     2: (empty)
                     3: JS_CONSTRUCTOR_PARAMETERS@50..53
                       0: L_PAREN@50..51 "(" [] []
@@ -160,13 +160,13 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@54..54
                       2: JS_STATEMENT_LIST@54..54
                       3: R_CURLY@54..55 "}" [] []
-                6: R_CURLY@55..57 "}" [Whitespace("\n")] []
+                6: R_CURLY@55..57 "}" [Newline("\n")] []
       1: (empty)
     2: JS_EXPRESSION_STATEMENT@57..71
       0: JS_COMPUTED_MEMBER_EXPRESSION@57..71
         0: JS_IDENTIFIER_EXPRESSION@57..61
           0: JS_REFERENCE_IDENTIFIER@57..61
-            0: IDENT@57..61 "foo" [Whitespace("\n")] []
+            0: IDENT@57..61 "foo" [Newline("\n")] []
         1: (empty)
         2: L_BRACK@61..62 "[" [] []
         3: JS_CLASS_EXPRESSION@62..70
@@ -179,4 +179,4 @@ JsModule {
           6: R_CURLY@69..70 "}" [] []
         4: R_BRACK@70..71 "]" [] []
       1: (empty)
-  3: EOF@71..72 "" [Whitespace("\n")] []
+  3: EOF@71..72 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_member_modifiers.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_member_modifiers.rast
@@ -38,7 +38,7 @@ JsModule {
             r_curly_token: R_CURLY@22..23 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@23..30 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@23..30 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@30..32 "A" [] [Whitespace(" ")],
             },
@@ -73,7 +73,7 @@ JsModule {
             r_curly_token: R_CURLY@56..57 "}" [] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@57..64 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@57..64 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@64..66 "A" [] [Whitespace(" ")],
             },
@@ -100,7 +100,7 @@ JsModule {
             r_curly_token: R_CURLY@75..76 "}" [] [],
         },
     ],
-    eof_token: EOF@76..77 "" [Whitespace("\n")] [],
+    eof_token: EOF@76..77 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..77
@@ -136,7 +136,7 @@ JsModule {
             3: R_CURLY@20..22 "}" [] [Whitespace(" ")]
       6: R_CURLY@22..23 "}" [] []
     1: JS_CLASS_STATEMENT@23..57
-      0: CLASS_KW@23..30 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@23..30 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@30..32
         0: IDENT@30..32 "A" [] [Whitespace(" ")]
       2: (empty)
@@ -164,7 +164,7 @@ JsModule {
             3: R_CURLY@54..56 "}" [] [Whitespace(" ")]
       6: R_CURLY@56..57 "}" [] []
     2: JS_CLASS_STATEMENT@57..76
-      0: CLASS_KW@57..64 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@57..64 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@64..66
         0: IDENT@64..66 "A" [] [Whitespace(" ")]
       2: (empty)
@@ -185,4 +185,4 @@ JsModule {
           9: (empty)
           10: (empty)
       6: R_CURLY@75..76 "}" [] []
-  3: EOF@76..77 "" [Whitespace("\n")] []
+  3: EOF@76..77 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/class_static_constructor_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_static_constructor_method.rast
@@ -38,7 +38,7 @@ JsModule {
             r_curly_token: R_CURLY@34..35 "}" [] [],
         },
     ],
-    eof_token: EOF@35..36 "" [Whitespace("\n")] [],
+    eof_token: EOF@35..36 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..36
@@ -73,4 +73,4 @@ JsModule {
             2: JS_STATEMENT_LIST@32..32
             3: R_CURLY@32..34 "}" [] [Whitespace(" ")]
       6: R_CURLY@34..35 "}" [] []
-  3: EOF@35..36 "" [Whitespace("\n")] []
+  3: EOF@35..36 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/computed_member_expression.rast
@@ -24,7 +24,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@8..12 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: missing (optional),
@@ -46,7 +46,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@19..23 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@19..23 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: missing (optional),
@@ -63,7 +63,7 @@ JsModule {
                 object: JsComputedMemberExpression {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
-                            value_token: IDENT@30..34 "foo" [Whitespace("\n")] [],
+                            value_token: IDENT@30..34 "foo" [Newline("\n")] [],
                         },
                     },
                     optional_chain_token: missing (optional),
@@ -90,7 +90,7 @@ JsModule {
             expression: JsComputedMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@44..48 "foo" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token: QUESTIONDOT@48..50 "?." [] [],
@@ -105,7 +105,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@55..56 "" [Whitespace("\n")] [],
+    eof_token: EOF@55..56 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..56
@@ -128,7 +128,7 @@ JsModule {
       0: JS_COMPUTED_MEMBER_EXPRESSION@8..19
         0: JS_IDENTIFIER_EXPRESSION@8..12
           0: JS_REFERENCE_IDENTIFIER@8..12
-            0: IDENT@8..12 "foo" [Whitespace("\n")] []
+            0: IDENT@8..12 "foo" [Newline("\n")] []
         1: (empty)
         2: L_BRACK@12..13 "[" [] []
         3: JS_BINARY_EXPRESSION@13..18
@@ -143,7 +143,7 @@ JsModule {
       0: JS_COMPUTED_MEMBER_EXPRESSION@19..30
         0: JS_IDENTIFIER_EXPRESSION@19..23
           0: JS_REFERENCE_IDENTIFIER@19..23
-            0: IDENT@19..23 "foo" [Whitespace("\n")] []
+            0: IDENT@19..23 "foo" [Newline("\n")] []
         1: (empty)
         2: L_BRACK@23..24 "[" [] []
         3: JS_STRING_LITERAL_EXPRESSION@24..29
@@ -155,7 +155,7 @@ JsModule {
         0: JS_COMPUTED_MEMBER_EXPRESSION@30..39
           0: JS_IDENTIFIER_EXPRESSION@30..34
             0: JS_REFERENCE_IDENTIFIER@30..34
-              0: IDENT@30..34 "foo" [Whitespace("\n")] []
+              0: IDENT@30..34 "foo" [Newline("\n")] []
           1: (empty)
           2: L_BRACK@34..35 "[" [] []
           3: JS_IDENTIFIER_EXPRESSION@35..38
@@ -173,7 +173,7 @@ JsModule {
       0: JS_COMPUTED_MEMBER_EXPRESSION@44..55
         0: JS_IDENTIFIER_EXPRESSION@44..48
           0: JS_REFERENCE_IDENTIFIER@44..48
-            0: IDENT@44..48 "foo" [Whitespace("\n")] []
+            0: IDENT@44..48 "foo" [Newline("\n")] []
         1: QUESTIONDOT@48..50 "?." [] []
         2: L_BRACK@50..51 "[" [] []
         3: JS_IDENTIFIER_EXPRESSION@51..54
@@ -181,4 +181,4 @@ JsModule {
             0: IDENT@51..54 "bar" [] []
         4: R_BRACK@54..55 "]" [] []
       1: (empty)
-  3: EOF@55..56 "" [Whitespace("\n")] []
+  3: EOF@55..56 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/conditional_expr.rast
@@ -28,7 +28,7 @@ JsModule {
             expression: JsConditionalExpression {
                 test: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@15..20 "foo" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@15..20 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 question_mark_token: QUESTION@20..22 "?" [] [Whitespace(" ")],
@@ -61,7 +61,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@43..44 "" [Whitespace("\n")] [],
+    eof_token: EOF@43..44 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..44
@@ -86,7 +86,7 @@ JsModule {
       0: JS_CONDITIONAL_EXPRESSION@15..43
         0: JS_IDENTIFIER_EXPRESSION@15..20
           0: JS_REFERENCE_IDENTIFIER@15..20
-            0: IDENT@15..20 "foo" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@15..20 "foo" [Newline("\n")] [Whitespace(" ")]
         1: QUESTION@20..22 "?" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@22..26
           0: JS_REFERENCE_IDENTIFIER@22..26
@@ -105,4 +105,4 @@ JsModule {
             0: JS_REFERENCE_IDENTIFIER@40..43
               0: IDENT@40..43 "baz" [] []
       1: (empty)
-  3: EOF@43..44 "" [Whitespace("\n")] []
+  3: EOF@43..44 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
@@ -14,7 +14,7 @@ JsModule {
                 JsConstructorClassMember {
                     access_modifier: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@11..24 "constructor" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@11..24 "constructor" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
@@ -38,7 +38,7 @@ JsModule {
                                 expression: JsAssignmentExpression {
                                     left: JsStaticMemberAssignment {
                                         object: JsThisExpression {
-                                            this_token: THIS_KW@29..36 "this" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            this_token: THIS_KW@29..36 "this" [Newline("\n"), Whitespace("\t\t")] [],
                                         },
                                         dot_token: DOT@36..37 "." [] [],
                                         member: JsName {
@@ -55,14 +55,14 @@ JsModule {
                                 semicolon_token: SEMICOLON@42..43 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@43..46 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@43..46 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@46..48 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@46..48 "}" [Newline("\n")] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@48..55 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@48..55 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@55..59 "Bar" [] [Whitespace(" ")],
             },
@@ -73,7 +73,7 @@ JsModule {
                 JsConstructorClassMember {
                     access_modifier: missing (optional),
                     name: JsLiteralMemberName {
-                        value: JS_STRING_LITERAL@60..75 "\"constructor\"" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: JS_STRING_LITERAL@60..75 "\"constructor\"" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
@@ -97,7 +97,7 @@ JsModule {
                                 expression: JsAssignmentExpression {
                                     left: JsStaticMemberAssignment {
                                         object: JsThisExpression {
-                                            this_token: THIS_KW@80..87 "this" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            this_token: THIS_KW@80..87 "this" [Newline("\n"), Whitespace("\t\t")] [],
                                         },
                                         dot_token: DOT@87..88 "." [] [],
                                         member: JsName {
@@ -114,14 +114,14 @@ JsModule {
                                 semicolon_token: SEMICOLON@93..94 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@94..97 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@94..97 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@97..99 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@97..99 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@99..100 "" [Whitespace("\n")] [],
+    eof_token: EOF@99..100 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..100
@@ -139,7 +139,7 @@ JsModule {
         0: JS_CONSTRUCTOR_CLASS_MEMBER@11..46
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@11..24
-            0: IDENT@11..24 "constructor" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@11..24 "constructor" [Newline("\n"), Whitespace("\t")] []
           2: (empty)
           3: JS_CONSTRUCTOR_PARAMETERS@24..28
             0: L_PAREN@24..25 "(" [] []
@@ -158,7 +158,7 @@ JsModule {
                 0: JS_ASSIGNMENT_EXPRESSION@29..42
                   0: JS_STATIC_MEMBER_ASSIGNMENT@29..39
                     0: JS_THIS_EXPRESSION@29..36
-                      0: THIS_KW@29..36 "this" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: THIS_KW@29..36 "this" [Newline("\n"), Whitespace("\t\t")] []
                     1: DOT@36..37 "." [] []
                     2: JS_NAME@37..39
                       0: IDENT@37..39 "a" [] [Whitespace(" ")]
@@ -167,10 +167,10 @@ JsModule {
                     0: JS_REFERENCE_IDENTIFIER@41..42
                       0: IDENT@41..42 "a" [] []
                 1: SEMICOLON@42..43 ";" [] []
-            3: R_CURLY@43..46 "}" [Whitespace("\n"), Whitespace("\t")] []
-      6: R_CURLY@46..48 "}" [Whitespace("\n")] []
+            3: R_CURLY@43..46 "}" [Newline("\n"), Whitespace("\t")] []
+      6: R_CURLY@46..48 "}" [Newline("\n")] []
     1: JS_CLASS_STATEMENT@48..99
-      0: CLASS_KW@48..55 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@48..55 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@55..59
         0: IDENT@55..59 "Bar" [] [Whitespace(" ")]
       2: (empty)
@@ -180,7 +180,7 @@ JsModule {
         0: JS_CONSTRUCTOR_CLASS_MEMBER@60..97
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@60..75
-            0: JS_STRING_LITERAL@60..75 "\"constructor\"" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@60..75 "\"constructor\"" [Newline("\n"), Whitespace("\t")] []
           2: (empty)
           3: JS_CONSTRUCTOR_PARAMETERS@75..79
             0: L_PAREN@75..76 "(" [] []
@@ -199,7 +199,7 @@ JsModule {
                 0: JS_ASSIGNMENT_EXPRESSION@80..93
                   0: JS_STATIC_MEMBER_ASSIGNMENT@80..90
                     0: JS_THIS_EXPRESSION@80..87
-                      0: THIS_KW@80..87 "this" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: THIS_KW@80..87 "this" [Newline("\n"), Whitespace("\t\t")] []
                     1: DOT@87..88 "." [] []
                     2: JS_NAME@88..90
                       0: IDENT@88..90 "b" [] [Whitespace(" ")]
@@ -208,6 +208,6 @@ JsModule {
                     0: JS_REFERENCE_IDENTIFIER@92..93
                       0: IDENT@92..93 "b" [] []
                 1: SEMICOLON@93..94 ";" [] []
-            3: R_CURLY@94..97 "}" [Whitespace("\n"), Whitespace("\t")] []
-      6: R_CURLY@97..99 "}" [Whitespace("\n")] []
-  3: EOF@99..100 "" [Whitespace("\n")] []
+            3: R_CURLY@94..97 "}" [Newline("\n"), Whitespace("\t")] []
+      6: R_CURLY@97..99 "}" [Newline("\n")] []
+  3: EOF@99..100 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/continue_stmt.rast
@@ -13,36 +13,36 @@ JsModule {
                 l_curly_token: L_CURLY@13..14 "{" [] [],
                 statements: JsStatementList [
                     JsContinueStatement {
-                        continue_token: CONTINUE_KW@14..25 "continue" [Whitespace("\n"), Whitespace("  ")] [],
+                        continue_token: CONTINUE_KW@14..25 "continue" [Newline("\n"), Whitespace("  ")] [],
                         label_token: missing (optional),
                         semicolon_token: SEMICOLON@25..26 ";" [] [],
                     },
                     JsLabeledStatement {
-                        label_token: IDENT@26..32 "foo" [Whitespace("\n"), Whitespace("  ")] [],
+                        label_token: IDENT@26..32 "foo" [Newline("\n"), Whitespace("  ")] [],
                         colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
                         body: JsBlockStatement {
                             l_curly_token: L_CURLY@34..35 "{" [] [],
                             statements: JsStatementList [
                                 JsContinueStatement {
-                                    continue_token: CONTINUE_KW@35..49 "continue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                    continue_token: CONTINUE_KW@35..49 "continue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                     label_token: IDENT@49..52 "foo" [] [],
                                     semicolon_token: SEMICOLON@52..53 ";" [] [],
                                 },
                             ],
-                            r_curly_token: R_CURLY@53..57 "}" [Whitespace("\n"), Whitespace("\t ")] [],
+                            r_curly_token: R_CURLY@53..57 "}" [Newline("\n"), Whitespace("\t ")] [],
                         },
                     },
                     JsContinueStatement {
-                        continue_token: CONTINUE_KW@57..68 "continue" [Whitespace("\n"), Whitespace("  ")] [],
+                        continue_token: CONTINUE_KW@57..68 "continue" [Newline("\n"), Whitespace("  ")] [],
                         label_token: missing (optional),
                         semicolon_token: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@68..70 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@68..70 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@70..71 "" [Whitespace("\n")] [],
+    eof_token: EOF@70..71 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..71
@@ -59,23 +59,23 @@ JsModule {
         0: L_CURLY@13..14 "{" [] []
         1: JS_STATEMENT_LIST@14..68
           0: JS_CONTINUE_STATEMENT@14..26
-            0: CONTINUE_KW@14..25 "continue" [Whitespace("\n"), Whitespace("  ")] []
+            0: CONTINUE_KW@14..25 "continue" [Newline("\n"), Whitespace("  ")] []
             1: (empty)
             2: SEMICOLON@25..26 ";" [] []
           1: JS_LABELED_STATEMENT@26..57
-            0: IDENT@26..32 "foo" [Whitespace("\n"), Whitespace("  ")] []
+            0: IDENT@26..32 "foo" [Newline("\n"), Whitespace("  ")] []
             1: COLON@32..34 ":" [] [Whitespace(" ")]
             2: JS_BLOCK_STATEMENT@34..57
               0: L_CURLY@34..35 "{" [] []
               1: JS_STATEMENT_LIST@35..53
                 0: JS_CONTINUE_STATEMENT@35..53
-                  0: CONTINUE_KW@35..49 "continue" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                  0: CONTINUE_KW@35..49 "continue" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                   1: IDENT@49..52 "foo" [] []
                   2: SEMICOLON@52..53 ";" [] []
-              2: R_CURLY@53..57 "}" [Whitespace("\n"), Whitespace("\t ")] []
+              2: R_CURLY@53..57 "}" [Newline("\n"), Whitespace("\t ")] []
           2: JS_CONTINUE_STATEMENT@57..68
-            0: CONTINUE_KW@57..68 "continue" [Whitespace("\n"), Whitespace("  ")] []
+            0: CONTINUE_KW@57..68 "continue" [Newline("\n"), Whitespace("  ")] []
             1: (empty)
             2: (empty)
-        2: R_CURLY@68..70 "}" [Whitespace("\n")] []
-  3: EOF@70..71 "" [Whitespace("\n")] []
+        2: R_CURLY@68..70 "}" [Newline("\n")] []
+  3: EOF@70..71 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/debugger_stmt.rast
@@ -7,7 +7,7 @@ JsModule {
             semicolon_token: SEMICOLON@8..9 ";" [] [],
         },
     ],
-    eof_token: EOF@9..10 "" [Whitespace("\n")] [],
+    eof_token: EOF@9..10 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..10
@@ -17,4 +17,4 @@ JsModule {
     0: JS_DEBUGGER_STATEMENT@0..9
       0: DEBUGGER_KW@0..8 "debugger" [] []
       1: SEMICOLON@8..9 ";" [] []
-  3: EOF@9..10 "" [Whitespace("\n")] []
+  3: EOF@9..10 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/directives.rast
+++ b/crates/rslint_parser/test_data/inline/ok/directives.rast
@@ -2,14 +2,14 @@ JsScript {
     interpreter_token: missing (optional),
     directives: JsDirectiveList [
         JsDirective {
-            value_token: JS_STRING_LITERAL@0..19 "\"use new\"" [Comments("// SCRIPT"), Whitespace("\n")] [],
+            value_token: JS_STRING_LITERAL@0..19 "\"use new\"" [Comments("// SCRIPT"), Newline("\n")] [],
             semicolon_token: missing (optional),
         },
     ],
     statements: JsStatementList [
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@19..24 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@19..24 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -30,13 +30,13 @@ JsScript {
         },
         JsExpressionStatement {
             expression: JsStringLiteralExpression {
-                value_token: JS_STRING_LITERAL@31..44 "\"use strict\"" [Whitespace("\n")] [],
+                value_token: JS_STRING_LITERAL@31..44 "\"use strict\"" [Newline("\n")] [],
             },
             semicolon_token: SEMICOLON@44..64 ";" [] [Whitespace(" "), Comments("// not a directive")],
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@64..74 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@64..74 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@74..78 "test" [] [],
@@ -52,14 +52,14 @@ JsScript {
                 l_curly_token: L_CURLY@81..82 "{" [] [],
                 directives: JsDirectiveList [
                     JsDirective {
-                        value_token: JS_STRING_LITERAL@82..96 "'use strict'" [Whitespace("\n"), Whitespace("\t")] [],
+                        value_token: JS_STRING_LITERAL@82..96 "'use strict'" [Newline("\n"), Whitespace("\t")] [],
                         semicolon_token: SEMICOLON@96..97 ";" [] [],
                     },
                 ],
                 statements: JsStatementList [
                     JsVariableStatement {
                         declarations: JsVariableDeclarations {
-                            kind: LET_KW@97..103 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            kind: LET_KW@97..103 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                             items: JsVariableDeclarationList [
                                 JsVariableDeclaration {
                                     id: JsIdentifierBinding {
@@ -80,17 +80,17 @@ JsScript {
                     },
                     JsExpressionStatement {
                         expression: JsStringLiteralExpression {
-                            value_token: JS_STRING_LITERAL@110..124 "'use strict'" [Whitespace("\n"), Whitespace("\t")] [],
+                            value_token: JS_STRING_LITERAL@110..124 "'use strict'" [Newline("\n"), Whitespace("\t")] [],
                         },
                         semicolon_token: SEMICOLON@124..144 ";" [] [Whitespace(" "), Comments("// not a directive")],
                     },
                 ],
-                r_curly_token: R_CURLY@144..146 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@144..146 "}" [Newline("\n")] [],
             },
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@146..148 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@146..148 "(" [Newline("\n")] [],
                 expression: JsFunctionExpression {
                     async_token: missing (optional),
                     function_token: FUNCTION_KW@148..157 "function" [] [Whitespace(" ")],
@@ -107,14 +107,14 @@ JsScript {
                         l_curly_token: L_CURLY@160..161 "{" [] [],
                         directives: JsDirectiveList [
                             JsDirective {
-                                value_token: JS_STRING_LITERAL@161..175 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                                value_token: JS_STRING_LITERAL@161..175 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                                 semicolon_token: SEMICOLON@175..176 ";" [] [],
                             },
                         ],
                         statements: JsStatementList [
                             JsVariableStatement {
                                 declarations: JsVariableDeclarations {
-                                    kind: LET_KW@176..182 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                    kind: LET_KW@176..182 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                     items: JsVariableDeclarationList [
                                         JsVariableDeclaration {
                                             id: JsIdentifierBinding {
@@ -135,12 +135,12 @@ JsScript {
                             },
                             JsExpressionStatement {
                                 expression: JsStringLiteralExpression {
-                                    value_token: JS_STRING_LITERAL@189..203 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                                    value_token: JS_STRING_LITERAL@189..203 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                                 },
                                 semicolon_token: SEMICOLON@203..223 ";" [] [Whitespace(" "), Comments("// not a directive")],
                             },
                         ],
-                        r_curly_token: R_CURLY@223..225 "}" [Whitespace("\n")] [],
+                        r_curly_token: R_CURLY@223..225 "}" [Newline("\n")] [],
                     },
                 },
                 r_paren_token: R_PAREN@225..226 ")" [] [],
@@ -149,7 +149,7 @@ JsScript {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@227..232 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@227..232 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -173,14 +173,14 @@ JsScript {
                                     l_curly_token: L_CURLY@242..243 "{" [] [],
                                     directives: JsDirectiveList [
                                         JsDirective {
-                                            value_token: JS_STRING_LITERAL@243..257 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value_token: JS_STRING_LITERAL@243..257 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                                             semicolon_token: SEMICOLON@257..258 ";" [] [],
                                         },
                                     ],
                                     statements: JsStatementList [
                                         JsVariableStatement {
                                             declarations: JsVariableDeclarations {
-                                                kind: LET_KW@258..264 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                                kind: LET_KW@258..264 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                                 items: JsVariableDeclarationList [
                                                     JsVariableDeclaration {
                                                         id: JsIdentifierBinding {
@@ -201,12 +201,12 @@ JsScript {
                                         },
                                         JsExpressionStatement {
                                             expression: JsStringLiteralExpression {
-                                                value_token: JS_STRING_LITERAL@271..285 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                                                value_token: JS_STRING_LITERAL@271..285 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                                             },
                                             semicolon_token: SEMICOLON@285..306 ";" [] [Whitespace("  "), Comments("// not a directive")],
                                         },
                                     ],
-                                    r_curly_token: R_CURLY@306..308 "}" [Whitespace("\n")] [],
+                                    r_curly_token: R_CURLY@306..308 "}" [Newline("\n")] [],
                                 },
                             },
                         },
@@ -216,31 +216,31 @@ JsScript {
             semicolon_token: missing (optional),
         },
         JsBlockStatement {
-            l_curly_token: L_CURLY@308..310 "{" [Whitespace("\n")] [],
+            l_curly_token: L_CURLY@308..310 "{" [Newline("\n")] [],
             statements: JsStatementList [
                 JsExpressionStatement {
                     expression: JsStringLiteralExpression {
-                        value_token: JS_STRING_LITERAL@310..324 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] [],
+                        value_token: JS_STRING_LITERAL@310..324 "\"use strict\"" [Newline("\n"), Whitespace("\t")] [],
                     },
                     semicolon_token: SEMICOLON@324..344 ";" [] [Whitespace(" "), Comments("// not a directive")],
                 },
             ],
-            r_curly_token: R_CURLY@344..346 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@344..346 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@346..347 "" [Whitespace("\n")] [],
+    eof_token: EOF@346..347 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..347
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..19
     0: JS_DIRECTIVE@0..19
-      0: JS_STRING_LITERAL@0..19 "\"use new\"" [Comments("// SCRIPT"), Whitespace("\n")] []
+      0: JS_STRING_LITERAL@0..19 "\"use new\"" [Comments("// SCRIPT"), Newline("\n")] []
       1: (empty)
   2: JS_STATEMENT_LIST@19..346
     0: JS_VARIABLE_STATEMENT@19..31
       0: JS_VARIABLE_DECLARATIONS@19..30
-        0: LET_KW@19..24 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@19..24 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@24..30
           0: JS_VARIABLE_DECLARATION@24..30
             0: JS_IDENTIFIER_BINDING@24..26
@@ -254,11 +254,11 @@ JsScript {
       1: SEMICOLON@30..31 ";" [] []
     1: JS_EXPRESSION_STATEMENT@31..64
       0: JS_STRING_LITERAL_EXPRESSION@31..44
-        0: JS_STRING_LITERAL@31..44 "\"use strict\"" [Whitespace("\n")] []
+        0: JS_STRING_LITERAL@31..44 "\"use strict\"" [Newline("\n")] []
       1: SEMICOLON@44..64 ";" [] [Whitespace(" "), Comments("// not a directive")]
     2: JS_FUNCTION_STATEMENT@64..146
       0: (empty)
-      1: FUNCTION_KW@64..74 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@64..74 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@74..78
         0: IDENT@74..78 "test" [] []
@@ -272,12 +272,12 @@ JsScript {
         0: L_CURLY@81..82 "{" [] []
         1: JS_DIRECTIVE_LIST@82..97
           0: JS_DIRECTIVE@82..97
-            0: JS_STRING_LITERAL@82..96 "'use strict'" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@82..96 "'use strict'" [Newline("\n"), Whitespace("\t")] []
             1: SEMICOLON@96..97 ";" [] []
         2: JS_STATEMENT_LIST@97..144
           0: JS_VARIABLE_STATEMENT@97..110
             0: JS_VARIABLE_DECLARATIONS@97..109
-              0: LET_KW@97..103 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+              0: LET_KW@97..103 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
               1: JS_VARIABLE_DECLARATION_LIST@103..109
                 0: JS_VARIABLE_DECLARATION@103..109
                   0: JS_IDENTIFIER_BINDING@103..105
@@ -291,12 +291,12 @@ JsScript {
             1: SEMICOLON@109..110 ";" [] []
           1: JS_EXPRESSION_STATEMENT@110..144
             0: JS_STRING_LITERAL_EXPRESSION@110..124
-              0: JS_STRING_LITERAL@110..124 "'use strict'" [Whitespace("\n"), Whitespace("\t")] []
+              0: JS_STRING_LITERAL@110..124 "'use strict'" [Newline("\n"), Whitespace("\t")] []
             1: SEMICOLON@124..144 ";" [] [Whitespace(" "), Comments("// not a directive")]
-        3: R_CURLY@144..146 "}" [Whitespace("\n")] []
+        3: R_CURLY@144..146 "}" [Newline("\n")] []
     3: JS_EXPRESSION_STATEMENT@146..227
       0: JS_PARENTHESIZED_EXPRESSION@146..226
-        0: L_PAREN@146..148 "(" [Whitespace("\n")] []
+        0: L_PAREN@146..148 "(" [Newline("\n")] []
         1: JS_FUNCTION_EXPRESSION@148..225
           0: (empty)
           1: FUNCTION_KW@148..157 "function" [] [Whitespace(" ")]
@@ -312,12 +312,12 @@ JsScript {
             0: L_CURLY@160..161 "{" [] []
             1: JS_DIRECTIVE_LIST@161..176
               0: JS_DIRECTIVE@161..176
-                0: JS_STRING_LITERAL@161..175 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+                0: JS_STRING_LITERAL@161..175 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
                 1: SEMICOLON@175..176 ";" [] []
             2: JS_STATEMENT_LIST@176..223
               0: JS_VARIABLE_STATEMENT@176..189
                 0: JS_VARIABLE_DECLARATIONS@176..188
-                  0: LET_KW@176..182 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                  0: LET_KW@176..182 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                   1: JS_VARIABLE_DECLARATION_LIST@182..188
                     0: JS_VARIABLE_DECLARATION@182..188
                       0: JS_IDENTIFIER_BINDING@182..184
@@ -331,14 +331,14 @@ JsScript {
                 1: SEMICOLON@188..189 ";" [] []
               1: JS_EXPRESSION_STATEMENT@189..223
                 0: JS_STRING_LITERAL_EXPRESSION@189..203
-                  0: JS_STRING_LITERAL@189..203 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+                  0: JS_STRING_LITERAL@189..203 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
                 1: SEMICOLON@203..223 ";" [] [Whitespace(" "), Comments("// not a directive")]
-            3: R_CURLY@223..225 "}" [Whitespace("\n")] []
+            3: R_CURLY@223..225 "}" [Newline("\n")] []
         2: R_PAREN@225..226 ")" [] []
       1: SEMICOLON@226..227 ";" [] []
     4: JS_VARIABLE_STATEMENT@227..308
       0: JS_VARIABLE_DECLARATIONS@227..308
-        0: LET_KW@227..232 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@227..232 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@232..308
           0: JS_VARIABLE_DECLARATION@232..308
             0: JS_IDENTIFIER_BINDING@232..234
@@ -360,12 +360,12 @@ JsScript {
                   0: L_CURLY@242..243 "{" [] []
                   1: JS_DIRECTIVE_LIST@243..258
                     0: JS_DIRECTIVE@243..258
-                      0: JS_STRING_LITERAL@243..257 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+                      0: JS_STRING_LITERAL@243..257 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
                       1: SEMICOLON@257..258 ";" [] []
                   2: JS_STATEMENT_LIST@258..306
                     0: JS_VARIABLE_STATEMENT@258..271
                       0: JS_VARIABLE_DECLARATIONS@258..270
-                        0: LET_KW@258..264 "let" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                        0: LET_KW@258..264 "let" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                         1: JS_VARIABLE_DECLARATION_LIST@264..270
                           0: JS_VARIABLE_DECLARATION@264..270
                             0: JS_IDENTIFIER_BINDING@264..266
@@ -379,16 +379,16 @@ JsScript {
                       1: SEMICOLON@270..271 ";" [] []
                     1: JS_EXPRESSION_STATEMENT@271..306
                       0: JS_STRING_LITERAL_EXPRESSION@271..285
-                        0: JS_STRING_LITERAL@271..285 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+                        0: JS_STRING_LITERAL@271..285 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
                       1: SEMICOLON@285..306 ";" [] [Whitespace("  "), Comments("// not a directive")]
-                  3: R_CURLY@306..308 "}" [Whitespace("\n")] []
+                  3: R_CURLY@306..308 "}" [Newline("\n")] []
       1: (empty)
     5: JS_BLOCK_STATEMENT@308..346
-      0: L_CURLY@308..310 "{" [Whitespace("\n")] []
+      0: L_CURLY@308..310 "{" [Newline("\n")] []
       1: JS_STATEMENT_LIST@310..344
         0: JS_EXPRESSION_STATEMENT@310..344
           0: JS_STRING_LITERAL_EXPRESSION@310..324
-            0: JS_STRING_LITERAL@310..324 "\"use strict\"" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@310..324 "\"use strict\"" [Newline("\n"), Whitespace("\t")] []
           1: SEMICOLON@324..344 ";" [] [Whitespace(" "), Comments("// not a directive")]
-      2: R_CURLY@344..346 "}" [Whitespace("\n")] []
-  3: EOF@346..347 "" [Whitespace("\n")] []
+      2: R_CURLY@344..346 "}" [Newline("\n")] []
+  3: EOF@346..347 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -40,7 +40,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsDoWhileStatement {
-            do_token: DO_KW@35..39 "do" [Whitespace("\n")] [Whitespace(" ")],
+            do_token: DO_KW@35..39 "do" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@39..40 "{" [] [],
                 statements: JsStatementList [
@@ -49,7 +49,7 @@ JsModule {
                             callee: JsStaticMemberExpression {
                                 object: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
-                                        value_token: IDENT@40..49 "console" [Whitespace("\n"), Whitespace("\t")] [],
+                                        value_token: IDENT@40..49 "console" [Newline("\n"), Whitespace("\t")] [],
                                     },
                                 },
                                 operator: DOT@49..50 "." [] [],
@@ -72,7 +72,7 @@ JsModule {
                         semicolon_token: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@61..64 "}" [Whitespace("\n")] [Whitespace(" ")],
+                r_curly_token: R_CURLY@61..64 "}" [Newline("\n")] [Whitespace(" ")],
             },
             while_token: WHILE_KW@64..70 "while" [] [Whitespace(" ")],
             l_paren_token: L_PAREN@70..71 "(" [] [],
@@ -84,7 +84,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@77..82 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@77..82 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -104,16 +104,16 @@ JsModule {
             semicolon_token: SEMICOLON@87..88 ";" [] [],
         },
         JsDoWhileStatement {
-            do_token: DO_KW@88..91 "do" [Whitespace("\n")] [],
+            do_token: DO_KW@88..91 "do" [Newline("\n")] [],
             body: JsDoWhileStatement {
-                do_token: DO_KW@91..95 "do" [Whitespace("\n")] [Whitespace(" ")],
+                do_token: DO_KW@91..95 "do" [Newline("\n")] [Whitespace(" ")],
                 body: JsBlockStatement {
                     l_curly_token: L_CURLY@95..96 "{" [] [],
                     statements: JsStatementList [
                         JsExpressionStatement {
                             expression: JsAssignmentExpression {
                                 left: JsIdentifierAssignment {
-                                    name_token: IDENT@96..100 "a" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                    name_token: IDENT@96..100 "a" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                 },
                                 operator_token: EQ@100..102 "=" [] [Whitespace(" ")],
                                 right: JsBinaryExpression {
@@ -131,7 +131,7 @@ JsModule {
                             semicolon_token: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@107..110 "}" [Whitespace("\n")] [Whitespace(" ")],
+                    r_curly_token: R_CURLY@107..110 "}" [Newline("\n")] [Whitespace(" ")],
                 },
                 while_token: WHILE_KW@110..115 "while" [] [],
                 l_paren_token: L_PAREN@115..116 "(" [] [],
@@ -149,7 +149,7 @@ JsModule {
                 r_paren_token: R_PAREN@121..122 ")" [] [],
                 semicolon_token: missing (optional),
             },
-            while_token: WHILE_KW@122..129 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@122..129 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@129..130 "(" [] [],
             test: JsBinaryExpression {
                 left: JsIdentifierExpression {
@@ -166,7 +166,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@138..139 "" [Whitespace("\n")] [],
+    eof_token: EOF@138..139 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..139
@@ -200,7 +200,7 @@ JsModule {
       5: R_PAREN@34..35 ")" [] []
       6: (empty)
     1: JS_DO_WHILE_STATEMENT@35..77
-      0: DO_KW@35..39 "do" [Whitespace("\n")] [Whitespace(" ")]
+      0: DO_KW@35..39 "do" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@39..64
         0: L_CURLY@39..40 "{" [] []
         1: JS_STATEMENT_LIST@40..61
@@ -209,7 +209,7 @@ JsModule {
               0: JS_STATIC_MEMBER_EXPRESSION@40..53
                 0: JS_IDENTIFIER_EXPRESSION@40..49
                   0: JS_REFERENCE_IDENTIFIER@40..49
-                    0: IDENT@40..49 "console" [Whitespace("\n"), Whitespace("\t")] []
+                    0: IDENT@40..49 "console" [Newline("\n"), Whitespace("\t")] []
                 1: DOT@49..50 "." [] []
                 2: JS_NAME@50..53
                   0: IDENT@50..53 "log" [] []
@@ -222,7 +222,7 @@ JsModule {
                     0: JS_STRING_LITERAL@54..60 "\"test\"" [] []
                 2: R_PAREN@60..61 ")" [] []
             1: (empty)
-        2: R_CURLY@61..64 "}" [Whitespace("\n")] [Whitespace(" ")]
+        2: R_CURLY@61..64 "}" [Newline("\n")] [Whitespace(" ")]
       2: WHILE_KW@64..70 "while" [] [Whitespace(" ")]
       3: L_PAREN@70..71 "(" [] []
       4: JS_BOOLEAN_LITERAL_EXPRESSION@71..75
@@ -231,7 +231,7 @@ JsModule {
       6: SEMICOLON@76..77 ";" [] []
     2: JS_VARIABLE_STATEMENT@77..88
       0: JS_VARIABLE_DECLARATIONS@77..87
-        0: LET_KW@77..82 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@77..82 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@82..87
           0: JS_VARIABLE_DECLARATION@82..87
             0: JS_IDENTIFIER_BINDING@82..84
@@ -244,16 +244,16 @@ JsModule {
                 0: JS_NUMBER_LITERAL@86..87 "1" [] []
       1: SEMICOLON@87..88 ";" [] []
     3: JS_DO_WHILE_STATEMENT@88..138
-      0: DO_KW@88..91 "do" [Whitespace("\n")] []
+      0: DO_KW@88..91 "do" [Newline("\n")] []
       1: JS_DO_WHILE_STATEMENT@91..122
-        0: DO_KW@91..95 "do" [Whitespace("\n")] [Whitespace(" ")]
+        0: DO_KW@91..95 "do" [Newline("\n")] [Whitespace(" ")]
         1: JS_BLOCK_STATEMENT@95..110
           0: L_CURLY@95..96 "{" [] []
           1: JS_STATEMENT_LIST@96..107
             0: JS_EXPRESSION_STATEMENT@96..107
               0: JS_ASSIGNMENT_EXPRESSION@96..107
                 0: JS_IDENTIFIER_ASSIGNMENT@96..100
-                  0: IDENT@96..100 "a" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                  0: IDENT@96..100 "a" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                 1: EQ@100..102 "=" [] [Whitespace(" ")]
                 2: JS_BINARY_EXPRESSION@102..107
                   0: JS_IDENTIFIER_EXPRESSION@102..104
@@ -263,7 +263,7 @@ JsModule {
                   2: JS_NUMBER_LITERAL_EXPRESSION@106..107
                     0: JS_NUMBER_LITERAL@106..107 "1" [] []
               1: (empty)
-          2: R_CURLY@107..110 "}" [Whitespace("\n")] [Whitespace(" ")]
+          2: R_CURLY@107..110 "}" [Newline("\n")] [Whitespace(" ")]
         2: WHILE_KW@110..115 "while" [] []
         3: L_PAREN@115..116 "(" [] []
         4: JS_BINARY_EXPRESSION@116..121
@@ -275,7 +275,7 @@ JsModule {
             0: JS_NUMBER_LITERAL@120..121 "5" [] []
         5: R_PAREN@121..122 ")" [] []
         6: (empty)
-      2: WHILE_KW@122..129 "while" [Whitespace("\n")] [Whitespace(" ")]
+      2: WHILE_KW@122..129 "while" [Newline("\n")] [Whitespace(" ")]
       3: L_PAREN@129..130 "(" [] []
       4: JS_BINARY_EXPRESSION@130..137
         0: JS_IDENTIFIER_EXPRESSION@130..132
@@ -286,4 +286,4 @@ JsModule {
           0: JS_NUMBER_LITERAL@134..137 "100" [] []
       5: R_PAREN@137..138 ")" [] []
       6: (empty)
-  3: EOF@138..139 "" [Whitespace("\n")] []
+  3: EOF@138..139 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/do_while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_stmt.rast
@@ -18,7 +18,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsDoWhileStatement {
-            do_token: DO_KW@19..23 "do" [Whitespace("\n")] [Whitespace(" ")],
+            do_token: DO_KW@19..23 "do" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
                 statements: JsStatementList [
@@ -56,7 +56,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsDoWhileStatement {
-            do_token: DO_KW@58..62 "do" [Whitespace("\n")] [Whitespace(" ")],
+            do_token: DO_KW@58..62 "do" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@62..64 "{" [] [Whitespace(" ")],
                 statements: JsStatementList [
@@ -77,7 +77,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@85..86 "" [Whitespace("\n")] [],
+    eof_token: EOF@85..86 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..86
@@ -97,7 +97,7 @@ JsModule {
       5: R_PAREN@18..19 ")" [] []
       6: (empty)
     1: JS_DO_WHILE_STATEMENT@19..58
-      0: DO_KW@19..23 "do" [Whitespace("\n")] [Whitespace(" ")]
+      0: DO_KW@19..23 "do" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@23..46
         0: L_CURLY@23..25 "{" [] [Whitespace(" ")]
         1: JS_STATEMENT_LIST@25..44
@@ -124,7 +124,7 @@ JsModule {
       5: R_PAREN@57..58 ")" [] []
       6: (empty)
     2: JS_DO_WHILE_STATEMENT@58..85
-      0: DO_KW@58..62 "do" [Whitespace("\n")] [Whitespace(" ")]
+      0: DO_KW@58..62 "do" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@62..73
         0: L_CURLY@62..64 "{" [] [Whitespace(" ")]
         1: JS_STATEMENT_LIST@64..71
@@ -139,4 +139,4 @@ JsModule {
         0: TRUE_KW@80..84 "true" [] []
       5: R_PAREN@84..85 ")" [] []
       6: (empty)
-  3: EOF@85..86 "" [Whitespace("\n")] []
+  3: EOF@85..86 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/empty_stmt.rast
@@ -6,7 +6,7 @@ JsModule {
             semicolon_token: SEMICOLON@0..1 ";" [] [],
         },
     ],
-    eof_token: EOF@1..2 "" [Whitespace("\n")] [],
+    eof_token: EOF@1..2 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..2
@@ -15,4 +15,4 @@ JsModule {
   2: JS_MODULE_ITEM_LIST@0..1
     0: JS_EMPTY_STATEMENT@0..1
       0: SEMICOLON@0..1 ";" [] []
-  3: EOF@1..2 "" [Whitespace("\n")] []
+  3: EOF@1..2 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_as_identifier.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_as_identifier.rast
@@ -19,7 +19,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@14..22 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@14..22 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@22..24 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -39,7 +39,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@34..35 "" [Whitespace("\n")] [],
+    eof_token: EOF@34..35 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..35
@@ -58,7 +58,7 @@ JsModule {
         2: R_CURLY@12..13 "}" [] []
         3: SEMICOLON@13..14 ";" [] []
     1: JS_EXPORT@14..34
-      0: EXPORT_KW@14..22 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@14..22 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@22..34
         0: L_CURLY@22..24 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@24..33
@@ -71,4 +71,4 @@ JsModule {
               0: IDENT@30..33 "as" [] [Whitespace(" ")]
         2: R_CURLY@33..34 "}" [] []
         3: (empty)
-  3: EOF@34..35 "" [Whitespace("\n")] []
+  3: EOF@34..35 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_class_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_class_clause.rast
@@ -17,7 +17,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@17..25 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@17..25 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportClassClause {
                 class_token: CLASS_KW@25..31 "class" [] [Whitespace(" ")],
                 id: JsIdentifierBinding {
@@ -38,7 +38,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@45..46 "" [Whitespace("\n")] [],
+    eof_token: EOF@45..46 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..46
@@ -57,7 +57,7 @@ JsModule {
         5: JS_CLASS_MEMBER_LIST@16..16
         6: R_CURLY@16..17 "}" [] []
     1: JS_EXPORT@17..45
-      0: EXPORT_KW@17..25 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@17..25 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_CLASS_CLAUSE@25..45
         0: CLASS_KW@25..31 "class" [] [Whitespace(" ")]
         1: JS_IDENTIFIER_BINDING@31..33
@@ -71,4 +71,4 @@ JsModule {
         4: L_CURLY@43..44 "{" [] []
         5: JS_CLASS_MEMBER_LIST@44..44
         6: R_CURLY@44..45 "}" [] []
-  3: EOF@45..46 "" [Whitespace("\n")] []
+  3: EOF@45..46 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_default_class_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_default_class_clause.rast
@@ -16,7 +16,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -34,4 +34,4 @@ JsModule {
         5: L_CURLY@21..22 "{" [] []
         6: JS_CLASS_MEMBER_LIST@22..22
         7: R_CURLY@22..23 "}" [] []
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_default_expression_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_default_expression_clause.rast
@@ -15,7 +15,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@17..18 "" [Whitespace("\n")] [],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..18
@@ -30,4 +30,4 @@ JsModule {
           0: JS_REFERENCE_IDENTIFIER@15..16
             0: IDENT@15..16 "a" [] []
         2: SEMICOLON@16..17 ";" [] []
-  3: EOF@17..18 "" [Whitespace("\n")] []
+  3: EOF@17..18 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_default_function_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_default_function_clause.rast
@@ -44,7 +44,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@37..38 "" [Whitespace("\n")] [],
+    eof_token: EOF@37..38 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..38
@@ -82,4 +82,4 @@ JsModule {
           1: JS_DIRECTIVE_LIST@36..36
           2: JS_STATEMENT_LIST@36..36
           3: R_CURLY@36..37 "}" [] []
-  3: EOF@37..38 "" [Whitespace("\n")] []
+  3: EOF@37..38 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_from_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_from_clause.rast
@@ -16,7 +16,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@18..26 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: STAR@26..28 "*" [] [Whitespace(" ")],
                 export_as: JsExportAsClause {
@@ -34,7 +34,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@42..50 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@42..50 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: STAR@50..52 "*" [] [Whitespace(" ")],
                 export_as: JsExportAsClause {
@@ -52,7 +52,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@71..79 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFromClause {
                 star_token: STAR@79..81 "*" [] [Whitespace(" ")],
                 export_as: missing (optional),
@@ -76,7 +76,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@115..116 "" [Whitespace("\n")] [],
+    eof_token: EOF@115..116 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..116
@@ -94,7 +94,7 @@ JsModule {
         4: (empty)
         5: SEMICOLON@17..18 ";" [] []
     1: JS_EXPORT@18..42
-      0: EXPORT_KW@18..26 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@26..42
         0: STAR@26..28 "*" [] [Whitespace(" ")]
         1: JS_EXPORT_AS_CLAUSE@28..33
@@ -107,7 +107,7 @@ JsModule {
         4: (empty)
         5: SEMICOLON@41..42 ";" [] []
     2: JS_EXPORT@42..71
-      0: EXPORT_KW@42..50 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@42..50 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@50..71
         0: STAR@50..52 "*" [] [Whitespace(" ")]
         1: JS_EXPORT_AS_CLAUSE@52..63
@@ -120,7 +120,7 @@ JsModule {
         4: (empty)
         5: (empty)
     3: JS_EXPORT@71..115
-      0: EXPORT_KW@71..79 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@71..79 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FROM_CLAUSE@79..115
         0: STAR@79..81 "*" [] [Whitespace(" ")]
         1: (empty)
@@ -137,4 +137,4 @@ JsModule {
               2: JS_STRING_LITERAL@107..114 "\"json\"" [] [Whitespace(" ")]
           3: R_CURLY@114..115 "}" [] []
         5: (empty)
-  3: EOF@115..116 "" [Whitespace("\n")] []
+  3: EOF@115..116 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_function_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_function_clause.rast
@@ -43,7 +43,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@29..37 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@29..37 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFunctionClause {
                 async_token: missing (optional),
                 function_token: FUNCTION_KW@37..45 "function" [] [],
@@ -83,7 +83,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@60..68 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@60..68 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportFunctionClause {
                 async_token: ASYNC_KW@68..74 "async" [] [Whitespace(" ")],
                 function_token: FUNCTION_KW@74..83 "function" [] [Whitespace(" ")],
@@ -124,7 +124,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@98..99 "" [Whitespace("\n")] [],
+    eof_token: EOF@98..99 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..99
@@ -162,7 +162,7 @@ JsModule {
           2: JS_STATEMENT_LIST@28..28
           3: R_CURLY@28..29 "}" [] []
     1: JS_EXPORT@29..60
-      0: EXPORT_KW@29..37 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@29..37 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FUNCTION_CLAUSE@37..60
         0: (empty)
         1: FUNCTION_KW@37..45 "function" [] []
@@ -192,7 +192,7 @@ JsModule {
           2: JS_STATEMENT_LIST@59..59
           3: R_CURLY@59..60 "}" [] []
     2: JS_EXPORT@60..98
-      0: EXPORT_KW@60..68 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@60..68 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_FUNCTION_CLAUSE@68..98
         0: ASYNC_KW@68..74 "async" [] [Whitespace(" ")]
         1: FUNCTION_KW@74..83 "function" [] [Whitespace(" ")]
@@ -222,4 +222,4 @@ JsModule {
           1: JS_DIRECTIVE_LIST@97..97
           2: JS_STATEMENT_LIST@97..97
           3: R_CURLY@97..98 "}" [] []
-  3: EOF@98..99 "" [Whitespace("\n")] []
+  3: EOF@98..99 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_named_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_named_clause.rast
@@ -19,7 +19,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@13..21 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@21..23 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -61,7 +61,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@55..63 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@55..63 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@63..65 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -77,7 +77,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@70..71 "" [Whitespace("\n")] [],
+    eof_token: EOF@70..71 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..71
@@ -96,7 +96,7 @@ JsModule {
         2: R_CURLY@11..12 "}" [] []
         3: SEMICOLON@12..13 ";" [] []
     1: JS_EXPORT@13..55
-      0: EXPORT_KW@13..21 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@21..55
         0: L_CURLY@21..23 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@23..54
@@ -126,7 +126,7 @@ JsModule {
         2: R_CURLY@54..55 "}" [] []
         3: (empty)
     2: JS_EXPORT@55..70
-      0: EXPORT_KW@55..63 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@55..63 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@63..70
         0: L_CURLY@63..65 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@65..68
@@ -136,4 +136,4 @@ JsModule {
               0: IDENT@65..68 "as" [] [Whitespace(" ")]
         2: R_CURLY@68..69 "}" [] []
         3: SEMICOLON@69..70 ";" [] []
-  3: EOF@70..71 "" [Whitespace("\n")] []
+  3: EOF@70..71 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_named_from_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_named_from_clause.rast
@@ -33,7 +33,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@33..41 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -86,7 +86,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@86..94 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@94..96 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -108,7 +108,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@112..120 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@112..120 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@120..122 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -135,7 +135,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@150..158 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@150..158 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@158..160 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -162,7 +162,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@182..190 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@182..190 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedFromClause {
                 l_curly_token: L_CURLY@190..192 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedFromSpecifierList [
@@ -195,7 +195,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@230..231 "" [Whitespace("\n")] [],
+    eof_token: EOF@230..231 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..231
@@ -225,7 +225,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@32..33 ";" [] []
     1: JS_EXPORT@33..86
-      0: EXPORT_KW@33..41 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@41..86
         0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@43..74
@@ -262,7 +262,7 @@ JsModule {
         5: (empty)
         6: (empty)
     2: JS_EXPORT@86..112
-      0: EXPORT_KW@86..94 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@86..94 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@94..112
         0: L_CURLY@94..96 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@96..99
@@ -278,7 +278,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@111..112 ";" [] []
     3: JS_EXPORT@112..150
-      0: EXPORT_KW@112..120 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@112..120 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@120..150
         0: L_CURLY@120..122 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@122..137
@@ -297,7 +297,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@149..150 ";" [] []
     4: JS_EXPORT@150..182
-      0: EXPORT_KW@150..158 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@150..158 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@158..182
         0: L_CURLY@158..160 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@160..169
@@ -316,7 +316,7 @@ JsModule {
         5: (empty)
         6: SEMICOLON@181..182 ";" [] []
     5: JS_EXPORT@182..230
-      0: EXPORT_KW@182..190 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@182..190 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_FROM_CLAUSE@190..230
         0: L_CURLY@190..192 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_FROM_SPECIFIER_LIST@192..194
@@ -339,4 +339,4 @@ JsModule {
               2: JS_STRING_LITERAL@222..229 "\"json\"" [] [Whitespace(" ")]
           3: R_CURLY@229..230 "}" [] []
         6: (empty)
-  3: EOF@230..231 "" [Whitespace("\n")] []
+  3: EOF@230..231 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/export_variable_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/export_variable_clause.rast
@@ -22,7 +22,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@13..21 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportVariableClause {
                 declarations: JsVariableDeclarations {
                     kind: CONST_KW@21..27 "const" [] [Whitespace(" ")],
@@ -46,7 +46,7 @@ JsModule {
             },
         },
         JsExport {
-            export_token: EXPORT_KW@33..41 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportVariableClause {
                 declarations: JsVariableDeclarations {
                     kind: VAR_KW@41..45 "var" [] [Whitespace(" ")],
@@ -88,7 +88,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@57..58 "" [Whitespace("\n")] [],
+    eof_token: EOF@57..58 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..58
@@ -109,7 +109,7 @@ JsModule {
               3: (empty)
         1: SEMICOLON@12..13 ";" [] []
     1: JS_EXPORT@13..33
-      0: EXPORT_KW@13..21 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@13..21 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_VARIABLE_CLAUSE@21..33
         0: JS_VARIABLE_DECLARATIONS@21..32
           0: CONST_KW@21..27 "const" [] [Whitespace(" ")]
@@ -125,7 +125,7 @@ JsModule {
                   0: JS_NUMBER_LITERAL@31..32 "3" [] []
         1: SEMICOLON@32..33 ";" [] []
     2: JS_EXPORT@33..57
-      0: EXPORT_KW@33..41 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@33..41 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_VARIABLE_CLAUSE@41..57
         0: JS_VARIABLE_DECLARATIONS@41..56
           0: VAR_KW@41..45 "var" [] [Whitespace(" ")]
@@ -154,4 +154,4 @@ JsModule {
                 1: JS_NUMBER_LITERAL_EXPRESSION@55..56
                   0: JS_NUMBER_LITERAL@55..56 "3" [] []
         1: SEMICOLON@56..57 ";" [] []
-  3: EOF@57..58 "" [Whitespace("\n")] []
+  3: EOF@57..58 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_in_initializer_loose_mode.rast
@@ -3,7 +3,7 @@ JsScript {
     directives: JsDirectiveList [],
     statements: JsStatementList [
         JsForInStatement {
-            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@14..15 "(" [] [],
             initializer: JsForVariableDeclaration {
                 kind_token: VAR_KW@15..19 "var" [] [Whitespace(" ")],
@@ -35,7 +35,7 @@ JsScript {
             },
         },
     ],
-    eof_token: EOF@34..35 "" [Whitespace("\n")] [],
+    eof_token: EOF@34..35 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..35
@@ -43,7 +43,7 @@ JsScript {
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_STATEMENT_LIST@0..34
     0: JS_FOR_IN_STATEMENT@0..34
-      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@0..14 "for" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@14..15 "(" [] []
       2: JS_FOR_VARIABLE_DECLARATION@15..25
         0: VAR_KW@15..19 "var" [] [Whitespace(" ")]
@@ -66,4 +66,4 @@ JsScript {
         0: L_CURLY@32..33 "{" [] []
         1: JS_STATEMENT_LIST@33..33
         2: R_CURLY@33..34 "}" [] []
-  3: EOF@34..35 "" [Whitespace("\n")] []
+  3: EOF@34..35 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/for_stmt.rast
@@ -50,7 +50,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@31..36 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@36..37 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -94,7 +94,7 @@ JsModule {
             },
         },
         JsForInStatement {
-            for_token: FOR_KW@63..68 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@63..68 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@68..69 "(" [] [],
             initializer: JsIdentifierAssignment {
                 name_token: IDENT@69..73 "foo" [] [Whitespace(" ")],
@@ -113,7 +113,7 @@ JsModule {
             },
         },
         JsForStatement {
-            for_token: FOR_KW@82..87 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@82..87 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@87..88 "(" [] [],
             initializer: missing (optional),
             first_semi_token: SEMICOLON@88..89 ";" [] [],
@@ -128,7 +128,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@94..99 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@94..99 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: missing (optional),
             l_paren_token: L_PAREN@99..100 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -156,7 +156,7 @@ JsModule {
             },
         },
         JsForStatement {
-            for_token: FOR_KW@117..122 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@117..122 "for" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@122..123 "(" [] [],
             initializer: JsVariableDeclarations {
                 kind: LET_KW@123..127 "let" [] [Whitespace(" ")],
@@ -219,7 +219,7 @@ JsModule {
             },
         },
         JsForOfStatement {
-            for_token: FOR_KW@155..160 "for" [Whitespace("\n")] [Whitespace(" ")],
+            for_token: FOR_KW@155..160 "for" [Newline("\n")] [Whitespace(" ")],
             await_token: AWAIT_KW@160..166 "await" [] [Whitespace(" ")],
             l_paren_token: L_PAREN@166..167 "(" [] [],
             initializer: JsForVariableDeclaration {
@@ -247,7 +247,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@182..183 "" [Whitespace("\n")] [],
+    eof_token: EOF@182..183 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..183
@@ -288,7 +288,7 @@ JsModule {
         1: JS_STATEMENT_LIST@30..30
         2: R_CURLY@30..31 "}" [] []
     1: JS_FOR_OF_STATEMENT@31..63
-      0: FOR_KW@31..36 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@31..36 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@36..37 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@37..54
@@ -321,7 +321,7 @@ JsModule {
         1: JS_STATEMENT_LIST@62..62
         2: R_CURLY@62..63 "}" [] []
     2: JS_FOR_IN_STATEMENT@63..82
-      0: FOR_KW@63..68 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@63..68 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@68..69 "(" [] []
       2: JS_IDENTIFIER_ASSIGNMENT@69..73
         0: IDENT@69..73 "foo" [] [Whitespace(" ")]
@@ -336,7 +336,7 @@ JsModule {
         1: JS_STATEMENT_LIST@81..81
         2: R_CURLY@81..82 "}" [] []
     3: JS_FOR_STATEMENT@82..94
-      0: FOR_KW@82..87 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@82..87 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@87..88 "(" [] []
       2: (empty)
       3: SEMICOLON@88..89 ";" [] []
@@ -349,7 +349,7 @@ JsModule {
         1: JS_STATEMENT_LIST@93..93
         2: R_CURLY@93..94 "}" [] []
     4: JS_FOR_OF_STATEMENT@94..117
-      0: FOR_KW@94..99 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@94..99 "for" [Newline("\n")] [Whitespace(" ")]
       1: (empty)
       2: L_PAREN@99..100 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@100..108
@@ -371,7 +371,7 @@ JsModule {
         1: JS_STATEMENT_LIST@116..116
         2: R_CURLY@116..117 "}" [] []
     5: JS_FOR_STATEMENT@117..155
-      0: FOR_KW@117..122 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@117..122 "for" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@122..123 "(" [] []
       2: JS_VARIABLE_DECLARATIONS@123..139
         0: LET_KW@123..127 "let" [] [Whitespace(" ")]
@@ -415,7 +415,7 @@ JsModule {
         1: JS_STATEMENT_LIST@154..154
         2: R_CURLY@154..155 "}" [] []
     6: JS_FOR_OF_STATEMENT@155..182
-      0: FOR_KW@155..160 "for" [Whitespace("\n")] [Whitespace(" ")]
+      0: FOR_KW@155..160 "for" [Newline("\n")] [Whitespace(" ")]
       1: AWAIT_KW@160..166 "await" [] [Whitespace(" ")]
       2: L_PAREN@166..167 "(" [] []
       3: JS_FOR_VARIABLE_DECLARATION@167..173
@@ -436,4 +436,4 @@ JsModule {
         0: L_CURLY@180..181 "{" [] []
         1: JS_STATEMENT_LIST@181..181
         2: R_CURLY@181..182 "}" [] []
-  3: EOF@182..183 "" [Whitespace("\n")] []
+  3: EOF@182..183 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/function_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_decl.rast
@@ -25,7 +25,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@17..27 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@17..27 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: STAR@27..28 "*" [] [],
             id: JsIdentifierBinding {
                 name_token: IDENT@28..31 "foo" [] [],
@@ -45,7 +45,7 @@ JsModule {
             },
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@36..43 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@36..43 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")],
             star_token: STAR@52..53 "*" [] [],
             id: JsIdentifierBinding {
@@ -66,7 +66,7 @@ JsModule {
             },
         },
         JsFunctionStatement {
-            async_token: ASYNC_KW@61..68 "async" [Whitespace("\n")] [Whitespace(" ")],
+            async_token: ASYNC_KW@61..68 "async" [Newline("\n")] [Whitespace(" ")],
             function_token: FUNCTION_KW@68..77 "function" [] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
@@ -88,7 +88,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@85..95 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@85..95 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: STAR@95..96 "*" [] [],
             id: JsIdentifierBinding {
                 name_token: IDENT@96..99 "foo" [] [],
@@ -106,7 +106,7 @@ JsModule {
                 statements: JsStatementList [
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@103..112 "yield" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            yield_token: YIELD_KW@103..112 "yield" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             argument: JsYieldArgument {
                                 star_token: missing (optional),
                                 expression: JsIdentifierExpression {
@@ -119,11 +119,11 @@ JsModule {
                         semicolon_token: SEMICOLON@115..116 ";" [] [],
                     },
                 ],
-                r_curly_token: R_CURLY@116..118 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@116..118 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@118..119 "" [Whitespace("\n")] [],
+    eof_token: EOF@118..119 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..119
@@ -149,7 +149,7 @@ JsModule {
         3: R_CURLY@16..17 "}" [] []
     1: JS_FUNCTION_STATEMENT@17..36
       0: (empty)
-      1: FUNCTION_KW@17..27 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@17..27 "function" [Newline("\n")] [Whitespace(" ")]
       2: STAR@27..28 "*" [] []
       3: JS_IDENTIFIER_BINDING@28..31
         0: IDENT@28..31 "foo" [] []
@@ -165,7 +165,7 @@ JsModule {
         2: JS_STATEMENT_LIST@35..35
         3: R_CURLY@35..36 "}" [] []
     2: JS_FUNCTION_STATEMENT@36..61
-      0: ASYNC_KW@36..43 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@36..43 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@43..52 "function" [] [Whitespace(" ")]
       2: STAR@52..53 "*" [] []
       3: JS_IDENTIFIER_BINDING@53..56
@@ -182,7 +182,7 @@ JsModule {
         2: JS_STATEMENT_LIST@60..60
         3: R_CURLY@60..61 "}" [] []
     3: JS_FUNCTION_STATEMENT@61..85
-      0: ASYNC_KW@61..68 "async" [Whitespace("\n")] [Whitespace(" ")]
+      0: ASYNC_KW@61..68 "async" [Newline("\n")] [Whitespace(" ")]
       1: FUNCTION_KW@68..77 "function" [] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@77..80
@@ -200,7 +200,7 @@ JsModule {
         3: R_CURLY@84..85 "}" [] []
     4: JS_FUNCTION_STATEMENT@85..118
       0: (empty)
-      1: FUNCTION_KW@85..95 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@85..95 "function" [Newline("\n")] [Whitespace(" ")]
       2: STAR@95..96 "*" [] []
       3: JS_IDENTIFIER_BINDING@96..99
         0: IDENT@96..99 "foo" [] []
@@ -216,12 +216,12 @@ JsModule {
         2: JS_STATEMENT_LIST@103..116
           0: JS_EXPRESSION_STATEMENT@103..116
             0: JS_YIELD_EXPRESSION@103..115
-              0: YIELD_KW@103..112 "yield" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+              0: YIELD_KW@103..112 "yield" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
               1: JS_YIELD_ARGUMENT@112..115
                 0: (empty)
                 1: JS_IDENTIFIER_EXPRESSION@112..115
                   0: JS_REFERENCE_IDENTIFIER@112..115
                     0: IDENT@112..115 "foo" [] []
             1: SEMICOLON@115..116 ";" [] []
-        3: R_CURLY@116..118 "}" [Whitespace("\n")] []
-  3: EOF@118..119 "" [Whitespace("\n")] []
+        3: R_CURLY@116..118 "}" [Newline("\n")] []
+  3: EOF@118..119 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/function_declaration_script.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_declaration_script.rast
@@ -4,7 +4,7 @@ JsScript {
     statements: JsStatementList [
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@19..23 "test" [] [],
@@ -32,7 +32,7 @@ JsScript {
             },
         },
     ],
-    eof_token: EOF@33..34 "" [Whitespace("\n")] [],
+    eof_token: EOF@33..34 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..34
@@ -41,7 +41,7 @@ JsScript {
   2: JS_STATEMENT_LIST@0..33
     0: JS_FUNCTION_STATEMENT@0..33
       0: (empty)
-      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@19..23
         0: IDENT@19..23 "test" [] []
@@ -61,4 +61,4 @@ JsScript {
         1: JS_DIRECTIVE_LIST@32..32
         2: JS_STATEMENT_LIST@32..32
         3: R_CURLY@32..33 "}" [] []
-  3: EOF@33..34 "" [Whitespace("\n")] []
+  3: EOF@33..34 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/function_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_expr.rast
@@ -41,7 +41,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@21..26 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -79,7 +79,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@47..48 "" [Whitespace("\n")] [],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..48
@@ -116,7 +116,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@21..47
       0: JS_VARIABLE_DECLARATIONS@21..47
-        0: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@21..26 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@26..47
           0: JS_VARIABLE_DECLARATION@26..47
             0: JS_IDENTIFIER_BINDING@26..28
@@ -143,4 +143,4 @@ JsModule {
                   2: JS_STATEMENT_LIST@46..46
                   3: R_CURLY@46..47 "}" [] []
       1: (empty)
-  3: EOF@47..48 "" [Whitespace("\n")] []
+  3: EOF@47..48 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@15..21 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@15..21 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@21..24 "foo" [] [],
                     },
@@ -33,7 +33,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@29..35 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@29..35 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@35..41 "static" [] [],
                     },
@@ -49,7 +49,7 @@ JsModule {
                 },
                 JsGetterClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@46..55 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@46..55 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     get_token: GET_KW@55..59 "get" [] [Whitespace(" ")],
                     name: JsLiteralMemberName {
@@ -69,7 +69,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@67..73 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@67..73 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: JS_STRING_LITERAL@73..78 "\"baz\"" [] [],
                     },
@@ -87,7 +87,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@83..89 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@83..89 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsComputedMemberName {
                         l_brack_token: L_BRACK@89..90 "[" [] [],
                         expression: JsBinaryExpression {
@@ -115,7 +115,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@105..111 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@105..111 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: JS_NUMBER_LITERAL@111..112 "5" [] [],
                     },
@@ -133,7 +133,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    get_token: GET_KW@117..123 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    get_token: GET_KW@117..123 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsPrivateClassMemberName {
                         hash_token: HASH@123..124 "#" [] [],
                         id_token: IDENT@124..131 "private" [] [],
@@ -149,10 +149,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@136..138 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@136..138 "}" [Newline("\n")] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@138..145 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@138..145 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@145..156 "NotGetters" [] [Whitespace(" ")],
             },
@@ -167,7 +167,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@157..162 "get" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@157..162 "get" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -187,7 +187,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@167..175 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@167..175 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@175..178 "get" [] [],
@@ -208,7 +208,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@183..192 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@183..192 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
@@ -230,10 +230,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@200..202 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@200..202 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@202..203 "" [Whitespace("\n")] [],
+    eof_token: EOF@202..203 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..203
@@ -252,7 +252,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@15..21 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@15..21 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@21..24
             0: IDENT@21..24 "foo" [] []
           5: L_PAREN@24..25 "(" [] []
@@ -267,7 +267,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@29..35 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@29..35 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@35..41
             0: IDENT@35..41 "static" [] []
           5: L_PAREN@41..42 "(" [] []
@@ -280,7 +280,7 @@ JsModule {
             3: R_CURLY@45..46 "}" [] []
         2: JS_GETTER_CLASS_MEMBER@46..67
           0: (empty)
-          1: STATIC_KW@46..55 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          1: STATIC_KW@46..55 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           2: (empty)
           3: GET_KW@55..59 "get" [] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@59..62
@@ -297,7 +297,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@67..73 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@67..73 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@73..78
             0: JS_STRING_LITERAL@73..78 "\"baz\"" [] []
           5: L_PAREN@78..79 "(" [] []
@@ -312,7 +312,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@83..89 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@83..89 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_COMPUTED_MEMBER_NAME@89..100
             0: L_BRACK@89..90 "[" [] []
             1: JS_BINARY_EXPRESSION@90..99
@@ -334,7 +334,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@105..111 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@105..111 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@111..112
             0: JS_NUMBER_LITERAL@111..112 "5" [] []
           5: L_PAREN@112..113 "(" [] []
@@ -349,7 +349,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: GET_KW@117..123 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: GET_KW@117..123 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_PRIVATE_CLASS_MEMBER_NAME@123..131
             0: HASH@123..124 "#" [] []
             1: IDENT@124..131 "private" [] []
@@ -361,9 +361,9 @@ JsModule {
             1: JS_DIRECTIVE_LIST@135..135
             2: JS_STATEMENT_LIST@135..135
             3: R_CURLY@135..136 "}" [] []
-      6: R_CURLY@136..138 "}" [Whitespace("\n")] []
+      6: R_CURLY@136..138 "}" [Newline("\n")] []
     1: JS_CLASS_STATEMENT@138..202
-      0: CLASS_KW@138..145 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@138..145 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@145..156
         0: IDENT@145..156 "NotGetters" [] [Whitespace(" ")]
       2: (empty)
@@ -377,7 +377,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@157..162
-            0: IDENT@157..162 "get" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@157..162 "get" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@162..165
             0: L_PAREN@162..163 "(" [] []
@@ -393,7 +393,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@167..175 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: ASYNC_KW@167..175 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@175..178
             0: IDENT@175..178 "get" [] []
@@ -410,7 +410,7 @@ JsModule {
             3: R_CURLY@182..183 "}" [] []
         2: JS_METHOD_CLASS_MEMBER@183..200
           0: (empty)
-          1: STATIC_KW@183..192 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          1: STATIC_KW@183..192 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: (empty)
@@ -427,5 +427,5 @@ JsModule {
             1: JS_DIRECTIVE_LIST@199..199
             2: JS_STATEMENT_LIST@199..199
             3: R_CURLY@199..200 "}" [] []
-      6: R_CURLY@200..202 "}" [Whitespace("\n")] []
-  3: EOF@202..203 "" [Whitespace("\n")] []
+      6: R_CURLY@200..202 "}" [Newline("\n")] []
+  3: EOF@202..203 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
@@ -18,7 +18,7 @@ JsModule {
                                 l_curly_token: L_CURLY@8..9 "{" [] [],
                                 members: JsObjectMemberList [
                                     JsGetterObjectMember {
-                                        get_token: GET_KW@9..15 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        get_token: GET_KW@9..15 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: IDENT@15..18 "foo" [] [],
                                         },
@@ -30,7 +30,7 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@22..33 "return" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@22..33 "return" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
                                                     argument: JsIdentifierExpression {
                                                         name: JsReferenceIdentifier {
                                                             value_token: IDENT@33..36 "foo" [] [],
@@ -39,12 +39,12 @@ JsModule {
                                                     semicolon_token: SEMICOLON@36..37 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@37..40 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@37..40 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@40..41 "," [] [],
                                     JsGetterObjectMember {
-                                        get_token: GET_KW@41..47 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        get_token: GET_KW@41..47 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: JS_STRING_LITERAL@47..52 "\"bar\"" [] [],
                                         },
@@ -56,19 +56,19 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@56..66 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@56..66 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
                                                     argument: JsStringLiteralExpression {
                                                         value_token: JS_STRING_LITERAL@66..71 "\"bar\"" [] [],
                                                     },
                                                     semicolon_token: SEMICOLON@71..72 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@72..75 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@72..75 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@75..76 "," [] [],
                                     JsGetterObjectMember {
-                                        get_token: GET_KW@76..82 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        get_token: GET_KW@76..82 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsComputedMemberName {
                                             l_brack_token: L_BRACK@82..83 "[" [] [],
                                             expression: JsBinaryExpression {
@@ -90,7 +90,7 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@97..107 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@97..107 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
                                                     argument: JsBinaryExpression {
                                                         left: JsStringLiteralExpression {
                                                             value_token: JS_STRING_LITERAL@107..111 "\"a\"" [] [Whitespace(" ")],
@@ -103,12 +103,12 @@ JsModule {
                                                     semicolon_token: missing (optional),
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@116..119 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@116..119 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@119..120 "," [] [],
                                     JsGetterObjectMember {
-                                        get_token: GET_KW@120..126 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                        get_token: GET_KW@120..126 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: JS_NUMBER_LITERAL@126..127 "5" [] [],
                                         },
@@ -120,14 +120,14 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@131..141 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@131..141 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
                                                     argument: JsNumberLiteralExpression {
                                                         value_token: JS_NUMBER_LITERAL@141..142 "5" [] [],
                                                     },
                                                     semicolon_token: SEMICOLON@142..143 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@143..146 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                                            r_curly_token: R_CURLY@143..146 "}" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                     },
                                     COMMA@146..147 "," [] [],
@@ -135,7 +135,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: IDENT@147..152 "get" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value: IDENT@147..152 "get" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -149,18 +149,18 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@156..166 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@156..166 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
                                                     argument: JsStringLiteralExpression {
                                                         value_token: JS_STRING_LITERAL@166..201 "\"This is a method and not a getter\"" [] [],
                                                     },
                                                     semicolon_token: SEMICOLON@201..202 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@202..205 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                                            r_curly_token: R_CURLY@202..205 "}" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@205..207 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@205..207 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -169,7 +169,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@207..208 "" [Whitespace("\n")] [],
+    eof_token: EOF@207..208 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..208
@@ -191,7 +191,7 @@ JsModule {
                 0: L_CURLY@8..9 "{" [] []
                 1: JS_OBJECT_MEMBER_LIST@9..205
                   0: JS_GETTER_OBJECT_MEMBER@9..40
-                    0: GET_KW@9..15 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: GET_KW@9..15 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@15..18
                       0: IDENT@15..18 "foo" [] []
                     2: L_PAREN@18..19 "(" [] []
@@ -202,15 +202,15 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@22..22
                       2: JS_STATEMENT_LIST@22..37
                         0: JS_RETURN_STATEMENT@22..37
-                          0: RETURN_KW@22..33 "return" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")]
+                          0: RETURN_KW@22..33 "return" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")]
                           1: JS_IDENTIFIER_EXPRESSION@33..36
                             0: JS_REFERENCE_IDENTIFIER@33..36
                               0: IDENT@33..36 "foo" [] []
                           2: SEMICOLON@36..37 ";" [] []
-                      3: R_CURLY@37..40 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@37..40 "}" [Newline("\n"), Whitespace(" ")] []
                   1: COMMA@40..41 "," [] []
                   2: JS_GETTER_OBJECT_MEMBER@41..75
-                    0: GET_KW@41..47 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: GET_KW@41..47 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@47..52
                       0: JS_STRING_LITERAL@47..52 "\"bar\"" [] []
                     2: L_PAREN@52..53 "(" [] []
@@ -221,14 +221,14 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@56..56
                       2: JS_STATEMENT_LIST@56..72
                         0: JS_RETURN_STATEMENT@56..72
-                          0: RETURN_KW@56..66 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")]
+                          0: RETURN_KW@56..66 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
                           1: JS_STRING_LITERAL_EXPRESSION@66..71
                             0: JS_STRING_LITERAL@66..71 "\"bar\"" [] []
                           2: SEMICOLON@71..72 ";" [] []
-                      3: R_CURLY@72..75 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@72..75 "}" [Newline("\n"), Whitespace(" ")] []
                   3: COMMA@75..76 "," [] []
                   4: JS_GETTER_OBJECT_MEMBER@76..119
-                    0: GET_KW@76..82 "get" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: GET_KW@76..82 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_COMPUTED_MEMBER_NAME@82..93
                       0: L_BRACK@82..83 "[" [] []
                       1: JS_BINARY_EXPRESSION@83..92
@@ -246,7 +246,7 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@97..97
                       2: JS_STATEMENT_LIST@97..116
                         0: JS_RETURN_STATEMENT@97..116
-                          0: RETURN_KW@97..107 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")]
+                          0: RETURN_KW@97..107 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
                           1: JS_BINARY_EXPRESSION@107..116
                             0: JS_STRING_LITERAL_EXPRESSION@107..111
                               0: JS_STRING_LITERAL@107..111 "\"a\"" [] [Whitespace(" ")]
@@ -254,10 +254,10 @@ JsModule {
                             2: JS_STRING_LITERAL_EXPRESSION@113..116
                               0: JS_STRING_LITERAL@113..116 "\"b\"" [] []
                           2: (empty)
-                      3: R_CURLY@116..119 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@116..119 "}" [Newline("\n"), Whitespace(" ")] []
                   5: COMMA@119..120 "," [] []
                   6: JS_GETTER_OBJECT_MEMBER@120..146
-                    0: GET_KW@120..126 "get" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                    0: GET_KW@120..126 "get" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@126..127
                       0: JS_NUMBER_LITERAL@126..127 "5" [] []
                     2: L_PAREN@127..128 "(" [] []
@@ -268,17 +268,17 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@131..131
                       2: JS_STATEMENT_LIST@131..143
                         0: JS_RETURN_STATEMENT@131..143
-                          0: RETURN_KW@131..141 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")]
+                          0: RETURN_KW@131..141 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
                           1: JS_NUMBER_LITERAL_EXPRESSION@141..142
                             0: JS_NUMBER_LITERAL@141..142 "5" [] []
                           2: SEMICOLON@142..143 ";" [] []
-                      3: R_CURLY@143..146 "}" [Whitespace("\n"), Whitespace("\t")] []
+                      3: R_CURLY@143..146 "}" [Newline("\n"), Whitespace("\t")] []
                   7: COMMA@146..147 "," [] []
                   8: JS_METHOD_OBJECT_MEMBER@147..205
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@147..152
-                      0: IDENT@147..152 "get" [Whitespace("\n"), Whitespace("\t")] []
+                      0: IDENT@147..152 "get" [Newline("\n"), Whitespace("\t")] []
                     3: (empty)
                     4: JS_PARAMETERS@152..155
                       0: L_PAREN@152..153 "(" [] []
@@ -290,11 +290,11 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@156..156
                       2: JS_STATEMENT_LIST@156..202
                         0: JS_RETURN_STATEMENT@156..202
-                          0: RETURN_KW@156..166 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")]
+                          0: RETURN_KW@156..166 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
                           1: JS_STRING_LITERAL_EXPRESSION@166..201
                             0: JS_STRING_LITERAL@166..201 "\"This is a method and not a getter\"" [] []
                           2: SEMICOLON@201..202 ";" [] []
-                      3: R_CURLY@202..205 "}" [Whitespace("\n"), Whitespace("\t")] []
-                2: R_CURLY@205..207 "}" [Whitespace("\n")] []
+                      3: R_CURLY@202..205 "}" [Newline("\n"), Whitespace("\t")] []
+                2: R_CURLY@205..207 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@207..208 "" [Whitespace("\n")] []
+  3: EOF@207..208 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -20,7 +20,7 @@ JsModule {
                 optional_chain_token_token: missing (optional),
                 type_args: missing (optional),
                 arguments: JsCallArguments {
-                    l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@7..9 "(" [Newline("\n")] [],
                     args: JsCallArgumentList [
                         JsIdentifierExpression {
                             name: JsReferenceIdentifier {
@@ -34,7 +34,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@13..14 "" [Whitespace("\n")] [],
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..14
@@ -55,11 +55,11 @@ JsModule {
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@7..13
-          0: L_PAREN@7..9 "(" [Whitespace("\n")] []
+          0: L_PAREN@7..9 "(" [Newline("\n")] []
           1: JS_CALL_ARGUMENT_LIST@9..12
             0: JS_IDENTIFIER_EXPRESSION@9..12
               0: JS_REFERENCE_IDENTIFIER@9..12
                 0: IDENT@9..12 "foo" [] []
           2: R_PAREN@12..13 ")" [] []
       1: (empty)
-  3: EOF@13..14 "" [Whitespace("\n")] []
+  3: EOF@13..14 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/identifier.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier.rast
@@ -11,7 +11,7 @@ JsModule {
             semicolon_token: SEMICOLON@3..4 ";" [] [],
         },
     ],
-    eof_token: EOF@4..5 "" [Whitespace("\n")] [],
+    eof_token: EOF@4..5 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..5
@@ -23,4 +23,4 @@ JsModule {
         0: JS_REFERENCE_IDENTIFIER@0..3
           0: IDENT@0..3 "foo" [] []
       1: SEMICOLON@3..4 ";" [] []
-  3: EOF@4..5 "" [Whitespace("\n")] []
+  3: EOF@4..5 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/identifier_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_loose_mode.rast
@@ -5,7 +5,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@0..13 "foo" [Comments("// SCRIPT"), Whitespace("\n")] [],
+                    value_token: IDENT@0..13 "foo" [Comments("// SCRIPT"), Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@13..14 ";" [] [],
@@ -13,7 +13,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@14..20 "yield" [Whitespace("\n")] [],
+                    value_token: IDENT@14..20 "yield" [Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@20..21 ";" [] [],
@@ -21,13 +21,13 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@21..27 "await" [Whitespace("\n")] [],
+                    value_token: IDENT@21..27 "await" [Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@27..28 ";" [] [],
         },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..29
@@ -37,16 +37,16 @@ JsScript {
     0: JS_EXPRESSION_STATEMENT@0..14
       0: JS_IDENTIFIER_EXPRESSION@0..13
         0: JS_REFERENCE_IDENTIFIER@0..13
-          0: IDENT@0..13 "foo" [Comments("// SCRIPT"), Whitespace("\n")] []
+          0: IDENT@0..13 "foo" [Comments("// SCRIPT"), Newline("\n")] []
       1: SEMICOLON@13..14 ";" [] []
     1: JS_EXPRESSION_STATEMENT@14..21
       0: JS_IDENTIFIER_EXPRESSION@14..20
         0: JS_REFERENCE_IDENTIFIER@14..20
-          0: IDENT@14..20 "yield" [Whitespace("\n")] []
+          0: IDENT@14..20 "yield" [Newline("\n")] []
       1: SEMICOLON@20..21 ";" [] []
     2: JS_EXPRESSION_STATEMENT@21..28
       0: JS_IDENTIFIER_EXPRESSION@21..27
         0: JS_REFERENCE_IDENTIFIER@21..27
-          0: IDENT@21..27 "await" [Whitespace("\n")] []
+          0: IDENT@21..27 "await" [Newline("\n")] []
       1: SEMICOLON@27..28 ";" [] []
-  3: EOF@28..29 "" [Whitespace("\n")] []
+  3: EOF@28..29 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
+++ b/crates/rslint_parser/test_data/inline/ok/identifier_reference.rast
@@ -5,7 +5,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@0..13 "foo" [Comments("// SCRIPT"), Whitespace("\n")] [],
+                    value_token: IDENT@0..13 "foo" [Comments("// SCRIPT"), Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@13..14 ";" [] [],
@@ -13,7 +13,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@14..20 "yield" [Whitespace("\n")] [],
+                    value_token: IDENT@14..20 "yield" [Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@20..21 ";" [] [],
@@ -21,13 +21,13 @@ JsScript {
         JsExpressionStatement {
             expression: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
-                    value_token: IDENT@21..27 "await" [Whitespace("\n")] [],
+                    value_token: IDENT@21..27 "await" [Newline("\n")] [],
                 },
             },
             semicolon_token: SEMICOLON@27..28 ";" [] [],
         },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..29
@@ -37,16 +37,16 @@ JsScript {
     0: JS_EXPRESSION_STATEMENT@0..14
       0: JS_IDENTIFIER_EXPRESSION@0..13
         0: JS_REFERENCE_IDENTIFIER@0..13
-          0: IDENT@0..13 "foo" [Comments("// SCRIPT"), Whitespace("\n")] []
+          0: IDENT@0..13 "foo" [Comments("// SCRIPT"), Newline("\n")] []
       1: SEMICOLON@13..14 ";" [] []
     1: JS_EXPRESSION_STATEMENT@14..21
       0: JS_IDENTIFIER_EXPRESSION@14..20
         0: JS_REFERENCE_IDENTIFIER@14..20
-          0: IDENT@14..20 "yield" [Whitespace("\n")] []
+          0: IDENT@14..20 "yield" [Newline("\n")] []
       1: SEMICOLON@20..21 ";" [] []
     2: JS_EXPRESSION_STATEMENT@21..28
       0: JS_IDENTIFIER_EXPRESSION@21..27
         0: JS_REFERENCE_IDENTIFIER@21..27
-          0: IDENT@21..27 "await" [Whitespace("\n")] []
+          0: IDENT@21..27 "await" [Newline("\n")] []
       1: SEMICOLON@27..28 ";" [] []
-  3: EOF@28..29 "" [Whitespace("\n")] []
+  3: EOF@28..29 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/if_stmt.rast
@@ -24,7 +24,7 @@ JsModule {
             },
         },
         JsIfStatement {
-            if_token: IF_KW@20..24 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@20..24 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@24..25 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@25..29 "true" [] [],
@@ -38,7 +38,7 @@ JsModule {
             else_clause: missing (optional),
         },
         JsIfStatement {
-            if_token: IF_KW@33..37 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@33..37 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@37..38 "(" [] [],
             test: JsBooleanLiteralExpression {
                 value_token: TRUE_KW@38..42 "true" [] [],
@@ -53,7 +53,7 @@ JsModule {
             else_clause: missing (optional),
         },
         JsIfStatement {
-            if_token: IF_KW@49..53 "if" [Whitespace("\n")] [Whitespace(" ")],
+            if_token: IF_KW@49..53 "if" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@53..54 "(" [] [],
             test: JsIdentifierExpression {
                 name: JsReferenceIdentifier {
@@ -92,7 +92,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@87..88 "" [Whitespace("\n")] [],
+    eof_token: EOF@87..88 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..88
@@ -116,7 +116,7 @@ JsModule {
           1: JS_STATEMENT_LIST@19..19
           2: R_CURLY@19..20 "}" [] []
     1: JS_IF_STATEMENT@20..33
-      0: IF_KW@20..24 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@20..24 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@24..25 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@25..29
         0: TRUE_KW@25..29 "true" [] []
@@ -127,7 +127,7 @@ JsModule {
         2: R_CURLY@32..33 "}" [] []
       5: (empty)
     2: JS_IF_STATEMENT@33..49
-      0: IF_KW@33..37 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@33..37 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@37..38 "(" [] []
       2: JS_BOOLEAN_LITERAL_EXPRESSION@38..42
         0: TRUE_KW@38..42 "true" [] []
@@ -138,7 +138,7 @@ JsModule {
         1: (empty)
       5: (empty)
     3: JS_IF_STATEMENT@49..87
-      0: IF_KW@49..53 "if" [Whitespace("\n")] [Whitespace(" ")]
+      0: IF_KW@49..53 "if" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@53..54 "(" [] []
       2: JS_IDENTIFIER_EXPRESSION@54..57
         0: JS_REFERENCE_IDENTIFIER@54..57
@@ -166,4 +166,4 @@ JsModule {
               0: L_CURLY@85..86 "{" [] []
               1: JS_STATEMENT_LIST@86..86
               2: R_CURLY@86..87 "}" [] []
-  3: EOF@87..88 "" [Whitespace("\n")] []
+  3: EOF@87..88 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_as_identifier.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_as_identifier.rast
@@ -26,7 +26,7 @@ JsModule {
             semicolon_token: SEMICOLON@25..26 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@26..34 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@26..34 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -53,7 +53,7 @@ JsModule {
             semicolon_token: SEMICOLON@58..59 ";" [] [],
         },
     ],
-    eof_token: EOF@59..60 "" [Whitespace("\n")] [],
+    eof_token: EOF@59..60 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..60
@@ -77,7 +77,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@25..26 ";" [] []
     1: JS_IMPORT@26..59
-      0: IMPORT_KW@26..34 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@26..34 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@34..58
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@34..47
@@ -95,4 +95,4 @@ JsModule {
           0: JS_STRING_LITERAL@52..58 "\"test\"" [] []
         4: (empty)
       2: SEMICOLON@58..59 ";" [] []
-  3: EOF@59..60 "" [Whitespace("\n")] []
+  3: EOF@59..60 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_assertion.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_assertion.rast
@@ -24,7 +24,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsImport {
-            import_token: IMPORT_KW@34..42 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@34..42 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@42..48 "\"foo\"" [] [Whitespace(" ")],
@@ -45,7 +45,7 @@ JsModule {
             semicolon_token: SEMICOLON@73..74 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@74..82 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@74..82 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@82..86 "foo" [] [Whitespace(" ")],
@@ -70,7 +70,7 @@ JsModule {
             semicolon_token: SEMICOLON@125..126 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@126..134 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@126..134 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -104,7 +104,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsImport {
-            import_token: IMPORT_KW@178..186 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@178..186 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@186..190 "foo" [] [Whitespace(" ")],
@@ -135,14 +135,14 @@ JsModule {
             semicolon_token: SEMICOLON@253..254 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@254..262 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@254..262 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@262..266 "\"x\"" [] [Whitespace(" ")],
                 },
                 assertion: JsImportAssertion {
                     assert_token: ASSERT_KW@266..272 "assert" [] [],
-                    l_curly_token: L_CURLY@272..275 "{" [Whitespace("\n")] [Whitespace(" ")],
+                    l_curly_token: L_CURLY@272..275 "{" [Newline("\n")] [Whitespace(" ")],
                     assertions: JsImportAssertionEntryList [
                         JsImportAssertionEntry {
                             key: IDENT@275..279 "type" [] [],
@@ -156,7 +156,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@289..290 "" [Whitespace("\n")] [],
+    eof_token: EOF@289..290 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..290
@@ -179,7 +179,7 @@ JsModule {
           3: R_CURLY@33..34 "}" [] []
       2: (empty)
     1: JS_IMPORT@34..74
-      0: IMPORT_KW@34..42 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@34..42 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@42..73
         0: JS_MODULE_SOURCE@42..48
           0: JS_STRING_LITERAL@42..48 "\"foo\"" [] [Whitespace(" ")]
@@ -194,7 +194,7 @@ JsModule {
           3: R_CURLY@72..73 "}" [] []
       2: SEMICOLON@73..74 ";" [] []
     2: JS_IMPORT@74..126
-      0: IMPORT_KW@74..82 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@74..82 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@82..125
         0: JS_IDENTIFIER_BINDING@82..86
           0: IDENT@82..86 "foo" [] [Whitespace(" ")]
@@ -212,7 +212,7 @@ JsModule {
           3: R_CURLY@124..125 "}" [] []
       2: SEMICOLON@125..126 ";" [] []
     3: JS_IMPORT@126..178
-      0: IMPORT_KW@126..134 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@126..134 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@134..178
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@134..141
@@ -236,7 +236,7 @@ JsModule {
           3: R_CURLY@177..178 "}" [] []
       2: (empty)
     4: JS_IMPORT@178..254
-      0: IMPORT_KW@178..186 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@178..186 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@186..253
         0: JS_IDENTIFIER_BINDING@186..190
           0: IDENT@186..190 "foo" [] [Whitespace(" ")]
@@ -259,13 +259,13 @@ JsModule {
           3: R_CURLY@252..253 "}" [] []
       2: SEMICOLON@253..254 ";" [] []
     5: JS_IMPORT@254..289
-      0: IMPORT_KW@254..262 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@254..262 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@262..289
         0: JS_MODULE_SOURCE@262..266
           0: JS_STRING_LITERAL@262..266 "\"x\"" [] [Whitespace(" ")]
         1: JS_IMPORT_ASSERTION@266..289
           0: ASSERT_KW@266..272 "assert" [] []
-          1: L_CURLY@272..275 "{" [Whitespace("\n")] [Whitespace(" ")]
+          1: L_CURLY@272..275 "{" [Newline("\n")] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@275..288
             0: JS_IMPORT_ASSERTION_ENTRY@275..288
               0: IDENT@275..279 "type" [] []
@@ -273,4 +273,4 @@ JsModule {
               2: JS_STRING_LITERAL@281..288 "\"json\"" [] [Whitespace(" ")]
           3: R_CURLY@288..289 "}" [] []
       2: (empty)
-  3: EOF@289..290 "" [Whitespace("\n")] []
+  3: EOF@289..290 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_bare_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_bare_clause.rast
@@ -13,7 +13,7 @@ JsModule {
             semicolon_token: SEMICOLON@13..14 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@14..22 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@14..22 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportBareClause {
                 source: JsModuleSource {
                     value_token: JS_STRING_LITERAL@22..36 "\"no_semicolon\"" [] [],
@@ -23,7 +23,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@36..37 "" [Whitespace("\n")] [],
+    eof_token: EOF@36..37 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..37
@@ -38,10 +38,10 @@ JsModule {
         1: (empty)
       2: SEMICOLON@13..14 ";" [] []
     1: JS_IMPORT@14..36
-      0: IMPORT_KW@14..22 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@14..22 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@22..36
         0: JS_MODULE_SOURCE@22..36
           0: JS_STRING_LITERAL@22..36 "\"no_semicolon\"" [] []
         1: (empty)
       2: (empty)
-  3: EOF@36..37 "" [Whitespace("\n")] []
+  3: EOF@36..37 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -19,7 +19,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsImportCallExpression {
-                import_token: IMPORT_KW@13..20 "import" [Whitespace("\n")] [],
+                import_token: IMPORT_KW@13..20 "import" [Newline("\n")] [],
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@20..21 "(" [] [],
                     args: JsCallArgumentList [
@@ -61,11 +61,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-<<<<<<< HEAD
-    eof_token: EOF@57..58 "" [Whitespace("\n")] [],
-=======
-    eof_token: EOF@13..14 "" [Newline("\n")] [],
->>>>>>> 949e9a78c (avoid alloc in get_trivia)
+    eof_token: EOF@57..58 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..58
@@ -84,7 +80,7 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@13..57
       0: JS_IMPORT_CALL_EXPRESSION@13..57
-        0: IMPORT_KW@13..20 "import" [Whitespace("\n")] []
+        0: IMPORT_KW@13..20 "import" [Newline("\n")] []
         1: JS_CALL_ARGUMENTS@20..57
           0: L_PAREN@20..21 "(" [] []
           1: JS_CALL_ARGUMENT_LIST@21..56
@@ -111,8 +107,4 @@ JsModule {
               2: R_CURLY@55..56 "}" [] []
           2: R_PAREN@56..57 ")" [] []
       1: (empty)
-<<<<<<< HEAD
-  3: EOF@57..58 "" [Whitespace("\n")] []
-=======
-  3: EOF@13..14 "" [Newline("\n")] []
->>>>>>> 949e9a78c (avoid alloc in get_trivia)
+  3: EOF@57..58 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_call.rast
@@ -61,7 +61,11 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
+<<<<<<< HEAD
     eof_token: EOF@57..58 "" [Whitespace("\n")] [],
+=======
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
+>>>>>>> 949e9a78c (avoid alloc in get_trivia)
 }
 
 0: JS_MODULE@0..58
@@ -107,4 +111,8 @@ JsModule {
               2: R_CURLY@55..56 "}" [] []
           2: R_PAREN@56..57 ")" [] []
       1: (empty)
+<<<<<<< HEAD
   3: EOF@57..58 "" [Whitespace("\n")] []
+=======
+  3: EOF@13..14 "" [Newline("\n")] []
+>>>>>>> 949e9a78c (avoid alloc in get_trivia)

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -19,7 +19,7 @@ JsModule {
             semicolon_token: SEMICOLON@26..27 ";" [] [],
         },
     ],
-    eof_token: EOF@27..28 "" [Whitespace("\n")] [],
+    eof_token: EOF@27..28 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..28
@@ -38,4 +38,4 @@ JsModule {
           0: JS_STRING_LITERAL@21..26 "\"bla\"" [] []
         5: (empty)
       2: SEMICOLON@26..27 ";" [] []
-  3: EOF@27..28 "" [Whitespace("\n")] []
+  3: EOF@27..28 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_default_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_default_clause.rast
@@ -17,7 +17,7 @@ JsModule {
             semicolon_token: SEMICOLON@22..23 ";" [] [],
         },
     ],
-    eof_token: EOF@23..24 "" [Whitespace("\n")] [],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..24
@@ -34,4 +34,4 @@ JsModule {
           0: JS_STRING_LITERAL@16..22 "\"test\"" [] []
         3: (empty)
       2: SEMICOLON@22..23 ";" [] []
-  3: EOF@23..24 "" [Whitespace("\n")] []
+  3: EOF@23..24 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_meta.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_meta.rast
@@ -11,7 +11,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -24,4 +24,4 @@ JsModule {
         1: DOT@6..7 "." [] []
         2: META_KW@7..11 "meta" [] []
       1: (empty)
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_named_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_named_clause.rast
@@ -20,7 +20,7 @@ JsModule {
             semicolon_token: SEMICOLON@18..19 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@19..27 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@19..27 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -56,7 +56,7 @@ JsModule {
             semicolon_token: SEMICOLON@48..49 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@49..57 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@49..57 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: JsDefaultImportSpecifier {
                     local_name: JsIdentifierBinding {
@@ -84,7 +84,7 @@ JsModule {
             semicolon_token: SEMICOLON@74..75 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@75..83 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@75..83 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: JsDefaultImportSpecifier {
                     local_name: JsIdentifierBinding {
@@ -108,7 +108,7 @@ JsModule {
             semicolon_token: SEMICOLON@101..102 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@102..110 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@102..110 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -155,7 +155,7 @@ JsModule {
             semicolon_token: SEMICOLON@157..158 ";" [] [],
         },
     ],
-    eof_token: EOF@158..159 "" [Whitespace("\n")] [],
+    eof_token: EOF@158..159 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..159
@@ -176,7 +176,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@18..19 ";" [] []
     1: JS_IMPORT@19..49
-      0: IMPORT_KW@19..27 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@19..27 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@27..48
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@27..40
@@ -201,7 +201,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@48..49 ";" [] []
     2: JS_IMPORT@49..75
-      0: IMPORT_KW@49..57 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@49..57 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@57..74
         0: JS_DEFAULT_IMPORT_SPECIFIER@57..60
           0: JS_IDENTIFIER_BINDING@57..58
@@ -220,7 +220,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@74..75 ";" [] []
     3: JS_IMPORT@75..102
-      0: IMPORT_KW@75..83 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@75..83 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@83..101
         0: JS_DEFAULT_IMPORT_SPECIFIER@83..86
           0: JS_IDENTIFIER_BINDING@83..84
@@ -237,7 +237,7 @@ JsModule {
         4: (empty)
       2: SEMICOLON@101..102 ";" [] []
     4: JS_IMPORT@102..158
-      0: IMPORT_KW@102..110 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@102..110 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@110..157
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@110..149
@@ -269,4 +269,4 @@ JsModule {
           0: JS_STRING_LITERAL@154..157 "\"b\"" [] []
         4: (empty)
       2: SEMICOLON@157..158 ";" [] []
-  3: EOF@158..159 "" [Whitespace("\n")] []
+  3: EOF@158..159 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
@@ -20,7 +20,7 @@ JsModule {
                 optional_chain_token_token: missing (optional),
                 type_args: missing (optional),
                 arguments: JsCallArguments {
-                    l_paren_token: L_PAREN@7..9 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@7..9 "(" [Newline("\n")] [],
                     args: JsCallArgumentList [
                         JsIdentifierExpression {
                             name: JsReferenceIdentifier {
@@ -34,7 +34,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@13..14 "" [Whitespace("\n")] [],
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..14
@@ -55,11 +55,11 @@ JsModule {
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@7..13
-          0: L_PAREN@7..9 "(" [Whitespace("\n")] []
+          0: L_PAREN@7..9 "(" [Newline("\n")] []
           1: JS_CALL_ARGUMENT_LIST@9..12
             0: JS_IDENTIFIER_EXPRESSION@9..12
               0: JS_REFERENCE_IDENTIFIER@9..12
                 0: IDENT@9..12 "foo" [] []
           2: R_PAREN@12..13 ")" [] []
       1: (empty)
-  3: EOF@13..14 "" [Whitespace("\n")] []
+  3: EOF@13..14 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_unary_expressions.rast
@@ -23,7 +23,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: VOID_KW@17..23 "void" [Whitespace("\n")] [Whitespace(" ")],
+                operator: VOID_KW@17..23 "void" [Newline("\n")] [Whitespace(" ")],
                 argument: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@23..24 "a" [] [],
@@ -34,7 +34,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: TYPEOF_KW@25..33 "typeof" [Whitespace("\n")] [Whitespace(" ")],
+                operator: TYPEOF_KW@25..33 "typeof" [Newline("\n")] [Whitespace(" ")],
                 argument: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@33..34 "a" [] [],
@@ -45,7 +45,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: PLUS@35..37 "+" [Whitespace("\n")] [],
+                operator: PLUS@35..37 "+" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@37..38 "1" [] [],
                 },
@@ -54,7 +54,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: MINUS@39..41 "-" [Whitespace("\n")] [],
+                operator: MINUS@39..41 "-" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@41..42 "1" [] [],
                 },
@@ -63,7 +63,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: TILDE@43..45 "~" [Whitespace("\n")] [],
+                operator: TILDE@43..45 "~" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@45..46 "1" [] [],
                 },
@@ -72,7 +72,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: BANG@47..49 "!" [Whitespace("\n")] [],
+                operator: BANG@47..49 "!" [Newline("\n")] [],
                 argument: JsBooleanLiteralExpression {
                     value_token: TRUE_KW@49..53 "true" [] [],
                 },
@@ -83,7 +83,7 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsBinaryExpression {
                     left: JsUnaryExpression {
-                        operator: MINUS@54..56 "-" [Whitespace("\n")] [],
+                        operator: MINUS@54..56 "-" [Newline("\n")] [],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@56..58 "a" [] [Whitespace(" ")],
@@ -113,7 +113,7 @@ JsModule {
             semicolon_token: SEMICOLON@67..68 ";" [] [],
         },
     ],
-    eof_token: EOF@68..69 "" [Whitespace("\n")] [],
+    eof_token: EOF@68..69 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..69
@@ -135,39 +135,39 @@ JsModule {
       1: SEMICOLON@16..17 ";" [] []
     1: JS_EXPRESSION_STATEMENT@17..25
       0: JS_UNARY_EXPRESSION@17..24
-        0: VOID_KW@17..23 "void" [Whitespace("\n")] [Whitespace(" ")]
+        0: VOID_KW@17..23 "void" [Newline("\n")] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@23..24
           0: JS_REFERENCE_IDENTIFIER@23..24
             0: IDENT@23..24 "a" [] []
       1: SEMICOLON@24..25 ";" [] []
     2: JS_EXPRESSION_STATEMENT@25..35
       0: JS_UNARY_EXPRESSION@25..34
-        0: TYPEOF_KW@25..33 "typeof" [Whitespace("\n")] [Whitespace(" ")]
+        0: TYPEOF_KW@25..33 "typeof" [Newline("\n")] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@33..34
           0: JS_REFERENCE_IDENTIFIER@33..34
             0: IDENT@33..34 "a" [] []
       1: SEMICOLON@34..35 ";" [] []
     3: JS_EXPRESSION_STATEMENT@35..39
       0: JS_UNARY_EXPRESSION@35..38
-        0: PLUS@35..37 "+" [Whitespace("\n")] []
+        0: PLUS@35..37 "+" [Newline("\n")] []
         1: JS_NUMBER_LITERAL_EXPRESSION@37..38
           0: JS_NUMBER_LITERAL@37..38 "1" [] []
       1: SEMICOLON@38..39 ";" [] []
     4: JS_EXPRESSION_STATEMENT@39..43
       0: JS_UNARY_EXPRESSION@39..42
-        0: MINUS@39..41 "-" [Whitespace("\n")] []
+        0: MINUS@39..41 "-" [Newline("\n")] []
         1: JS_NUMBER_LITERAL_EXPRESSION@41..42
           0: JS_NUMBER_LITERAL@41..42 "1" [] []
       1: SEMICOLON@42..43 ";" [] []
     5: JS_EXPRESSION_STATEMENT@43..47
       0: JS_UNARY_EXPRESSION@43..46
-        0: TILDE@43..45 "~" [Whitespace("\n")] []
+        0: TILDE@43..45 "~" [Newline("\n")] []
         1: JS_NUMBER_LITERAL_EXPRESSION@45..46
           0: JS_NUMBER_LITERAL@45..46 "1" [] []
       1: SEMICOLON@46..47 ";" [] []
     6: JS_EXPRESSION_STATEMENT@47..54
       0: JS_UNARY_EXPRESSION@47..53
-        0: BANG@47..49 "!" [Whitespace("\n")] []
+        0: BANG@47..49 "!" [Newline("\n")] []
         1: JS_BOOLEAN_LITERAL_EXPRESSION@49..53
           0: TRUE_KW@49..53 "true" [] []
       1: SEMICOLON@53..54 ";" [] []
@@ -175,7 +175,7 @@ JsModule {
       0: JS_BINARY_EXPRESSION@54..67
         0: JS_BINARY_EXPRESSION@54..63
           0: JS_UNARY_EXPRESSION@54..58
-            0: MINUS@54..56 "-" [Whitespace("\n")] []
+            0: MINUS@54..56 "-" [Newline("\n")] []
             1: JS_IDENTIFIER_EXPRESSION@56..58
               0: JS_REFERENCE_IDENTIFIER@56..58
                 0: IDENT@56..58 "a" [] [Whitespace(" ")]
@@ -192,4 +192,4 @@ JsModule {
             0: JS_REFERENCE_IDENTIFIER@66..67
               0: IDENT@66..67 "a" [] []
       1: SEMICOLON@67..68 ";" [] []
-  3: EOF@68..69 "" [Whitespace("\n")] []
+  3: EOF@68..69 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/labeled_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/labeled_statement.rast
@@ -13,7 +13,7 @@ JsModule {
             },
         },
         JsLabeledStatement {
-            label_token: IDENT@9..16 "label1" [Whitespace("\n")] [],
+            label_token: IDENT@9..16 "label1" [Newline("\n")] [],
             colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
             body: JsExpressionStatement {
                 expression: JsNumberLiteralExpression {
@@ -23,7 +23,7 @@ JsModule {
             },
         },
         JsLabeledStatement {
-            label_token: IDENT@19..26 "label2" [Whitespace("\n")] [],
+            label_token: IDENT@19..26 "label2" [Newline("\n")] [],
             colon_token: COLON@26..28 ":" [] [Whitespace(" ")],
             body: JsExpressionStatement {
                 expression: JsNumberLiteralExpression {
@@ -33,7 +33,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@29..30 "" [Whitespace("\n")] [],
+    eof_token: EOF@29..30 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..30
@@ -48,17 +48,17 @@ JsModule {
           0: JS_NUMBER_LITERAL@8..9 "1" [] []
         1: (empty)
     1: JS_LABELED_STATEMENT@9..19
-      0: IDENT@9..16 "label1" [Whitespace("\n")] []
+      0: IDENT@9..16 "label1" [Newline("\n")] []
       1: COLON@16..18 ":" [] [Whitespace(" ")]
       2: JS_EXPRESSION_STATEMENT@18..19
         0: JS_NUMBER_LITERAL_EXPRESSION@18..19
           0: JS_NUMBER_LITERAL@18..19 "1" [] []
         1: (empty)
     2: JS_LABELED_STATEMENT@19..29
-      0: IDENT@19..26 "label2" [Whitespace("\n")] []
+      0: IDENT@19..26 "label2" [Newline("\n")] []
       1: COLON@26..28 ":" [] [Whitespace(" ")]
       2: JS_EXPRESSION_STATEMENT@28..29
         0: JS_NUMBER_LITERAL_EXPRESSION@28..29
           0: JS_NUMBER_LITERAL@28..29 "2" [] []
         1: (empty)
-  3: EOF@29..30 "" [Whitespace("\n")] []
+  3: EOF@29..30 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/literals.rast
+++ b/crates/rslint_parser/test_data/inline/ok/literals.rast
@@ -10,42 +10,42 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsBooleanLiteralExpression {
-                value_token: TRUE_KW@1..6 "true" [Whitespace("\n")] [],
+                value_token: TRUE_KW@1..6 "true" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
             expression: JsBooleanLiteralExpression {
-                value_token: FALSE_KW@6..12 "false" [Whitespace("\n")] [],
+                value_token: FALSE_KW@6..12 "false" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
             expression: JsBigIntLiteralExpression {
-                value_token: JS_BIG_INT_LITERAL@12..15 "5n" [Whitespace("\n")] [],
+                value_token: JS_BIG_INT_LITERAL@12..15 "5n" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
             expression: JsStringLiteralExpression {
-                value_token: JS_STRING_LITERAL@15..21 "\"foo\"" [Whitespace("\n")] [],
+                value_token: JS_STRING_LITERAL@15..21 "\"foo\"" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
             expression: JsStringLiteralExpression {
-                value_token: JS_STRING_LITERAL@21..27 "'bar'" [Whitespace("\n")] [],
+                value_token: JS_STRING_LITERAL@21..27 "'bar'" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
             expression: JsNullLiteralExpression {
-                value_token: NULL_KW@27..32 "null" [Whitespace("\n")] [],
+                value_token: NULL_KW@27..32 "null" [Newline("\n")] [],
             },
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@32..33 "" [Whitespace("\n")] [],
+    eof_token: EOF@32..33 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..33
@@ -58,26 +58,26 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@1..6
       0: JS_BOOLEAN_LITERAL_EXPRESSION@1..6
-        0: TRUE_KW@1..6 "true" [Whitespace("\n")] []
+        0: TRUE_KW@1..6 "true" [Newline("\n")] []
       1: (empty)
     2: JS_EXPRESSION_STATEMENT@6..12
       0: JS_BOOLEAN_LITERAL_EXPRESSION@6..12
-        0: FALSE_KW@6..12 "false" [Whitespace("\n")] []
+        0: FALSE_KW@6..12 "false" [Newline("\n")] []
       1: (empty)
     3: JS_EXPRESSION_STATEMENT@12..15
       0: JS_BIG_INT_LITERAL_EXPRESSION@12..15
-        0: JS_BIG_INT_LITERAL@12..15 "5n" [Whitespace("\n")] []
+        0: JS_BIG_INT_LITERAL@12..15 "5n" [Newline("\n")] []
       1: (empty)
     4: JS_EXPRESSION_STATEMENT@15..21
       0: JS_STRING_LITERAL_EXPRESSION@15..21
-        0: JS_STRING_LITERAL@15..21 "\"foo\"" [Whitespace("\n")] []
+        0: JS_STRING_LITERAL@15..21 "\"foo\"" [Newline("\n")] []
       1: (empty)
     5: JS_EXPRESSION_STATEMENT@21..27
       0: JS_STRING_LITERAL_EXPRESSION@21..27
-        0: JS_STRING_LITERAL@21..27 "'bar'" [Whitespace("\n")] []
+        0: JS_STRING_LITERAL@21..27 "'bar'" [Newline("\n")] []
       1: (empty)
     6: JS_EXPRESSION_STATEMENT@27..32
       0: JS_NULL_LITERAL_EXPRESSION@27..32
-        0: NULL_KW@27..32 "null" [Whitespace("\n")] []
+        0: NULL_KW@27..32 "null" [Newline("\n")] []
       1: (empty)
-  3: EOF@32..33 "" [Whitespace("\n")] []
+  3: EOF@32..33 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/logical_expressions.rast
@@ -22,7 +22,7 @@ JsModule {
             expression: JsLogicalExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@10..13 "a" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@10..13 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: PIPE2@13..16 "||" [] [Whitespace(" ")],
@@ -38,7 +38,7 @@ JsModule {
             expression: JsLogicalExpression {
                 left: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@17..20 "a" [Whitespace("\n")] [Whitespace(" ")],
+                        value_token: IDENT@17..20 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
                 operator: AMP2@20..23 "&&" [] [Whitespace(" ")],
@@ -51,7 +51,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@24..25 "" [Whitespace("\n")] [],
+    eof_token: EOF@24..25 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..25
@@ -72,7 +72,7 @@ JsModule {
       0: JS_LOGICAL_EXPRESSION@10..17
         0: JS_IDENTIFIER_EXPRESSION@10..13
           0: JS_REFERENCE_IDENTIFIER@10..13
-            0: IDENT@10..13 "a" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@10..13 "a" [Newline("\n")] [Whitespace(" ")]
         1: PIPE2@13..16 "||" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@16..17
           0: JS_REFERENCE_IDENTIFIER@16..17
@@ -82,10 +82,10 @@ JsModule {
       0: JS_LOGICAL_EXPRESSION@17..24
         0: JS_IDENTIFIER_EXPRESSION@17..20
           0: JS_REFERENCE_IDENTIFIER@17..20
-            0: IDENT@17..20 "a" [Whitespace("\n")] [Whitespace(" ")]
+            0: IDENT@17..20 "a" [Newline("\n")] [Whitespace(" ")]
         1: AMP2@20..23 "&&" [] [Whitespace(" ")]
         2: JS_IDENTIFIER_EXPRESSION@23..24
           0: JS_REFERENCE_IDENTIFIER@23..24
             0: IDENT@23..24 "b" [] []
       1: (empty)
-  3: EOF@24..25 "" [Whitespace("\n")] []
+  3: EOF@24..25 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
@@ -18,7 +18,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@12..20 "method" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@12..20 "method" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -38,7 +38,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@25..33 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@25..33 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@33..44 "asyncMethod" [] [],
@@ -61,7 +61,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@49..56 "async" [Whitespace("\n"), Whitespace("\t")] [],
+                    async_token: ASYNC_KW@49..56 "async" [Newline("\n"), Whitespace("\t")] [],
                     star_token: STAR@56..58 "*" [] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@58..78 "asyncGeneratorMethod" [] [],
@@ -85,7 +85,7 @@ JsModule {
                     static_token: missing (optional),
                     abstract_token: missing (optional),
                     async_token: missing (optional),
-                    star_token: STAR@83..87 "*" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    star_token: STAR@83..87 "*" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@87..102 "generatorMethod" [] [],
                     },
@@ -110,7 +110,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: JS_STRING_LITERAL@107..114 "\"foo\"" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: JS_STRING_LITERAL@107..114 "\"foo\"" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -133,7 +133,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsComputedMemberName {
-                        l_brack_token: L_BRACK@119..122 "[" [Whitespace("\n"), Whitespace("\t")] [],
+                        l_brack_token: L_BRACK@119..122 "[" [Newline("\n"), Whitespace("\t")] [],
                         expression: JsBinaryExpression {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@122..128 "\"foo\"" [] [Whitespace(" ")],
@@ -166,7 +166,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: JS_NUMBER_LITERAL@141..144 "5" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: JS_NUMBER_LITERAL@141..144 "5" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -189,7 +189,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsPrivateClassMemberName {
-                        hash_token: HASH@149..152 "#" [Whitespace("\n"), Whitespace("\t")] [],
+                        hash_token: HASH@149..152 "#" [Newline("\n"), Whitespace("\t")] [],
                         id_token: IDENT@152..159 "private" [] [],
                     },
                     type_parameters: missing (optional),
@@ -207,10 +207,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@164..166 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@164..166 "}" [Newline("\n")] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@166..173 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@166..173 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@173..192 "ContextualKeywords" [] [Whitespace(" ")],
             },
@@ -225,7 +225,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@193..231 "static" [Whitespace("\n"), Whitespace("   "), Comments("// Methods called static"), Whitespace("\n"), Whitespace("\t  ")] [],
+                        value: IDENT@193..231 "static" [Newline("\n"), Whitespace("   "), Comments("// Methods called static"), Newline("\n"), Whitespace("\t  ")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -245,7 +245,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@236..246 "async" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@236..246 "async" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@246..252 "static" [] [],
@@ -269,7 +269,7 @@ JsModule {
                     static_token: missing (optional),
                     abstract_token: missing (optional),
                     async_token: missing (optional),
-                    star_token: STAR@257..263 "*" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    star_token: STAR@257..263 "*" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@263..269 "static" [] [],
                     },
@@ -291,7 +291,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@274..283 "async" [Whitespace("\n"), Whitespace("   ")] [],
+                    async_token: ASYNC_KW@274..283 "async" [Newline("\n"), Whitespace("   ")] [],
                     star_token: STAR@283..285 "*" [] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@285..291 "static" [] [],
@@ -317,7 +317,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@296..307 "declare" [Whitespace("\n"), Whitespace("   ")] [],
+                        value: IDENT@296..307 "declare" [Newline("\n"), Whitespace("   ")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -340,7 +340,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@312..319 "get" [Whitespace("\n"), Whitespace("\t  ")] [],
+                        value: IDENT@312..319 "get" [Newline("\n"), Whitespace("\t  ")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -363,7 +363,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@345..352 "set" [Whitespace("\n"), Whitespace("\t  ")] [],
+                        value: IDENT@345..352 "set" [Newline("\n"), Whitespace("\t  ")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -380,10 +380,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@378..380 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@378..380 "}" [Newline("\n")] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@380..387 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@380..387 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@387..394 "Static" [] [Whitespace(" ")],
             },
@@ -393,7 +393,7 @@ JsModule {
             members: JsClassMemberList [
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@395..406 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@395..406 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
@@ -416,7 +416,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@417..428 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@417..428 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@428..434 "async" [] [Whitespace(" ")],
                     star_token: missing (optional),
@@ -439,7 +439,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@450..461 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@450..461 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@461..466 "async" [] [],
                     star_token: STAR@466..468 "*" [] [Whitespace(" ")],
@@ -462,7 +462,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@493..504 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@493..504 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: STAR@504..506 "*" [] [Whitespace(" ")],
@@ -485,7 +485,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@526..537 "static" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@526..537 "static" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
@@ -508,7 +508,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@548..559 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@548..559 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@559..565 "async" [] [Whitespace(" ")],
                     star_token: missing (optional),
@@ -531,7 +531,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@576..587 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@576..587 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@587..592 "async" [] [],
                     star_token: STAR@592..594 "*" [] [Whitespace(" ")],
@@ -554,7 +554,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@605..616 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@605..616 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: STAR@616..618 "*" [] [Whitespace(" ")],
@@ -576,10 +576,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@629..631 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@629..631 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@631..632 "" [Whitespace("\n")] [],
+    eof_token: EOF@631..632 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..632
@@ -601,7 +601,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@12..20
-            0: IDENT@12..20 "method" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@12..20 "method" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@20..23
             0: L_PAREN@20..21 "(" [] []
@@ -617,7 +617,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@25..33 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: ASYNC_KW@25..33 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@33..44
             0: IDENT@33..44 "asyncMethod" [] []
@@ -636,7 +636,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@49..56 "async" [Whitespace("\n"), Whitespace("\t")] []
+          3: ASYNC_KW@49..56 "async" [Newline("\n"), Whitespace("\t")] []
           4: STAR@56..58 "*" [] [Whitespace(" ")]
           5: JS_LITERAL_MEMBER_NAME@58..78
             0: IDENT@58..78 "asyncGeneratorMethod" [] []
@@ -656,7 +656,7 @@ JsModule {
           1: (empty)
           2: (empty)
           3: (empty)
-          4: STAR@83..87 "*" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          4: STAR@83..87 "*" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           5: JS_LITERAL_MEMBER_NAME@87..102
             0: IDENT@87..102 "generatorMethod" [] []
           6: (empty)
@@ -677,7 +677,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@107..114
-            0: JS_STRING_LITERAL@107..114 "\"foo\"" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@107..114 "\"foo\"" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@114..117
             0: L_PAREN@114..115 "(" [] []
@@ -696,7 +696,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_COMPUTED_MEMBER_NAME@119..136
-            0: L_BRACK@119..122 "[" [Whitespace("\n"), Whitespace("\t")] []
+            0: L_BRACK@119..122 "[" [Newline("\n"), Whitespace("\t")] []
             1: JS_BINARY_EXPRESSION@122..135
               0: JS_STRING_LITERAL_EXPRESSION@122..128
                 0: JS_STRING_LITERAL@122..128 "\"foo\"" [] [Whitespace(" ")]
@@ -722,7 +722,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@141..144
-            0: JS_NUMBER_LITERAL@141..144 "5" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_NUMBER_LITERAL@141..144 "5" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@144..147
             0: L_PAREN@144..145 "(" [] []
@@ -741,7 +741,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@149..159
-            0: HASH@149..152 "#" [Whitespace("\n"), Whitespace("\t")] []
+            0: HASH@149..152 "#" [Newline("\n"), Whitespace("\t")] []
             1: IDENT@152..159 "private" [] []
           6: (empty)
           7: JS_PARAMETERS@159..162
@@ -754,9 +754,9 @@ JsModule {
             1: JS_DIRECTIVE_LIST@163..163
             2: JS_STATEMENT_LIST@163..163
             3: R_CURLY@163..164 "}" [] []
-      6: R_CURLY@164..166 "}" [Whitespace("\n")] []
+      6: R_CURLY@164..166 "}" [Newline("\n")] []
     1: JS_CLASS_STATEMENT@166..380
-      0: CLASS_KW@166..173 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@166..173 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@173..192
         0: IDENT@173..192 "ContextualKeywords" [] [Whitespace(" ")]
       2: (empty)
@@ -770,7 +770,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@193..231
-            0: IDENT@193..231 "static" [Whitespace("\n"), Whitespace("   "), Comments("// Methods called static"), Whitespace("\n"), Whitespace("\t  ")] []
+            0: IDENT@193..231 "static" [Newline("\n"), Whitespace("   "), Comments("// Methods called static"), Newline("\n"), Whitespace("\t  ")] []
           6: (empty)
           7: JS_PARAMETERS@231..234
             0: L_PAREN@231..232 "(" [] []
@@ -786,7 +786,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@236..246 "async" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          3: ASYNC_KW@236..246 "async" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@246..252
             0: IDENT@246..252 "static" [] []
@@ -806,7 +806,7 @@ JsModule {
           1: (empty)
           2: (empty)
           3: (empty)
-          4: STAR@257..263 "*" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          4: STAR@257..263 "*" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           5: JS_LITERAL_MEMBER_NAME@263..269
             0: IDENT@263..269 "static" [] []
           6: (empty)
@@ -824,7 +824,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@274..283 "async" [Whitespace("\n"), Whitespace("   ")] []
+          3: ASYNC_KW@274..283 "async" [Newline("\n"), Whitespace("   ")] []
           4: STAR@283..285 "*" [] [Whitespace(" ")]
           5: JS_LITERAL_MEMBER_NAME@285..291
             0: IDENT@285..291 "static" [] []
@@ -846,7 +846,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@296..307
-            0: IDENT@296..307 "declare" [Whitespace("\n"), Whitespace("   ")] []
+            0: IDENT@296..307 "declare" [Newline("\n"), Whitespace("   ")] []
           6: (empty)
           7: JS_PARAMETERS@307..310
             0: L_PAREN@307..308 "(" [] []
@@ -865,7 +865,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@312..319
-            0: IDENT@312..319 "get" [Whitespace("\n"), Whitespace("\t  ")] []
+            0: IDENT@312..319 "get" [Newline("\n"), Whitespace("\t  ")] []
           6: (empty)
           7: JS_PARAMETERS@319..322
             0: L_PAREN@319..320 "(" [] []
@@ -884,7 +884,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@345..352
-            0: IDENT@345..352 "set" [Whitespace("\n"), Whitespace("\t  ")] []
+            0: IDENT@345..352 "set" [Newline("\n"), Whitespace("\t  ")] []
           6: (empty)
           7: JS_PARAMETERS@352..355
             0: L_PAREN@352..353 "(" [] []
@@ -896,9 +896,9 @@ JsModule {
             1: JS_DIRECTIVE_LIST@356..356
             2: JS_STATEMENT_LIST@356..356
             3: R_CURLY@356..378 "}" [] [Whitespace(" "), Comments("// Method called set")]
-      6: R_CURLY@378..380 "}" [Whitespace("\n")] []
+      6: R_CURLY@378..380 "}" [Newline("\n")] []
     2: JS_CLASS_STATEMENT@380..631
-      0: CLASS_KW@380..387 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@380..387 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@387..394
         0: IDENT@387..394 "Static" [] [Whitespace(" ")]
       2: (empty)
@@ -907,7 +907,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@395..629
         0: JS_METHOD_CLASS_MEMBER@395..417
           0: (empty)
-          1: STATIC_KW@395..406 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@395..406 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: (empty)
@@ -926,7 +926,7 @@ JsModule {
             3: R_CURLY@416..417 "}" [] []
         1: JS_METHOD_CLASS_MEMBER@417..450
           0: (empty)
-          1: STATIC_KW@417..428 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@417..428 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@428..434 "async" [] [Whitespace(" ")]
           4: (empty)
@@ -945,7 +945,7 @@ JsModule {
             3: R_CURLY@449..450 "}" [] []
         2: JS_METHOD_CLASS_MEMBER@450..493
           0: (empty)
-          1: STATIC_KW@450..461 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@450..461 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@461..466 "async" [] []
           4: STAR@466..468 "*" [] [Whitespace(" ")]
@@ -964,7 +964,7 @@ JsModule {
             3: R_CURLY@492..493 "}" [] []
         3: JS_METHOD_CLASS_MEMBER@493..526
           0: (empty)
-          1: STATIC_KW@493..504 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@493..504 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: STAR@504..506 "*" [] [Whitespace(" ")]
@@ -983,7 +983,7 @@ JsModule {
             3: R_CURLY@525..526 "}" [] []
         4: JS_METHOD_CLASS_MEMBER@526..548
           0: (empty)
-          1: STATIC_KW@526..537 "static" [Whitespace("\n"), Whitespace("   ")] [Whitespace(" ")]
+          1: STATIC_KW@526..537 "static" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: (empty)
@@ -1002,7 +1002,7 @@ JsModule {
             3: R_CURLY@547..548 "}" [] []
         5: JS_METHOD_CLASS_MEMBER@548..576
           0: (empty)
-          1: STATIC_KW@548..559 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@548..559 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@559..565 "async" [] [Whitespace(" ")]
           4: (empty)
@@ -1021,7 +1021,7 @@ JsModule {
             3: R_CURLY@575..576 "}" [] []
         6: JS_METHOD_CLASS_MEMBER@576..605
           0: (empty)
-          1: STATIC_KW@576..587 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@576..587 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@587..592 "async" [] []
           4: STAR@592..594 "*" [] [Whitespace(" ")]
@@ -1040,7 +1040,7 @@ JsModule {
             3: R_CURLY@604..605 "}" [] []
         7: JS_METHOD_CLASS_MEMBER@605..629
           0: (empty)
-          1: STATIC_KW@605..616 "static" [Whitespace("\n"), Whitespace("\t  ")] [Whitespace(" ")]
+          1: STATIC_KW@605..616 "static" [Newline("\n"), Whitespace("\t  ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: STAR@616..618 "*" [] [Whitespace(" ")]
@@ -1057,5 +1057,5 @@ JsModule {
             1: JS_DIRECTIVE_LIST@628..628
             2: JS_STATEMENT_LIST@628..628
             3: R_CURLY@628..629 "}" [] []
-      6: R_CURLY@629..631 "}" [Whitespace("\n")] []
-  3: EOF@631..632 "" [Whitespace("\n")] []
+      6: R_CURLY@629..631 "}" [Newline("\n")] []
+  3: EOF@631..632 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/module.rast
+++ b/crates/rslint_parser/test_data/inline/ok/module.rast
@@ -17,7 +17,7 @@ JsModule {
             semicolon_token: SEMICOLON@17..18 ";" [] [],
         },
         JsExport {
-            export_token: EXPORT_KW@18..26 "export" [Whitespace("\n")] [Whitespace(" ")],
+            export_token: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")],
             export_clause: JsExportNamedClause {
                 l_curly_token: L_CURLY@26..28 "{" [] [Whitespace(" ")],
                 specifiers: JsExportNamedSpecifierList [
@@ -36,7 +36,7 @@ JsModule {
             expression: JsCallExpression {
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@32..34 "c" [Whitespace("\n")] [],
+                        value_token: IDENT@32..34 "c" [Newline("\n")] [],
                     },
                 },
                 optional_chain_token_token: missing (optional),
@@ -50,7 +50,7 @@ JsModule {
             semicolon_token: SEMICOLON@36..37 ";" [] [],
         },
         JsImport {
-            import_token: IMPORT_KW@37..45 "import" [Whitespace("\n")] [Whitespace(" ")],
+            import_token: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
@@ -73,7 +73,7 @@ JsModule {
             semicolon_token: SEMICOLON@59..60 ";" [] [],
         },
     ],
-    eof_token: EOF@60..61 "" [Whitespace("\n")] [],
+    eof_token: EOF@60..61 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..61
@@ -91,7 +91,7 @@ JsModule {
         3: (empty)
       2: SEMICOLON@17..18 ";" [] []
     1: JS_EXPORT@18..32
-      0: EXPORT_KW@18..26 "export" [Whitespace("\n")] [Whitespace(" ")]
+      0: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")]
       1: JS_EXPORT_NAMED_CLAUSE@26..32
         0: L_CURLY@26..28 "{" [] [Whitespace(" ")]
         1: JS_EXPORT_NAMED_SPECIFIER_LIST@28..30
@@ -105,7 +105,7 @@ JsModule {
       0: JS_CALL_EXPRESSION@32..36
         0: JS_IDENTIFIER_EXPRESSION@32..34
           0: JS_REFERENCE_IDENTIFIER@32..34
-            0: IDENT@32..34 "c" [Whitespace("\n")] []
+            0: IDENT@32..34 "c" [Newline("\n")] []
         1: (empty)
         2: (empty)
         3: JS_CALL_ARGUMENTS@34..36
@@ -114,7 +114,7 @@ JsModule {
           2: R_PAREN@35..36 ")" [] []
       1: SEMICOLON@36..37 ";" [] []
     3: JS_IMPORT@37..60
-      0: IMPORT_KW@37..45 "import" [Whitespace("\n")] [Whitespace(" ")]
+      0: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@45..59
         0: (empty)
         1: JS_NAMED_IMPORT_SPECIFIERS@45..51
@@ -129,4 +129,4 @@ JsModule {
           0: JS_STRING_LITERAL@56..59 "\"c\"" [] []
         4: (empty)
       2: SEMICOLON@59..60 ";" [] []
-  3: EOF@60..61 "" [Whitespace("\n")] []
+  3: EOF@60..61 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/new_exprs.rast
@@ -21,7 +21,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsNewExpression {
-                new_token: NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")],
+                new_token: NEW_KW@9..14 "new" [Newline("\n")] [Whitespace(" ")],
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@14..17 "foo" [] [],
@@ -34,7 +34,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: NewTarget {
-                new_token: NEW_KW@18..22 "new" [Whitespace("\n")] [],
+                new_token: NEW_KW@18..22 "new" [Newline("\n")] [],
                 dot_token: DOT@22..23 "." [] [],
                 target_token: TARGET_KW@23..29 "target" [] [],
             },
@@ -42,7 +42,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsNewExpression {
-                new_token: NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")],
+                new_token: NEW_KW@29..34 "new" [Newline("\n")] [Whitespace(" ")],
                 callee: JsNewExpression {
                     new_token: NEW_KW@34..38 "new" [] [Whitespace(" ")],
                     callee: JsNewExpression {
@@ -74,7 +74,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsNewExpression {
-                new_token: NEW_KW@52..57 "new" [Whitespace("\n")] [Whitespace(" ")],
+                new_token: NEW_KW@52..57 "new" [Newline("\n")] [Whitespace(" ")],
                 callee: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@57..60 "Foo" [] [],
@@ -170,7 +170,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@112..113 "" [Whitespace("\n")] [],
+    eof_token: EOF@112..113 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..113
@@ -191,7 +191,7 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@9..18
       0: JS_NEW_EXPRESSION@9..17
-        0: NEW_KW@9..14 "new" [Whitespace("\n")] [Whitespace(" ")]
+        0: NEW_KW@9..14 "new" [Newline("\n")] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@14..17
           0: JS_REFERENCE_IDENTIFIER@14..17
             0: IDENT@14..17 "foo" [] []
@@ -200,13 +200,13 @@ JsModule {
       1: SEMICOLON@17..18 ";" [] []
     2: JS_EXPRESSION_STATEMENT@18..29
       0: NEW_TARGET@18..29
-        0: NEW_KW@18..22 "new" [Whitespace("\n")] []
+        0: NEW_KW@18..22 "new" [Newline("\n")] []
         1: DOT@22..23 "." [] []
         2: TARGET_KW@23..29 "target" [] []
       1: (empty)
     3: JS_EXPRESSION_STATEMENT@29..52
       0: JS_NEW_EXPRESSION@29..51
-        0: NEW_KW@29..34 "new" [Whitespace("\n")] [Whitespace(" ")]
+        0: NEW_KW@29..34 "new" [Newline("\n")] [Whitespace(" ")]
         1: JS_NEW_EXPRESSION@34..51
           0: NEW_KW@34..38 "new" [] [Whitespace(" ")]
           1: JS_NEW_EXPRESSION@38..51
@@ -230,7 +230,7 @@ JsModule {
       1: SEMICOLON@51..52 ";" [] []
     4: JS_EXPRESSION_STATEMENT@52..112
       0: JS_NEW_EXPRESSION@52..112
-        0: NEW_KW@52..57 "new" [Whitespace("\n")] [Whitespace(" ")]
+        0: NEW_KW@52..57 "new" [Newline("\n")] [Whitespace(" ")]
         1: JS_IDENTIFIER_EXPRESSION@57..60
           0: JS_REFERENCE_IDENTIFIER@57..60
             0: IDENT@57..60 "Foo" [] []
@@ -295,4 +295,4 @@ JsModule {
                     0: IDENT@108..111 "bar" [] []
           2: R_PAREN@111..112 ")" [] []
       1: (empty)
-  3: EOF@112..113 "" [Whitespace("\n")] []
+  3: EOF@112..113 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_assignment_target.rast
@@ -24,7 +24,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@10..12 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@10..12 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@12..14 "{" [] [Whitespace(" ")],
@@ -58,7 +58,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@31..33 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@31..33 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@33..35 "{" [] [Whitespace(" ")],
@@ -119,7 +119,7 @@ JsModule {
             semicolon_token: SEMICOLON@83..84 ";" [] [],
         },
     ],
-    eof_token: EOF@84..85 "" [Whitespace("\n")] [],
+    eof_token: EOF@84..85 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..85
@@ -143,7 +143,7 @@ JsModule {
       1: SEMICOLON@9..10 ";" [] []
     1: JS_EXPRESSION_STATEMENT@10..31
       0: JS_PARENTHESIZED_EXPRESSION@10..30
-        0: L_PAREN@10..12 "(" [Whitespace("\n")] []
+        0: L_PAREN@10..12 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@12..29
           0: JS_OBJECT_ASSIGNMENT_PATTERN@12..25
             0: L_CURLY@12..14 "{" [] [Whitespace(" ")]
@@ -167,7 +167,7 @@ JsModule {
       1: SEMICOLON@30..31 ";" [] []
     2: JS_EXPRESSION_STATEMENT@31..84
       0: JS_PARENTHESIZED_EXPRESSION@31..83
-        0: L_PAREN@31..33 "(" [Whitespace("\n")] []
+        0: L_PAREN@31..33 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@33..82
           0: JS_OBJECT_ASSIGNMENT_PATTERN@33..78
             0: L_CURLY@33..35 "{" [] [Whitespace(" ")]
@@ -208,4 +208,4 @@ JsModule {
             2: R_CURLY@81..82 "}" [] []
         2: R_PAREN@82..83 ")" [] []
       1: SEMICOLON@83..84 ";" [] []
-  3: EOF@84..85 "" [Whitespace("\n")] []
+  3: EOF@84..85 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr.rast
@@ -27,7 +27,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@11..16 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -56,7 +56,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@26..27 "" [Whitespace("\n")] [],
+    eof_token: EOF@26..27 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..27
@@ -81,7 +81,7 @@ JsModule {
       1: SEMICOLON@10..11 ";" [] []
     1: JS_VARIABLE_STATEMENT@11..26
       0: JS_VARIABLE_DECLARATIONS@11..26
-        0: LET_KW@11..16 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@11..16 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@16..26
           0: JS_VARIABLE_DECLARATION@16..26
             0: JS_IDENTIFIER_BINDING@16..18
@@ -99,4 +99,4 @@ JsModule {
                   1: COMMA@24..25 "," [] []
                 2: R_CURLY@25..26 "}" [] []
       1: (empty)
-  3: EOF@26..27 "" [Whitespace("\n")] []
+  3: EOF@26..27 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -18,7 +18,7 @@ JsModule {
                                 l_curly_token: L_CURLY@8..9 "{" [] [],
                                 members: JsObjectMemberList [
                                     JsMethodObjectMember {
-                                        async_token: ASYNC_KW@9..18 "async" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        async_token: ASYNC_KW@9..18 "async" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
                                             value: IDENT@18..21 "foo" [] [],
@@ -39,7 +39,7 @@ JsModule {
                                     },
                                     COMMA@26..27 "," [] [],
                                     JsMethodObjectMember {
-                                        async_token: ASYNC_KW@27..36 "async" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        async_token: ASYNC_KW@27..36 "async" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                                         star_token: STAR@36..37 "*" [] [],
                                         name: JsLiteralMemberName {
                                             value: IDENT@37..40 "foo" [] [],
@@ -59,7 +59,7 @@ JsModule {
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@45..47 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -68,7 +68,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@47..48 "" [Whitespace("\n")] [],
+    eof_token: EOF@47..48 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..48
@@ -90,7 +90,7 @@ JsModule {
                 0: L_CURLY@8..9 "{" [] []
                 1: JS_OBJECT_MEMBER_LIST@9..45
                   0: JS_METHOD_OBJECT_MEMBER@9..26
-                    0: ASYNC_KW@9..18 "async" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                    0: ASYNC_KW@9..18 "async" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@18..21
                       0: IDENT@18..21 "foo" [] []
@@ -107,7 +107,7 @@ JsModule {
                       3: R_CURLY@25..26 "}" [] []
                   1: COMMA@26..27 "," [] []
                   2: JS_METHOD_OBJECT_MEMBER@27..45
-                    0: ASYNC_KW@27..36 "async" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+                    0: ASYNC_KW@27..36 "async" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
                     1: STAR@36..37 "*" [] []
                     2: JS_LITERAL_MEMBER_NAME@37..40
                       0: IDENT@37..40 "foo" [] []
@@ -122,6 +122,6 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@44..44
                       2: JS_STATEMENT_LIST@44..44
                       3: R_CURLY@44..45 "}" [] []
-                2: R_CURLY@45..47 "}" [Whitespace("\n")] []
+                2: R_CURLY@45..47 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@47..48 "" [Whitespace("\n")] []
+  3: EOF@47..48 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -47,7 +47,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@21..22 "" [Whitespace("\n")] [],
+    eof_token: EOF@21..22 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..22
@@ -86,4 +86,4 @@ JsModule {
                       3: R_CURLY@18..20 "}" [] [Whitespace(" ")]
                 2: R_CURLY@20..21 "}" [] []
       1: (empty)
-  3: EOF@21..22 "" [Whitespace("\n")] []
+  3: EOF@21..22 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_literal_prop.rast
@@ -36,7 +36,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@19..20 "" [Whitespace("\n")] [],
+    eof_token: EOF@19..20 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..20
@@ -65,4 +65,4 @@ JsModule {
                       0: TRUE_KW@13..18 "true" [] [Whitespace(" ")]
                 2: R_CURLY@18..19 "}" [] []
       1: (empty)
-  3: EOF@19..20 "" [Whitespace("\n")] []
+  3: EOF@19..20 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_ident_prop.rast
@@ -21,7 +21,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@7..8 "" [Whitespace("\n")] [],
+    eof_token: EOF@7..8 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..8
@@ -40,4 +40,4 @@ JsModule {
           2: R_CURLY@5..6 "}" [] []
         2: R_PAREN@6..7 ")" [] []
       1: (empty)
-  3: EOF@7..8 "" [Whitespace("\n")] []
+  3: EOF@7..8 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -21,7 +21,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: IDENT@9..14 "foo" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value: IDENT@9..14 "foo" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -42,7 +42,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: JS_STRING_LITERAL@20..27 "\"bar\"" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value: JS_STRING_LITERAL@20..27 "\"bar\"" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -87,7 +87,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsComputedMemberName {
-                                            l_brack_token: L_BRACK@40..43 "[" [Whitespace("\n"), Whitespace("\t")] [],
+                                            l_brack_token: L_BRACK@40..43 "[" [Newline("\n"), Whitespace("\t")] [],
                                             expression: JsBinaryExpression {
                                                 left: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@43..49 "\"foo\"" [] [Whitespace(" ")],
@@ -126,7 +126,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: JS_NUMBER_LITERAL@64..67 "5" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value: JS_NUMBER_LITERAL@64..67 "5" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -150,7 +150,7 @@ JsModule {
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@79..81 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@79..81 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -159,7 +159,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@81..82 "" [Whitespace("\n")] [],
+    eof_token: EOF@81..82 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..82
@@ -184,7 +184,7 @@ JsModule {
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@9..14
-                      0: IDENT@9..14 "foo" [Whitespace("\n"), Whitespace("\t")] []
+                      0: IDENT@9..14 "foo" [Newline("\n"), Whitespace("\t")] []
                     3: (empty)
                     4: JS_PARAMETERS@14..17
                       0: L_PAREN@14..15 "(" [] []
@@ -201,7 +201,7 @@ JsModule {
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@20..27
-                      0: JS_STRING_LITERAL@20..27 "\"bar\"" [Whitespace("\n"), Whitespace("\t")] []
+                      0: JS_STRING_LITERAL@20..27 "\"bar\"" [Newline("\n"), Whitespace("\t")] []
                     3: (empty)
                     4: JS_PARAMETERS@27..37
                       0: L_PAREN@27..28 "(" [] []
@@ -235,7 +235,7 @@ JsModule {
                     0: (empty)
                     1: (empty)
                     2: JS_COMPUTED_MEMBER_NAME@40..57
-                      0: L_BRACK@40..43 "[" [Whitespace("\n"), Whitespace("\t")] []
+                      0: L_BRACK@40..43 "[" [Newline("\n"), Whitespace("\t")] []
                       1: JS_BINARY_EXPRESSION@43..56
                         0: JS_STRING_LITERAL_EXPRESSION@43..49
                           0: JS_STRING_LITERAL@43..49 "\"foo\"" [] [Whitespace(" ")]
@@ -264,7 +264,7 @@ JsModule {
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@64..67
-                      0: JS_NUMBER_LITERAL@64..67 "5" [Whitespace("\n"), Whitespace("\t")] []
+                      0: JS_NUMBER_LITERAL@64..67 "5" [Newline("\n"), Whitespace("\t")] []
                     3: (empty)
                     4: JS_PARAMETERS@67..77
                       0: L_PAREN@67..68 "(" [] []
@@ -280,6 +280,6 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@78..78
                       2: JS_STATEMENT_LIST@78..78
                       3: R_CURLY@78..79 "}" [] []
-                2: R_CURLY@79..81 "}" [Whitespace("\n")] []
+                2: R_CURLY@79..81 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@81..82 "" [Whitespace("\n")] []
+  3: EOF@81..82 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_spread_prop.rast
@@ -35,7 +35,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@16..17 "" [Whitespace("\n")] [],
+    eof_token: EOF@16..17 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..17
@@ -63,4 +63,4 @@ JsModule {
                         0: IDENT@12..15 "foo" [] []
                 2: R_CURLY@15..16 "}" [] []
       1: (empty)
-  3: EOF@16..17 "" [Whitespace("\n")] []
+  3: EOF@16..17 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_member_name.rast
@@ -84,7 +84,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@52..53 "" [Whitespace("\n")] [],
+    eof_token: EOF@52..53 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..53
@@ -145,4 +145,4 @@ JsModule {
                         0: IDENT@48..51 "foo" [] []
                 2: R_CURLY@51..52 "}" [] []
       1: (empty)
-  3: EOF@52..53 "" [Whitespace("\n")] []
+  3: EOF@52..53 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_prop_name.rast
@@ -84,7 +84,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@52..53 "" [Whitespace("\n")] [],
+    eof_token: EOF@52..53 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..53
@@ -145,4 +145,4 @@ JsModule {
                         0: IDENT@48..51 "foo" [] []
                 2: R_CURLY@51..52 "}" [] []
       1: (empty)
-  3: EOF@52..53 "" [Whitespace("\n")] []
+  3: EOF@52..53 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_property_binding.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_property_binding.rast
@@ -40,7 +40,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@22..27 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@22..27 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -82,7 +82,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@50..51 "" [Whitespace("\n")] [],
+    eof_token: EOF@50..51 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..51
@@ -116,7 +116,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@22..50
       0: JS_VARIABLE_DECLARATIONS@22..50
-        0: LET_KW@22..27 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@22..27 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@27..50
           0: JS_VARIABLE_DECLARATION@27..50
             0: JS_OBJECT_BINDING_PATTERN@27..46
@@ -143,4 +143,4 @@ JsModule {
                 1: JS_OBJECT_MEMBER_LIST@49..49
                 2: R_CURLY@49..50 "}" [] []
       1: (empty)
-  3: EOF@50..51 "" [Whitespace("\n")] []
+  3: EOF@50..51 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/object_shorthand_property.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_shorthand_property.rast
@@ -43,7 +43,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -102,7 +102,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@54..55 "" [Whitespace("\n")] [],
+    eof_token: EOF@54..55 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..55
@@ -137,7 +137,7 @@ JsModule {
       1: (empty)
     1: JS_VARIABLE_STATEMENT@16..54
       0: JS_VARIABLE_DECLARATIONS@16..54
-        0: LET_KW@16..21 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@16..21 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@21..54
           0: JS_VARIABLE_DECLARATION@21..54
             0: JS_OBJECT_BINDING_PATTERN@21..51
@@ -175,4 +175,4 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@53..54
                   0: IDENT@53..54 "c" [] []
       1: (empty)
-  3: EOF@54..55 "" [Whitespace("\n")] []
+  3: EOF@54..55 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/parameter_list.rast
+++ b/crates/rslint_parser/test_data/inline/ok/parameter_list.rast
@@ -51,7 +51,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@62..63 "" [Whitespace("\n")] [],
+    eof_token: EOF@62..63 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..63
@@ -93,4 +93,4 @@ JsModule {
         1: JS_DIRECTIVE_LIST@61..61
         2: JS_STATEMENT_LIST@61..61
         3: R_CURLY@61..62 "}" [] []
-  3: EOF@62..63 "" [Whitespace("\n")] []
+  3: EOF@62..63 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -19,7 +19,7 @@ JsModule {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsParameters {
-                    l_paren_token: L_PAREN@6..8 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@6..8 "(" [Newline("\n")] [],
                     items: JsParameterList [
                         JsParameter {
                             binding: JsIdentifierBinding {
@@ -44,7 +44,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@19..21 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@19..21 "(" [Newline("\n")] [],
                 expression: JsBinaryExpression {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")],
@@ -63,7 +63,7 @@ JsModule {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsParameters {
-                    l_paren_token: L_PAREN@28..30 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@28..30 "(" [Newline("\n")] [],
                     items: JsParameterList [
                         JsParameter {
                             binding: JsObjectBindingPattern {
@@ -131,7 +131,7 @@ JsModule {
                 async_token: missing (optional),
                 type_parameters: missing (optional),
                 parameters: JsParameters {
-                    l_paren_token: L_PAREN@64..66 "(" [Whitespace("\n")] [],
+                    l_paren_token: L_PAREN@64..66 "(" [Newline("\n")] [],
                     items: JsParameterList [
                         JsParameter {
                             binding: JsIdentifierBinding {
@@ -162,7 +162,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@84..85 "" [Whitespace("\n")] [],
+    eof_token: EOF@84..85 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..85
@@ -182,7 +182,7 @@ JsModule {
         0: (empty)
         1: (empty)
         2: JS_PARAMETERS@6..13
-          0: L_PAREN@6..8 "(" [Whitespace("\n")] []
+          0: L_PAREN@6..8 "(" [Newline("\n")] []
           1: JS_PARAMETER_LIST@8..11
             0: JS_PARAMETER@8..11
               0: JS_IDENTIFIER_BINDING@8..11
@@ -200,7 +200,7 @@ JsModule {
       1: SEMICOLON@18..19 ";" [] []
     2: JS_EXPRESSION_STATEMENT@19..28
       0: JS_PARENTHESIZED_EXPRESSION@19..27
-        0: L_PAREN@19..21 "(" [Whitespace("\n")] []
+        0: L_PAREN@19..21 "(" [Newline("\n")] []
         1: JS_BINARY_EXPRESSION@21..26
           0: JS_NUMBER_LITERAL_EXPRESSION@21..23
             0: JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")]
@@ -214,7 +214,7 @@ JsModule {
         0: (empty)
         1: (empty)
         2: JS_PARAMETERS@28..58
-          0: L_PAREN@28..30 "(" [Whitespace("\n")] []
+          0: L_PAREN@28..30 "(" [Newline("\n")] []
           1: JS_PARAMETER_LIST@30..56
             0: JS_PARAMETER@30..56
               0: JS_OBJECT_BINDING_PATTERN@30..56
@@ -263,7 +263,7 @@ JsModule {
         0: (empty)
         1: (empty)
         2: JS_PARAMETERS@64..79
-          0: L_PAREN@64..66 "(" [Whitespace("\n")] []
+          0: L_PAREN@64..66 "(" [Newline("\n")] []
           1: JS_PARAMETER_LIST@66..77
             0: JS_PARAMETER@66..69
               0: JS_IDENTIFIER_BINDING@66..69
@@ -284,4 +284,4 @@ JsModule {
           2: JS_STATEMENT_LIST@83..83
           3: R_CURLY@83..84 "}" [] []
       1: (empty)
-  3: EOF@84..85 "" [Whitespace("\n")] []
+  3: EOF@84..85 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/post_update_expr.rast
@@ -14,14 +14,14 @@ JsModule {
         JsExpressionStatement {
             expression: JsPostUpdateExpression {
                 operand: JsIdentifierAssignment {
-                    name_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                    name_token: IDENT@5..9 "foo" [Newline("\n")] [],
                 },
                 operator: MINUS2@9..11 "--" [] [],
             },
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -37,7 +37,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@5..11
       0: JS_POST_UPDATE_EXPRESSION@5..11
         0: JS_IDENTIFIER_ASSIGNMENT@5..9
-          0: IDENT@5..9 "foo" [Whitespace("\n")] []
+          0: IDENT@5..9 "foo" [Newline("\n")] []
         1: MINUS2@9..11 "--" [] []
       1: (empty)
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/postfix_expr.rast
@@ -14,14 +14,14 @@ JsModule {
         JsExpressionStatement {
             expression: JsPostUpdateExpression {
                 operand: JsIdentifierAssignment {
-                    name_token: IDENT@5..9 "foo" [Whitespace("\n")] [],
+                    name_token: IDENT@5..9 "foo" [Newline("\n")] [],
                 },
                 operator: MINUS2@9..11 "--" [] [],
             },
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -37,7 +37,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@5..11
       0: JS_POST_UPDATE_EXPRESSION@5..11
         0: JS_IDENTIFIER_ASSIGNMENT@5..9
-          0: IDENT@5..9 "foo" [Whitespace("\n")] []
+          0: IDENT@5..9 "foo" [Newline("\n")] []
         1: MINUS2@9..11 "--" [] []
       1: (empty)
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/pre_update_expr.rast
@@ -13,7 +13,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: MINUS2@5..8 "--" [Whitespace("\n")] [],
+                operator: MINUS2@5..8 "--" [Newline("\n")] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@8..11 "foo" [] [],
                 },
@@ -21,7 +21,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@11..12 "" [Whitespace("\n")] [],
+    eof_token: EOF@11..12 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..12
@@ -36,8 +36,8 @@ JsModule {
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@5..11
       0: JS_PRE_UPDATE_EXPRESSION@5..11
-        0: MINUS2@5..8 "--" [Whitespace("\n")] []
+        0: MINUS2@5..8 "--" [Newline("\n")] []
         1: JS_IDENTIFIER_ASSIGNMENT@8..11
           0: IDENT@8..11 "foo" [] []
       1: (empty)
-  3: EOF@11..12 "" [Whitespace("\n")] []
+  3: EOF@11..12 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
@@ -31,7 +31,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@10..12 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@10..12 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@12..13 "{" [] [],
@@ -62,7 +62,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@24..26 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@24..26 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@26..27 "{" [] [],
@@ -116,7 +116,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@47..49 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@47..49 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@49..50 "{" [] [],
@@ -155,7 +155,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@65..67 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@65..67 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@67..68 "{" [] [],
@@ -195,7 +195,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@91..93 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@91..93 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@93..94 "{" [] [],
@@ -227,7 +227,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@114..116 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@114..116 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@116..117 "{" [] [],
@@ -263,7 +263,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@140..142 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@140..142 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@142..143 "{" [] [],
@@ -310,7 +310,7 @@ JsModule {
             semicolon_token: SEMICOLON@169..170 ";" [] [],
         },
     ],
-    eof_token: EOF@170..171 "" [Whitespace("\n")] [],
+    eof_token: EOF@170..171 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..171
@@ -338,7 +338,7 @@ JsModule {
       1: SEMICOLON@9..10 ";" [] []
     1: JS_EXPRESSION_STATEMENT@10..24
       0: JS_PARENTHESIZED_EXPRESSION@10..23
-        0: L_PAREN@10..12 "(" [Whitespace("\n")] []
+        0: L_PAREN@10..12 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@12..22
           0: JS_OBJECT_ASSIGNMENT_PATTERN@12..18
             0: L_CURLY@12..13 "{" [] []
@@ -360,7 +360,7 @@ JsModule {
       1: SEMICOLON@23..24 ";" [] []
     2: JS_EXPRESSION_STATEMENT@24..47
       0: JS_PARENTHESIZED_EXPRESSION@24..46
-        0: L_PAREN@24..26 "(" [Whitespace("\n")] []
+        0: L_PAREN@24..26 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@26..45
           0: JS_OBJECT_ASSIGNMENT_PATTERN@26..41
             0: L_CURLY@26..27 "{" [] []
@@ -398,7 +398,7 @@ JsModule {
       1: SEMICOLON@46..47 ";" [] []
     3: JS_EXPRESSION_STATEMENT@47..65
       0: JS_PARENTHESIZED_EXPRESSION@47..64
-        0: L_PAREN@47..49 "(" [Whitespace("\n")] []
+        0: L_PAREN@47..49 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@49..63
           0: JS_OBJECT_ASSIGNMENT_PATTERN@49..59
             0: L_CURLY@49..50 "{" [] []
@@ -426,7 +426,7 @@ JsModule {
       1: SEMICOLON@64..65 ";" [] []
     4: JS_EXPRESSION_STATEMENT@65..91
       0: JS_PARENTHESIZED_EXPRESSION@65..90
-        0: L_PAREN@65..67 "(" [Whitespace("\n")] []
+        0: L_PAREN@65..67 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@67..89
           0: JS_OBJECT_ASSIGNMENT_PATTERN@67..85
             0: L_CURLY@67..68 "{" [] []
@@ -454,7 +454,7 @@ JsModule {
       1: SEMICOLON@90..91 ";" [] []
     5: JS_EXPRESSION_STATEMENT@91..114
       0: JS_PARENTHESIZED_EXPRESSION@91..113
-        0: L_PAREN@91..93 "(" [Whitespace("\n")] []
+        0: L_PAREN@91..93 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@93..112
           0: JS_OBJECT_ASSIGNMENT_PATTERN@93..108
             0: L_CURLY@93..94 "{" [] []
@@ -476,7 +476,7 @@ JsModule {
       1: SEMICOLON@113..114 ";" [] []
     6: JS_EXPRESSION_STATEMENT@114..140
       0: JS_PARENTHESIZED_EXPRESSION@114..139
-        0: L_PAREN@114..116 "(" [Whitespace("\n")] []
+        0: L_PAREN@114..116 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@116..138
           0: JS_OBJECT_ASSIGNMENT_PATTERN@116..134
             0: L_CURLY@116..117 "{" [] []
@@ -501,7 +501,7 @@ JsModule {
       1: SEMICOLON@139..140 ";" [] []
     7: JS_EXPRESSION_STATEMENT@140..170
       0: JS_PARENTHESIZED_EXPRESSION@140..169
-        0: L_PAREN@140..142 "(" [Whitespace("\n")] []
+        0: L_PAREN@140..142 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@142..168
           0: JS_OBJECT_ASSIGNMENT_PATTERN@142..164
             0: L_CURLY@142..143 "{" [] []
@@ -533,4 +533,4 @@ JsModule {
             2: R_CURLY@167..168 "}" [] []
         2: R_PAREN@168..169 ")" [] []
       1: SEMICOLON@169..170 ";" [] []
-  3: EOF@170..171 "" [Whitespace("\n")] []
+  3: EOF@170..171 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_class_member.rast
@@ -18,7 +18,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@11..21 "property" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@11..21 "property" [Newline("\n"), Whitespace("\t")] [],
                     },
                     question_mark_token: missing (optional),
                     excl_token: missing (optional),
@@ -33,7 +33,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@21..30 "declare" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@21..30 "declare" [Newline("\n"), Whitespace("\t")] [],
                     },
                     question_mark_token: missing (optional),
                     excl_token: missing (optional),
@@ -48,7 +48,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@31..53 "initializedProperty" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        value: IDENT@31..53 "initializedProperty" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     },
                     question_mark_token: missing (optional),
                     excl_token: missing (optional),
@@ -68,7 +68,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: JS_STRING_LITERAL@58..63 "\"a\"" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: JS_STRING_LITERAL@58..63 "\"a\"" [Newline("\n"), Whitespace("\t")] [],
                     },
                     question_mark_token: missing (optional),
                     excl_token: missing (optional),
@@ -83,7 +83,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: JS_NUMBER_LITERAL@64..67 "5" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: JS_NUMBER_LITERAL@64..67 "5" [Newline("\n"), Whitespace("\t")] [],
                     },
                     question_mark_token: missing (optional),
                     excl_token: missing (optional),
@@ -98,7 +98,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsComputedMemberName {
-                        l_brack_token: L_BRACK@67..70 "[" [Whitespace("\n"), Whitespace("\t")] [],
+                        l_brack_token: L_BRACK@67..70 "[" [Newline("\n"), Whitespace("\t")] [],
                         expression: JsBinaryExpression {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@70..74 "\"a\"" [] [Whitespace(" ")],
@@ -119,7 +119,7 @@ JsModule {
                 JsPropertyClassMember {
                     declare_token: missing (optional),
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@80..89 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@80..89 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
@@ -134,7 +134,7 @@ JsModule {
                 JsPropertyClassMember {
                     declare_token: missing (optional),
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@103..112 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@103..112 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsLiteralMemberName {
@@ -158,7 +158,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsPrivateClassMemberName {
-                        hash_token: HASH@141..144 "#" [Whitespace("\n"), Whitespace("\t")] [],
+                        hash_token: HASH@141..144 "#" [Newline("\n"), Whitespace("\t")] [],
                         id_token: IDENT@144..151 "private" [] [],
                     },
                     question_mark_token: missing (optional),
@@ -174,7 +174,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsPrivateClassMemberName {
-                        hash_token: HASH@151..154 "#" [Whitespace("\n"), Whitespace("\t")] [],
+                        hash_token: HASH@151..154 "#" [Newline("\n"), Whitespace("\t")] [],
                         id_token: IDENT@154..173 "privateInitialized" [] [Whitespace(" ")],
                     },
                     question_mark_token: missing (optional),
@@ -191,7 +191,7 @@ JsModule {
                 JsPropertyClassMember {
                     declare_token: missing (optional),
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@178..187 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@178..187 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsPrivateClassMemberName {
@@ -207,7 +207,7 @@ JsModule {
                 JsPropertyClassMember {
                     declare_token: missing (optional),
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@201..210 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@201..210 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsPrivateClassMemberName {
@@ -226,10 +226,10 @@ JsModule {
                     semicolon_token: missing (optional),
                 },
             ],
-            r_curly_token: R_CURLY@247..249 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@247..249 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@249..250 "" [Whitespace("\n")] [],
+    eof_token: EOF@249..250 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..250
@@ -251,7 +251,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@11..21
-            0: IDENT@11..21 "property" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@11..21 "property" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: (empty)
           8: (empty)
@@ -264,7 +264,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@21..30
-            0: IDENT@21..30 "declare" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@21..30 "declare" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: (empty)
           8: (empty)
@@ -277,7 +277,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@31..53
-            0: IDENT@31..53 "initializedProperty" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            0: IDENT@31..53 "initializedProperty" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           6: (empty)
           7: (empty)
           8: (empty)
@@ -293,7 +293,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@58..63
-            0: JS_STRING_LITERAL@58..63 "\"a\"" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_STRING_LITERAL@58..63 "\"a\"" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: (empty)
           8: (empty)
@@ -306,7 +306,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@64..67
-            0: JS_NUMBER_LITERAL@64..67 "5" [Whitespace("\n"), Whitespace("\t")] []
+            0: JS_NUMBER_LITERAL@64..67 "5" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: (empty)
           8: (empty)
@@ -319,7 +319,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_COMPUTED_MEMBER_NAME@67..80
-            0: L_BRACK@67..70 "[" [Whitespace("\n"), Whitespace("\t")] []
+            0: L_BRACK@67..70 "[" [Newline("\n"), Whitespace("\t")] []
             1: JS_BINARY_EXPRESSION@70..79
               0: JS_STRING_LITERAL_EXPRESSION@70..74
                 0: JS_STRING_LITERAL@70..74 "\"a\"" [] [Whitespace(" ")]
@@ -335,7 +335,7 @@ JsModule {
         6: JS_PROPERTY_CLASS_MEMBER@80..103
           0: (empty)
           1: (empty)
-          2: STATIC_KW@80..89 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: STATIC_KW@80..89 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@89..103
@@ -348,7 +348,7 @@ JsModule {
         7: JS_PROPERTY_CLASS_MEMBER@103..141
           0: (empty)
           1: (empty)
-          2: STATIC_KW@103..112 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: STATIC_KW@103..112 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@112..138
@@ -368,7 +368,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@141..151
-            0: HASH@141..144 "#" [Whitespace("\n"), Whitespace("\t")] []
+            0: HASH@141..144 "#" [Newline("\n"), Whitespace("\t")] []
             1: IDENT@144..151 "private" [] []
           6: (empty)
           7: (empty)
@@ -382,7 +382,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@151..173
-            0: HASH@151..154 "#" [Whitespace("\n"), Whitespace("\t")] []
+            0: HASH@151..154 "#" [Newline("\n"), Whitespace("\t")] []
             1: IDENT@154..173 "privateInitialized" [] [Whitespace(" ")]
           6: (empty)
           7: (empty)
@@ -395,7 +395,7 @@ JsModule {
         10: JS_PROPERTY_CLASS_MEMBER@178..201
           0: (empty)
           1: (empty)
-          2: STATIC_KW@178..187 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: STATIC_KW@178..187 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@187..201
@@ -409,7 +409,7 @@ JsModule {
         11: JS_PROPERTY_CLASS_MEMBER@201..247
           0: (empty)
           1: (empty)
-          2: STATIC_KW@201..210 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: STATIC_KW@201..210 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@210..244
@@ -423,5 +423,5 @@ JsModule {
             1: JS_NUMBER_LITERAL_EXPRESSION@246..247
               0: JS_NUMBER_LITERAL@246..247 "1" [] []
           10: (empty)
-      6: R_CURLY@247..249 "}" [Whitespace("\n")] []
-  3: EOF@249..250 "" [Whitespace("\n")] []
+      6: R_CURLY@247..249 "}" [Newline("\n")] []
+  3: EOF@249..250 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
@@ -31,7 +31,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@18..20 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@18..20 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@20..22 "{" [] [Whitespace(" ")],
@@ -62,7 +62,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@39..41 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@39..41 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],
@@ -97,7 +97,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@60..62 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@60..62 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@62..64 "{" [] [Whitespace(" ")],
@@ -144,7 +144,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@84..86 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@84..86 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@86..88 "{" [] [Whitespace(" ")],
@@ -194,7 +194,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsParenthesizedExpression {
-                l_paren_token: L_PAREN@117..119 "(" [Whitespace("\n")] [],
+                l_paren_token: L_PAREN@117..119 "(" [Newline("\n")] [],
                 expression: JsAssignmentExpression {
                     left: JsObjectAssignmentPattern {
                         l_curly_token: L_CURLY@119..121 "{" [] [Whitespace(" ")],
@@ -233,7 +233,7 @@ JsModule {
             semicolon_token: SEMICOLON@139..140 ";" [] [],
         },
     ],
-    eof_token: EOF@140..141 "" [Whitespace("\n")] [],
+    eof_token: EOF@140..141 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..141
@@ -260,7 +260,7 @@ JsModule {
       1: SEMICOLON@17..18 ";" [] []
     1: JS_EXPRESSION_STATEMENT@18..39
       0: JS_PARENTHESIZED_EXPRESSION@18..38
-        0: L_PAREN@18..20 "(" [Whitespace("\n")] []
+        0: L_PAREN@18..20 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@20..37
           0: JS_OBJECT_ASSIGNMENT_PATTERN@20..34
             0: L_CURLY@20..22 "{" [] [Whitespace(" ")]
@@ -281,7 +281,7 @@ JsModule {
       1: SEMICOLON@38..39 ";" [] []
     2: JS_EXPRESSION_STATEMENT@39..60
       0: JS_PARENTHESIZED_EXPRESSION@39..59
-        0: L_PAREN@39..41 "(" [Whitespace("\n")] []
+        0: L_PAREN@39..41 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@41..58
           0: JS_OBJECT_ASSIGNMENT_PATTERN@41..55
             0: L_CURLY@41..43 "{" [] [Whitespace(" ")]
@@ -304,7 +304,7 @@ JsModule {
       1: SEMICOLON@59..60 ";" [] []
     3: JS_EXPRESSION_STATEMENT@60..84
       0: JS_PARENTHESIZED_EXPRESSION@60..83
-        0: L_PAREN@60..62 "(" [Whitespace("\n")] []
+        0: L_PAREN@60..62 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@62..82
           0: JS_OBJECT_ASSIGNMENT_PATTERN@62..79
             0: L_CURLY@62..64 "{" [] [Whitespace(" ")]
@@ -336,7 +336,7 @@ JsModule {
       1: SEMICOLON@83..84 ";" [] []
     4: JS_EXPRESSION_STATEMENT@84..117
       0: JS_PARENTHESIZED_EXPRESSION@84..116
-        0: L_PAREN@84..86 "(" [Whitespace("\n")] []
+        0: L_PAREN@84..86 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@86..115
           0: JS_OBJECT_ASSIGNMENT_PATTERN@86..112
             0: L_CURLY@86..88 "{" [] [Whitespace(" ")]
@@ -370,7 +370,7 @@ JsModule {
       1: SEMICOLON@116..117 ";" [] []
     5: JS_EXPRESSION_STATEMENT@117..140
       0: JS_PARENTHESIZED_EXPRESSION@117..139
-        0: L_PAREN@117..119 "(" [Whitespace("\n")] []
+        0: L_PAREN@117..119 "(" [Newline("\n")] []
         1: JS_ASSIGNMENT_EXPRESSION@119..138
           0: JS_OBJECT_ASSIGNMENT_PATTERN@119..135
             0: L_CURLY@119..121 "{" [] [Whitespace(" ")]
@@ -395,4 +395,4 @@ JsModule {
               0: IDENT@137..138 "c" [] []
         2: R_PAREN@138..139 ")" [] []
       1: SEMICOLON@139..140 ";" [] []
-  3: EOF@140..141 "" [Whitespace("\n")] []
+  3: EOF@140..141 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/rest_property_binding.rast
+++ b/crates/rslint_parser/test_data/inline/ok/rest_property_binding.rast
@@ -36,7 +36,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@20..25 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@20..25 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -80,7 +80,7 @@ JsModule {
             semicolon_token: SEMICOLON@44..45 ";" [] [],
         },
     ],
-    eof_token: EOF@45..46 "" [Whitespace("\n")] [],
+    eof_token: EOF@45..46 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..46
@@ -110,7 +110,7 @@ JsModule {
       1: SEMICOLON@19..20 ";" [] []
     1: JS_VARIABLE_STATEMENT@20..45
       0: JS_VARIABLE_DECLARATIONS@20..44
-        0: LET_KW@20..25 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@20..25 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@25..44
           0: JS_VARIABLE_DECLARATION@25..44
             0: JS_OBJECT_BINDING_PATTERN@25..41
@@ -138,4 +138,4 @@ JsModule {
                 0: JS_REFERENCE_IDENTIFIER@43..44
                   0: IDENT@43..44 "c" [] []
       1: SEMICOLON@44..45 ";" [] []
-  3: EOF@45..46 "" [Whitespace("\n")] []
+  3: EOF@45..46 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/return_stmt.rast
@@ -18,12 +18,12 @@ JsModule {
                     directives: JsDirectiveList [],
                     statements: JsStatementList [
                         JsReturnStatement {
-                            return_token: RETURN_KW@7..16 "return" [Whitespace("\n"), Whitespace("  ")] [],
+                            return_token: RETURN_KW@7..16 "return" [Newline("\n"), Whitespace("  ")] [],
                             argument: missing (optional),
                             semicolon_token: SEMICOLON@16..17 ";" [] [],
                         },
                         JsReturnStatement {
-                            return_token: RETURN_KW@17..27 "return" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")],
+                            return_token: RETURN_KW@17..27 "return" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
                             argument: JsIdentifierExpression {
                                 name: JsReferenceIdentifier {
                                     value_token: IDENT@27..30 "foo" [] [],
@@ -32,18 +32,18 @@ JsModule {
                             semicolon_token: SEMICOLON@30..31 ";" [] [],
                         },
                         JsReturnStatement {
-                            return_token: RETURN_KW@31..40 "return" [Whitespace("\n"), Whitespace("  ")] [],
+                            return_token: RETURN_KW@31..40 "return" [Newline("\n"), Whitespace("  ")] [],
                             argument: missing (optional),
                             semicolon_token: missing (optional),
                         },
                     ],
-                    r_curly_token: R_CURLY@40..42 "}" [Whitespace("\n")] [],
+                    r_curly_token: R_CURLY@40..42 "}" [Newline("\n")] [],
                 },
             },
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@42..43 "" [Whitespace("\n")] [],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..43
@@ -65,19 +65,19 @@ JsModule {
           1: JS_DIRECTIVE_LIST@7..7
           2: JS_STATEMENT_LIST@7..40
             0: JS_RETURN_STATEMENT@7..17
-              0: RETURN_KW@7..16 "return" [Whitespace("\n"), Whitespace("  ")] []
+              0: RETURN_KW@7..16 "return" [Newline("\n"), Whitespace("  ")] []
               1: (empty)
               2: SEMICOLON@16..17 ";" [] []
             1: JS_RETURN_STATEMENT@17..31
-              0: RETURN_KW@17..27 "return" [Whitespace("\n"), Whitespace("  ")] [Whitespace(" ")]
+              0: RETURN_KW@17..27 "return" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
               1: JS_IDENTIFIER_EXPRESSION@27..30
                 0: JS_REFERENCE_IDENTIFIER@27..30
                   0: IDENT@27..30 "foo" [] []
               2: SEMICOLON@30..31 ";" [] []
             2: JS_RETURN_STATEMENT@31..40
-              0: RETURN_KW@31..40 "return" [Whitespace("\n"), Whitespace("  ")] []
+              0: RETURN_KW@31..40 "return" [Newline("\n"), Whitespace("  ")] []
               1: (empty)
               2: (empty)
-          3: R_CURLY@40..42 "}" [Whitespace("\n")] []
+          3: R_CURLY@40..42 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@42..43 "" [Whitespace("\n")] []
+  3: EOF@42..43 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
+++ b/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
@@ -21,7 +21,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: IDENT@9..16 "test" [Whitespace("\n"), Whitespace("  ")] [],
+                                            value: IDENT@9..16 "test" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -36,7 +36,7 @@ JsModule {
                                             statements: JsStatementList [
                                                 JsVariableStatement {
                                                     declarations: JsVariableDeclarations {
-                                                        kind: LET_KW@20..29 "let" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")],
+                                                        kind: LET_KW@20..29 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
                                                         items: JsVariableDeclarationList [
                                                             JsVariableDeclaration {
                                                                 id: JsIdentifierBinding {
@@ -56,11 +56,11 @@ JsModule {
                                                     semicolon_token: SEMICOLON@40..41 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@41..45 "}" [Whitespace("\n"), Whitespace("  ")] [],
+                                            r_curly_token: R_CURLY@41..45 "}" [Newline("\n"), Whitespace("  ")] [],
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@45..47 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@45..47 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -69,7 +69,7 @@ JsModule {
             semicolon_token: SEMICOLON@47..48 ";" [] [],
         },
     ],
-    eof_token: EOF@48..49 "" [Whitespace("\n")] [],
+    eof_token: EOF@48..49 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..49
@@ -94,7 +94,7 @@ JsModule {
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@9..16
-                      0: IDENT@9..16 "test" [Whitespace("\n"), Whitespace("  ")] []
+                      0: IDENT@9..16 "test" [Newline("\n"), Whitespace("  ")] []
                     3: (empty)
                     4: JS_PARAMETERS@16..19
                       0: L_PAREN@16..17 "(" [] []
@@ -107,7 +107,7 @@ JsModule {
                       2: JS_STATEMENT_LIST@20..41
                         0: JS_VARIABLE_STATEMENT@20..41
                           0: JS_VARIABLE_DECLARATIONS@20..40
-                            0: LET_KW@20..29 "let" [Whitespace("\n"), Whitespace("    ")] [Whitespace(" ")]
+                            0: LET_KW@20..29 "let" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
                             1: JS_VARIABLE_DECLARATION_LIST@29..40
                               0: JS_VARIABLE_DECLARATION@29..40
                                 0: JS_IDENTIFIER_BINDING@29..31
@@ -119,7 +119,7 @@ JsModule {
                                   1: JS_STRING_LITERAL_EXPRESSION@33..40
                                     0: JS_STRING_LITERAL@33..40 "\"inner\"" [] []
                           1: SEMICOLON@40..41 ";" [] []
-                      3: R_CURLY@41..45 "}" [Whitespace("\n"), Whitespace("  ")] []
-                2: R_CURLY@45..47 "}" [Whitespace("\n")] []
+                      3: R_CURLY@41..45 "}" [Newline("\n"), Whitespace("  ")] []
+                2: R_CURLY@45..47 "}" [Newline("\n")] []
       1: SEMICOLON@47..48 ";" [] []
-  3: EOF@48..49 "" [Whitespace("\n")] []
+  3: EOF@48..49 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/semicolons.rast
+++ b/crates/rslint_parser/test_data/inline/ok/semicolons.rast
@@ -27,7 +27,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@14..19 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -50,7 +50,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@27..32 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -66,7 +66,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@36..41 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -82,7 +82,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@44..49 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -98,7 +98,7 @@ JsModule {
         },
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@52..62 "function" [Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@62..65 "foo" [] [],
@@ -126,7 +126,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@83..84 "" [Whitespace("\n")] [],
+    eof_token: EOF@83..84 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..84
@@ -150,7 +150,7 @@ JsModule {
       1: SEMICOLON@13..14 ";" [] []
     1: JS_VARIABLE_STATEMENT@14..27
       0: JS_VARIABLE_DECLARATIONS@14..26
-        0: LET_KW@14..19 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@14..19 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@19..26
           0: JS_VARIABLE_DECLARATION@19..26
             0: JS_IDENTIFIER_BINDING@19..23
@@ -165,7 +165,7 @@ JsModule {
       1: SEMICOLON@26..27 ";" [] []
     2: JS_VARIABLE_STATEMENT@27..36
       0: JS_VARIABLE_DECLARATIONS@27..35
-        0: LET_KW@27..32 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@27..32 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@32..35
           0: JS_VARIABLE_DECLARATION@32..35
             0: JS_IDENTIFIER_BINDING@32..35
@@ -176,7 +176,7 @@ JsModule {
       1: SEMICOLON@35..36 ";" [] []
     3: JS_VARIABLE_STATEMENT@36..44
       0: JS_VARIABLE_DECLARATIONS@36..44
-        0: LET_KW@36..41 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@36..41 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@41..44
           0: JS_VARIABLE_DECLARATION@41..44
             0: JS_IDENTIFIER_BINDING@41..44
@@ -187,7 +187,7 @@ JsModule {
       1: (empty)
     4: JS_VARIABLE_STATEMENT@44..52
       0: JS_VARIABLE_DECLARATIONS@44..52
-        0: LET_KW@44..49 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@44..49 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@49..52
           0: JS_VARIABLE_DECLARATION@49..52
             0: JS_IDENTIFIER_BINDING@49..52
@@ -198,7 +198,7 @@ JsModule {
       1: (empty)
     5: JS_FUNCTION_STATEMENT@52..83
       0: (empty)
-      1: FUNCTION_KW@52..62 "function" [Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@52..62 "function" [Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@62..65
         0: IDENT@62..65 "foo" [] []
@@ -218,4 +218,4 @@ JsModule {
               0: TRUE_KW@77..82 "true" [] [Whitespace(" ")]
             2: (empty)
         3: R_CURLY@82..83 "}" [] []
-  3: EOF@83..84 "" [Whitespace("\n")] []
+  3: EOF@83..84 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/sequence_expr.rast
@@ -33,7 +33,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@13..14 "" [Whitespace("\n")] [],
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..14
@@ -60,4 +60,4 @@ JsModule {
               2: JS_NUMBER_LITERAL_EXPRESSION@12..13
                 0: JS_NUMBER_LITERAL@12..13 "5" [] []
       1: (empty)
-  3: EOF@13..14 "" [Whitespace("\n")] []
+  3: EOF@13..14 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
@@ -15,7 +15,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@15..21 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@15..21 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@21..24 "foo" [] [],
                     },
@@ -39,7 +39,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@30..36 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@30..36 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: IDENT@36..42 "static" [] [],
                     },
@@ -61,7 +61,7 @@ JsModule {
                 },
                 JsSetterClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@48..57 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@48..57 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     set_token: SET_KW@57..61 "set" [] [Whitespace(" ")],
                     name: JsLiteralMemberName {
@@ -87,7 +87,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@70..76 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@70..76 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: JS_STRING_LITERAL@76..81 "\"baz\"" [] [],
                     },
@@ -111,7 +111,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@87..93 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@87..93 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsComputedMemberName {
                         l_brack_token: L_BRACK@93..94 "[" [] [],
                         expression: JsBinaryExpression {
@@ -145,7 +145,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@110..116 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@110..116 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsLiteralMemberName {
                         value: JS_NUMBER_LITERAL@116..117 "5" [] [],
                     },
@@ -169,7 +169,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    set_token: SET_KW@123..129 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    set_token: SET_KW@123..129 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     name: JsPrivateClassMemberName {
                         hash_token: HASH@129..130 "#" [] [],
                         id_token: IDENT@130..137 "private" [] [],
@@ -191,10 +191,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@143..145 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@143..145 "}" [Newline("\n")] [],
         },
         JsClassStatement {
-            class_token: CLASS_KW@145..152 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@145..152 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@152..163 "NotSetters" [] [Whitespace(" ")],
             },
@@ -209,7 +209,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@164..169 "set" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@164..169 "set" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -237,7 +237,7 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     abstract_token: missing (optional),
-                    async_token: ASYNC_KW@175..183 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    async_token: ASYNC_KW@175..183 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@183..186 "set" [] [],
@@ -266,7 +266,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@192..201 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    static_token: STATIC_KW@192..201 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
@@ -296,10 +296,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@210..212 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@210..212 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@212..213 "" [Whitespace("\n")] [],
+    eof_token: EOF@212..213 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..213
@@ -318,7 +318,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@15..21 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@15..21 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@21..24
             0: IDENT@21..24 "foo" [] []
           5: L_PAREN@24..25 "(" [] []
@@ -337,7 +337,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@30..36 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@30..36 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@36..42
             0: IDENT@36..42 "static" [] []
           5: L_PAREN@42..43 "(" [] []
@@ -354,7 +354,7 @@ JsModule {
             3: R_CURLY@47..48 "}" [] []
         2: JS_SETTER_CLASS_MEMBER@48..70
           0: (empty)
-          1: STATIC_KW@48..57 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          1: STATIC_KW@48..57 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           2: (empty)
           3: SET_KW@57..61 "set" [] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@61..64
@@ -375,7 +375,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@70..76 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@70..76 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@76..81
             0: JS_STRING_LITERAL@76..81 "\"baz\"" [] []
           5: L_PAREN@81..82 "(" [] []
@@ -394,7 +394,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@87..93 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@87..93 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_COMPUTED_MEMBER_NAME@93..104
             0: L_BRACK@93..94 "[" [] []
             1: JS_BINARY_EXPRESSION@94..103
@@ -420,7 +420,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@110..116 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@110..116 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_LITERAL_MEMBER_NAME@116..117
             0: JS_NUMBER_LITERAL@116..117 "5" [] []
           5: L_PAREN@117..118 "(" [] []
@@ -439,7 +439,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: SET_KW@123..129 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: SET_KW@123..129 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: JS_PRIVATE_CLASS_MEMBER_NAME@129..137
             0: HASH@129..130 "#" [] []
             1: IDENT@130..137 "private" [] []
@@ -455,9 +455,9 @@ JsModule {
             1: JS_DIRECTIVE_LIST@142..142
             2: JS_STATEMENT_LIST@142..142
             3: R_CURLY@142..143 "}" [] []
-      6: R_CURLY@143..145 "}" [Whitespace("\n")] []
+      6: R_CURLY@143..145 "}" [Newline("\n")] []
     1: JS_CLASS_STATEMENT@145..212
-      0: CLASS_KW@145..152 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@145..152 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@152..163
         0: IDENT@152..163 "NotSetters" [] [Whitespace(" ")]
       2: (empty)
@@ -471,7 +471,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@164..169
-            0: IDENT@164..169 "set" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@164..169 "set" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@169..173
             0: L_PAREN@169..170 "(" [] []
@@ -492,7 +492,7 @@ JsModule {
           0: (empty)
           1: (empty)
           2: (empty)
-          3: ASYNC_KW@175..183 "async" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          3: ASYNC_KW@175..183 "async" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@183..186
             0: IDENT@183..186 "set" [] []
@@ -514,7 +514,7 @@ JsModule {
             3: R_CURLY@191..192 "}" [] []
         2: JS_METHOD_CLASS_MEMBER@192..210
           0: (empty)
-          1: STATIC_KW@192..201 "static" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+          1: STATIC_KW@192..201 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: (empty)
@@ -536,5 +536,5 @@ JsModule {
             1: JS_DIRECTIVE_LIST@209..209
             2: JS_STATEMENT_LIST@209..209
             3: R_CURLY@209..210 "}" [] []
-      6: R_CURLY@210..212 "}" [Whitespace("\n")] []
-  3: EOF@212..213 "" [Whitespace("\n")] []
+      6: R_CURLY@210..212 "}" [Newline("\n")] []
+  3: EOF@212..213 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
@@ -18,7 +18,7 @@ JsModule {
                                 l_curly_token: L_CURLY@8..9 "{" [] [],
                                 members: JsObjectMemberList [
                                     JsSetterObjectMember {
-                                        set_token: SET_KW@9..15 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        set_token: SET_KW@9..15 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: IDENT@15..18 "foo" [] [],
                                         },
@@ -35,12 +35,12 @@ JsModule {
                                             l_curly_token: L_CURLY@26..27 "{" [] [],
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [],
-                                            r_curly_token: R_CURLY@27..30 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@27..30 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@30..31 "," [] [],
                                     JsSetterObjectMember {
-                                        set_token: SET_KW@31..37 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        set_token: SET_KW@31..37 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: JS_STRING_LITERAL@37..42 "\"bar\"" [] [],
                                         },
@@ -57,12 +57,12 @@ JsModule {
                                             l_curly_token: L_CURLY@50..51 "{" [] [],
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [],
-                                            r_curly_token: R_CURLY@51..54 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@51..54 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@54..55 "," [] [],
                                     JsSetterObjectMember {
-                                        set_token: SET_KW@55..61 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                                        set_token: SET_KW@55..61 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                                         name: JsComputedMemberName {
                                             l_brack_token: L_BRACK@61..62 "[" [] [],
                                             expression: JsBinaryExpression {
@@ -89,12 +89,12 @@ JsModule {
                                             l_curly_token: L_CURLY@80..81 "{" [] [],
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [],
-                                            r_curly_token: R_CURLY@81..84 "}" [Whitespace("\n"), Whitespace(" ")] [],
+                                            r_curly_token: R_CURLY@81..84 "}" [Newline("\n"), Whitespace(" ")] [],
                                         },
                                     },
                                     COMMA@84..85 "," [] [],
                                     JsSetterObjectMember {
-                                        set_token: SET_KW@85..91 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                                        set_token: SET_KW@85..91 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                                         name: JsLiteralMemberName {
                                             value: JS_NUMBER_LITERAL@91..92 "5" [] [],
                                         },
@@ -111,7 +111,7 @@ JsModule {
                                             l_curly_token: L_CURLY@100..101 "{" [] [],
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [],
-                                            r_curly_token: R_CURLY@101..104 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                                            r_curly_token: R_CURLY@101..104 "}" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                     },
                                     COMMA@104..105 "," [] [],
@@ -119,7 +119,7 @@ JsModule {
                                         async_token: missing (optional),
                                         star_token: missing (optional),
                                         name: JsLiteralMemberName {
-                                            value: IDENT@105..110 "set" [Whitespace("\n"), Whitespace("\t")] [],
+                                            value: IDENT@105..110 "set" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                         type_params: missing (optional),
                                         parameters: JsParameters {
@@ -133,18 +133,18 @@ JsModule {
                                             directives: JsDirectiveList [],
                                             statements: JsStatementList [
                                                 JsReturnStatement {
-                                                    return_token: RETURN_KW@114..124 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                                                    return_token: RETURN_KW@114..124 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
                                                     argument: JsStringLiteralExpression {
                                                         value_token: JS_STRING_LITERAL@124..159 "\"This is a method and not a setter\"" [] [],
                                                     },
                                                     semicolon_token: SEMICOLON@159..160 ";" [] [],
                                                 },
                                             ],
-                                            r_curly_token: R_CURLY@160..163 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                                            r_curly_token: R_CURLY@160..163 "}" [Newline("\n"), Whitespace("\t")] [],
                                         },
                                     },
                                 ],
-                                r_curly_token: R_CURLY@163..165 "}" [Whitespace("\n")] [],
+                                r_curly_token: R_CURLY@163..165 "}" [Newline("\n")] [],
                             },
                         },
                     },
@@ -153,7 +153,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@165..166 "" [Whitespace("\n")] [],
+    eof_token: EOF@165..166 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..166
@@ -175,7 +175,7 @@ JsModule {
                 0: L_CURLY@8..9 "{" [] []
                 1: JS_OBJECT_MEMBER_LIST@9..163
                   0: JS_SETTER_OBJECT_MEMBER@9..30
-                    0: SET_KW@9..15 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: SET_KW@9..15 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@15..18
                       0: IDENT@15..18 "foo" [] []
                     2: L_PAREN@18..19 "(" [] []
@@ -189,10 +189,10 @@ JsModule {
                       0: L_CURLY@26..27 "{" [] []
                       1: JS_DIRECTIVE_LIST@27..27
                       2: JS_STATEMENT_LIST@27..27
-                      3: R_CURLY@27..30 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@27..30 "}" [Newline("\n"), Whitespace(" ")] []
                   1: COMMA@30..31 "," [] []
                   2: JS_SETTER_OBJECT_MEMBER@31..54
-                    0: SET_KW@31..37 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: SET_KW@31..37 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@37..42
                       0: JS_STRING_LITERAL@37..42 "\"bar\"" [] []
                     2: L_PAREN@42..43 "(" [] []
@@ -206,10 +206,10 @@ JsModule {
                       0: L_CURLY@50..51 "{" [] []
                       1: JS_DIRECTIVE_LIST@51..51
                       2: JS_STATEMENT_LIST@51..51
-                      3: R_CURLY@51..54 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@51..54 "}" [Newline("\n"), Whitespace(" ")] []
                   3: COMMA@54..55 "," [] []
                   4: JS_SETTER_OBJECT_MEMBER@55..84
-                    0: SET_KW@55..61 "set" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+                    0: SET_KW@55..61 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
                     1: JS_COMPUTED_MEMBER_NAME@61..72
                       0: L_BRACK@61..62 "[" [] []
                       1: JS_BINARY_EXPRESSION@62..71
@@ -230,10 +230,10 @@ JsModule {
                       0: L_CURLY@80..81 "{" [] []
                       1: JS_DIRECTIVE_LIST@81..81
                       2: JS_STATEMENT_LIST@81..81
-                      3: R_CURLY@81..84 "}" [Whitespace("\n"), Whitespace(" ")] []
+                      3: R_CURLY@81..84 "}" [Newline("\n"), Whitespace(" ")] []
                   5: COMMA@84..85 "," [] []
                   6: JS_SETTER_OBJECT_MEMBER@85..104
-                    0: SET_KW@85..91 "set" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+                    0: SET_KW@85..91 "set" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
                     1: JS_LITERAL_MEMBER_NAME@91..92
                       0: JS_NUMBER_LITERAL@91..92 "5" [] []
                     2: L_PAREN@92..93 "(" [] []
@@ -247,13 +247,13 @@ JsModule {
                       0: L_CURLY@100..101 "{" [] []
                       1: JS_DIRECTIVE_LIST@101..101
                       2: JS_STATEMENT_LIST@101..101
-                      3: R_CURLY@101..104 "}" [Whitespace("\n"), Whitespace("\t")] []
+                      3: R_CURLY@101..104 "}" [Newline("\n"), Whitespace("\t")] []
                   7: COMMA@104..105 "," [] []
                   8: JS_METHOD_OBJECT_MEMBER@105..163
                     0: (empty)
                     1: (empty)
                     2: JS_LITERAL_MEMBER_NAME@105..110
-                      0: IDENT@105..110 "set" [Whitespace("\n"), Whitespace("\t")] []
+                      0: IDENT@105..110 "set" [Newline("\n"), Whitespace("\t")] []
                     3: (empty)
                     4: JS_PARAMETERS@110..113
                       0: L_PAREN@110..111 "(" [] []
@@ -265,11 +265,11 @@ JsModule {
                       1: JS_DIRECTIVE_LIST@114..114
                       2: JS_STATEMENT_LIST@114..160
                         0: JS_RETURN_STATEMENT@114..160
-                          0: RETURN_KW@114..124 "return" [Whitespace("\n"), Whitespace("\t ")] [Whitespace(" ")]
+                          0: RETURN_KW@114..124 "return" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
                           1: JS_STRING_LITERAL_EXPRESSION@124..159
                             0: JS_STRING_LITERAL@124..159 "\"This is a method and not a setter\"" [] []
                           2: SEMICOLON@159..160 ";" [] []
-                      3: R_CURLY@160..163 "}" [Whitespace("\n"), Whitespace("\t")] []
-                2: R_CURLY@163..165 "}" [Whitespace("\n")] []
+                      3: R_CURLY@160..163 "}" [Newline("\n"), Whitespace("\t")] []
+                2: R_CURLY@163..165 "}" [Newline("\n")] []
       1: (empty)
-  3: EOF@165..166 "" [Whitespace("\n")] []
+  3: EOF@165..166 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
@@ -20,7 +20,7 @@ JsModule {
             expression: JsStaticMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@7..11 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@7..11 "foo" [Newline("\n")] [],
                     },
                 },
                 operator: DOT@11..12 "." [] [],
@@ -34,7 +34,7 @@ JsModule {
             expression: JsStaticMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@17..21 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@17..21 "foo" [Newline("\n")] [],
                     },
                 },
                 operator: DOT@21..22 "." [] [],
@@ -48,7 +48,7 @@ JsModule {
             expression: JsStaticMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@27..31 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@27..31 "foo" [Newline("\n")] [],
                     },
                 },
                 operator: DOT@31..32 "." [] [],
@@ -62,7 +62,7 @@ JsModule {
             expression: JsStaticMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@35..39 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@35..39 "foo" [Newline("\n")] [],
                     },
                 },
                 operator: QUESTIONDOT@39..41 "?." [] [],
@@ -76,7 +76,7 @@ JsModule {
             expression: JsStaticMemberExpression {
                 object: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
-                        value_token: IDENT@44..48 "foo" [Whitespace("\n")] [],
+                        value_token: IDENT@44..48 "foo" [Newline("\n")] [],
                     },
                 },
                 operator: QUESTIONDOT@48..50 "?." [] [],
@@ -87,7 +87,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsClassStatement {
-            class_token: CLASS_KW@53..60 "class" [Whitespace("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@53..60 "class" [Newline("\n")] [Whitespace(" ")],
             id: JsIdentifierBinding {
                 name_token: IDENT@60..65 "Test" [] [Whitespace(" ")],
             },
@@ -102,7 +102,7 @@ JsModule {
                     readonly_token: missing (optional),
                     abstract_token: missing (optional),
                     name: JsPrivateClassMemberName {
-                        hash_token: HASH@66..69 "#" [Whitespace("\n"), Whitespace("\t")] [],
+                        hash_token: HASH@66..69 "#" [Newline("\n"), Whitespace("\t")] [],
                         id_token: IDENT@69..72 "bar" [] [],
                     },
                     question_mark_token: missing (optional),
@@ -118,7 +118,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@72..78 "test" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@72..78 "test" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -142,7 +142,7 @@ JsModule {
                             JsExpressionStatement {
                                 expression: JsStaticMemberExpression {
                                     object: JsThisExpression {
-                                        this_token: THIS_KW@87..94 "this" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                        this_token: THIS_KW@87..94 "this" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
                                     operator: DOT@94..95 "." [] [],
                                     member: JsPrivateName {
@@ -155,7 +155,7 @@ JsModule {
                             JsExpressionStatement {
                                 expression: JsStaticMemberExpression {
                                     object: JsThisExpression {
-                                        this_token: THIS_KW@100..107 "this" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                        this_token: THIS_KW@100..107 "this" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
                                     operator: QUESTIONDOT@107..109 "?." [] [],
                                     member: JsPrivateName {
@@ -169,7 +169,7 @@ JsModule {
                                 expression: JsStaticMemberExpression {
                                     object: JsIdentifierExpression {
                                         name: JsReferenceIdentifier {
-                                            value_token: IDENT@114..122 "other" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            value_token: IDENT@114..122 "other" [Newline("\n"), Whitespace("\t\t")] [],
                                         },
                                     },
                                     operator: DOT@122..123 "." [] [],
@@ -184,7 +184,7 @@ JsModule {
                                 expression: JsStaticMemberExpression {
                                     object: JsIdentifierExpression {
                                         name: JsReferenceIdentifier {
-                                            value_token: IDENT@128..136 "other" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            value_token: IDENT@128..136 "other" [Newline("\n"), Whitespace("\t\t")] [],
                                         },
                                     },
                                     operator: QUESTIONDOT@136..138 "?." [] [],
@@ -196,14 +196,14 @@ JsModule {
                                 semicolon_token: SEMICOLON@142..143 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@143..146 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@143..146 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@146..148 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@146..148 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@148..149 "" [Whitespace("\n")] [],
+    eof_token: EOF@148..149 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..149
@@ -223,7 +223,7 @@ JsModule {
       0: JS_STATIC_MEMBER_EXPRESSION@7..17
         0: JS_IDENTIFIER_EXPRESSION@7..11
           0: JS_REFERENCE_IDENTIFIER@7..11
-            0: IDENT@7..11 "foo" [Whitespace("\n")] []
+            0: IDENT@7..11 "foo" [Newline("\n")] []
         1: DOT@11..12 "." [] []
         2: JS_NAME@12..17
           0: IDENT@12..17 "await" [] []
@@ -232,7 +232,7 @@ JsModule {
       0: JS_STATIC_MEMBER_EXPRESSION@17..27
         0: JS_IDENTIFIER_EXPRESSION@17..21
           0: JS_REFERENCE_IDENTIFIER@17..21
-            0: IDENT@17..21 "foo" [Whitespace("\n")] []
+            0: IDENT@17..21 "foo" [Newline("\n")] []
         1: DOT@21..22 "." [] []
         2: JS_NAME@22..27
           0: IDENT@22..27 "yield" [] []
@@ -241,7 +241,7 @@ JsModule {
       0: JS_STATIC_MEMBER_EXPRESSION@27..35
         0: JS_IDENTIFIER_EXPRESSION@27..31
           0: JS_REFERENCE_IDENTIFIER@27..31
-            0: IDENT@27..31 "foo" [Whitespace("\n")] []
+            0: IDENT@27..31 "foo" [Newline("\n")] []
         1: DOT@31..32 "." [] []
         2: JS_NAME@32..35
           0: IDENT@32..35 "for" [] []
@@ -250,7 +250,7 @@ JsModule {
       0: JS_STATIC_MEMBER_EXPRESSION@35..44
         0: JS_IDENTIFIER_EXPRESSION@35..39
           0: JS_REFERENCE_IDENTIFIER@35..39
-            0: IDENT@35..39 "foo" [Whitespace("\n")] []
+            0: IDENT@35..39 "foo" [Newline("\n")] []
         1: QUESTIONDOT@39..41 "?." [] []
         2: JS_NAME@41..44
           0: IDENT@41..44 "for" [] []
@@ -259,13 +259,13 @@ JsModule {
       0: JS_STATIC_MEMBER_EXPRESSION@44..53
         0: JS_IDENTIFIER_EXPRESSION@44..48
           0: JS_REFERENCE_IDENTIFIER@44..48
-            0: IDENT@44..48 "foo" [Whitespace("\n")] []
+            0: IDENT@44..48 "foo" [Newline("\n")] []
         1: QUESTIONDOT@48..50 "?." [] []
         2: JS_NAME@50..53
           0: IDENT@50..53 "bar" [] []
       1: (empty)
     6: JS_CLASS_STATEMENT@53..148
-      0: CLASS_KW@53..60 "class" [Whitespace("\n")] [Whitespace(" ")]
+      0: CLASS_KW@53..60 "class" [Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@60..65
         0: IDENT@60..65 "Test" [] [Whitespace(" ")]
       2: (empty)
@@ -279,7 +279,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_PRIVATE_CLASS_MEMBER_NAME@66..72
-            0: HASH@66..69 "#" [Whitespace("\n"), Whitespace("\t")] []
+            0: HASH@66..69 "#" [Newline("\n"), Whitespace("\t")] []
             1: IDENT@69..72 "bar" [] []
           6: (empty)
           7: (empty)
@@ -293,7 +293,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@72..78
-            0: IDENT@72..78 "test" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@72..78 "test" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@78..86
             0: L_PAREN@78..79 "(" [] []
@@ -312,7 +312,7 @@ JsModule {
               0: JS_EXPRESSION_STATEMENT@87..100
                 0: JS_STATIC_MEMBER_EXPRESSION@87..99
                   0: JS_THIS_EXPRESSION@87..94
-                    0: THIS_KW@87..94 "this" [Whitespace("\n"), Whitespace("\t\t")] []
+                    0: THIS_KW@87..94 "this" [Newline("\n"), Whitespace("\t\t")] []
                   1: DOT@94..95 "." [] []
                   2: JS_PRIVATE_NAME@95..99
                     0: HASH@95..96 "#" [] []
@@ -321,7 +321,7 @@ JsModule {
               1: JS_EXPRESSION_STATEMENT@100..114
                 0: JS_STATIC_MEMBER_EXPRESSION@100..113
                   0: JS_THIS_EXPRESSION@100..107
-                    0: THIS_KW@100..107 "this" [Whitespace("\n"), Whitespace("\t\t")] []
+                    0: THIS_KW@100..107 "this" [Newline("\n"), Whitespace("\t\t")] []
                   1: QUESTIONDOT@107..109 "?." [] []
                   2: JS_PRIVATE_NAME@109..113
                     0: HASH@109..110 "#" [] []
@@ -331,7 +331,7 @@ JsModule {
                 0: JS_STATIC_MEMBER_EXPRESSION@114..127
                   0: JS_IDENTIFIER_EXPRESSION@114..122
                     0: JS_REFERENCE_IDENTIFIER@114..122
-                      0: IDENT@114..122 "other" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: IDENT@114..122 "other" [Newline("\n"), Whitespace("\t\t")] []
                   1: DOT@122..123 "." [] []
                   2: JS_PRIVATE_NAME@123..127
                     0: HASH@123..124 "#" [] []
@@ -341,12 +341,12 @@ JsModule {
                 0: JS_STATIC_MEMBER_EXPRESSION@128..142
                   0: JS_IDENTIFIER_EXPRESSION@128..136
                     0: JS_REFERENCE_IDENTIFIER@128..136
-                      0: IDENT@128..136 "other" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: IDENT@128..136 "other" [Newline("\n"), Whitespace("\t\t")] []
                   1: QUESTIONDOT@136..138 "?." [] []
                   2: JS_PRIVATE_NAME@138..142
                     0: HASH@138..139 "#" [] []
                     1: IDENT@139..142 "bar" [] []
                 1: SEMICOLON@142..143 ";" [] []
-            3: R_CURLY@143..146 "}" [Whitespace("\n"), Whitespace("\t")] []
-      6: R_CURLY@146..148 "}" [Whitespace("\n")] []
-  3: EOF@148..149 "" [Whitespace("\n")] []
+            3: R_CURLY@143..146 "}" [Newline("\n"), Whitespace("\t")] []
+      6: R_CURLY@146..148 "}" [Newline("\n")] []
+  3: EOF@148..149 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -13,7 +13,7 @@ JsModule {
             members: JsClassMemberList [
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@11..20 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@11..20 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: missing (optional),
@@ -44,7 +44,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@31..40 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@31..40 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: missing (optional),
                     star_token: STAR@40..41 "*" [] [],
@@ -67,7 +67,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@49..58 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@49..58 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@58..64 "async" [] [Whitespace(" ")],
                     star_token: missing (optional),
@@ -90,7 +90,7 @@ JsModule {
                 },
                 JsMethodClassMember {
                     access_modifier: missing (optional),
-                    static_token: STATIC_KW@72..81 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    static_token: STATIC_KW@72..81 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     abstract_token: missing (optional),
                     async_token: ASYNC_KW@81..87 "async" [] [Whitespace(" ")],
                     star_token: STAR@87..88 "*" [] [],
@@ -112,10 +112,10 @@ JsModule {
                     },
                 },
             ],
-            r_curly_token: R_CURLY@96..98 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@96..98 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@98..99 "" [Whitespace("\n")] [],
+    eof_token: EOF@98..99 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..99
@@ -132,7 +132,7 @@ JsModule {
       5: JS_CLASS_MEMBER_LIST@11..96
         0: JS_METHOD_CLASS_MEMBER@11..31
           0: (empty)
-          1: STATIC_KW@11..20 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: STATIC_KW@11..20 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: (empty)
@@ -156,7 +156,7 @@ JsModule {
             3: R_CURLY@30..31 "}" [] []
         1: JS_METHOD_CLASS_MEMBER@31..49
           0: (empty)
-          1: STATIC_KW@31..40 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: STATIC_KW@31..40 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           2: (empty)
           3: (empty)
           4: STAR@40..41 "*" [] []
@@ -175,7 +175,7 @@ JsModule {
             3: R_CURLY@48..49 "}" [] []
         2: JS_METHOD_CLASS_MEMBER@49..72
           0: (empty)
-          1: STATIC_KW@49..58 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: STATIC_KW@49..58 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@58..64 "async" [] [Whitespace(" ")]
           4: (empty)
@@ -194,7 +194,7 @@ JsModule {
             3: R_CURLY@71..72 "}" [] []
         3: JS_METHOD_CLASS_MEMBER@72..96
           0: (empty)
-          1: STATIC_KW@72..81 "static" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: STATIC_KW@72..81 "static" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           2: (empty)
           3: ASYNC_KW@81..87 "async" [] [Whitespace(" ")]
           4: STAR@87..88 "*" [] []
@@ -211,5 +211,5 @@ JsModule {
             1: JS_DIRECTIVE_LIST@95..95
             2: JS_STATEMENT_LIST@95..95
             3: R_CURLY@95..96 "}" [] []
-      6: R_CURLY@96..98 "}" [Whitespace("\n")] []
-  3: EOF@98..99 "" [Whitespace("\n")] []
+      6: R_CURLY@96..98 "}" [Newline("\n")] []
+  3: EOF@98..99 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -26,7 +26,7 @@ JsModule {
                         callee: JsCallExpression {
                             callee: JsIdentifierExpression {
                                 name: JsReferenceIdentifier {
-                                    value_token: IDENT@8..12 "foo" [Whitespace("\n")] [],
+                                    value_token: IDENT@8..12 "foo" [Newline("\n")] [],
                                 },
                             },
                             optional_chain_token_token: missing (optional),
@@ -83,7 +83,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@32..33 "" [Whitespace("\n")] [],
+    eof_token: EOF@32..33 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..33
@@ -108,7 +108,7 @@ JsModule {
             0: JS_CALL_EXPRESSION@8..17
               0: JS_IDENTIFIER_EXPRESSION@8..12
                 0: JS_REFERENCE_IDENTIFIER@8..12
-                  0: IDENT@8..12 "foo" [Whitespace("\n")] []
+                  0: IDENT@8..12 "foo" [Newline("\n")] []
               1: (empty)
               2: (empty)
               3: JS_CALL_ARGUMENTS@12..17
@@ -143,4 +143,4 @@ JsModule {
             0: IDENT@28..31 "bar" [] []
         4: R_BRACK@31..32 "]" [] []
       1: (empty)
-  3: EOF@32..33 "" [Whitespace("\n")] []
+  3: EOF@32..33 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -21,7 +21,7 @@ JsModule {
                 JsConstructorClassMember {
                     access_modifier: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@22..35 "constructor" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@22..35 "constructor" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
@@ -36,7 +36,7 @@ JsModule {
                             JsExpressionStatement {
                                 expression: JsCallExpression {
                                     callee: JsSuperExpression {
-                                        super_token: SUPER_KW@39..47 "super" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                        super_token: SUPER_KW@39..47 "super" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
                                     optional_chain_token_token: missing (optional),
                                     type_args: missing (optional),
@@ -49,7 +49,7 @@ JsModule {
                                 semicolon_token: SEMICOLON@49..50 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@50..53 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@50..53 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
                 JsMethodClassMember {
@@ -59,7 +59,7 @@ JsModule {
                     async_token: missing (optional),
                     star_token: missing (optional),
                     name: JsLiteralMemberName {
-                        value: IDENT@53..59 "test" [Whitespace("\n"), Whitespace("\t")] [],
+                        value: IDENT@53..59 "test" [Newline("\n"), Whitespace("\t")] [],
                     },
                     type_parameters: missing (optional),
                     parameters: JsParameters {
@@ -76,7 +76,7 @@ JsModule {
                                 expression: JsCallExpression {
                                     callee: JsStaticMemberExpression {
                                         object: JsSuperExpression {
-                                            super_token: SUPER_KW@63..71 "super" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                            super_token: SUPER_KW@63..71 "super" [Newline("\n"), Whitespace("\t\t")] [],
                                         },
                                         operator: DOT@71..72 "." [] [],
                                         member: JsName {
@@ -108,7 +108,7 @@ JsModule {
                             JsExpressionStatement {
                                 expression: JsComputedMemberExpression {
                                     object: JsSuperExpression {
-                                        super_token: SUPER_KW@83..91 "super" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                        super_token: SUPER_KW@83..91 "super" [Newline("\n"), Whitespace("\t\t")] [],
                                     },
                                     optional_chain_token: missing (optional),
                                     l_brack_token: L_BRACK@91..92 "[" [] [],
@@ -120,14 +120,14 @@ JsModule {
                                 semicolon_token: SEMICOLON@94..95 ";" [] [],
                             },
                         ],
-                        r_curly_token: R_CURLY@95..98 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                        r_curly_token: R_CURLY@95..98 "}" [Newline("\n"), Whitespace("\t")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@98..100 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@98..100 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@100..101 "" [Whitespace("\n")] [],
+    eof_token: EOF@100..101 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..101
@@ -149,7 +149,7 @@ JsModule {
         0: JS_CONSTRUCTOR_CLASS_MEMBER@22..53
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@22..35
-            0: IDENT@22..35 "constructor" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@22..35 "constructor" [Newline("\n"), Whitespace("\t")] []
           2: (empty)
           3: JS_CONSTRUCTOR_PARAMETERS@35..38
             0: L_PAREN@35..36 "(" [] []
@@ -162,7 +162,7 @@ JsModule {
               0: JS_EXPRESSION_STATEMENT@39..50
                 0: JS_CALL_EXPRESSION@39..49
                   0: JS_SUPER_EXPRESSION@39..47
-                    0: SUPER_KW@39..47 "super" [Whitespace("\n"), Whitespace("\t\t")] []
+                    0: SUPER_KW@39..47 "super" [Newline("\n"), Whitespace("\t\t")] []
                   1: (empty)
                   2: (empty)
                   3: JS_CALL_ARGUMENTS@47..49
@@ -170,7 +170,7 @@ JsModule {
                     1: JS_CALL_ARGUMENT_LIST@48..48
                     2: R_PAREN@48..49 ")" [] []
                 1: SEMICOLON@49..50 ";" [] []
-            3: R_CURLY@50..53 "}" [Whitespace("\n"), Whitespace("\t")] []
+            3: R_CURLY@50..53 "}" [Newline("\n"), Whitespace("\t")] []
         1: JS_METHOD_CLASS_MEMBER@53..98
           0: (empty)
           1: (empty)
@@ -178,7 +178,7 @@ JsModule {
           3: (empty)
           4: (empty)
           5: JS_LITERAL_MEMBER_NAME@53..59
-            0: IDENT@53..59 "test" [Whitespace("\n"), Whitespace("\t")] []
+            0: IDENT@53..59 "test" [Newline("\n"), Whitespace("\t")] []
           6: (empty)
           7: JS_PARAMETERS@59..62
             0: L_PAREN@59..60 "(" [] []
@@ -193,7 +193,7 @@ JsModule {
                 0: JS_CALL_EXPRESSION@63..82
                   0: JS_STATIC_MEMBER_EXPRESSION@63..76
                     0: JS_SUPER_EXPRESSION@63..71
-                      0: SUPER_KW@63..71 "super" [Whitespace("\n"), Whitespace("\t\t")] []
+                      0: SUPER_KW@63..71 "super" [Newline("\n"), Whitespace("\t\t")] []
                     1: DOT@71..72 "." [] []
                     2: JS_NAME@72..76
                       0: IDENT@72..76 "test" [] []
@@ -214,13 +214,13 @@ JsModule {
               1: JS_EXPRESSION_STATEMENT@83..95
                 0: JS_COMPUTED_MEMBER_EXPRESSION@83..94
                   0: JS_SUPER_EXPRESSION@83..91
-                    0: SUPER_KW@83..91 "super" [Whitespace("\n"), Whitespace("\t\t")] []
+                    0: SUPER_KW@83..91 "super" [Newline("\n"), Whitespace("\t\t")] []
                   1: (empty)
                   2: L_BRACK@91..92 "[" [] []
                   3: JS_NUMBER_LITERAL_EXPRESSION@92..93
                     0: JS_NUMBER_LITERAL@92..93 "1" [] []
                   4: R_BRACK@93..94 "]" [] []
                 1: SEMICOLON@94..95 ";" [] []
-            3: R_CURLY@95..98 "}" [Whitespace("\n"), Whitespace("\t")] []
-      6: R_CURLY@98..100 "}" [Whitespace("\n")] []
-  3: EOF@100..101 "" [Whitespace("\n")] []
+            3: R_CURLY@95..98 "}" [Newline("\n"), Whitespace("\t")] []
+      6: R_CURLY@98..100 "}" [Newline("\n")] []
+  3: EOF@100..101 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/switch_stmt.rast
@@ -14,7 +14,7 @@ JsModule {
             l_curly_token: L_CURLY@13..14 "{" [] [],
             cases: JsSwitchCaseList [
                 JsCaseClause {
-                    case_token: CASE_KW@14..21 "case" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                    case_token: CASE_KW@14..21 "case" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                     test: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@21..24 "bar" [] [],
@@ -24,15 +24,15 @@ JsModule {
                     consequent: JsStatementList [],
                 },
                 JsDefaultClause {
-                    default_token: DEFAULT_KW@25..34 "default" [Whitespace("\n"), Whitespace(" ")] [],
+                    default_token: DEFAULT_KW@25..34 "default" [Newline("\n"), Whitespace(" ")] [],
                     colon_token: COLON@34..35 ":" [] [],
                     consequent: JsStatementList [],
                 },
             ],
-            r_curly_token: R_CURLY@35..37 "}" [Whitespace("\n")] [],
+            r_curly_token: R_CURLY@35..37 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@37..38 "" [Whitespace("\n")] [],
+    eof_token: EOF@37..38 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..38
@@ -49,15 +49,15 @@ JsModule {
       4: L_CURLY@13..14 "{" [] []
       5: JS_SWITCH_CASE_LIST@14..35
         0: JS_CASE_CLAUSE@14..25
-          0: CASE_KW@14..21 "case" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+          0: CASE_KW@14..21 "case" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           1: JS_IDENTIFIER_EXPRESSION@21..24
             0: JS_REFERENCE_IDENTIFIER@21..24
               0: IDENT@21..24 "bar" [] []
           2: COLON@24..25 ":" [] []
           3: JS_STATEMENT_LIST@25..25
         1: JS_DEFAULT_CLAUSE@25..35
-          0: DEFAULT_KW@25..34 "default" [Whitespace("\n"), Whitespace(" ")] []
+          0: DEFAULT_KW@25..34 "default" [Newline("\n"), Whitespace(" ")] []
           1: COLON@34..35 ":" [] []
           2: JS_STATEMENT_LIST@35..35
-      6: R_CURLY@35..37 "}" [Whitespace("\n")] []
-  3: EOF@37..38 "" [Whitespace("\n")] []
+      6: R_CURLY@35..37 "}" [Newline("\n")] []
+  3: EOF@37..38 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -41,7 +41,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@21..26 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -65,7 +65,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@33..38 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -99,7 +99,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@51..56 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -126,7 +126,7 @@ JsModule {
             semicolon_token: SEMICOLON@65..66 ";" [] [],
         },
     ],
-    eof_token: EOF@66..67 "" [Whitespace("\n")] [],
+    eof_token: EOF@66..67 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..67
@@ -160,7 +160,7 @@ JsModule {
       1: SEMICOLON@20..21 ";" [] []
     1: JS_VARIABLE_STATEMENT@21..33
       0: JS_VARIABLE_DECLARATIONS@21..32
-        0: LET_KW@21..26 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@21..26 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@26..32
           0: JS_VARIABLE_DECLARATION@26..32
             0: JS_IDENTIFIER_BINDING@26..28
@@ -177,7 +177,7 @@ JsModule {
       1: SEMICOLON@32..33 ";" [] []
     2: JS_VARIABLE_STATEMENT@33..51
       0: JS_VARIABLE_DECLARATIONS@33..50
-        0: LET_KW@33..38 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@33..38 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@38..50
           0: JS_VARIABLE_DECLARATION@38..50
             0: JS_IDENTIFIER_BINDING@38..40
@@ -200,7 +200,7 @@ JsModule {
       1: SEMICOLON@50..51 ";" [] []
     3: JS_VARIABLE_STATEMENT@51..66
       0: JS_VARIABLE_DECLARATIONS@51..65
-        0: LET_KW@51..56 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@51..56 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@56..65
           0: JS_VARIABLE_DECLARATION@56..65
             0: JS_IDENTIFIER_BINDING@56..58
@@ -217,4 +217,4 @@ JsModule {
                     0: TEMPLATE_CHUNK@61..64 "foo" [] []
                 3: BACKTICK@64..65 "`" [] []
       1: SEMICOLON@65..66 ";" [] []
-  3: EOF@66..67 "" [Whitespace("\n")] []
+  3: EOF@66..67 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/this_expr.rast
@@ -11,7 +11,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsStaticMemberExpression {
                 object: JsThisExpression {
-                    this_token: THIS_KW@4..9 "this" [Whitespace("\n")] [],
+                    this_token: THIS_KW@4..9 "this" [Newline("\n")] [],
                 },
                 operator: DOT@9..10 "." [] [],
                 member: JsName {
@@ -21,7 +21,7 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@13..14 "" [Whitespace("\n")] [],
+    eof_token: EOF@13..14 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..14
@@ -35,9 +35,9 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@4..13
       0: JS_STATIC_MEMBER_EXPRESSION@4..13
         0: JS_THIS_EXPRESSION@4..9
-          0: THIS_KW@4..9 "this" [Whitespace("\n")] []
+          0: THIS_KW@4..9 "this" [Newline("\n")] []
         1: DOT@9..10 "." [] []
         2: JS_NAME@10..13
           0: IDENT@10..13 "foo" [] []
       1: (empty)
-  3: EOF@13..14 "" [Whitespace("\n")] []
+  3: EOF@13..14 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/throw_stmt.rast
@@ -25,14 +25,14 @@ JsModule {
             semicolon_token: SEMICOLON@22..23 ";" [] [],
         },
         JsThrowStatement {
-            throw_token: THROW_KW@23..30 "throw" [Whitespace("\n")] [Whitespace(" ")],
+            throw_token: THROW_KW@23..30 "throw" [Newline("\n")] [Whitespace(" ")],
             argument: JsStringLiteralExpression {
                 value_token: JS_STRING_LITERAL@30..35 "\"foo\"" [] [],
             },
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@35..36 "" [Whitespace("\n")] [],
+    eof_token: EOF@35..36 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..36
@@ -55,8 +55,8 @@ JsModule {
           2: R_PAREN@21..22 ")" [] []
       2: SEMICOLON@22..23 ";" [] []
     1: JS_THROW_STATEMENT@23..35
-      0: THROW_KW@23..30 "throw" [Whitespace("\n")] [Whitespace(" ")]
+      0: THROW_KW@23..30 "throw" [Newline("\n")] [Whitespace(" ")]
       1: JS_STRING_LITERAL_EXPRESSION@30..35
         0: JS_STRING_LITERAL@30..35 "\"foo\"" [] []
       2: (empty)
-  3: EOF@35..36 "" [Whitespace("\n")] []
+  3: EOF@35..36 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -20,7 +20,7 @@ JsModule {
             },
         },
         JsTryStatement {
-            try_token: TRY_KW@15..20 "try" [Whitespace("\n")] [Whitespace(" ")],
+            try_token: TRY_KW@15..20 "try" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@20..21 "{" [] [],
                 statements: JsStatementList [],
@@ -43,7 +43,7 @@ JsModule {
             },
         },
         JsTryFinallyStatement {
-            try_token: TRY_KW@35..40 "try" [Whitespace("\n")] [Whitespace(" ")],
+            try_token: TRY_KW@35..40 "try" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@40..41 "{" [] [],
                 statements: JsStatementList [],
@@ -68,7 +68,7 @@ JsModule {
             },
         },
         JsTryFinallyStatement {
-            try_token: TRY_KW@62..67 "try" [Whitespace("\n")] [Whitespace(" ")],
+            try_token: TRY_KW@62..67 "try" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@67..68 "{" [] [],
                 statements: JsStatementList [],
@@ -99,7 +99,7 @@ JsModule {
             },
         },
         JsTryFinallyStatement {
-            try_token: TRY_KW@93..98 "try" [Whitespace("\n")] [Whitespace(" ")],
+            try_token: TRY_KW@93..98 "try" [Newline("\n")] [Whitespace(" ")],
             body: JsBlockStatement {
                 l_curly_token: L_CURLY@98..99 "{" [] [],
                 statements: JsStatementList [],
@@ -116,7 +116,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@111..112 "" [Whitespace("\n")] [],
+    eof_token: EOF@111..112 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..112
@@ -137,7 +137,7 @@ JsModule {
           1: JS_STATEMENT_LIST@14..14
           2: R_CURLY@14..15 "}" [] []
     1: JS_TRY_STATEMENT@15..35
-      0: TRY_KW@15..20 "try" [Whitespace("\n")] [Whitespace(" ")]
+      0: TRY_KW@15..20 "try" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@20..23
         0: L_CURLY@20..21 "{" [] []
         1: JS_STATEMENT_LIST@21..21
@@ -154,7 +154,7 @@ JsModule {
           1: JS_STATEMENT_LIST@34..34
           2: R_CURLY@34..35 "}" [] []
     2: JS_TRY_FINALLY_STATEMENT@35..62
-      0: TRY_KW@35..40 "try" [Whitespace("\n")] [Whitespace(" ")]
+      0: TRY_KW@35..40 "try" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@40..43
         0: L_CURLY@40..41 "{" [] []
         1: JS_STATEMENT_LIST@41..41
@@ -173,7 +173,7 @@ JsModule {
           1: JS_STATEMENT_LIST@61..61
           2: R_CURLY@61..62 "}" [] []
     3: JS_TRY_FINALLY_STATEMENT@62..93
-      0: TRY_KW@62..67 "try" [Whitespace("\n")] [Whitespace(" ")]
+      0: TRY_KW@62..67 "try" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@67..70
         0: L_CURLY@67..68 "{" [] []
         1: JS_STATEMENT_LIST@68..68
@@ -196,7 +196,7 @@ JsModule {
           1: JS_STATEMENT_LIST@92..92
           2: R_CURLY@92..93 "}" [] []
     4: JS_TRY_FINALLY_STATEMENT@93..111
-      0: TRY_KW@93..98 "try" [Whitespace("\n")] [Whitespace(" ")]
+      0: TRY_KW@93..98 "try" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@98..101
         0: L_CURLY@98..99 "{" [] []
         1: JS_STATEMENT_LIST@99..99
@@ -208,4 +208,4 @@ JsModule {
           0: L_CURLY@109..110 "{" [] []
           1: JS_STATEMENT_LIST@110..110
           2: R_CURLY@110..111 "}" [] []
-  3: EOF@111..112 "" [Whitespace("\n")] []
+  3: EOF@111..112 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keyword_assignments.rast
@@ -17,7 +17,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@12..22 "abstract" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@12..22 "abstract" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@22..24 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -29,7 +29,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@26..37 "namespace" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@26..37 "namespace" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@37..39 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -41,7 +41,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@41..47 "type" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@41..47 "type" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@47..49 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -53,7 +53,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@51..59 "module" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@51..59 "module" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@59..61 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -65,7 +65,7 @@ JsModule {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@63..71 "global" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@63..71 "global" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@71..73 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -75,7 +75,7 @@ JsModule {
             semicolon_token: SEMICOLON@74..75 ";" [] [],
         },
     ],
-    eof_token: EOF@75..76 "" [Whitespace("\n")] [],
+    eof_token: EOF@75..76 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..76
@@ -93,7 +93,7 @@ JsModule {
     1: JS_EXPRESSION_STATEMENT@12..26
       0: JS_ASSIGNMENT_EXPRESSION@12..25
         0: JS_IDENTIFIER_ASSIGNMENT@12..22
-          0: IDENT@12..22 "abstract" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@12..22 "abstract" [Newline("\n")] [Whitespace(" ")]
         1: EQ@22..24 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@24..25
           0: JS_NUMBER_LITERAL@24..25 "2" [] []
@@ -101,7 +101,7 @@ JsModule {
     2: JS_EXPRESSION_STATEMENT@26..41
       0: JS_ASSIGNMENT_EXPRESSION@26..40
         0: JS_IDENTIFIER_ASSIGNMENT@26..37
-          0: IDENT@26..37 "namespace" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@26..37 "namespace" [Newline("\n")] [Whitespace(" ")]
         1: EQ@37..39 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@39..40
           0: JS_NUMBER_LITERAL@39..40 "3" [] []
@@ -109,7 +109,7 @@ JsModule {
     3: JS_EXPRESSION_STATEMENT@41..51
       0: JS_ASSIGNMENT_EXPRESSION@41..50
         0: JS_IDENTIFIER_ASSIGNMENT@41..47
-          0: IDENT@41..47 "type" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@41..47 "type" [Newline("\n")] [Whitespace(" ")]
         1: EQ@47..49 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@49..50
           0: JS_NUMBER_LITERAL@49..50 "4" [] []
@@ -117,7 +117,7 @@ JsModule {
     4: JS_EXPRESSION_STATEMENT@51..63
       0: JS_ASSIGNMENT_EXPRESSION@51..62
         0: JS_IDENTIFIER_ASSIGNMENT@51..59
-          0: IDENT@51..59 "module" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@51..59 "module" [Newline("\n")] [Whitespace(" ")]
         1: EQ@59..61 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@61..62
           0: JS_NUMBER_LITERAL@61..62 "5" [] []
@@ -125,9 +125,9 @@ JsModule {
     5: JS_EXPRESSION_STATEMENT@63..75
       0: JS_ASSIGNMENT_EXPRESSION@63..74
         0: JS_IDENTIFIER_ASSIGNMENT@63..71
-          0: IDENT@63..71 "global" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@63..71 "global" [Newline("\n")] [Whitespace(" ")]
         1: EQ@71..73 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@73..74
           0: JS_NUMBER_LITERAL@73..74 "6" [] []
       1: SEMICOLON@74..75 ";" [] []
-  3: EOF@75..76 "" [Whitespace("\n")] []
+  3: EOF@75..76 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_keywords_assignments_script.rast
@@ -5,7 +5,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@0..20 "interface" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@0..20 "interface" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@20..22 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -17,7 +17,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@24..33 "private" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@24..33 "private" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@33..35 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -29,7 +29,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@37..48 "protected" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@37..48 "protected" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@48..50 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -41,7 +41,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@52..60 "public" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@52..60 "public" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@60..62 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -53,7 +53,7 @@ JsScript {
         JsExpressionStatement {
             expression: JsAssignmentExpression {
                 left: JsIdentifierAssignment {
-                    name_token: IDENT@64..76 "implements" [Whitespace("\n")] [Whitespace(" ")],
+                    name_token: IDENT@64..76 "implements" [Newline("\n")] [Whitespace(" ")],
                 },
                 operator_token: EQ@76..78 "=" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
@@ -63,7 +63,7 @@ JsScript {
             semicolon_token: SEMICOLON@79..80 ";" [] [],
         },
     ],
-    eof_token: EOF@80..81 "" [Whitespace("\n")] [],
+    eof_token: EOF@80..81 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..81
@@ -73,7 +73,7 @@ JsScript {
     0: JS_EXPRESSION_STATEMENT@0..24
       0: JS_ASSIGNMENT_EXPRESSION@0..23
         0: JS_IDENTIFIER_ASSIGNMENT@0..20
-          0: IDENT@0..20 "interface" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@0..20 "interface" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
         1: EQ@20..22 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@22..23
           0: JS_NUMBER_LITERAL@22..23 "1" [] []
@@ -81,7 +81,7 @@ JsScript {
     1: JS_EXPRESSION_STATEMENT@24..37
       0: JS_ASSIGNMENT_EXPRESSION@24..36
         0: JS_IDENTIFIER_ASSIGNMENT@24..33
-          0: IDENT@24..33 "private" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@24..33 "private" [Newline("\n")] [Whitespace(" ")]
         1: EQ@33..35 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@35..36
           0: JS_NUMBER_LITERAL@35..36 "2" [] []
@@ -89,7 +89,7 @@ JsScript {
     2: JS_EXPRESSION_STATEMENT@37..52
       0: JS_ASSIGNMENT_EXPRESSION@37..51
         0: JS_IDENTIFIER_ASSIGNMENT@37..48
-          0: IDENT@37..48 "protected" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@37..48 "protected" [Newline("\n")] [Whitespace(" ")]
         1: EQ@48..50 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@50..51
           0: JS_NUMBER_LITERAL@50..51 "3" [] []
@@ -97,7 +97,7 @@ JsScript {
     3: JS_EXPRESSION_STATEMENT@52..64
       0: JS_ASSIGNMENT_EXPRESSION@52..63
         0: JS_IDENTIFIER_ASSIGNMENT@52..60
-          0: IDENT@52..60 "public" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@52..60 "public" [Newline("\n")] [Whitespace(" ")]
         1: EQ@60..62 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@62..63
           0: JS_NUMBER_LITERAL@62..63 "4" [] []
@@ -105,9 +105,9 @@ JsScript {
     4: JS_EXPRESSION_STATEMENT@64..80
       0: JS_ASSIGNMENT_EXPRESSION@64..79
         0: JS_IDENTIFIER_ASSIGNMENT@64..76
-          0: IDENT@64..76 "implements" [Whitespace("\n")] [Whitespace(" ")]
+          0: IDENT@64..76 "implements" [Newline("\n")] [Whitespace(" ")]
         1: EQ@76..78 "=" [] [Whitespace(" ")]
         2: JS_NUMBER_LITERAL_EXPRESSION@78..79
           0: JS_NUMBER_LITERAL@78..79 "5" [] []
       1: SEMICOLON@79..80 ";" [] []
-  3: EOF@80..81 "" [Whitespace("\n")] []
+  3: EOF@80..81 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/var_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/var_decl.rast
@@ -25,7 +25,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@10..15 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -62,7 +62,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@32..37 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -87,7 +87,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@46..53 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -108,7 +108,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")],
+                kind: CONST_KW@59..66 "const" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsObjectBindingPattern {
@@ -157,7 +157,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")],
+                kind: LET_KW@91..96 "let" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -220,7 +220,7 @@ JsModule {
         },
         JsVariableStatement {
             declarations: JsVariableDeclarations {
-                kind: VAR_KW@154..159 "var" [Whitespace("\n")] [Whitespace(" ")],
+                kind: VAR_KW@154..159 "var" [Newline("\n")] [Whitespace(" ")],
                 items: JsVariableDeclarationList [
                     JsVariableDeclaration {
                         id: JsIdentifierBinding {
@@ -271,7 +271,7 @@ JsModule {
             semicolon_token: SEMICOLON@172..173 ";" [] [],
         },
     ],
-    eof_token: EOF@173..174 "" [Whitespace("\n")] [],
+    eof_token: EOF@173..174 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..174
@@ -294,7 +294,7 @@ JsModule {
       1: SEMICOLON@9..10 ";" [] []
     1: JS_VARIABLE_STATEMENT@10..32
       0: JS_VARIABLE_DECLARATIONS@10..31
-        0: LET_KW@10..15 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@10..15 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@15..31
           0: JS_VARIABLE_DECLARATION@15..31
             0: JS_OBJECT_BINDING_PATTERN@15..28
@@ -319,7 +319,7 @@ JsModule {
       1: SEMICOLON@31..32 ";" [] []
     2: JS_VARIABLE_STATEMENT@32..46
       0: JS_VARIABLE_DECLARATIONS@32..45
-        0: LET_KW@32..37 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@32..37 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@37..45
           0: JS_VARIABLE_DECLARATION@37..40
             0: JS_IDENTIFIER_BINDING@37..40
@@ -337,7 +337,7 @@ JsModule {
       1: SEMICOLON@45..46 ";" [] []
     3: JS_VARIABLE_STATEMENT@46..59
       0: JS_VARIABLE_DECLARATIONS@46..58
-        0: CONST_KW@46..53 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@46..53 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@53..58
           0: JS_VARIABLE_DECLARATION@53..58
             0: JS_IDENTIFIER_BINDING@53..55
@@ -351,7 +351,7 @@ JsModule {
       1: SEMICOLON@58..59 ";" [] []
     4: JS_VARIABLE_STATEMENT@59..91
       0: JS_VARIABLE_DECLARATIONS@59..90
-        0: CONST_KW@59..66 "const" [Whitespace("\n")] [Whitespace(" ")]
+        0: CONST_KW@59..66 "const" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@66..90
           0: JS_VARIABLE_DECLARATION@66..90
             0: JS_OBJECT_BINDING_PATTERN@66..86
@@ -385,7 +385,7 @@ JsModule {
       1: SEMICOLON@90..91 ";" [] []
     5: JS_VARIABLE_STATEMENT@91..154
       0: JS_VARIABLE_DECLARATIONS@91..153
-        0: LET_KW@91..96 "let" [Whitespace("\n")] [Whitespace(" ")]
+        0: LET_KW@91..96 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@96..153
           0: JS_VARIABLE_DECLARATION@96..109
             0: JS_IDENTIFIER_BINDING@96..100
@@ -429,7 +429,7 @@ JsModule {
       1: SEMICOLON@153..154 ";" [] []
     6: JS_VARIABLE_STATEMENT@154..173
       0: JS_VARIABLE_DECLARATIONS@154..172
-        0: VAR_KW@154..159 "var" [Whitespace("\n")] [Whitespace(" ")]
+        0: VAR_KW@154..159 "var" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@159..172
           0: JS_VARIABLE_DECLARATION@159..160
             0: JS_IDENTIFIER_BINDING@159..160
@@ -466,4 +466,4 @@ JsModule {
             2: (empty)
             3: (empty)
       1: SEMICOLON@172..173 ";" [] []
-  3: EOF@173..174 "" [Whitespace("\n")] []
+  3: EOF@173..174 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/while_stmt.rast
@@ -16,7 +16,7 @@ JsModule {
             },
         },
         JsWhileStatement {
-            while_token: WHILE_KW@15..22 "while" [Whitespace("\n")] [Whitespace(" ")],
+            while_token: WHILE_KW@15..22 "while" [Newline("\n")] [Whitespace(" ")],
             l_paren_token: L_PAREN@22..23 "(" [] [],
             test: JsNumberLiteralExpression {
                 value_token: JS_NUMBER_LITERAL@23..24 "5" [] [],
@@ -29,7 +29,7 @@ JsModule {
             },
         },
     ],
-    eof_token: EOF@28..29 "" [Whitespace("\n")] [],
+    eof_token: EOF@28..29 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..29
@@ -47,7 +47,7 @@ JsModule {
         1: JS_STATEMENT_LIST@14..14
         2: R_CURLY@14..15 "}" [] []
     1: JS_WHILE_STATEMENT@15..28
-      0: WHILE_KW@15..22 "while" [Whitespace("\n")] [Whitespace(" ")]
+      0: WHILE_KW@15..22 "while" [Newline("\n")] [Whitespace(" ")]
       1: L_PAREN@22..23 "(" [] []
       2: JS_NUMBER_LITERAL_EXPRESSION@23..24
         0: JS_NUMBER_LITERAL@23..24 "5" [] []
@@ -56,4 +56,4 @@ JsModule {
         0: L_CURLY@26..27 "{" [] []
         1: JS_STATEMENT_LIST@27..27
         2: R_CURLY@27..28 "}" [] []
-  3: EOF@28..29 "" [Whitespace("\n")] []
+  3: EOF@28..29 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -4,7 +4,7 @@ JsScript {
     statements: JsStatementList [
         JsFunctionStatement {
             async_token: missing (optional),
-            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")],
+            function_token: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")],
             star_token: missing (optional),
             id: JsIdentifierBinding {
                 name_token: IDENT@19..20 "f" [] [],
@@ -37,7 +37,7 @@ JsScript {
                 directives: JsDirectiveList [],
                 statements: JsStatementList [
                     JsWithStatement {
-                        with_token: WITH_KW@28..35 "with" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        with_token: WITH_KW@28..35 "with" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
                         l_paren_token: L_PAREN@35..36 "(" [] [],
                         object: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
@@ -53,7 +53,7 @@ JsScript {
                                         callee: JsStaticMemberExpression {
                                             object: JsIdentifierExpression {
                                                 name: JsReferenceIdentifier {
-                                                    value_token: IDENT@40..50 "console" [Whitespace("\n"), Whitespace("\t\t")] [],
+                                                    value_token: IDENT@40..50 "console" [Newline("\n"), Whitespace("\t\t")] [],
                                                 },
                                             },
                                             operator: DOT@50..51 "." [] [],
@@ -78,15 +78,15 @@ JsScript {
                                     semicolon_token: SEMICOLON@57..58 ";" [] [],
                                 },
                             ],
-                            r_curly_token: R_CURLY@58..61 "}" [Whitespace("\n"), Whitespace("\t")] [],
+                            r_curly_token: R_CURLY@58..61 "}" [Newline("\n"), Whitespace("\t")] [],
                         },
                     },
                 ],
-                r_curly_token: R_CURLY@61..63 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@61..63 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@63..64 "" [Whitespace("\n")] [],
+    eof_token: EOF@63..64 "" [Newline("\n")] [],
 }
 
 0: JS_SCRIPT@0..64
@@ -95,7 +95,7 @@ JsScript {
   2: JS_STATEMENT_LIST@0..63
     0: JS_FUNCTION_STATEMENT@0..63
       0: (empty)
-      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Whitespace("\n")] [Whitespace(" ")]
+      1: FUNCTION_KW@0..19 "function" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" ")]
       2: (empty)
       3: JS_IDENTIFIER_BINDING@19..20
         0: IDENT@19..20 "f" [] []
@@ -121,7 +121,7 @@ JsScript {
         1: JS_DIRECTIVE_LIST@28..28
         2: JS_STATEMENT_LIST@28..61
           0: JS_WITH_STATEMENT@28..61
-            0: WITH_KW@28..35 "with" [Whitespace("\n"), Whitespace("\t")] [Whitespace(" ")]
+            0: WITH_KW@28..35 "with" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
             1: L_PAREN@35..36 "(" [] []
             2: JS_IDENTIFIER_EXPRESSION@36..37
               0: JS_REFERENCE_IDENTIFIER@36..37
@@ -135,7 +135,7 @@ JsScript {
                     0: JS_STATIC_MEMBER_EXPRESSION@40..54
                       0: JS_IDENTIFIER_EXPRESSION@40..50
                         0: JS_REFERENCE_IDENTIFIER@40..50
-                          0: IDENT@40..50 "console" [Whitespace("\n"), Whitespace("\t\t")] []
+                          0: IDENT@40..50 "console" [Newline("\n"), Whitespace("\t\t")] []
                       1: DOT@50..51 "." [] []
                       2: JS_NAME@51..54
                         0: IDENT@51..54 "log" [] []
@@ -149,6 +149,6 @@ JsScript {
                             0: IDENT@55..56 "x" [] []
                       2: R_PAREN@56..57 ")" [] []
                   1: SEMICOLON@57..58 ";" [] []
-              2: R_CURLY@58..61 "}" [Whitespace("\n"), Whitespace("\t")] []
-        3: R_CURLY@61..63 "}" [Whitespace("\n")] []
-  3: EOF@63..64 "" [Whitespace("\n")] []
+              2: R_CURLY@58..61 "}" [Newline("\n"), Whitespace("\t")] []
+        3: R_CURLY@61..63 "}" [Newline("\n")] []
+  3: EOF@63..64 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/yield_expr.rast
@@ -22,7 +22,7 @@ JsModule {
                 statements: JsStatementList [
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@17..25 "yield" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")],
+                            yield_token: YIELD_KW@17..25 "yield" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                             argument: JsYieldArgument {
                                 star_token: missing (optional),
                                 expression: JsIdentifierExpression {
@@ -36,7 +36,7 @@ JsModule {
                     },
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@29..36 "yield" [Whitespace("\n"), Whitespace(" ")] [],
+                            yield_token: YIELD_KW@29..36 "yield" [Newline("\n"), Whitespace(" ")] [],
                             argument: JsYieldArgument {
                                 star_token: STAR@36..38 "*" [] [Whitespace(" ")],
                                 expression: JsIdentifierExpression {
@@ -50,31 +50,31 @@ JsModule {
                     },
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@42..49 "yield" [Whitespace("\n"), Whitespace(" ")] [],
+                            yield_token: YIELD_KW@42..49 "yield" [Newline("\n"), Whitespace(" ")] [],
                             argument: missing (optional),
                         },
                         semicolon_token: SEMICOLON@49..50 ";" [] [],
                     },
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@50..57 "yield" [Whitespace("\n"), Whitespace(" ")] [],
+                            yield_token: YIELD_KW@50..57 "yield" [Newline("\n"), Whitespace(" ")] [],
                             argument: missing (optional),
                         },
                         semicolon_token: missing (optional),
                     },
                     JsExpressionStatement {
                         expression: JsYieldExpression {
-                            yield_token: YIELD_KW@57..64 "yield" [Whitespace("\n"), Whitespace(" ")] [],
+                            yield_token: YIELD_KW@57..64 "yield" [Newline("\n"), Whitespace(" ")] [],
                             argument: missing (optional),
                         },
                         semicolon_token: missing (optional),
                     },
                 ],
-                r_curly_token: R_CURLY@64..66 "}" [Whitespace("\n")] [],
+                r_curly_token: R_CURLY@64..66 "}" [Newline("\n")] [],
             },
         },
     ],
-    eof_token: EOF@66..67 "" [Whitespace("\n")] [],
+    eof_token: EOF@66..67 "" [Newline("\n")] [],
 }
 
 0: JS_MODULE@0..67
@@ -99,7 +99,7 @@ JsModule {
         2: JS_STATEMENT_LIST@17..64
           0: JS_EXPRESSION_STATEMENT@17..29
             0: JS_YIELD_EXPRESSION@17..28
-              0: YIELD_KW@17..25 "yield" [Whitespace("\n"), Whitespace(" ")] [Whitespace(" ")]
+              0: YIELD_KW@17..25 "yield" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
               1: JS_YIELD_ARGUMENT@25..28
                 0: (empty)
                 1: JS_IDENTIFIER_EXPRESSION@25..28
@@ -108,7 +108,7 @@ JsModule {
             1: SEMICOLON@28..29 ";" [] []
           1: JS_EXPRESSION_STATEMENT@29..42
             0: JS_YIELD_EXPRESSION@29..41
-              0: YIELD_KW@29..36 "yield" [Whitespace("\n"), Whitespace(" ")] []
+              0: YIELD_KW@29..36 "yield" [Newline("\n"), Whitespace(" ")] []
               1: JS_YIELD_ARGUMENT@36..41
                 0: STAR@36..38 "*" [] [Whitespace(" ")]
                 1: JS_IDENTIFIER_EXPRESSION@38..41
@@ -117,18 +117,18 @@ JsModule {
             1: SEMICOLON@41..42 ";" [] []
           2: JS_EXPRESSION_STATEMENT@42..50
             0: JS_YIELD_EXPRESSION@42..49
-              0: YIELD_KW@42..49 "yield" [Whitespace("\n"), Whitespace(" ")] []
+              0: YIELD_KW@42..49 "yield" [Newline("\n"), Whitespace(" ")] []
               1: (empty)
             1: SEMICOLON@49..50 ";" [] []
           3: JS_EXPRESSION_STATEMENT@50..57
             0: JS_YIELD_EXPRESSION@50..57
-              0: YIELD_KW@50..57 "yield" [Whitespace("\n"), Whitespace(" ")] []
+              0: YIELD_KW@50..57 "yield" [Newline("\n"), Whitespace(" ")] []
               1: (empty)
             1: (empty)
           4: JS_EXPRESSION_STATEMENT@57..64
             0: JS_YIELD_EXPRESSION@57..64
-              0: YIELD_KW@57..64 "yield" [Whitespace("\n"), Whitespace(" ")] []
+              0: YIELD_KW@57..64 "yield" [Newline("\n"), Whitespace(" ")] []
               1: (empty)
             1: (empty)
-        3: R_CURLY@64..66 "}" [Whitespace("\n")] []
-  3: EOF@66..67 "" [Whitespace("\n")] []
+        3: R_CURLY@64..66 "}" [Newline("\n")] []
+  3: EOF@66..67 "" [Newline("\n")] []


### PR DESCRIPTION
PS: The changes are quite small actually. But the new token changed every ```.rast``` file.

Exposing ```NEWLINE``` token as ```GreenTokenTrivia::NewLine``` and ```SyntaxTriviaPieceNewline```; and ```MULTILINE_COMMENT``` as ```SyntaxTriviaPieceComments::has_newline()```.

@ematipico and @Boshen and @leops Any chance our formatter can take advantage of these changes?

### Less allocs

Now ```get_trivia``` does not allocate memory needlessly.

Before:

```
> cargo run -p xtask --release --features "dhat-on" -- coverage-libs --filter=jquery
...
dhat: Total:     33,774,984 bytes in 50,388 blocks
...
```

After
```
> cargo run -p xtask --release --features "dhat-on" -- coverage-libs --filter=jquery
...
dhat: Total:     33,703,768 bytes in 48,100 blocks
...
```

This difference is exactly the numbers of allocs we are doing according ```valgrind```.

Before 
![image](https://user-images.githubusercontent.com/83425/149232036-54e94bb3-63c7-417b-a0bd-9d817dace1f3.png)

After
![image](https://user-images.githubusercontent.com/83425/149232066-2bfd00f8-10ff-42c0-a224-51830e37def4.png)

