### PR TITLE
fix(rslint_parser): Fix private name with whitespace

### DIFF
--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1017,8 +1017,11 @@ pub(crate) fn parse_private_class_member_name(p: &mut Parser) -> ParsedSyntax {
         // 	# test;
         // }
         p.error(
-            p.err_builder("Unexpected space between # and identifier")
-                .primary(hash_end..p.cur_tok().start(), "remove the space here"),
+            p.err_builder("Unexpected space or comment between `#` and identifier")
+                .primary(
+                    hash_end..p.cur_tok().start(),
+                    "remove the space or comment here",
+                ),
         );
         Present(m.complete(p, JS_UNKNOWN))
     } else {

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -665,7 +665,7 @@ fn parse_private_name(p: &mut Parser) -> ParsedSyntax {
         // 	# test;
         // }
         p.error(
-            p.err_builder("Unexpected space between # and identifier")
+            p.err_builder("Unexpected space or comment between `#` and identifier")
                 .primary(hash_end..p.cur_tok().start(), "remove the space here"),
         );
         Present(m.complete(p, JS_UNKNOWN))

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -656,9 +656,23 @@ fn parse_private_name(p: &mut Parser) -> ParsedSyntax {
     }
 
     let m = p.start();
+    let hash_end = p.cur_tok().range().end;
     p.expect(T![#]);
-    p.expect(T![ident]);
-    Present(m.complete(p, JS_PRIVATE_NAME))
+
+    if p.at(T![ident]) && hash_end != p.cur_tok().start() {
+        // test_err private_name_with_space
+        // class A {
+        // 	# test;
+        // }
+        p.error(
+            p.err_builder("Unexpected space between # and identifier")
+                .primary(hash_end..p.cur_tok().start(), "remove the space here"),
+        );
+        Present(m.complete(p, JS_UNKNOWN))
+    } else {
+        p.expect(T![ident]);
+        Present(m.complete(p, JS_PRIVATE_NAME))
+    }
 }
 
 pub(super) fn parse_any_name(p: &mut Parser) -> ParsedSyntax {

--- a/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
+++ b/crates/rslint_parser/test_data/inline/err/block_stmt_in_class.rast
@@ -47,11 +47,11 @@ JsModule {
       0: R_CURLY@10..11 "}" [] []
   3: EOF@11..12 "" [Newline("\n")] []
 --
-error[SyntaxError]: expected a property , a method, a getter, or a setter but instead found '{'
+error[SyntaxError]: expected an identifier, a string literal, a number literal, a private field name, or a computed name but instead found '{'
   ┌─ block_stmt_in_class.js:1:9
   │
 1 │ class S{{}}
-  │         ^ Expected a property , a method, a getter, or a setter here
+  │         ^ Expected an identifier, a string literal, a number literal, a private field name, or a computed name here
 
 --
 error[SyntaxError]: expected a statement but instead found '}'

--- a/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.js
+++ b/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.js
@@ -1,0 +1,3 @@
+class A {
+	# test;
+}

--- a/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.rast
@@ -1,0 +1,92 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..8 "A" [] [Whitespace(" ")],
+            },
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@8..9 "{" [] [],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        JsUnknown {
+                            items: [
+                                HASH@9..13 "#" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@13..17 "test" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@17..18 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@18..20 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..21
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..20
+    0: JS_CLASS_STATEMENT@0..20
+      0: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@6..8
+        0: IDENT@6..8 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: L_CURLY@8..9 "{" [] []
+      5: JS_CLASS_MEMBER_LIST@9..18
+        0: JS_UNKNOWN_MEMBER@9..13
+          0: JS_UNKNOWN@9..13
+            0: HASH@9..13 "#" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+        1: JS_PROPERTY_CLASS_MEMBER@13..18
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@13..17
+            0: IDENT@13..17 "test" [] []
+          6: (empty)
+          7: (empty)
+          8: (empty)
+          9: (empty)
+          10: SEMICOLON@17..18 ";" [] []
+      6: R_CURLY@18..20 "}" [Newline("\n")] []
+  3: EOF@20..21 "" [Newline("\n")] []
+--
+error[SyntaxError]: Unexpected space between # and identifier
+  ┌─ private_member_name_with_space.js:2:3
+  │
+2 │     # test;
+  │      ^ remove the space here
+
+--
+error[SyntaxError]: expected a semicolon for a class property, but found none
+  ┌─ private_member_name_with_space.js:2:2
+  │
+2 │     # test;
+  │     ^^
+
+--
+class A {
+	# test;
+}

--- a/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_member_name_with_space.rast
@@ -73,11 +73,11 @@ JsModule {
       6: R_CURLY@18..20 "}" [Newline("\n")] []
   3: EOF@20..21 "" [Newline("\n")] []
 --
-error[SyntaxError]: Unexpected space between # and identifier
+error[SyntaxError]: Unexpected space or comment between `#` and identifier
   ┌─ private_member_name_with_space.js:2:3
   │
 2 │     # test;
-  │      ^ remove the space here
+  │      ^ remove the space or comment here
 
 --
 error[SyntaxError]: expected a semicolon for a class property, but found none

--- a/crates/rslint_parser/test_data/inline/err/private_name_with_space.js
+++ b/crates/rslint_parser/test_data/inline/err/private_name_with_space.js
@@ -1,0 +1,3 @@
+class A {
+	# test;
+}

--- a/crates/rslint_parser/test_data/inline/err/private_name_with_space.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_name_with_space.rast
@@ -73,11 +73,11 @@ JsModule {
       6: R_CURLY@18..20 "}" [Newline("\n")] []
   3: EOF@20..21 "" [Newline("\n")] []
 --
-error[SyntaxError]: Unexpected space between # and identifier
+error[SyntaxError]: Unexpected space or comment between `#` and identifier
   ┌─ private_name_with_space.js:2:3
   │
 2 │     # test;
-  │      ^ remove the space here
+  │      ^ remove the space or comment here
 
 --
 error[SyntaxError]: expected a semicolon for a class property, but found none

--- a/crates/rslint_parser/test_data/inline/err/private_name_with_space.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_name_with_space.rast
@@ -1,0 +1,92 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..8 "A" [] [Whitespace(" ")],
+            },
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@8..9 "{" [] [],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        JsUnknown {
+                            items: [
+                                HASH@9..13 "#" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                            ],
+                        },
+                    ],
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@13..17 "test" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    excl_token: missing (optional),
+                    ty: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@17..18 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@18..20 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..21
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..20
+    0: JS_CLASS_STATEMENT@0..20
+      0: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@6..8
+        0: IDENT@6..8 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: L_CURLY@8..9 "{" [] []
+      5: JS_CLASS_MEMBER_LIST@9..18
+        0: JS_UNKNOWN_MEMBER@9..13
+          0: JS_UNKNOWN@9..13
+            0: HASH@9..13 "#" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+        1: JS_PROPERTY_CLASS_MEMBER@13..18
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@13..17
+            0: IDENT@13..17 "test" [] []
+          6: (empty)
+          7: (empty)
+          8: (empty)
+          9: (empty)
+          10: SEMICOLON@17..18 ";" [] []
+      6: R_CURLY@18..20 "}" [Newline("\n")] []
+  3: EOF@20..21 "" [Newline("\n")] []
+--
+error[SyntaxError]: Unexpected space between # and identifier
+  ┌─ private_name_with_space.js:2:3
+  │
+2 │     # test;
+  │      ^ remove the space here
+
+--
+error[SyntaxError]: expected a semicolon for a class property, but found none
+  ┌─ private_name_with_space.js:2:2
+  │
+2 │     # test;
+  │     ^^
+
+--
+class A {
+	# test;
+}


### PR DESCRIPTION

## Summary
Trivia isn't allowed between a `#` token and the private name identifier. This PR changes the
*private member name* and *private name* implementation to emit an error if there's a whitespace between the `#` and identifier name.


## Test Plan

Added two new parser tests that handle whitespace between private member names
