### PR TITLE
ci: speed up and remove windows build

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       os: [windows-latest, ubuntu-latest]
+       os: [ubuntu-latest]
 
     steps:
       - name: Checkout PR Branch

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Fetch Main Branch
+        run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main
+
       - name: Install toolchain
         run: rustup show
 
@@ -39,7 +42,7 @@ jobs:
         run: cargo run -p xtask --release -- coverage --json > new_results.json
 
       - name: Checkout Main Branch
-        run: git fetch origin main && git checkout main
+        run: git checkout main
 
       - name: Run Test262 suite on main branch
         continue-on-error: true


### PR DESCRIPTION
## Summary
* speed up Test262 by fetching less
* remove windows build as its slower, and performances the same as linux
* now down to ~2 mins