### PR TITLE
Disallow declarations in single statement context

### DIFF
--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -70,7 +70,6 @@ const STARTS_EXPR: TokenSet = token_set![
 	T![...],
 	T![this],
 	T![yield],
-	T![enum],
 	T![await],
 	T![function],
 	T![class],

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -5,14 +5,15 @@ use crate::syntax::class::parse_initializer_clause;
 use crate::syntax::expr::parse_expr_or_assignment;
 use crate::syntax::js_parse_error;
 use crate::syntax::js_parse_error::expected_binding;
-use crate::syntax::stmt::{is_semi, parse_block_impl};
+use crate::syntax::stmt::{is_semi, parse_block_impl, StatementContext};
 use crate::syntax::typescript::{
 	maybe_eat_incorrect_modifier, maybe_ts_type_annotation, ts_type, ts_type_or_type_predicate_ann,
 	ts_type_params,
 };
 use crate::JsSyntaxFeature::TypeScript;
 use crate::ParsedSyntax::{Absent, Present};
-use crate::{Marker, ParseRecovery, Parser, SyntaxFeature};
+use crate::{CompletedMarker, JsSyntaxFeature, Marker, ParseRecovery, Parser, SyntaxFeature};
+use rome_rowan::SyntaxKind;
 use rslint_syntax::JsSyntaxKind::*;
 use rslint_syntax::{JsSyntaxKind, T};
 
@@ -46,23 +47,41 @@ use rslint_syntax::{JsSyntaxKind, T};
 //
 // test_err function_broken
 // function foo())})}{{{  {}
-pub(super) fn parse_function_statement(p: &mut Parser) -> ParsedSyntax {
+pub(super) fn parse_function_statement(p: &mut Parser, context: StatementContext) -> ParsedSyntax {
 	if !is_at_function(p) {
 		return Absent;
 	}
 
 	let m = p.start();
-	parse_function(p, m, FunctionKind::Statement)
-}
+	let mut function = parse_function(
+		p,
+		m,
+		FunctionKind::Statement {
+			declaration: context.is_single_statement(),
+		},
+	);
 
-/// A function statement but does not allow for async or generator functions. Matches the `FunctionDeclaration` from the ECMA spec
-pub(super) fn parse_function_declaration(p: &mut Parser) -> ParsedSyntax {
-	if !is_at_function(p) {
-		return Absent;
+	if context != StatementContext::StatementList && !function.kind().is_unknown() {
+		if JsSyntaxFeature::StrictMode.is_supported(p) {
+			// test_err function_in_single_statement_context_strict
+			// if (true) function a() {}
+			// label1: function a() {}
+			// while (true) function a() {}
+			p.error(p.err_builder("In strict mode code, functions can only be declared at top level or inside a block").primary(function.range(p), "wrap the function in a block statement"));
+			function.change_to_unknown(p);
+		} else if !matches!(context, StatementContext::If | StatementContext::Label) {
+			// test function_in_if_or_labelled_stmt_loose_mode
+			// // SCRIPT
+			// label1: function a() {}
+			// if (true) function a() {} else function b() {}
+			// if (true) function c() {}
+			// if (true) "test"; else function d() {}
+			p.error(p.err_builder("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if or labelled statement").primary(function.range(p), "wrap the function in a block statement"));
+			function.change_to_unknown(p);
+		}
 	}
 
-	let m = p.start();
-	parse_function(p, m, FunctionKind::Declaration)
+	Present(function)
 }
 
 pub(super) fn parse_function_expression(p: &mut Parser) -> ParsedSyntax {
@@ -71,7 +90,7 @@ pub(super) fn parse_function_expression(p: &mut Parser) -> ParsedSyntax {
 	}
 
 	let m = p.start();
-	parse_function(p, m, FunctionKind::Expression)
+	Present(parse_function(p, m, FunctionKind::Expression))
 }
 
 // test export_function_clause
@@ -84,7 +103,7 @@ pub(super) fn parse_export_function_clause(p: &mut Parser) -> ParsedSyntax {
 	}
 
 	let m = p.start();
-	parse_function(p, m, FunctionKind::Export)
+	Present(parse_function(p, m, FunctionKind::Export))
 }
 
 // test export_default_function_clause
@@ -96,13 +115,12 @@ pub(super) fn parse_export_default_function_case(p: &mut Parser) -> ParsedSyntax
 
 	let m = p.start();
 	p.bump(T![default]);
-	parse_function(p, m, FunctionKind::ExportDefault)
+	Present(parse_function(p, m, FunctionKind::ExportDefault))
 }
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 enum FunctionKind {
-	Statement,
-	Declaration,
+	Statement { declaration: bool },
 	Expression,
 	Export,
 	ExportDefault,
@@ -112,12 +130,16 @@ impl FunctionKind {
 	fn is_id_optional(&self) -> bool {
 		matches!(self, FunctionKind::Expression | FunctionKind::ExportDefault)
 	}
+
+	fn is_statement(&self) -> bool {
+		matches!(self, FunctionKind::Statement { .. })
+	}
 }
 
 impl From<FunctionKind> for JsSyntaxKind {
 	fn from(kind: FunctionKind) -> Self {
 		match kind {
-			FunctionKind::Statement | FunctionKind::Declaration => JS_FUNCTION_STATEMENT,
+			FunctionKind::Statement { .. } => JS_FUNCTION_STATEMENT,
 			FunctionKind::Expression => JS_FUNCTION_EXPRESSION,
 			FunctionKind::Export => JS_EXPORT_FUNCTION_CLAUSE,
 			FunctionKind::ExportDefault => JS_EXPORT_DEFAULT_FUNCTION_CLAUSE,
@@ -129,9 +151,9 @@ fn is_at_function(p: &Parser) -> bool {
 	p.at_ts(token_set![T![async], T![function]]) || is_at_async_function(p, LineBreak::DoNotCheck)
 }
 
-fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax {
+fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> CompletedMarker {
 	let mut uses_invalid_syntax =
-		kind == FunctionKind::Statement && p.eat(T![declare]) && TypeScript.is_unsupported(p);
+		kind.is_statement() && p.eat(T![declare]) && TypeScript.is_unsupported(p);
 	let mut flags = SignatureFlags::empty();
 
 	let in_async = is_at_async_function(p, LineBreak::DoNotCheck);
@@ -142,7 +164,8 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax
 
 	p.expect(T![function]);
 
-	if p.eat(T![*]) {
+	let in_generator = p.eat(T![*]);
+	if in_generator {
 		flags |= SignatureFlags::GENERATOR;
 	}
 
@@ -173,7 +196,7 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax
 		})
 		.ok();
 
-	if kind == FunctionKind::Statement {
+	if kind.is_statement() {
 		function_body_or_declaration(p, flags);
 	} else {
 		parse_function_body(p, flags).or_add_diagnostic(p, js_parse_error::expected_function_body);
@@ -181,7 +204,10 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax
 
 	let mut function = m.complete(p, kind.into());
 
-	if kind == FunctionKind::Declaration && (in_async || in_generator) {
+	// test_err async_or_generator_in_single_statement_context
+	// if (true) async function t() {}
+	// if (true) function* t() {}
+	if kind == (FunctionKind::Statement { declaration: true }) && (in_async || in_generator) {
 		p.error(p.err_builder("`async` and generator functions can only be declared at top level or inside a block").primary(function.range(p), ""));
 		uses_invalid_syntax = true;
 	}
@@ -190,7 +216,7 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> ParsedSyntax
 		function.change_to_unknown(p);
 	}
 
-	Present(function)
+	function
 }
 
 // test_err break_in_nested_function

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -17,8 +17,8 @@ use crate::syntax::js_parse_error::{
 	expected_named_import, expected_named_import_specifier, expected_statement,
 };
 use crate::syntax::stmt::{
-	is_at_variable_declarations, parse_statement, parse_variable_declaration_list, semi,
-	VariableDeclarationParent, STMT_RECOVERY_SET,
+	is_at_variable_declarations, parse_statement_or_declaration, parse_variable_declaration_list,
+	semi, VariableDeclarationParent, STMT_RECOVERY_SET,
 };
 use crate::syntax::util::expect_keyword;
 use crate::{
@@ -70,7 +70,7 @@ fn parse_module_item(p: &mut Parser) -> ParsedSyntax {
 	match p.cur() {
 		T![import] if !token_set![T![.], T!['(']].contains(p.nth(1)) => parse_import(p),
 		T![export] => parse_export(p),
-		_ => parse_statement(p),
+		_ => parse_statement_or_declaration(p),
 	}
 }
 

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -17,8 +17,8 @@ use crate::syntax::js_parse_error::{
 	expected_named_import, expected_named_import_specifier, expected_statement,
 };
 use crate::syntax::stmt::{
-	is_at_variable_declarations, parse_statement_or_declaration, parse_variable_declaration_list,
-	semi, VariableDeclarationParent, STMT_RECOVERY_SET,
+	is_at_variable_declarations, parse_statement, parse_variable_declaration_list, semi,
+	StatementContext, VariableDeclarationParent, STMT_RECOVERY_SET,
 };
 use crate::syntax::util::expect_keyword;
 use crate::{
@@ -70,7 +70,7 @@ fn parse_module_item(p: &mut Parser) -> ParsedSyntax {
 	match p.cur() {
 		T![import] if !token_set![T![.], T!['(']].contains(p.nth(1)) => parse_import(p),
 		T![export] => parse_export(p),
-		_ => parse_statement_or_declaration(p),
+		_ => parse_statement(p, StatementContext::StatementList),
 	}
 }
 

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -18,7 +18,9 @@ use crate::syntax::expr::{
 	is_at_expression, is_at_identifier, is_nth_at_name, parse_expr_or_assignment,
 	parse_expression_or_recover_to_next_statement, parse_identifier,
 };
-use crate::syntax::function::{is_at_async_function, parse_function_statement, LineBreak};
+use crate::syntax::function::{
+	is_at_async_function, parse_function_declaration, parse_function_statement, LineBreak,
+};
 use crate::syntax::js_parse_error;
 use crate::syntax::js_parse_error::{expected_binding, expected_statement};
 use crate::syntax::module::{parse_export, parse_import};
@@ -106,13 +108,26 @@ pub(super) fn is_semi(p: &Parser, offset: usize) -> bool {
 		|| p.has_linebreak_before_n(offset)
 }
 
+pub(crate) fn parse_statement_or_declaration(p: &mut Parser) -> ParsedSyntax {
+	match p.cur() {
+		T![const] => parse_variable_statement(p),
+		T![function] => parse_function_statement(p),
+		T![class] => parse_class_statement(p),
+		T![ident] if is_at_async_function(p, LineBreak::DoCheck) => parse_function_statement(p),
+		T![ident] if p.cur_src() == "let" && FOLLOWS_LET.contains(p.nth(1)) => {
+			parse_variable_statement(p)
+		}
+		_ => parse_statement(p),
+	}
+}
+
 /// A generic statement such as a block, if, while, with, etc
 ///
 /// Error handling and recovering happens inside this function, so the
 /// caller has to pass a recovery set.
 ///
 /// If not passed, [STMT_RECOVERY_SET] will be used as recovery set
-pub fn parse_statement(p: &mut Parser) -> ParsedSyntax {
+pub(crate) fn parse_statement(p: &mut Parser) -> ParsedSyntax {
 	match p.cur() {
 		// test_err import_decl_not_top_level
 		// {
@@ -160,11 +175,12 @@ pub fn parse_statement(p: &mut Parser) -> ParsedSyntax {
 			export.change_kind(p, JS_UNKNOWN_STATEMENT);
 			export
 		}),
-		T![;] => parse_empty_statement(p), // It is only ever Err if there's no ;
-		T!['{'] => parse_block_stmt(p),    // It is only ever None if there is no `{`,
-		T![if] => parse_if_statement(p),   // It is only ever Err if there's no if
-		T![with] => parse_with_statement(p), // ever only Err if there's no with keyword
-		T![while] => parse_while_statement(p), // It is only ever Err if there's no while keyword
+		T![;] => parse_empty_statement(p),
+		T![var] => parse_variable_statement(p),
+		T!['{'] => parse_block_stmt(p),
+		T![if] => parse_if_statement(p),
+		T![with] => parse_with_statement(p),
+		T![while] => parse_while_statement(p),
 		t if (t == T![enum] && is_nth_at_name(p, 1))
 			|| (t == T![const] && p.nth_at(1, T![enum]) && is_nth_at_name(p, 2)) =>
 		{
@@ -172,31 +188,27 @@ pub fn parse_statement(p: &mut Parser) -> ParsedSyntax {
 			res.err_if_not_ts(p, "enums can only be declared in TypeScript files");
 			Present(res)
 		}
-		T![var] | T![const] => parse_variable_statement(p),
 		T![for] => parse_for_statement(p),
 		T![do] => parse_do_statement(p),
 		T![switch] => parse_switch_statement(p),
-		T![try] => parse_try_statement(p), // it is only ever Err if there's no try
+		T![try] => parse_try_statement(p),
 		T![return] => parse_return_statement(p),
 		T![break] => parse_break_statement(p),
-		T![continue] => parse_continue_statement(p), // It is only ever Err if there's no continue keyword
+		T![continue] => parse_continue_statement(p),
 		T![throw] => parse_throw_statement(p),
 		T![debugger] => parse_debugger_statement(p),
-		T![function] => parse_function_statement(p),
-		T![class] => parse_class_statement(p),
-		T![ident] if is_at_async_function(p, LineBreak::DoCheck) => parse_function_statement(p),
 
-		T![ident] if p.cur_src() == "let" && FOLLOWS_LET.contains(p.nth(1)) => {
-			parse_variable_statement(p)
+		// Declarations for which an expression equivalent exist, need to explicilty return Absent here
+		T![function] | T![class] => {
+			// This is a declaration
+			Absent
 		}
+		T![ident] if p.cur_src() == "let" && FOLLOWS_LET.contains(p.nth(1)) => Absent,
+		T![ident] if is_at_async_function(p, LineBreak::DoCheck) => Absent,
+
 		// TODO: handle `<T>() => {};` with less of a hack
-		_ if is_at_expression(p) => {
-			if is_at_identifier(p) && p.nth_at(1, T![:]) {
-				parse_labeled_statement(p)
-			} else {
-				parse_expression_statement(p)
-			}
-		}
+		_ if is_at_identifier(p) && p.nth_at(1, T![:]) => parse_labeled_statement(p),
+		_ if is_at_expression(p) => parse_expression_statement(p),
 		_ => Absent,
 	}
 }
@@ -243,7 +255,14 @@ fn parse_labeled_statement(p: &mut Parser) -> ParsedSyntax {
 
 		let labelled_statement = identifier.undo_completion(p);
 		p.bump_any();
-		parse_statement(p).or_add_diagnostic(p, expected_statement);
+
+		let body = if StrictMode.is_supported(p) {
+			parse_statement(p)
+		} else {
+			parse_function_declaration(p).or_else(|| parse_statement(p))
+		};
+
+		body.or_add_diagnostic(p, expected_statement);
 
 		if let Some(label) = label {
 			p.state.labels.remove(&label);
@@ -293,7 +312,7 @@ fn parse_expression_statement(p: &mut Parser) -> ParsedSyntax {
 // }
 
 /// A debugger statement such as `debugger;`
-pub fn parse_debugger_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_debugger_statement(p: &mut Parser) -> ParsedSyntax {
 	if !p.at(T![debugger]) {
 		return Absent;
 	}
@@ -308,7 +327,7 @@ pub fn parse_debugger_statement(p: &mut Parser) -> ParsedSyntax {
 // test throw_stmt
 // throw new Error("foo");
 // throw "foo"
-pub fn parse_throw_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_throw_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err throw_stmt_err
 	// throw
 	// new Error("oh no :(")
@@ -354,7 +373,7 @@ pub fn parse_throw_statement(p: &mut Parser) -> ParsedSyntax {
 // }
 
 /// A break statement with an optional label such as `break a;`
-pub fn parse_break_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_break_statement(p: &mut Parser) -> ParsedSyntax {
 	if !p.at(T![break]) {
 		return Absent;
 	}
@@ -400,7 +419,7 @@ pub fn parse_break_statement(p: &mut Parser) -> ParsedSyntax {
 //   continue foo;
 // }
 /// A continue statement with an optional label such as `continue a;`
-pub fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
 	if !p.at(T![continue]) {
 		return Absent;
 	}
@@ -439,7 +458,7 @@ pub fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
 //   return
 // }
 /// A return statement with an optional value such as `return a;`
-pub fn parse_return_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_return_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err return_stmt_err
 	// return;
 	// return foo;
@@ -470,7 +489,7 @@ pub fn parse_return_statement(p: &mut Parser) -> ParsedSyntax {
 // test empty_stmt
 // ;
 /// An empty statement denoted by a single semicolon.
-pub fn parse_empty_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_empty_statement(p: &mut Parser) -> ParsedSyntax {
 	if p.at(T![;]) {
 		let m = p.start();
 		p.bump_any(); // bump ;
@@ -646,7 +665,7 @@ pub(crate) fn parse_statements(p: &mut Parser, stop_on_r_curly: bool) {
 			break;
 		}
 
-		if parse_statement(p)
+		if parse_statement_or_declaration(p)
 			.or_recover(
 				p,
 				&ParseRecovery::new(JS_UNKNOWN_STATEMENT, STMT_RECOVERY_SET),
@@ -662,7 +681,7 @@ pub(crate) fn parse_statements(p: &mut Parser, stop_on_r_curly: bool) {
 }
 
 /// An expression wrapped in parentheses such as `()`
-pub fn parenthesized_expression(p: &mut Parser) {
+fn parenthesized_expression(p: &mut Parser) {
 	let has_l_paren = p.expect(T!['(']);
 
 	p.with_state(AllowObjectExpression(has_l_paren), parse_expression)
@@ -677,7 +696,7 @@ pub fn parenthesized_expression(p: &mut Parser) {
 // if (true) {}
 // if (true) false
 // if (bar) {} else if (true) {} else {}
-pub fn parse_if_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_if_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err if_stmt_err
 	// if (true) else {}
 	// if (true) else
@@ -695,17 +714,37 @@ pub fn parse_if_statement(p: &mut Parser) -> ParsedSyntax {
 	parenthesized_expression(p);
 
 	// body
-	parse_statement(p).or_add_diagnostic(p, expected_statement);
+	parse_if_body(p).or_add_diagnostic(p, expected_statement);
 
 	// else clause
 	if p.at(T![else]) {
 		let else_clause = p.start();
 		p.bump_any(); // bump else
-		parse_statement(p).or_add_diagnostic(p, expected_statement);
+		parse_if_body(p).or_add_diagnostic(p, expected_statement);
 		else_clause.complete(p, JS_ELSE_CLAUSE);
 	}
 
 	Present(m.complete(p, JS_IF_STATEMENT))
+}
+
+fn parse_if_body(p: &mut Parser) -> ParsedSyntax {
+	if StrictMode.is_supported(p) {
+		parse_statement(p)
+	} else {
+		// B.3.3 FunctionDeclarations in IfStatement Statement Clauses
+		// test if_stmt_function_declaration_body
+		// if (true) function a() {} else function a() {}
+		// if (true) {} else function a() {}
+		// if (true) function a() {} else {}
+		// if (true) function a() {}
+		//
+		// test_err if_stmt_async_generator_body
+		// if (true) async function t() {}
+		// if (true) function* t() {}
+
+		// TODO IsLabeledFunctionDeclaration. Duplicate handling inside `parse_declaration that isn't erroring
+		parse_function_declaration(p).or_else(|| parse_statement(p))
+	}
 }
 
 // test with_statement
@@ -716,7 +755,7 @@ pub fn parse_if_statement(p: &mut Parser) -> ParsedSyntax {
 // 	}
 // }
 /// A with statement such as `with (foo) something()`
-pub fn parse_with_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_with_statement(p: &mut Parser) -> ParsedSyntax {
 	if !p.at(T![with]) {
 		return Absent;
 	}
@@ -741,7 +780,7 @@ pub fn parse_with_statement(p: &mut Parser) -> ParsedSyntax {
 // test while_stmt
 // while (true) {}
 // while (5) {}
-pub fn parse_while_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_while_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err while_stmt_err
 	// while true {}
 	// while {}
@@ -784,22 +823,20 @@ pub(crate) fn is_at_variable_declarations(p: &Parser) -> bool {
 // const a;
 // let [a];
 // const { b };
-pub(super) fn parse_variable_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_variable_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err var_decl_err
 	// var a =;
 	// const a = 5 let b = 5;
 	let start = p.cur_tok().start();
 
-	let declaration =
-		parse_variable_declaration_list(p, VariableDeclarationParent::VariableStatement)
-			.or_add_diagnostic(p, js_parse_error::expected_variable);
-	if let Some(declaration) = declaration {
-		let m = declaration.precede(p);
-		semi(p, start..p.cur_tok().start());
-		Present(m.complete(p, JS_VARIABLE_STATEMENT))
-	} else {
-		Absent
-	}
+	parse_variable_declaration_list(p, VariableDeclarationParent::VariableStatement).map(
+		|declaration| {
+			let m = declaration.precede(p);
+			semi(p, start..p.cur_tok().start());
+
+			m.complete(p, JS_VARIABLE_STATEMENT)
+		},
+	)
 }
 
 pub(super) fn parse_variable_declaration_list(
@@ -1085,7 +1122,7 @@ fn parse_variable_declaration(
 // do { } while (true)
 // do { throw Error("foo") } while (true)
 // do { break; } while (true)
-pub fn parse_do_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_do_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err do_while_stmt_err
 	// do while (true)
 	// do while ()
@@ -1237,7 +1274,7 @@ fn parse_for_of_or_in_head(p: &mut Parser) -> JsSyntaxKind {
 // for (let foo of []) {}
 // for (let i = 5, j = 6; i < j; ++j) {}
 // for await (let a of []) {}
-pub fn parse_for_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_for_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err for_stmt_err
 	// for ;; {}
 	// for let i = 5; i < 10; i++ {}
@@ -1286,11 +1323,11 @@ pub fn parse_for_statement(p: &mut Parser) -> ParsedSyntax {
 	Present(completed)
 }
 
-struct SwitchClausesList;
+struct SwitchCaseStatementList;
 
-impl ParseNodeList for SwitchClausesList {
+impl ParseNodeList for SwitchCaseStatementList {
 	fn parse_element(&mut self, p: &mut Parser) -> ParsedSyntax {
-		parse_statement(p)
+		parse_statement_or_declaration(p)
 	}
 
 	fn is_at_list_end(&mut self, p: &mut Parser) -> bool {
@@ -1310,28 +1347,6 @@ impl ParseNodeList for SwitchClausesList {
 	}
 }
 
-struct ConsList;
-impl ParseNodeList for ConsList {
-	fn parse_element(&mut self, p: &mut Parser) -> ParsedSyntax {
-		parse_statement(p)
-	}
-
-	fn is_at_list_end(&mut self, p: &mut Parser) -> bool {
-		p.at_ts(token_set![T![default], T![case], T!['}']])
-	}
-
-	fn recover(&mut self, p: &mut Parser, parsed_element: ParsedSyntax) -> RecoveryResult {
-		parsed_element.or_recover(
-			p,
-			&ParseRecovery::new(JS_UNKNOWN_STATEMENT, token_set!()),
-			js_parse_error::expected_case,
-		)
-	}
-
-	fn list_kind() -> JsSyntaxKind {
-		JS_STATEMENT_LIST
-	}
-}
 // We return the range in case its a default clause so we can report multiple default clauses in a better way
 fn parse_switch_clause(
 	p: &mut Parser,
@@ -1353,7 +1368,7 @@ fn parse_switch_clause(
 			};
 
 			p.expect(T![:]);
-			ConsList.parse_list(p);
+			SwitchCaseStatementList.parse_list(p);
 			let default = m.complete(p, syntax_kind);
 			if first_default.is_some() {
 				let err = p
@@ -1376,7 +1391,7 @@ fn parse_switch_clause(
 			parse_expression(p).or_add_diagnostic(p, js_parse_error::expected_expression);
 			p.expect(T![:]);
 
-			SwitchClausesList.parse_list(p);
+			SwitchCaseStatementList.parse_list(p);
 			Present(m.complete(p, JS_CASE_CLAUSE))
 		}
 		_ => {
@@ -1457,7 +1472,7 @@ impl ParseNodeList for SwitchCasesList {
 //  case bar:
 //  default:
 // }
-pub fn parse_switch_statement(p: &mut Parser) -> ParsedSyntax {
+fn parse_switch_statement(p: &mut Parser) -> ParsedSyntax {
 	// test_err switch_stmt_err
 	// switch foo {}
 	// switch {}

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -11,6 +11,7 @@ use std::panic::catch_unwind;
 use std::path::{Path, PathBuf};
 
 #[test]
+#[ignore]
 fn parser_smoke_test() {
 	let src = r#"
 var asyncFn = async function () {

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -11,7 +11,6 @@ use std::panic::catch_unwind;
 use std::path::{Path, PathBuf};
 
 #[test]
-#[ignore]
 fn parser_smoke_test() {
 	let src = r#"
 let [a, b] = [1, 2];

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -13,8 +13,10 @@ use std::path::{Path, PathBuf};
 #[test]
 fn parser_smoke_test() {
 	let src = r#"
-let [a, b] = [1, 2];
-    "#;
+var asyncFn = async function () {
+  var \u0061wait;
+};
+"#;
 
 	let module = parse_module(src, 0);
 

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -14,10 +14,8 @@ use std::path::{Path, PathBuf};
 #[ignore]
 fn parser_smoke_test() {
 	let src = r#"
-var asyncFn = async function () {
-  var \u0061wait;
-};
-"#;
+let [a, b] = [1, 2];
+    "#;
 
 	let module = parse_module(src, 0);
 

--- a/crates/rslint_parser/test_data/inline/err/async_or_generator_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/err/async_or_generator_in_single_statement_context.js
@@ -1,0 +1,2 @@
+if (true) async function t() {}
+if (true) function* t() {}

--- a/crates/rslint_parser/test_data/inline/err/async_or_generator_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/err/async_or_generator_in_single_statement_context.rast
@@ -1,0 +1,130 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsUnknownStatement {
+                items: [
+                    ASYNC_KW@10..16 "async" [] [Whitespace(" ")],
+                    FUNCTION_KW@16..25 "function" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@25..26 "t" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@26..27 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@29..30 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@30..31 "}" [] [],
+                    },
+                ],
+            },
+            else_clause: missing (optional),
+        },
+        JsIfStatement {
+            if_token: IF_KW@31..35 "if" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@35..36 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@36..40 "true" [] [],
+            },
+            r_paren_token: R_PAREN@40..42 ")" [] [Whitespace(" ")],
+            consequent: JsUnknownStatement {
+                items: [
+                    FUNCTION_KW@42..50 "function" [] [],
+                    STAR@50..52 "*" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@52..53 "t" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@53..54 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@54..56 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@56..57 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@57..58 "}" [] [],
+                    },
+                ],
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@58..59 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..59
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..58
+    0: JS_IF_STATEMENT@0..31
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@10..31
+        0: ASYNC_KW@10..16 "async" [] [Whitespace(" ")]
+        1: FUNCTION_KW@16..25 "function" [] [Whitespace(" ")]
+        2: JS_IDENTIFIER_BINDING@25..26
+          0: IDENT@25..26 "t" [] []
+        3: JS_PARAMETERS@26..29
+          0: L_PAREN@26..27 "(" [] []
+          1: JS_PARAMETER_LIST@27..27
+          2: R_PAREN@27..29 ")" [] [Whitespace(" ")]
+        4: JS_FUNCTION_BODY@29..31
+          0: L_CURLY@29..30 "{" [] []
+          1: JS_DIRECTIVE_LIST@30..30
+          2: JS_STATEMENT_LIST@30..30
+          3: R_CURLY@30..31 "}" [] []
+      5: (empty)
+    1: JS_IF_STATEMENT@31..58
+      0: IF_KW@31..35 "if" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@35..36 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@36..40
+        0: TRUE_KW@36..40 "true" [] []
+      3: R_PAREN@40..42 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@42..58
+        0: FUNCTION_KW@42..50 "function" [] []
+        1: STAR@50..52 "*" [] [Whitespace(" ")]
+        2: JS_IDENTIFIER_BINDING@52..53
+          0: IDENT@52..53 "t" [] []
+        3: JS_PARAMETERS@53..56
+          0: L_PAREN@53..54 "(" [] []
+          1: JS_PARAMETER_LIST@54..54
+          2: R_PAREN@54..56 ")" [] [Whitespace(" ")]
+        4: JS_FUNCTION_BODY@56..58
+          0: L_CURLY@56..57 "{" [] []
+          1: JS_DIRECTIVE_LIST@57..57
+          2: JS_STATEMENT_LIST@57..57
+          3: R_CURLY@57..58 "}" [] []
+      5: (empty)
+  3: EOF@58..59 "" [Newline("\n")] []
+--
+error[SyntaxError]: `async` and generator functions can only be declared at top level or inside a block
+  ┌─ async_or_generator_in_single_statement_context.js:1:11
+  │
+1 │ if (true) async function t() {}
+  │           ^^^^^^^^^^^^^^^^^^^^^
+
+--
+error[SyntaxError]: `async` and generator functions can only be declared at top level or inside a block
+  ┌─ async_or_generator_in_single_statement_context.js:2:11
+  │
+2 │ if (true) function* t() {}
+  │           ^^^^^^^^^^^^^^^^
+
+--
+if (true) async function t() {}
+if (true) function* t() {}

--- a/crates/rslint_parser/test_data/inline/err/class_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/err/class_in_single_statement_context.js
@@ -1,0 +1,1 @@
+if (true) class A {}

--- a/crates/rslint_parser/test_data/inline/err/class_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_in_single_statement_context.rast
@@ -1,0 +1,56 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsUnknownStatement {
+                items: [
+                    CLASS_KW@10..16 "class" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@16..18 "A" [] [Whitespace(" ")],
+                    },
+                    L_CURLY@18..19 "{" [] [],
+                    JsClassMemberList [],
+                    R_CURLY@19..20 "}" [] [],
+                ],
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..21
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..20
+    0: JS_IF_STATEMENT@0..20
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@10..20
+        0: CLASS_KW@10..16 "class" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@16..18
+          0: IDENT@16..18 "A" [] [Whitespace(" ")]
+        2: L_CURLY@18..19 "{" [] []
+        3: JS_CLASS_MEMBER_LIST@19..19
+        4: R_CURLY@19..20 "}" [] []
+      5: (empty)
+  3: EOF@20..21 "" [Newline("\n")] []
+--
+error[SyntaxError]: Classes can only be declared at top level or inside a block
+  ┌─ class_in_single_statement_context.js:1:11
+  │
+1 │ if (true) class A {}
+  │           ^^^^^^^^^^ wrap the class in a block statement
+
+--
+if (true) class A {}

--- a/crates/rslint_parser/test_data/inline/err/function_in_single_statement_context_strict.js
+++ b/crates/rslint_parser/test_data/inline/err/function_in_single_statement_context_strict.js
@@ -1,0 +1,3 @@
+if (true) function a() {}
+label1: function a() {}
+while (true) function a() {}

--- a/crates/rslint_parser/test_data/inline/err/function_in_single_statement_context_strict.rast
+++ b/crates/rslint_parser/test_data/inline/err/function_in_single_statement_context_strict.rast
@@ -1,0 +1,171 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsUnknownStatement {
+                items: [
+                    FUNCTION_KW@10..19 "function" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@19..20 "a" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@20..21 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@21..23 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@23..24 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@24..25 "}" [] [],
+                    },
+                ],
+            },
+            else_clause: missing (optional),
+        },
+        JsLabeledStatement {
+            label_token: IDENT@25..32 "label1" [Newline("\n")] [],
+            colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+            body: JsUnknownStatement {
+                items: [
+                    FUNCTION_KW@34..43 "function" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@43..44 "a" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@44..45 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@45..47 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@47..48 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@48..49 "}" [] [],
+                    },
+                ],
+            },
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@49..56 "while" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@56..57 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@57..61 "true" [] [],
+            },
+            r_paren_token: R_PAREN@61..63 ")" [] [Whitespace(" ")],
+            body: JsUnknownStatement {
+                items: [
+                    FUNCTION_KW@63..72 "function" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@72..73 "a" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@73..74 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@74..76 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@76..77 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@77..78 "}" [] [],
+                    },
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@78..79 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..79
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..78
+    0: JS_IF_STATEMENT@0..25
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@10..25
+        0: FUNCTION_KW@10..19 "function" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@19..20
+          0: IDENT@19..20 "a" [] []
+        2: JS_PARAMETERS@20..23
+          0: L_PAREN@20..21 "(" [] []
+          1: JS_PARAMETER_LIST@21..21
+          2: R_PAREN@21..23 ")" [] [Whitespace(" ")]
+        3: JS_FUNCTION_BODY@23..25
+          0: L_CURLY@23..24 "{" [] []
+          1: JS_DIRECTIVE_LIST@24..24
+          2: JS_STATEMENT_LIST@24..24
+          3: R_CURLY@24..25 "}" [] []
+      5: (empty)
+    1: JS_LABELED_STATEMENT@25..49
+      0: IDENT@25..32 "label1" [Newline("\n")] []
+      1: COLON@32..34 ":" [] [Whitespace(" ")]
+      2: JS_UNKNOWN_STATEMENT@34..49
+        0: FUNCTION_KW@34..43 "function" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@43..44
+          0: IDENT@43..44 "a" [] []
+        2: JS_PARAMETERS@44..47
+          0: L_PAREN@44..45 "(" [] []
+          1: JS_PARAMETER_LIST@45..45
+          2: R_PAREN@45..47 ")" [] [Whitespace(" ")]
+        3: JS_FUNCTION_BODY@47..49
+          0: L_CURLY@47..48 "{" [] []
+          1: JS_DIRECTIVE_LIST@48..48
+          2: JS_STATEMENT_LIST@48..48
+          3: R_CURLY@48..49 "}" [] []
+    2: JS_WHILE_STATEMENT@49..78
+      0: WHILE_KW@49..56 "while" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@56..57 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@57..61
+        0: TRUE_KW@57..61 "true" [] []
+      3: R_PAREN@61..63 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@63..78
+        0: FUNCTION_KW@63..72 "function" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@72..73
+          0: IDENT@72..73 "a" [] []
+        2: JS_PARAMETERS@73..76
+          0: L_PAREN@73..74 "(" [] []
+          1: JS_PARAMETER_LIST@74..74
+          2: R_PAREN@74..76 ")" [] [Whitespace(" ")]
+        3: JS_FUNCTION_BODY@76..78
+          0: L_CURLY@76..77 "{" [] []
+          1: JS_DIRECTIVE_LIST@77..77
+          2: JS_STATEMENT_LIST@77..77
+          3: R_CURLY@77..78 "}" [] []
+  3: EOF@78..79 "" [Newline("\n")] []
+--
+error[SyntaxError]: In strict mode code, functions can only be declared at top level or inside a block
+  ┌─ function_in_single_statement_context_strict.js:1:11
+  │
+1 │ if (true) function a() {}
+  │           ^^^^^^^^^^^^^^^ wrap the function in a block statement
+
+--
+error[SyntaxError]: In strict mode code, functions can only be declared at top level or inside a block
+  ┌─ function_in_single_statement_context_strict.js:2:9
+  │
+2 │ label1: function a() {}
+  │         ^^^^^^^^^^^^^^^ wrap the function in a block statement
+
+--
+error[SyntaxError]: In strict mode code, functions can only be declared at top level or inside a block
+  ┌─ function_in_single_statement_context_strict.js:3:14
+  │
+3 │ while (true) function a() {}
+  │              ^^^^^^^^^^^^^^^ wrap the function in a block statement
+
+--
+if (true) function a() {}
+label1: function a() {}
+while (true) function a() {}

--- a/crates/rslint_parser/test_data/inline/err/identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/identifier_err.rast
@@ -83,16 +83,12 @@ JsModule {
                 r_curly_token: R_CURLY@67..68 "}" [] [],
             },
         },
-        JsExpressionStatement {
-            expression: JsUnknownExpression {
-                items: [
-                    JsUnknown {
-                        items: [
-                            IDENT@68..73 "enum" [Newline("\n")] [],
-                        ],
-                    },
-                ],
-            },
+        JsUnknownStatement {
+            items: [
+                ENUM_KW@68..73 "enum" [Newline("\n")] [],
+            ],
+        },
+        JsEmptyStatement {
             semicolon_token: SEMICOLON@73..74 ";" [] [],
         },
         JsExpressionStatement {
@@ -181,17 +177,16 @@ JsModule {
         1: JS_DIRECTIVE_LIST@67..67
         2: JS_STATEMENT_LIST@67..67
         3: R_CURLY@67..68 "}" [] []
-    4: JS_EXPRESSION_STATEMENT@68..74
-      0: JS_UNKNOWN_EXPRESSION@68..73
-        0: JS_UNKNOWN@68..73
-          0: IDENT@68..73 "enum" [Newline("\n")] []
-      1: SEMICOLON@73..74 ";" [] []
-    5: JS_EXPRESSION_STATEMENT@74..86
+    4: JS_UNKNOWN_STATEMENT@68..73
+      0: ENUM_KW@68..73 "enum" [Newline("\n")] []
+    5: JS_EMPTY_STATEMENT@73..74
+      0: SEMICOLON@73..74 ";" [] []
+    6: JS_EXPRESSION_STATEMENT@74..86
       0: JS_UNKNOWN_EXPRESSION@74..85
         0: JS_UNKNOWN@74..85
           0: IDENT@74..85 "implements" [Newline("\n")] []
       1: SEMICOLON@85..86 ";" [] []
-    6: JS_EXPRESSION_STATEMENT@86..97
+    7: JS_EXPRESSION_STATEMENT@86..97
       0: JS_UNKNOWN_EXPRESSION@86..96
         0: JS_UNKNOWN@86..96
           0: IDENT@86..96 "interface" [Newline("\n")] []
@@ -226,11 +221,11 @@ error[SyntaxError]: Illegal use of `yield` as an identifier in generator functio
   │                ^^^^^
 
 --
-error[SyntaxError]: Illegal use of reserved keyword `enum` as an identifier
+error[SyntaxError]: expected a statement but instead found 'enum'
   ┌─ identifier_err.js:5:1
   │
 5 │ enum;
-  │ ^^^^
+  │ ^^^^ Expected a statement here
 
 --
 error[SyntaxError]: Illegal use of reserved keyword `implements` as an identifier in strict mode

--- a/crates/rslint_parser/test_data/inline/err/labelled_function_decl_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/err/labelled_function_decl_in_single_statement_context.js
@@ -1,0 +1,1 @@
+if (true) label1: label2: function a() {}

--- a/crates/rslint_parser/test_data/inline/err/labelled_function_decl_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/err/labelled_function_decl_in_single_statement_context.rast
@@ -1,0 +1,84 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsLabeledStatement {
+                label_token: IDENT@10..16 "label1" [] [],
+                colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
+                body: JsLabeledStatement {
+                    label_token: IDENT@18..24 "label2" [] [],
+                    colon_token: COLON@24..26 ":" [] [Whitespace(" ")],
+                    body: JsUnknownStatement {
+                        items: [
+                            FUNCTION_KW@26..35 "function" [] [Whitespace(" ")],
+                            JsIdentifierBinding {
+                                name_token: IDENT@35..36 "a" [] [],
+                            },
+                            JsParameters {
+                                l_paren_token: L_PAREN@36..37 "(" [] [],
+                                items: JsParameterList [],
+                                r_paren_token: R_PAREN@37..39 ")" [] [Whitespace(" ")],
+                            },
+                            JsFunctionBody {
+                                l_curly_token: L_CURLY@39..40 "{" [] [],
+                                directives: JsDirectiveList [],
+                                statements: JsStatementList [],
+                                r_curly_token: R_CURLY@40..41 "}" [] [],
+                            },
+                        ],
+                    },
+                },
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@41..42 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..42
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..41
+    0: JS_IF_STATEMENT@0..41
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_LABELED_STATEMENT@10..41
+        0: IDENT@10..16 "label1" [] []
+        1: COLON@16..18 ":" [] [Whitespace(" ")]
+        2: JS_LABELED_STATEMENT@18..41
+          0: IDENT@18..24 "label2" [] []
+          1: COLON@24..26 ":" [] [Whitespace(" ")]
+          2: JS_UNKNOWN_STATEMENT@26..41
+            0: FUNCTION_KW@26..35 "function" [] [Whitespace(" ")]
+            1: JS_IDENTIFIER_BINDING@35..36
+              0: IDENT@35..36 "a" [] []
+            2: JS_PARAMETERS@36..39
+              0: L_PAREN@36..37 "(" [] []
+              1: JS_PARAMETER_LIST@37..37
+              2: R_PAREN@37..39 ")" [] [Whitespace(" ")]
+            3: JS_FUNCTION_BODY@39..41
+              0: L_CURLY@39..40 "{" [] []
+              1: JS_DIRECTIVE_LIST@40..40
+              2: JS_STATEMENT_LIST@40..40
+              3: R_CURLY@40..41 "}" [] []
+      5: (empty)
+  3: EOF@41..42 "" [Newline("\n")] []
+--
+error[SyntaxError]: In strict mode code, functions can only be declared at top level or inside a block
+  ┌─ labelled_function_decl_in_single_statement_context.js:1:27
+  │
+1 │ if (true) label1: label2: function a() {}
+  │                           ^^^^^^^^^^^^^^^ wrap the function in a block statement
+
+--
+if (true) label1: label2: function a() {}

--- a/crates/rslint_parser/test_data/inline/err/labelled_function_declaration_strict_mode.js
+++ b/crates/rslint_parser/test_data/inline/err/labelled_function_declaration_strict_mode.js
@@ -1,0 +1,1 @@
+label1: function a() {}

--- a/crates/rslint_parser/test_data/inline/err/labelled_function_declaration_strict_mode.rast
+++ b/crates/rslint_parser/test_data/inline/err/labelled_function_declaration_strict_mode.rast
@@ -1,0 +1,61 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsLabeledStatement {
+            label_token: IDENT@0..6 "label1" [] [],
+            colon_token: COLON@6..8 ":" [] [Whitespace(" ")],
+            body: JsUnknownStatement {
+                items: [
+                    FUNCTION_KW@8..17 "function" [] [Whitespace(" ")],
+                    JsIdentifierBinding {
+                        name_token: IDENT@17..18 "a" [] [],
+                    },
+                    JsParameters {
+                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@19..21 ")" [] [Whitespace(" ")],
+                    },
+                    JsFunctionBody {
+                        l_curly_token: L_CURLY@21..22 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@22..23 "}" [] [],
+                    },
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@23..24 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..24
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..23
+    0: JS_LABELED_STATEMENT@0..23
+      0: IDENT@0..6 "label1" [] []
+      1: COLON@6..8 ":" [] [Whitespace(" ")]
+      2: JS_UNKNOWN_STATEMENT@8..23
+        0: FUNCTION_KW@8..17 "function" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@17..18
+          0: IDENT@17..18 "a" [] []
+        2: JS_PARAMETERS@18..21
+          0: L_PAREN@18..19 "(" [] []
+          1: JS_PARAMETER_LIST@19..19
+          2: R_PAREN@19..21 ")" [] [Whitespace(" ")]
+        3: JS_FUNCTION_BODY@21..23
+          0: L_CURLY@21..22 "{" [] []
+          1: JS_DIRECTIVE_LIST@22..22
+          2: JS_STATEMENT_LIST@22..22
+          3: R_CURLY@22..23 "}" [] []
+  3: EOF@23..24 "" [Newline("\n")] []
+--
+error[SyntaxError]: In strict mode code, functions can only be declared at top level or inside a block
+  ┌─ labelled_function_declaration_strict_mode.js:1:9
+  │
+1 │ label1: function a() {}
+  │         ^^^^^^^^^^^^^^^ wrap the function in a block statement
+
+--
+label1: function a() {}

--- a/crates/rslint_parser/test_data/inline/err/let_newline_in_async_function.js
+++ b/crates/rslint_parser/test_data/inline/err/let_newline_in_async_function.js
@@ -1,0 +1,4 @@
+async function f() {
+  let
+  await 0;
+}

--- a/crates/rslint_parser/test_data/inline/err/let_newline_in_async_function.rast
+++ b/crates/rslint_parser/test_data/inline/err/let_newline_in_async_function.rast
@@ -1,0 +1,112 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsFunctionStatement {
+            async_token: ASYNC_KW@0..6 "async" [] [Whitespace(" ")],
+            function_token: FUNCTION_KW@6..15 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@15..16 "f" [] [],
+            },
+            type_parameters: missing (optional),
+            parameters: JsParameters {
+                l_paren_token: L_PAREN@16..17 "(" [] [],
+                items: JsParameterList [],
+                r_paren_token: R_PAREN@17..19 ")" [] [Whitespace(" ")],
+            },
+            return_type: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@19..20 "{" [] [],
+                directives: JsDirectiveList [],
+                statements: JsStatementList [
+                    JsVariableStatement {
+                        declarations: JsVariableDeclarations {
+                            kind: LET_KW@20..26 "let" [Newline("\n"), Whitespace("  ")] [],
+                            items: JsVariableDeclarationList [
+                                JsVariableDeclaration {
+                                    id: JsUnknownBinding {
+                                        items: [
+                                            IDENT@26..35 "await" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                                        ],
+                                    },
+                                    excl_token: missing (optional),
+                                    type_annotation: missing (optional),
+                                    initializer: missing (optional),
+                                },
+                            ],
+                        },
+                        semicolon_token: missing (optional),
+                    },
+                    JsExpressionStatement {
+                        expression: JsNumberLiteralExpression {
+                            value_token: JS_NUMBER_LITERAL@35..36 "0" [] [],
+                        },
+                        semicolon_token: SEMICOLON@36..37 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@37..39 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..40
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..39
+    0: JS_FUNCTION_STATEMENT@0..39
+      0: ASYNC_KW@0..6 "async" [] [Whitespace(" ")]
+      1: FUNCTION_KW@6..15 "function" [] [Whitespace(" ")]
+      2: (empty)
+      3: JS_IDENTIFIER_BINDING@15..16
+        0: IDENT@15..16 "f" [] []
+      4: (empty)
+      5: JS_PARAMETERS@16..19
+        0: L_PAREN@16..17 "(" [] []
+        1: JS_PARAMETER_LIST@17..17
+        2: R_PAREN@17..19 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: JS_FUNCTION_BODY@19..39
+        0: L_CURLY@19..20 "{" [] []
+        1: JS_DIRECTIVE_LIST@20..20
+        2: JS_STATEMENT_LIST@20..37
+          0: JS_VARIABLE_STATEMENT@20..35
+            0: JS_VARIABLE_DECLARATIONS@20..35
+              0: LET_KW@20..26 "let" [Newline("\n"), Whitespace("  ")] []
+              1: JS_VARIABLE_DECLARATION_LIST@26..35
+                0: JS_VARIABLE_DECLARATION@26..35
+                  0: JS_UNKNOWN_BINDING@26..35
+                    0: IDENT@26..35 "await" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+                  1: (empty)
+                  2: (empty)
+                  3: (empty)
+            1: (empty)
+          1: JS_EXPRESSION_STATEMENT@35..37
+            0: JS_NUMBER_LITERAL_EXPRESSION@35..36
+              0: JS_NUMBER_LITERAL@35..36 "0" [] []
+            1: SEMICOLON@36..37 ";" [] []
+        3: R_CURLY@37..39 "}" [Newline("\n")] []
+  3: EOF@39..40 "" [Newline("\n")] []
+--
+error[SyntaxError]: Illegal use of `await` as an identifier in an async context
+  ┌─ let_newline_in_async_function.js:3:3
+  │
+3 │   await 0;
+  │   ^^^^^
+
+--
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ let_newline_in_async_function.js:3:9
+  │  
+2 │ ┌   let
+3 │ │   await 0;
+  │ │         ^ An explicit or implicit semicolon is expected here...
+  │ └────────' ...Which is required to end this statement
+
+--
+async function f() {
+  let
+  await 0;
+}

--- a/crates/rslint_parser/test_data/inline/err/lexical_declaration_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/err/lexical_declaration_in_single_statement_context.js
@@ -1,0 +1,2 @@
+if (true) let a;
+while (true) const b = 5;

--- a/crates/rslint_parser/test_data/inline/err/lexical_declaration_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/err/lexical_declaration_in_single_statement_context.rast
@@ -1,0 +1,126 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsUnknownStatement {
+                items: [
+                    JsVariableDeclarations {
+                        kind: LET_KW@10..14 "let" [] [Whitespace(" ")],
+                        items: JsVariableDeclarationList [
+                            JsVariableDeclaration {
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@14..15 "a" [] [],
+                                },
+                                excl_token: missing (optional),
+                                type_annotation: missing (optional),
+                                initializer: missing (optional),
+                            },
+                        ],
+                    },
+                    SEMICOLON@15..16 ";" [] [],
+                ],
+            },
+            else_clause: missing (optional),
+        },
+        JsWhileStatement {
+            while_token: WHILE_KW@16..23 "while" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@23..24 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@24..28 "true" [] [],
+            },
+            r_paren_token: R_PAREN@28..30 ")" [] [Whitespace(" ")],
+            body: JsUnknownStatement {
+                items: [
+                    JsVariableDeclarations {
+                        kind: CONST_KW@30..36 "const" [] [Whitespace(" ")],
+                        items: JsVariableDeclarationList [
+                            JsVariableDeclaration {
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@36..38 "b" [] [Whitespace(" ")],
+                                },
+                                excl_token: missing (optional),
+                                type_annotation: missing (optional),
+                                initializer: JsInitializerClause {
+                                    eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
+                                    expression: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@40..41 "5" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    SEMICOLON@41..42 ";" [] [],
+                ],
+            },
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..43
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..42
+    0: JS_IF_STATEMENT@0..16
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@10..16
+        0: JS_VARIABLE_DECLARATIONS@10..15
+          0: LET_KW@10..14 "let" [] [Whitespace(" ")]
+          1: JS_VARIABLE_DECLARATION_LIST@14..15
+            0: JS_VARIABLE_DECLARATION@14..15
+              0: JS_IDENTIFIER_BINDING@14..15
+                0: IDENT@14..15 "a" [] []
+              1: (empty)
+              2: (empty)
+              3: (empty)
+        1: SEMICOLON@15..16 ";" [] []
+      5: (empty)
+    1: JS_WHILE_STATEMENT@16..42
+      0: WHILE_KW@16..23 "while" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@23..24 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@24..28
+        0: TRUE_KW@24..28 "true" [] []
+      3: R_PAREN@28..30 ")" [] [Whitespace(" ")]
+      4: JS_UNKNOWN_STATEMENT@30..42
+        0: JS_VARIABLE_DECLARATIONS@30..41
+          0: CONST_KW@30..36 "const" [] [Whitespace(" ")]
+          1: JS_VARIABLE_DECLARATION_LIST@36..41
+            0: JS_VARIABLE_DECLARATION@36..41
+              0: JS_IDENTIFIER_BINDING@36..38
+                0: IDENT@36..38 "b" [] [Whitespace(" ")]
+              1: (empty)
+              2: (empty)
+              3: JS_INITIALIZER_CLAUSE@38..41
+                0: EQ@38..40 "=" [] [Whitespace(" ")]
+                1: JS_NUMBER_LITERAL_EXPRESSION@40..41
+                  0: JS_NUMBER_LITERAL@40..41 "5" [] []
+        1: SEMICOLON@41..42 ";" [] []
+  3: EOF@42..43 "" [Newline("\n")] []
+--
+error[SyntaxError]: Lexical declaration cannot appear in a single-statement context
+  ┌─ lexical_declaration_in_single_statement_context.js:1:11
+  │
+1 │ if (true) let a;
+  │           ^^^^^^ Wrap this declaration in a block statement
+
+--
+error[SyntaxError]: Lexical declaration cannot appear in a single-statement context
+  ┌─ lexical_declaration_in_single_statement_context.js:2:14
+  │
+2 │ while (true) const b = 5;
+  │              ^^^^^^^^^^^^ Wrap this declaration in a block statement
+
+--
+if (true) let a;
+while (true) const b = 5;

--- a/crates/rslint_parser/test_data/inline/ok/function_in_if_or_labelled_stmt_loose_mode.js
+++ b/crates/rslint_parser/test_data/inline/ok/function_in_if_or_labelled_stmt_loose_mode.js
@@ -1,0 +1,5 @@
+// SCRIPT
+label1: function a() {}
+if (true) function a() {} else function b() {}
+if (true) function c() {}
+if (true) "test"; else function d() {}

--- a/crates/rslint_parser/test_data/inline/ok/function_in_if_or_labelled_stmt_loose_mode.rast
+++ b/crates/rslint_parser/test_data/inline/ok/function_in_if_or_labelled_stmt_loose_mode.rast
@@ -1,0 +1,274 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsLabeledStatement {
+            label_token: IDENT@0..16 "label1" [Comments("// SCRIPT"), Newline("\n")] [],
+            colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
+            body: JsFunctionStatement {
+                async_token: missing (optional),
+                function_token: FUNCTION_KW@18..27 "function" [] [Whitespace(" ")],
+                star_token: missing (optional),
+                id: JsIdentifierBinding {
+                    name_token: IDENT@27..28 "a" [] [],
+                },
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@28..29 "(" [] [],
+                    items: JsParameterList [],
+                    r_paren_token: R_PAREN@29..31 ")" [] [Whitespace(" ")],
+                },
+                return_type: missing (optional),
+                body: JsFunctionBody {
+                    l_curly_token: L_CURLY@31..32 "{" [] [],
+                    directives: JsDirectiveList [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@32..33 "}" [] [],
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@33..37 "if" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@37..38 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@38..42 "true" [] [],
+            },
+            r_paren_token: R_PAREN@42..44 ")" [] [Whitespace(" ")],
+            consequent: JsFunctionStatement {
+                async_token: missing (optional),
+                function_token: FUNCTION_KW@44..53 "function" [] [Whitespace(" ")],
+                star_token: missing (optional),
+                id: JsIdentifierBinding {
+                    name_token: IDENT@53..54 "a" [] [],
+                },
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@54..55 "(" [] [],
+                    items: JsParameterList [],
+                    r_paren_token: R_PAREN@55..57 ")" [] [Whitespace(" ")],
+                },
+                return_type: missing (optional),
+                body: JsFunctionBody {
+                    l_curly_token: L_CURLY@57..58 "{" [] [],
+                    directives: JsDirectiveList [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@58..60 "}" [] [Whitespace(" ")],
+                },
+            },
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@60..65 "else" [] [Whitespace(" ")],
+                alternate: JsFunctionStatement {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@65..74 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@74..75 "b" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@75..76 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@76..78 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@78..79 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@79..80 "}" [] [],
+                    },
+                },
+            },
+        },
+        JsIfStatement {
+            if_token: IF_KW@80..84 "if" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@84..85 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@85..89 "true" [] [],
+            },
+            r_paren_token: R_PAREN@89..91 ")" [] [Whitespace(" ")],
+            consequent: JsFunctionStatement {
+                async_token: missing (optional),
+                function_token: FUNCTION_KW@91..100 "function" [] [Whitespace(" ")],
+                star_token: missing (optional),
+                id: JsIdentifierBinding {
+                    name_token: IDENT@100..101 "c" [] [],
+                },
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@101..102 "(" [] [],
+                    items: JsParameterList [],
+                    r_paren_token: R_PAREN@102..104 ")" [] [Whitespace(" ")],
+                },
+                return_type: missing (optional),
+                body: JsFunctionBody {
+                    l_curly_token: L_CURLY@104..105 "{" [] [],
+                    directives: JsDirectiveList [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@105..106 "}" [] [],
+                },
+            },
+            else_clause: missing (optional),
+        },
+        JsIfStatement {
+            if_token: IF_KW@106..110 "if" [Newline("\n")] [Whitespace(" ")],
+            l_paren_token: L_PAREN@110..111 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@111..115 "true" [] [],
+            },
+            r_paren_token: R_PAREN@115..117 ")" [] [Whitespace(" ")],
+            consequent: JsExpressionStatement {
+                expression: JsStringLiteralExpression {
+                    value_token: JS_STRING_LITERAL@117..123 "\"test\"" [] [],
+                },
+                semicolon_token: SEMICOLON@123..125 ";" [] [Whitespace(" ")],
+            },
+            else_clause: JsElseClause {
+                else_token: ELSE_KW@125..130 "else" [] [Whitespace(" ")],
+                alternate: JsFunctionStatement {
+                    async_token: missing (optional),
+                    function_token: FUNCTION_KW@130..139 "function" [] [Whitespace(" ")],
+                    star_token: missing (optional),
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@139..140 "d" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@140..141 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@141..143 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@143..144 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@144..145 "}" [] [],
+                    },
+                },
+            },
+        },
+    ],
+    eof_token: EOF@145..146 "" [Newline("\n")] [],
+}
+
+0: JS_SCRIPT@0..146
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..145
+    0: JS_LABELED_STATEMENT@0..33
+      0: IDENT@0..16 "label1" [Comments("// SCRIPT"), Newline("\n")] []
+      1: COLON@16..18 ":" [] [Whitespace(" ")]
+      2: JS_FUNCTION_STATEMENT@18..33
+        0: (empty)
+        1: FUNCTION_KW@18..27 "function" [] [Whitespace(" ")]
+        2: (empty)
+        3: JS_IDENTIFIER_BINDING@27..28
+          0: IDENT@27..28 "a" [] []
+        4: (empty)
+        5: JS_PARAMETERS@28..31
+          0: L_PAREN@28..29 "(" [] []
+          1: JS_PARAMETER_LIST@29..29
+          2: R_PAREN@29..31 ")" [] [Whitespace(" ")]
+        6: (empty)
+        7: JS_FUNCTION_BODY@31..33
+          0: L_CURLY@31..32 "{" [] []
+          1: JS_DIRECTIVE_LIST@32..32
+          2: JS_STATEMENT_LIST@32..32
+          3: R_CURLY@32..33 "}" [] []
+    1: JS_IF_STATEMENT@33..80
+      0: IF_KW@33..37 "if" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@37..38 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@38..42
+        0: TRUE_KW@38..42 "true" [] []
+      3: R_PAREN@42..44 ")" [] [Whitespace(" ")]
+      4: JS_FUNCTION_STATEMENT@44..60
+        0: (empty)
+        1: FUNCTION_KW@44..53 "function" [] [Whitespace(" ")]
+        2: (empty)
+        3: JS_IDENTIFIER_BINDING@53..54
+          0: IDENT@53..54 "a" [] []
+        4: (empty)
+        5: JS_PARAMETERS@54..57
+          0: L_PAREN@54..55 "(" [] []
+          1: JS_PARAMETER_LIST@55..55
+          2: R_PAREN@55..57 ")" [] [Whitespace(" ")]
+        6: (empty)
+        7: JS_FUNCTION_BODY@57..60
+          0: L_CURLY@57..58 "{" [] []
+          1: JS_DIRECTIVE_LIST@58..58
+          2: JS_STATEMENT_LIST@58..58
+          3: R_CURLY@58..60 "}" [] [Whitespace(" ")]
+      5: JS_ELSE_CLAUSE@60..80
+        0: ELSE_KW@60..65 "else" [] [Whitespace(" ")]
+        1: JS_FUNCTION_STATEMENT@65..80
+          0: (empty)
+          1: FUNCTION_KW@65..74 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@74..75
+            0: IDENT@74..75 "b" [] []
+          4: (empty)
+          5: JS_PARAMETERS@75..78
+            0: L_PAREN@75..76 "(" [] []
+            1: JS_PARAMETER_LIST@76..76
+            2: R_PAREN@76..78 ")" [] [Whitespace(" ")]
+          6: (empty)
+          7: JS_FUNCTION_BODY@78..80
+            0: L_CURLY@78..79 "{" [] []
+            1: JS_DIRECTIVE_LIST@79..79
+            2: JS_STATEMENT_LIST@79..79
+            3: R_CURLY@79..80 "}" [] []
+    2: JS_IF_STATEMENT@80..106
+      0: IF_KW@80..84 "if" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@84..85 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@85..89
+        0: TRUE_KW@85..89 "true" [] []
+      3: R_PAREN@89..91 ")" [] [Whitespace(" ")]
+      4: JS_FUNCTION_STATEMENT@91..106
+        0: (empty)
+        1: FUNCTION_KW@91..100 "function" [] [Whitespace(" ")]
+        2: (empty)
+        3: JS_IDENTIFIER_BINDING@100..101
+          0: IDENT@100..101 "c" [] []
+        4: (empty)
+        5: JS_PARAMETERS@101..104
+          0: L_PAREN@101..102 "(" [] []
+          1: JS_PARAMETER_LIST@102..102
+          2: R_PAREN@102..104 ")" [] [Whitespace(" ")]
+        6: (empty)
+        7: JS_FUNCTION_BODY@104..106
+          0: L_CURLY@104..105 "{" [] []
+          1: JS_DIRECTIVE_LIST@105..105
+          2: JS_STATEMENT_LIST@105..105
+          3: R_CURLY@105..106 "}" [] []
+      5: (empty)
+    3: JS_IF_STATEMENT@106..145
+      0: IF_KW@106..110 "if" [Newline("\n")] [Whitespace(" ")]
+      1: L_PAREN@110..111 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@111..115
+        0: TRUE_KW@111..115 "true" [] []
+      3: R_PAREN@115..117 ")" [] [Whitespace(" ")]
+      4: JS_EXPRESSION_STATEMENT@117..125
+        0: JS_STRING_LITERAL_EXPRESSION@117..123
+          0: JS_STRING_LITERAL@117..123 "\"test\"" [] []
+        1: SEMICOLON@123..125 ";" [] [Whitespace(" ")]
+      5: JS_ELSE_CLAUSE@125..145
+        0: ELSE_KW@125..130 "else" [] [Whitespace(" ")]
+        1: JS_FUNCTION_STATEMENT@130..145
+          0: (empty)
+          1: FUNCTION_KW@130..139 "function" [] [Whitespace(" ")]
+          2: (empty)
+          3: JS_IDENTIFIER_BINDING@139..140
+            0: IDENT@139..140 "d" [] []
+          4: (empty)
+          5: JS_PARAMETERS@140..143
+            0: L_PAREN@140..141 "(" [] []
+            1: JS_PARAMETER_LIST@141..141
+            2: R_PAREN@141..143 ")" [] [Whitespace(" ")]
+          6: (empty)
+          7: JS_FUNCTION_BODY@143..145
+            0: L_CURLY@143..144 "{" [] []
+            1: JS_DIRECTIVE_LIST@144..144
+            2: JS_STATEMENT_LIST@144..144
+            3: R_CURLY@144..145 "}" [] []
+  3: EOF@145..146 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/hoisted_declaration_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/ok/hoisted_declaration_in_single_statement_context.js
@@ -1,0 +1,1 @@
+if (true) var a;

--- a/crates/rslint_parser/test_data/inline/ok/hoisted_declaration_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/ok/hoisted_declaration_in_single_statement_context.rast
@@ -1,0 +1,56 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsVariableStatement {
+                declarations: JsVariableDeclarations {
+                    kind: VAR_KW@10..14 "var" [] [Whitespace(" ")],
+                    items: JsVariableDeclarationList [
+                        JsVariableDeclaration {
+                            id: JsIdentifierBinding {
+                                name_token: IDENT@14..15 "a" [] [],
+                            },
+                            excl_token: missing (optional),
+                            type_annotation: missing (optional),
+                            initializer: missing (optional),
+                        },
+                    ],
+                },
+                semicolon_token: SEMICOLON@15..16 ";" [] [],
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@16..17 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..17
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..16
+    0: JS_IF_STATEMENT@0..16
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_VARIABLE_STATEMENT@10..16
+        0: JS_VARIABLE_DECLARATIONS@10..15
+          0: VAR_KW@10..14 "var" [] [Whitespace(" ")]
+          1: JS_VARIABLE_DECLARATION_LIST@14..15
+            0: JS_VARIABLE_DECLARATION@14..15
+              0: JS_IDENTIFIER_BINDING@14..15
+                0: IDENT@14..15 "a" [] []
+              1: (empty)
+              2: (empty)
+              3: (empty)
+        1: SEMICOLON@15..16 ";" [] []
+      5: (empty)
+  3: EOF@16..17 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/labelled_function_declaration.js
+++ b/crates/rslint_parser/test_data/inline/ok/labelled_function_declaration.js
@@ -1,0 +1,2 @@
+// SCRIPT
+label1: function a() {}

--- a/crates/rslint_parser/test_data/inline/ok/labelled_function_declaration.rast
+++ b/crates/rslint_parser/test_data/inline/ok/labelled_function_declaration.rast
@@ -1,0 +1,58 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsLabeledStatement {
+            label_token: IDENT@0..16 "label1" [Comments("// SCRIPT"), Newline("\n")] [],
+            colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
+            body: JsFunctionStatement {
+                async_token: missing (optional),
+                function_token: FUNCTION_KW@18..27 "function" [] [Whitespace(" ")],
+                star_token: missing (optional),
+                id: JsIdentifierBinding {
+                    name_token: IDENT@27..28 "a" [] [],
+                },
+                type_parameters: missing (optional),
+                parameters: JsParameters {
+                    l_paren_token: L_PAREN@28..29 "(" [] [],
+                    items: JsParameterList [],
+                    r_paren_token: R_PAREN@29..31 ")" [] [Whitespace(" ")],
+                },
+                return_type: missing (optional),
+                body: JsFunctionBody {
+                    l_curly_token: L_CURLY@31..32 "{" [] [],
+                    directives: JsDirectiveList [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@32..33 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@33..34 "" [Newline("\n")] [],
+}
+
+0: JS_SCRIPT@0..34
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..33
+    0: JS_LABELED_STATEMENT@0..33
+      0: IDENT@0..16 "label1" [Comments("// SCRIPT"), Newline("\n")] []
+      1: COLON@16..18 ":" [] [Whitespace(" ")]
+      2: JS_FUNCTION_STATEMENT@18..33
+        0: (empty)
+        1: FUNCTION_KW@18..27 "function" [] [Whitespace(" ")]
+        2: (empty)
+        3: JS_IDENTIFIER_BINDING@27..28
+          0: IDENT@27..28 "a" [] []
+        4: (empty)
+        5: JS_PARAMETERS@28..31
+          0: L_PAREN@28..29 "(" [] []
+          1: JS_PARAMETER_LIST@29..29
+          2: R_PAREN@29..31 ")" [] [Whitespace(" ")]
+        6: (empty)
+        7: JS_FUNCTION_BODY@31..33
+          0: L_CURLY@31..32 "{" [] []
+          1: JS_DIRECTIVE_LIST@32..32
+          2: JS_STATEMENT_LIST@32..32
+          3: R_CURLY@32..33 "}" [] []
+  3: EOF@33..34 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/labelled_statement_in_single_statement_context.js
+++ b/crates/rslint_parser/test_data/inline/ok/labelled_statement_in_single_statement_context.js
@@ -1,0 +1,1 @@
+if (true) label1: var a = 10;

--- a/crates/rslint_parser/test_data/inline/ok/labelled_statement_in_single_statement_context.rast
+++ b/crates/rslint_parser/test_data/inline/ok/labelled_statement_in_single_statement_context.rast
@@ -1,0 +1,71 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsIfStatement {
+            if_token: IF_KW@0..3 "if" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            test: JsBooleanLiteralExpression {
+                value_token: TRUE_KW@4..8 "true" [] [],
+            },
+            r_paren_token: R_PAREN@8..10 ")" [] [Whitespace(" ")],
+            consequent: JsLabeledStatement {
+                label_token: IDENT@10..16 "label1" [] [],
+                colon_token: COLON@16..18 ":" [] [Whitespace(" ")],
+                body: JsVariableStatement {
+                    declarations: JsVariableDeclarations {
+                        kind: VAR_KW@18..22 "var" [] [Whitespace(" ")],
+                        items: JsVariableDeclarationList [
+                            JsVariableDeclaration {
+                                id: JsIdentifierBinding {
+                                    name_token: IDENT@22..24 "a" [] [Whitespace(" ")],
+                                },
+                                excl_token: missing (optional),
+                                type_annotation: missing (optional),
+                                initializer: JsInitializerClause {
+                                    eq_token: EQ@24..26 "=" [] [Whitespace(" ")],
+                                    expression: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@26..28 "10" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    semicolon_token: SEMICOLON@28..29 ";" [] [],
+                },
+            },
+            else_clause: missing (optional),
+        },
+    ],
+    eof_token: EOF@29..30 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..30
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..29
+    0: JS_IF_STATEMENT@0..29
+      0: IF_KW@0..3 "if" [] [Whitespace(" ")]
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_BOOLEAN_LITERAL_EXPRESSION@4..8
+        0: TRUE_KW@4..8 "true" [] []
+      3: R_PAREN@8..10 ")" [] [Whitespace(" ")]
+      4: JS_LABELED_STATEMENT@10..29
+        0: IDENT@10..16 "label1" [] []
+        1: COLON@16..18 ":" [] [Whitespace(" ")]
+        2: JS_VARIABLE_STATEMENT@18..29
+          0: JS_VARIABLE_DECLARATIONS@18..28
+            0: VAR_KW@18..22 "var" [] [Whitespace(" ")]
+            1: JS_VARIABLE_DECLARATION_LIST@22..28
+              0: JS_VARIABLE_DECLARATION@22..28
+                0: JS_IDENTIFIER_BINDING@22..24
+                  0: IDENT@22..24 "a" [] [Whitespace(" ")]
+                1: (empty)
+                2: (empty)
+                3: JS_INITIALIZER_CLAUSE@24..28
+                  0: EQ@24..26 "=" [] [Whitespace(" ")]
+                  1: JS_NUMBER_LITERAL_EXPRESSION@26..28
+                    0: JS_NUMBER_LITERAL@26..28 "10" [] []
+          1: SEMICOLON@28..29 ";" [] []
+      5: (empty)
+  3: EOF@29..30 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/let_asi_rule.js
+++ b/crates/rslint_parser/test_data/inline/ok/let_asi_rule.js
@@ -1,0 +1,5 @@
+// SCRIPT
+let // NO ASI
+x = 1;
+for await (var x of []) let // ASI
+x = 1;

--- a/crates/rslint_parser/test_data/inline/ok/let_asi_rule.rast
+++ b/crates/rslint_parser/test_data/inline/ok/let_asi_rule.rast
@@ -1,0 +1,122 @@
+JsScript {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    statements: JsStatementList [
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@0..23 "let" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" "), Comments("// NO ASI")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@23..26 "x" [Newline("\n")] [Whitespace(" ")],
+                        },
+                        excl_token: missing (optional),
+                        type_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@26..28 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@28..29 "1" [] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@29..30 ";" [] [],
+        },
+        JsForOfStatement {
+            for_token: FOR_KW@30..35 "for" [Newline("\n")] [Whitespace(" ")],
+            await_token: AWAIT_KW@35..41 "await" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@41..42 "(" [] [],
+            initializer: JsForVariableDeclaration {
+                kind_token: VAR_KW@42..46 "var" [] [Whitespace(" ")],
+                declaration: JsVariableDeclaration {
+                    id: JsIdentifierBinding {
+                        name_token: IDENT@46..48 "x" [] [Whitespace(" ")],
+                    },
+                    excl_token: missing (optional),
+                    type_annotation: missing (optional),
+                    initializer: missing (optional),
+                },
+            },
+            of_token: OF_KW@48..51 "of" [] [Whitespace(" ")],
+            expression: JsArrayExpression {
+                l_brack_token: L_BRACK@51..52 "[" [] [],
+                elements: JsArrayElementList [],
+                r_brack_token: R_BRACK@52..53 "]" [] [],
+            },
+            r_paren_token: R_PAREN@53..55 ")" [] [Whitespace(" ")],
+            body: JsExpressionStatement {
+                expression: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@55..65 "let" [] [Whitespace(" "), Comments("// ASI")],
+                    },
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@65..68 "x" [Newline("\n")] [Whitespace(" ")],
+                },
+                operator_token: EQ@68..70 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@70..71 "1" [] [],
+                },
+            },
+            semicolon_token: SEMICOLON@71..72 ";" [] [],
+        },
+    ],
+    eof_token: EOF@72..73 "" [Newline("\n")] [],
+}
+
+0: JS_SCRIPT@0..73
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_STATEMENT_LIST@0..72
+    0: JS_VARIABLE_STATEMENT@0..30
+      0: JS_VARIABLE_DECLARATIONS@0..29
+        0: LET_KW@0..23 "let" [Comments("// SCRIPT"), Newline("\n")] [Whitespace(" "), Comments("// NO ASI")]
+        1: JS_VARIABLE_DECLARATION_LIST@23..29
+          0: JS_VARIABLE_DECLARATION@23..29
+            0: JS_IDENTIFIER_BINDING@23..26
+              0: IDENT@23..26 "x" [Newline("\n")] [Whitespace(" ")]
+            1: (empty)
+            2: (empty)
+            3: JS_INITIALIZER_CLAUSE@26..29
+              0: EQ@26..28 "=" [] [Whitespace(" ")]
+              1: JS_NUMBER_LITERAL_EXPRESSION@28..29
+                0: JS_NUMBER_LITERAL@28..29 "1" [] []
+      1: SEMICOLON@29..30 ";" [] []
+    1: JS_FOR_OF_STATEMENT@30..65
+      0: FOR_KW@30..35 "for" [Newline("\n")] [Whitespace(" ")]
+      1: AWAIT_KW@35..41 "await" [] [Whitespace(" ")]
+      2: L_PAREN@41..42 "(" [] []
+      3: JS_FOR_VARIABLE_DECLARATION@42..48
+        0: VAR_KW@42..46 "var" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION@46..48
+          0: JS_IDENTIFIER_BINDING@46..48
+            0: IDENT@46..48 "x" [] [Whitespace(" ")]
+          1: (empty)
+          2: (empty)
+          3: (empty)
+      4: OF_KW@48..51 "of" [] [Whitespace(" ")]
+      5: JS_ARRAY_EXPRESSION@51..53
+        0: L_BRACK@51..52 "[" [] []
+        1: JS_ARRAY_ELEMENT_LIST@52..52
+        2: R_BRACK@52..53 "]" [] []
+      6: R_PAREN@53..55 ")" [] [Whitespace(" ")]
+      7: JS_EXPRESSION_STATEMENT@55..65
+        0: JS_IDENTIFIER_EXPRESSION@55..65
+          0: JS_REFERENCE_IDENTIFIER@55..65
+            0: IDENT@55..65 "let" [] [Whitespace(" "), Comments("// ASI")]
+        1: (empty)
+    2: JS_EXPRESSION_STATEMENT@65..72
+      0: JS_ASSIGNMENT_EXPRESSION@65..71
+        0: JS_IDENTIFIER_ASSIGNMENT@65..68
+          0: IDENT@65..68 "x" [Newline("\n")] [Whitespace(" ")]
+        1: EQ@68..70 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@70..71
+          0: JS_NUMBER_LITERAL@70..71 "1" [] []
+      1: SEMICOLON@71..72 ";" [] []
+  3: EOF@72..73 "" [Newline("\n")] []


### PR DESCRIPTION

## Summary

[Declarations](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#prod-Declaration) are not allowed in a single line statement context:

```
if (true) const a = 10
```

However, there are some exceptions:

* `IfStatement` and `LabelledStatement` allow `FunctionDeclaration`s (not async nor generators) in a single line statement context
* Labelled function declarations are not permitted in a single line statement context (`if (true) label1: function a() {}`) 

This PR extends `parse_statement` to respect if it's in a single line statement context or not and only allow the permitted productions. 

## Test Plan

I added multiple spec tests to verify these rules
