### PR TITLE
fix(rslint_parser): Static `constructor` member

### DIFF
--- a/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.js
+++ b/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.js
@@ -1,0 +1,4 @@
+class A {
+	static async * constructor() {}
+	static * constructor() {}
+}

--- a/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.rast
@@ -1,0 +1,118 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..8 "A" [] [Whitespace(" ")],
+            },
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@8..9 "{" [] [],
+            members: JsClassMemberList [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@9..18 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: ASYNC_KW@18..24 "async" [] [Whitespace(" ")],
+                    star_token: STAR@24..26 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@26..37 "constructor" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@37..38 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@38..40 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@40..41 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@41..42 "}" [] [],
+                    },
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: STATIC_KW@42..51 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: STAR@51..53 "*" [] [Whitespace(" ")],
+                    name: JsLiteralMemberName {
+                        value: IDENT@53..64 "constructor" [] [],
+                    },
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@64..65 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@65..67 ")" [] [Whitespace(" ")],
+                    },
+                    return_type: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@67..68 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@68..69 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@69..71 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@71..72 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..72
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..71
+    0: JS_CLASS_STATEMENT@0..71
+      0: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@6..8
+        0: IDENT@6..8 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: L_CURLY@8..9 "{" [] []
+      5: JS_CLASS_MEMBER_LIST@9..69
+        0: JS_METHOD_CLASS_MEMBER@9..42
+          0: (empty)
+          1: STATIC_KW@9..18 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: (empty)
+          3: ASYNC_KW@18..24 "async" [] [Whitespace(" ")]
+          4: STAR@24..26 "*" [] [Whitespace(" ")]
+          5: JS_LITERAL_MEMBER_NAME@26..37
+            0: IDENT@26..37 "constructor" [] []
+          6: (empty)
+          7: JS_PARAMETERS@37..40
+            0: L_PAREN@37..38 "(" [] []
+            1: JS_PARAMETER_LIST@38..38
+            2: R_PAREN@38..40 ")" [] [Whitespace(" ")]
+          8: (empty)
+          9: JS_FUNCTION_BODY@40..42
+            0: L_CURLY@40..41 "{" [] []
+            1: JS_DIRECTIVE_LIST@41..41
+            2: JS_STATEMENT_LIST@41..41
+            3: R_CURLY@41..42 "}" [] []
+        1: JS_METHOD_CLASS_MEMBER@42..69
+          0: (empty)
+          1: STATIC_KW@42..51 "static" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+          2: (empty)
+          3: (empty)
+          4: STAR@51..53 "*" [] [Whitespace(" ")]
+          5: JS_LITERAL_MEMBER_NAME@53..64
+            0: IDENT@53..64 "constructor" [] []
+          6: (empty)
+          7: JS_PARAMETERS@64..67
+            0: L_PAREN@64..65 "(" [] []
+            1: JS_PARAMETER_LIST@65..65
+            2: R_PAREN@65..67 ")" [] [Whitespace(" ")]
+          8: (empty)
+          9: JS_FUNCTION_BODY@67..69
+            0: L_CURLY@67..68 "{" [] []
+            1: JS_DIRECTIVE_LIST@68..68
+            2: JS_STATEMENT_LIST@68..68
+            3: R_CURLY@68..69 "}" [] []
+      6: R_CURLY@69..71 "}" [Newline("\n")] []
+  3: EOF@71..72 "" [Newline("\n")] []


### PR DESCRIPTION
## Summary

Static methods called `constructor` are valid JS, thus, these methods can be generators or async.

## Test Plan

Verified that it fixes the 262 tests, added a new parser test
