### PR TITLE
feat(rslint_parser): Parser State Checkpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,8 +1340,10 @@ name = "rslint_parser"
 version = "0.3.0"
 dependencies = [
  "bitflags",
+ "cfg-if",
  "drop_bomb",
  "expect-test",
+ "indexmap",
  "lexical",
  "num-bigint",
  "rome_rowan",

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -16,6 +16,8 @@ num-bigint = "0.4.3"
 lexical = { version = "5.2.0", features = ["radix"] }
 drop_bomb = "0.1.5"
 bitflags = "1.3.2"
+indexmap = "1.8.0"
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 expect-test = "1.2.2"

--- a/crates/rslint_parser/src/lib.rs
+++ b/crates/rslint_parser/src/lib.rs
@@ -84,12 +84,13 @@ pub use crate::{
     numbers::BigInt,
     parse::*,
     parser::{Checkpoint, CompletedMarker, Marker, ParseRecovery, Parser},
-    state::{ParserState, StrictMode},
     syntax_node::*,
     token_set::TokenSet,
     token_source::TokenSource,
     util::{SyntaxNodeExt, SyntaxTokenExt},
 };
+
+pub(crate) use state::{ParserState, StrictMode};
 
 pub use rome_rowan::{SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent};
 

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -689,8 +689,8 @@ impl CompletedMarker {
 /// A structure signifying the Parser progress at one point in time
 #[derive(Debug, Clone)]
 pub struct Checkpoint {
-    token_pos: usize,
-    pub(crate) event_pos: usize,
+    pub(super) token_pos: usize,
+    pub(super) event_pos: usize,
     errors_pos: usize,
     state: ParserStateCheckpoint,
 }

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -375,11 +375,11 @@ bitflags! {
     /// Flags describing the context of a function.
     pub(crate) struct SignatureFlags: u8 {
         /// Is the function in an async context
-        const ASYNC 		= 0b00001;
+        const ASYNC 		= 1 << 0;
         /// Is the function in a generator context
-        const GENERATOR 	= 0b00010;
+        const GENERATOR 	= 1 << 1;
         /// Is the function a constructor (or constructor context)
-        const CONSTRUCTOR 	= 0b00100;
+        const CONSTRUCTOR 	= 1 << 2;
     }
 }
 
@@ -415,40 +415,40 @@ bitflags! {
     struct ParsingContextFlags: u16 {
         /// Whether the parser is in a generator function like `function* a() {}`
         /// Matches the `Yield` parameter in the ECMA spec
-        const IN_GENERATOR = 0b0000000000000001;
+        const IN_GENERATOR = 1 << 0;
         /// Whether the parser is inside a function
-        const IN_FUNCTION = 0b0000000000000010;
+        const IN_FUNCTION = 1 << 2;
         /// Whatever the parser is inside a constructor
-        const IN_CONSTRUCTOR = 0b0000000000000100;
+        const IN_CONSTRUCTOR = 1 << 3;
 
         /// Is async allowed in this context. Either because it's an async function or top level await is supported.
         /// Equivalent to the `Async` generator in the ECMA spec
-        const IN_ASYNC = 0b0000000000001000;
+        const IN_ASYNC = 1 << 4;
 
         /// Whether the parser is parsing a top-level statement (not inside a class, function, parameter) or not
-        const TOP_LEVEL = 0b0000000000010000;
+        const TOP_LEVEL = 1 << 5;
 
         /// Whether `in` should be counted in a binary expression
         /// this is for `for...in` statements to prevent ambiguity.
-        const INCLUDE_IN = 0b0000000000100000;
+        const INCLUDE_IN = 1 << 6;
         /// Whether the parser is in a conditional expr (ternary expr)
-        const IN_CONDITION_EXPRESSION = 0b0000000001000000;
+        const IN_CONDITION_EXPRESSION = 1 << 7;
 
         /// Whether the parser is in an iteration or switch statement and
         /// `break` is allowed.
-        const BREAK_ALLOWED = 0b0000000010000000;
+        const BREAK_ALLOWED = 1 << 8;
 
         /// Whether the parser is in an iteration statement and `continue` is allowed.
-        const CONTINUE_ALLOWED = 0b0000000100000000;
+        const CONTINUE_ALLOWED = 1 << 9;
 
         /// If false, object expressions are not allowed to be parsed
         /// inside an expression.
         ///
         /// Also applies for object patterns
-        const ALLOW_OBJECT_EXPRESSION = 0b0000001000000000;
+        const ALLOW_OBJECT_EXPRESSION = 1 << 10;
 
         /// Whether we potentially are in a place to parse an arrow expression
-        const POTENTIAL_ARROW_START = 0b0000010000000000;
+        const POTENTIAL_ARROW_START = 1 << 11;
 
         const LOOP = Self::BREAK_ALLOWED.bits | Self::CONTINUE_ALLOWED.bits;
 

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -147,6 +147,8 @@ impl ParserState {
     }
 }
 
+/// Stores a checkpoint of the [ParserState].
+/// Allows rewinding the state to its previous state.
 #[derive(Debug, Clone)]
 pub(super) struct ParserStateCheckpoint {
     /// Additional data that we only want to store in debug mode
@@ -155,6 +157,7 @@ pub(super) struct ParserStateCheckpoint {
 }
 
 impl ParserStateCheckpoint {
+    /// Creates a snapshot of the passed in state.
     fn snapshot(state: &ParserState) -> Self {
         Self {
             #[cfg(debug_assertions)]
@@ -162,12 +165,17 @@ impl ParserStateCheckpoint {
         }
     }
 
+    /// Restores the `state values` to the time when this snapshot was created.
     fn rewind(self, state: &mut ParserState) {
         #[cfg(debug_assertions)]
         self.debug_checkpoint.rewind(state);
     }
 }
 
+/// Most of the [ParserState] is scoped state. It should, therefore, not be necessary to rewind
+/// that state because that's already taken care of by `with_state` and `with_scoped_state`.
+/// But, you can never no and better be safe than sorry. That's why we use some heuristics
+/// to verify that non of the scoped state did change and assert for it when rewinding.
 #[derive(Debug, Clone)]
 #[cfg(debug_assertions)]
 pub(super) struct DebugParserStateCheckpoint {
@@ -587,6 +595,8 @@ pub(crate) struct WithLabelSnapshot {
     label_set_len: usize,
 }
 
+/// Adds the labelled item with the given label to the `label_set`.
+/// Removes the label when the change is undone.
 pub(crate) struct WithLabel(pub String, pub LabelledItem);
 
 impl ChangeParserState for WithLabel {

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -206,7 +206,7 @@ impl DebugParserStateCheckpoint {
             label_set_len: state.label_set.len(),
             strict: state.strict.clone(),
             default_item: state.default_item.clone(),
-            duplicate_binding_parent: state.duplicate_binding_parent.clone(),
+            duplicate_binding_parent: state.duplicate_binding_parent,
             name_map_len: state.name_map.len(),
         }
     }

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -409,23 +409,23 @@ bitflags! {
         /// this is for `for...in` statements to prevent ambiguity.
         const INCLUDE_IN = 0b0000000000100000;
         /// Whether the parser is in a conditional expr (ternary expr)
-        const IN_CONDITION_EXPRESSION = 0b0000000010000000;
+        const IN_CONDITION_EXPRESSION = 0b0000000001000000;
 
         /// Whether the parser is in an iteration or switch statement and
         /// `break` is allowed.
-        const BREAK_ALLOWED = 0b0000000100000000;
+        const BREAK_ALLOWED = 0b0000000010000000;
 
         /// Whether the parser is in an iteration statement and `continue` is allowed.
-        const CONTINUE_ALLOWED = 0b0000001000000000;
+        const CONTINUE_ALLOWED = 0b0000000100000000;
 
         /// If false, object expressions are not allowed to be parsed
         /// inside an expression.
         ///
         /// Also applies for object patterns
-        const ALLOW_OBJECT_EXPRESSION = 0b0000010000000000;
+        const ALLOW_OBJECT_EXPRESSION = 0b0000001000000000;
 
         /// Whether we potentially are in a place to parse an arrow expression
-        const POTENTIAL_ARROW_START = 0b0000100000000000;
+        const POTENTIAL_ARROW_START = 0b0000010000000000;
 
         const LOOP = Self::BREAK_ALLOWED.bits | Self::CONTINUE_ALLOWED.bits;
 

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -149,6 +149,9 @@ impl ParserState {
 
 /// Stores a checkpoint of the [ParserState].
 /// Allows rewinding the state to its previous state.
+///
+/// It's important that creating and rewinding a snapshot is cheap. Consider the performance implications
+/// before adding new unscoped state.
 #[derive(Debug, Clone)]
 pub(super) struct ParserStateCheckpoint {
     /// Additional data that we only want to store in debug mode

--- a/crates/rslint_parser/src/syntax/assignment.rs
+++ b/crates/rslint_parser/src/syntax/assignment.rs
@@ -83,7 +83,7 @@ pub(crate) fn expression_to_assignment(
     target: CompletedMarker,
     checkpoint: Checkpoint,
 ) -> CompletedMarker {
-    if let Ok(assignment) = try_expression_to_assignment(p, target, checkpoint) {
+    if let Ok(assignment) = try_expression_to_assignment(p, target, checkpoint.clone()) {
         assignment
     } else {
         // Doesn't seem to be a valid assignment target. Recover and create an error.

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -825,7 +825,7 @@ fn parse_paren_or_arrow_expr(p: &mut Parser, can_be_arrow: bool) -> ParsedSyntax
                 }
                 let expr = parse_expr_or_assignment(p);
                 if expr.is_absent() && p.at(T![:]) {
-                    p.rewind(checkpoint);
+                    p.rewind(checkpoint.clone());
                     params_marker = Some(parse_arrow_function_parameters(p, SignatureFlags::empty()).unwrap());
                     break;
                 }

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -10,7 +10,7 @@ use crate::parser::{RecoveryError, RecoveryResult};
 use crate::state::{
     AllowObjectExpression, BreakableKind, ChangeParserState, EnableStrictMode,
     EnableStrictModeSnapshot, EnterBreakable, IncludeIn, LabelledItem,
-    StrictMode as StrictModeState,
+    StrictMode as StrictModeState, WithLabel,
 };
 use crate::syntax::assignment::expression_to_assignment_pattern;
 use crate::syntax::class::{parse_class_statement, parse_initializer_clause};
@@ -262,51 +262,53 @@ pub(crate) fn parse_statement(p: &mut Parser, context: StatementContext) -> Pars
 // label1: function a() {}
 fn parse_labeled_statement(p: &mut Parser, context: StatementContext) -> ParsedSyntax {
     parse_identifier(p, JS_LABELED_STATEMENT).map(|identifier| {
+		fn parse_body(p: &mut Parser, context: StatementContext) -> ParsedSyntax {
+			if is_at_identifier(p) && p.nth_at(1, T![:]) && StrictMode.is_unsupported(p) {
+				// Re-use the parent context to catch `if (true) label1: label2: function A() {}
+				parse_labeled_statement(p, context)
+			} else {
+				parse_statement(p, StatementContext::Label)
+			}
+		}
+
 		p.bump(T![:]);
 
-        let label = if !identifier.kind().is_unknown() {
-            let range = identifier.range(p);
-            let label = p.source(range);
+		let identifier_range = identifier.range(p);
+		let is_valid_identifier = !identifier.kind().is_unknown();
+		let labelled_statement = identifier.undo_completion(p);
+		let label = p.source(identifier_range);
 
-			if let Some(label_item) = p.state.label_set.get(label) {
-                let err = p
-                    .err_builder("Duplicate statement labels are not allowed")
-                    .secondary(
-						label_item.range().to_owned(),
-                        &format!("`{}` is first used as a label here", label),
-                    )
-                    .primary(
-                        range,
-                        &format!("a second use of `{}` here is not allowed", label),
-                    );
-
-                p.error(err);
-                None
-            } else {
-                let string = label.to_string();
-
-				let label_item = match p.cur() {
-					T![for] | T![do] | T![while] => LabelledItem::Iteration(range.as_range()),
-					_ => LabelledItem::Other(range.as_range())
+		let body = match p.state.get_labelled_item(label) {
+			None => {
+				let labelled_item = match p.cur() {
+					T![for] | T![do] | T![while] => LabelledItem::Iteration(identifier_range.as_range()),
+					_ => LabelledItem::Other(identifier_range.as_range())
 				};
+				let change = WithLabel(String::from(label), labelled_item);
+				p.with_state(change, |p| parse_body(p, context))
+			},
+			Some(label_item) if is_valid_identifier => {
+				let err = p
+				.err_builder("Duplicate statement labels are not allowed")
+				.secondary(
+				label_item.range().to_owned(),
+				&format!("`{}` is first used as a label here", label),
+				)
+				.primary(
+				identifier_range,
+				&format!("a second use of `{}` here is not allowed", label),
+				);
 
-				p.state.label_set.insert(string.clone(), label_item);
-                Some(string)
-            }
-        } else {
-            None
-        };
+				p.error(err);
+				parse_body(p, context)
+			},
+			Some(_) => {
+				// Don't add another error, the identifier is already invalid
+				parse_body(p, context)
+			}
+		};
 
-        let labelled_statement = identifier.undo_completion(p);
-
-        let body = if is_at_identifier(p) && p.nth_at(1, T![:]) && StrictMode.is_unsupported(p) {
-            // Re-use the parent context to catch `if (true) label1: label2: function A() {}
-            parse_labeled_statement(p, context)
-        } else {
-            parse_statement(p, StatementContext::Label)
-        }.or_add_diagnostic(p, expected_statement);
-
-        match body {
+        match body.or_add_diagnostic(p, expected_statement) {
             Some(mut body) if context.is_single_statement() && body.kind() == JS_FUNCTION_STATEMENT => {
                 // test_err labelled_function_decl_in_single_statement_context
                 // if (true) label1: label2: function a() {}
@@ -315,12 +317,7 @@ fn parse_labeled_statement(p: &mut Parser, context: StatementContext) -> ParsedS
             },
             // test labelled_statement_in_single_statement_context
             // if (true) label1: var a = 10;
-
             _ => {}
-        }
-
-        if let Some(label) = label {
-			p.state.label_set.remove(&label);
         }
 
         labelled_statement.complete(p, JS_LABELED_STATEMENT)
@@ -440,7 +437,7 @@ fn parse_break_statement(p: &mut Parser) -> ParsedSyntax {
         let label_token = p.cur_tok();
         let label_name = p.token_src(label_token);
 
-        let error = match p.state.label_set.get(label_name) {
+        let error = match p.state.get_labelled_item(label_name) {
             Some(_) => None,
             None => Some(
                 p.err_builder(&format!(
@@ -503,7 +500,7 @@ fn parse_continue_statement(p: &mut Parser) -> ParsedSyntax {
         let label_token = p.cur_tok();
         let label_name = p.token_src(label_token);
 
-        let error = match p.state.label_set.get(label_name) {
+        let error = match p.state.get_labelled_item(label_name) {
 			Some(LabelledItem::Iteration(_)) => None,
 			Some(LabelledItem::Other(range)) => {
 				Some(p.err_builder("A `continue` statement can only jump to a label of an enclosing `for`, `while` or `do while` statement.")

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -289,15 +289,15 @@ fn parse_labeled_statement(p: &mut Parser, context: StatementContext) -> ParsedS
 			},
 			Some(label_item) if is_valid_identifier => {
 				let err = p
-				.err_builder("Duplicate statement labels are not allowed")
-				.secondary(
-				label_item.range().to_owned(),
-				&format!("`{}` is first used as a label here", label),
-				)
-				.primary(
-				identifier_range,
-				&format!("a second use of `{}` here is not allowed", label),
-				);
+					.err_builder("Duplicate statement labels are not allowed")
+					.secondary(
+						label_item.range().to_owned(),
+						&format!("`{}` is first used as a label here", label),
+					)
+					.primary(
+						identifier_range,
+						&format!("a second use of `{}` here is not allowed", label),
+					);
 
 				p.error(err);
 				parse_body(p, context)

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -4,7 +4,7 @@ use super::expr::{parse_expr_or_assignment, parse_lhs_expr, parse_literal_expres
 use crate::parser::ParserProgress;
 #[allow(deprecated)]
 use crate::parser::SingleTokenParseRecovery;
-use crate::state::{InBindingListForSignature, SignatureFlags};
+use crate::state::SignatureFlags;
 use crate::syntax::binding::parse_binding;
 use crate::syntax::expr::{is_at_name, parse_any_name};
 use crate::syntax::function::parse_parameter_list;
@@ -259,16 +259,14 @@ pub fn ts_signature_member(p: &mut Parser, construct_sig: bool) -> Option<Comple
         no_recover!(p, ts_type_params(p));
     }
 
-    p.with_state(InBindingListForSignature(true), |p| {
-        parse_parameter_list(
-            p,
-            if construct_sig {
-                SignatureFlags::CONSTRUCTOR
-            } else {
-                SignatureFlags::empty()
-            },
-        )
-    })
+    parse_parameter_list(
+        p,
+        if construct_sig {
+            SignatureFlags::CONSTRUCTOR
+        } else {
+            SignatureFlags::empty()
+        },
+    )
     .ok();
 
     if p.at(T![:]) {


### PR DESCRIPTION
## Summary

#1929 revealed that rewinding a checkpoint isn't a guarantee that our parser is in its previous state, because it doesn't restore the state as well.

This isn't an issue for most of our state variables because most changes are scoped, automatically restored when exiting the parsing of a section.

However, the `hoisted` and `scoped` variables changes aren't scoped. A variable gets added when its first seen and the change is only undone when entering a new function or block (or class). Thus, re-parsing the same binding after a restore triggers a re-declaration error.

This PR is a preparation for #1929. It adds a `ParserStateCheckpoint` that ensures the `Parser` and its state are correctly rewinded when using checkpoints. The current implementation only adds debug assertions because the current state changes are all scoped, but it provides the infrastructure to rewind some state as well. The additional assertion will hopefully help to catch issues as noticed in #1929 sooner.

Creating a checkpoint must be cheap, that's why this PR changes the `ParserState` to use `IndexMap` that already is a dependency of the LSP crate. An `IndexMap` retains insertion order, thus, restoring to a previous state is as simple as calling `truncate(old_index)` on the map.
