### PR TITLE
feat: use rslint_errors Diagnostic in rome_analyze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "lspower",
  "rome_analyze",
  "rome_formatter",
+ "rslint_errors",
  "rslint_parser",
  "serde",
  "serde_json",

--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -31,7 +31,7 @@ pub struct AnalyzerContext<'a> {
 }
 
 impl<'a> AnalyzerContext<'a> {
-	pub fn new(
+	pub(crate) fn new(
 		analysis_server: &'a AnalysisServer,
 		file_id: FileId,
 		analyzer: &'a Analyzer,
@@ -43,18 +43,24 @@ impl<'a> AnalyzerContext<'a> {
 		}
 	}
 
+	/// Get the root [SyntaxNode] for the file being analyzed
 	pub fn tree(&self) -> SyntaxNode {
 		self.analysis_server.parse(self.file_id)
 	}
 
+	/// Iterate over syntax nodes in this file that can be cast to T
 	pub fn query_nodes<T: AstNode>(&self) -> impl Iterator<Item = T> {
 		self.analysis_server.query_nodes(self.file_id)
 	}
 
+	/// Find the deepest AST node of type T that covers a TextRange
 	pub fn find_node_at_range<T: AstNode>(&self, range: TextRange) -> Option<T> {
 		self.analysis_server.find_node_at_range(self.file_id, range)
 	}
 
+	/// Create an error [Diagnostic] which includes the [FileId] of the file being analyzed
+	/// and the analyzer's name as a "code". The provided [Span] is recorded as the primary
+	/// label for the diagnostic.
 	#[must_use]
 	pub fn error(&self, span: impl Span, message: impl Into<String>) -> Diagnostic {
 		let code = self.analyzer.name;

--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -4,9 +4,10 @@ pub(crate) mod use_single_case_statement;
 pub(crate) mod use_while;
 
 use once_cell::sync::Lazy;
+use rslint_errors::{Diagnostic, Span};
 use rslint_parser::{AstNode, SyntaxNode, TextRange};
 
-use crate::{analysis_server::AnalysisServer, ActionCategory, AnalyzerResult, FileId};
+use crate::{analysis_server::AnalysisServer, ActionCategory, Analysis, FileId};
 
 static ALL_ANALYZERS: Lazy<Vec<Analyzer>> = Lazy::new(|| {
 	vec![
@@ -20,19 +21,25 @@ static ALL_ANALYZERS: Lazy<Vec<Analyzer>> = Lazy::new(|| {
 pub struct Analyzer {
 	pub name: &'static str,
 	pub action_categories: Vec<ActionCategory>,
-	pub(crate) analyze: fn(&AnalyzerContext) -> AnalyzerResult,
+	pub(crate) analyze: fn(&AnalyzerContext) -> Option<Analysis>,
 }
 
 pub struct AnalyzerContext<'a> {
 	pub file_id: FileId,
 	analysis_server: &'a AnalysisServer,
+	analyzer: &'a Analyzer,
 }
 
 impl<'a> AnalyzerContext<'a> {
-	pub fn new(analysis_server: &'a AnalysisServer, file_id: FileId) -> Self {
+	pub fn new(
+		analysis_server: &'a AnalysisServer,
+		file_id: FileId,
+		analyzer: &'a Analyzer,
+	) -> Self {
 		Self {
 			analysis_server,
 			file_id,
+			analyzer,
 		}
 	}
 
@@ -46,6 +53,12 @@ impl<'a> AnalyzerContext<'a> {
 
 	pub fn find_node_at_range<T: AstNode>(&self, range: TextRange) -> Option<T> {
 		self.analysis_server.find_node_at_range(self.file_id, range)
+	}
+
+	#[must_use]
+	pub fn error(&self, span: impl Span, message: impl Into<String>) -> Diagnostic {
+		let code = self.analyzer.name;
+		Diagnostic::error(self.file_id, code, message.into()).primary(span, "")
 	}
 }
 

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -5,7 +5,7 @@ use rslint_parser::{
 	SyntaxResult,
 };
 
-use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext, Signal};
+use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
 pub fn create() -> Analyzer {
 	Analyzer {
@@ -30,7 +30,7 @@ fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
 			}
 
 			let message = format!("Do not use the {} operator", op.text_trimmed());
-			let signal: Signal = ctx.error(op, message).into_signal();
+			let signal = ctx.error(op, message).into_signal();
 			Some(signal)
 		})
 		.collect()

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use rslint_parser::{
 	ast::{self, JsAnyExpression},
 	AstNode,
@@ -6,17 +5,17 @@ use rslint_parser::{
 	SyntaxResult,
 };
 
-use crate::{ActionCategory, Analysis, Analyzer, AnalyzerContext, Signal};
+use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext, Signal};
 
 pub fn create() -> Analyzer {
 	Analyzer {
 		name: "noDoubleEquals",
-		action_categories: vec![ActionCategory::SafeFix],
+		action_categories: vec![],
 		analyze,
 	}
 }
 
-fn analyze(ctx: &AnalyzerContext) -> Result<Analysis> {
+fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
 	ctx.query_nodes::<ast::JsBinaryExpression>()
 		.filter_map(|n| {
 			let op = n.operator().ok()?;
@@ -30,8 +29,8 @@ fn analyze(ctx: &AnalyzerContext) -> Result<Analysis> {
 				return None;
 			}
 
-			let message = format!("rome: do not use the {} operator", op.text_trimmed());
-			let signal = Signal::diagnostic(op, message);
+			let message = format!("Do not use the {} operator", op.text_trimmed());
+			let signal: Signal = ctx.error(op, message).into_signal();
 			Some(signal)
 		})
 		.collect()

--- a/crates/rome_analyze/src/analyzers/no_var.rs
+++ b/crates/rome_analyze/src/analyzers/no_var.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
-use rslint_parser::{ast, JsSyntaxKind};
+use rslint_parser::{ast, AstNode};
 
-use crate::{Analysis, Analyzer, AnalyzerContext, Signal};
+use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
 pub fn create() -> Analyzer {
 	Analyzer {
@@ -11,9 +10,9 @@ pub fn create() -> Analyzer {
 	}
 }
 
-fn analyze(ctx: &AnalyzerContext) -> Result<Analysis> {
+fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
 	ctx.query_nodes::<ast::JsVariableDeclarations>()
-		.filter(|n| n.kind().map(|k| k.kind()) == Ok(JsSyntaxKind::VAR_KW))
-		.map(|n| Signal::diagnostic(n, "rome: do not use var"))
+		.filter(|n| n.is_var())
+		.map(|n| ctx.error(n.range(), "Do not use var").into_signal())
 		.collect()
 }

--- a/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
@@ -1,22 +1,21 @@
-use anyhow::Result;
-use rslint_parser::{ast, AstNodeList};
+use rslint_parser::{ast, AstNode, AstNodeList};
 
-use crate::{ActionCategory, Analysis, Analyzer, AnalyzerContext, Signal};
+use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
 pub fn create() -> Analyzer {
 	Analyzer {
 		name: "useSingleCaseStatement",
-		action_categories: vec![ActionCategory::Suggestion],
+		action_categories: vec![],
 		analyze,
 	}
 }
 
-fn analyze(ctx: &AnalyzerContext) -> Result<Analysis> {
+fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
 	ctx.query_nodes::<ast::JsCaseClause>()
 		.filter(|n| n.consequent().len() > 1)
 		.map(|node| {
-			let message = "rome: A switch case should only have a single statement.";
-			Signal::diagnostic(node, message)
+			let message = "A switch case should only have a single statement.";
+			ctx.error(node.range(), message).into_signal()
 		})
 		.collect()
 }

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -1,22 +1,21 @@
-use anyhow::Result;
-use rslint_parser::ast;
+use rslint_parser::{ast, AstNode};
 
-use crate::{ActionCategory, Analysis, Analyzer, AnalyzerContext, Signal};
+use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
 pub fn create() -> Analyzer {
 	Analyzer {
 		name: "useWhile",
-		action_categories: vec![ActionCategory::Suggestion],
+		action_categories: vec![],
 		analyze,
 	}
 }
 
-fn analyze(ctx: &AnalyzerContext) -> Result<Analysis> {
+fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
 	ctx.query_nodes::<ast::JsForStatement>()
 		.filter(|n| n.initializer().is_none() && n.update().is_none())
 		.map(|node| {
-			let message = "rome: Use a while loop instead of a for loop";
-			Signal::diagnostic(node, message)
+			let message = "Use a while loop instead of a for loop";
+			ctx.error(node.range(), message).into_signal()
 		})
 		.collect()
 }

--- a/crates/rome_analyze/src/assists.rs
+++ b/crates/rome_analyze/src/assists.rs
@@ -43,27 +43,33 @@ impl<'a> AssistContext<'a> {
 		}
 	}
 
+	/// Get the cursor_range for this AssistContext
 	pub(crate) fn range(&self) -> TextRange {
 		self.cursor_range
 	}
 
+	/// Get the root [SyntaxNode] for the file being analyzed
 	pub fn tree(&self) -> SyntaxNode {
 		self.analysis_server.parse(self.file_id)
 	}
 
+	/// Iterate over syntax nodes in the file being analyzed that can be cast to T
 	pub fn query_nodes<T: AstNode>(&self) -> impl Iterator<Item = T> {
 		self.analysis_server.query_nodes(self.file_id)
 	}
 
+	/// Find the deepest AST node of type T that covers a TextRange
 	pub fn find_node_at_range<T: AstNode>(&self, range: TextRange) -> Option<T> {
 		self.analysis_server.find_node_at_range(self.file_id, range)
 	}
 
+	/// Find the deepest AST node of type T that covers this AssistContext's cursor_range
 	pub fn find_node_at_cursor_range<T: AstNode>(&self) -> Option<T> {
 		self.analysis_server
 			.find_node_at_range(self.file_id, self.cursor_range)
 	}
 
+	/// Find the token that covers the start of the AssistContext's cursor_range
 	pub(crate) fn token_at_offset(&self) -> TokenAtOffset<SyntaxToken> {
 		self.tree().token_at_offset(self.offset)
 	}

--- a/crates/rome_analyze/src/lib.rs
+++ b/crates/rome_analyze/src/lib.rs
@@ -10,5 +10,5 @@ pub use analysis_server::{AnalysisServer, FileId};
 pub use analyzers::{Analyzer, AnalyzerContext};
 pub use assists::AssistContext;
 pub use categories::ActionCategory;
-pub use signals::{Action, Analysis, AnalyzerResult, Signal, TextAction};
+pub use signals::{Action, Analysis, DiagnosticExt, Signal, TextAction};
 pub use syntax_edit::{Indel, SyntaxEdit};

--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -18,6 +18,8 @@ impl Signal {
 		matches!(self, Signal::Action(_))
 	}
 
+	/// For an [Action], returns the valid range.
+	/// For a [Diagnostic], returns the text range of the primary label.
 	pub fn range(&self) -> Option<TextRange> {
 		match self {
 			Signal::Diagnostic(it) => it.range(),
@@ -88,7 +90,7 @@ impl FromIterator<AnalyzeDiagnostic> for Analysis {
 #[derive(Debug, Clone)]
 /// Combines an rslint_errors Diagnostic with [SyntaxEdit] actions.
 ///
-/// The suggestions on a [Diagnostic] are only suitable for text edits.
+/// The suggestions on a [rslint_errors::Diagnostic] are only suitable for text edits.
 /// Perhaps that diagnostic type can be modified so that this type is
 /// unnecessary, but we may not want the core diagnostics format to directly
 /// reference syntax nodes.
@@ -112,6 +114,7 @@ impl AnalyzeDiagnostic {
 		}
 	}
 
+	/// Get the [TextRange] corresponding to the primary label of this diagnostic.
 	pub fn range(&self) -> Option<TextRange> {
 		self.diagnostic.primary_text_range()
 	}
@@ -169,18 +172,21 @@ impl From<Vec<Signal>> for Analysis {
 	}
 }
 
+/// An extension trait for [rslint_errors::Diagnostic]
+/// In the future, the Diagnostic format might be modified directly.
 pub trait DiagnosticExt {
 	fn into_signal(self) -> Signal;
 
-	// This could be added directly to rslint_errors::Diagnostic
 	fn primary_text_range(&self) -> Option<TextRange>;
 }
 
 impl DiagnosticExt for Diagnostic {
+	/// Convenience method to wrap a [Diagnostic] in [Signal::Diagnostic]
 	fn into_signal(self) -> Signal {
 		Signal::Diagnostic(self.into())
 	}
 
+	/// Get the [TextRange] of the diagnostic's primary label
 	fn primary_text_range(&self) -> Option<TextRange> {
 		self.primary.as_ref().map(|p| p.span.range.as_text_range())
 	}

--- a/crates/rome_analyze/src/suppressions.rs
+++ b/crates/rome_analyze/src/suppressions.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
 use rslint_parser::{SyntaxNode, SyntaxToken, TextRange};
 
 const ROME_IGNORE: &str = "rome-ignore";
@@ -28,7 +27,7 @@ impl Suppressions {
 	}
 }
 
-pub fn compute(node: SyntaxNode) -> Result<Suppressions> {
+pub fn compute(node: SyntaxNode) -> Suppressions {
 	let mut suppressions: HashMap<String, Vec<TextRange>> = HashMap::new();
 
 	for token in node.descendants_tokens() {
@@ -55,7 +54,7 @@ pub fn compute(node: SyntaxNode) -> Result<Suppressions> {
 			}
 		}
 	}
-	Ok(Suppressions { suppressions })
+	Suppressions { suppressions }
 }
 
 // TODO: Improve this logic

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.35"
 indexmap = "1.6.2"
 rome_formatter = { path = "../rome_formatter" }
 rome_analyze = { path = "../rome_analyze" }
+rslint_errors = { path = "../rslint_errors", version = "0.2.0" }
 rslint_parser = { path = "../rslint_parser" } 
 lspower = "1.1.0"
 tokio = { version = "1", features = ["full" ]}

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -7,7 +7,7 @@ use rslint_parser::parse_text;
 use crate::line_index;
 
 pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
-	let tree = parse_text(text, file_id.0).syntax();
+	let tree = parse_text(text, file_id).syntax();
 
 	let options = FormatOptions {
 		indent_style: IndentStyle::Tab,

--- a/crates/rome_lsp/src/url_interner.rs
+++ b/crates/rome_lsp/src/url_interner.rs
@@ -18,7 +18,7 @@ impl UrlInterner {
 	/// If `path` does not exists in `self`, returns [`None`].
 	#[allow(unused)]
 	pub(crate) fn get(&self, path: &Url) -> Option<FileId> {
-		self.map.get_index_of(path).map(FileId)
+		self.map.get_index_of(path)
 	}
 
 	/// Insert `path` in `self`.
@@ -28,7 +28,7 @@ impl UrlInterner {
 	pub(crate) fn intern(&mut self, path: Url) -> FileId {
 		let (id, _added) = self.map.insert_full(path);
 		assert!(id < usize::MAX);
-		FileId(id)
+		id
 	}
 
 	/// Returns the path corresponding to `id`.
@@ -38,6 +38,6 @@ impl UrlInterner {
 	/// Panics if `id` does not exists in `self`.
 	#[allow(dead_code)]
 	pub(crate) fn lookup(&self, id: FileId) -> &Url {
-		self.map.get_index(id.0 as usize).unwrap()
+		self.map.get_index(id).unwrap()
 	}
 }

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::line_index::{LineCol, LineIndex};
 use lspower::lsp::{self, CodeAction, CodeActionKind, Diagnostic, TextEdit, Url, WorkspaceEdit};
-use rome_analyze::{Indel, TextAction};
+use rome_analyze::{DiagnosticExt, Indel, TextAction};
 use tracing::trace;
 
 use rslint_parser::{TextRange, TextSize};
@@ -71,4 +71,17 @@ pub(crate) fn text_action_to_lsp(
 		disabled: None,
 		data: None,
 	}
+}
+
+pub(crate) fn diagnostic_to_lsp(
+	diagnostic: rslint_errors::Diagnostic,
+	line_index: &LineIndex,
+) -> Option<lsp::Diagnostic> {
+	let text_range = diagnostic.primary_text_range()?;
+	let lsp_range = crate::utils::range(line_index, text_range);
+	let message = diagnostic.title;
+	let code = diagnostic.code.map(lspower::lsp::NumberOrString::String);
+	let source = Some("rome".into());
+	let diagnostic = Diagnostic::new(lsp_range, None, code, source, message, None, None);
+	Some(diagnostic)
 }

--- a/crates/rome_lsp/src/utils.rs
+++ b/crates/rome_lsp/src/utils.rs
@@ -73,6 +73,10 @@ pub(crate) fn text_action_to_lsp(
 	}
 }
 
+/// Convert an [rslint_errors::Diagnostic] to a [lsp::Diagnostic], using the span
+/// of the diagnostic's primary label as the diagnostic range.
+/// Requires a [LineIndex] to convert a byte offset range to the line/col range
+/// expected by LSP.
 pub(crate) fn diagnostic_to_lsp(
 	diagnostic: rslint_errors::Diagnostic,
 	line_index: &LineIndex,


### PR DESCRIPTION


## Summary


- An `AnalyzeDiagnostic` now uses an `rslint_errors::Diagnostic` internally. That `Diagnostic` format may not perfectly match our needs, but it makes sense to unify around a single core diagnostics type for all of our crates. We can either modify it incrementally or replace it later, as needed.

- Analyzers now return `Option<Analysis>` instead of `Result<Analysis>`.
    - As analyzers are meant to inspect the syntax tree of an entire file, it’s often not ideal for them to bail early using `?` on fallible functions (e.g. when attempting to access the children of an AST node). It’s preferable for errors to be collected and included as part of the normal return value (similar to how our parser works). TODO: Add error-handling infrastructure for `Analysis`
    - The return type is an `Option` as an ergonomic way of returning an “empty” analysis. An analyzer might only be applicable at all under certain conditions and would want to return early if not. E.g. `context.maybe_get_foo_details()?`

- A new `AnalyzerContext` is now (cheaply) created before calling each analyzer and contains a reference to the analyzer being called. This allows for context methods to access information about the analyzer (like its name) under the hood. Same for `AssistContext`

- Published LSP diagnostics include the analyzer name as the `code` and “rome” as the `source`

