### PR TITLE
refactor(rslint_parser): Use `f64` and `i64` to parse numbers, remove lexical

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "ascii_table"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,29 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical"
-version = "5.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f404a90a744e32e8be729034fc33b90cf2a56418fbf594d69aa3c0214ad414e5"
-dependencies = [
- "cfg-if",
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,7 +1315,6 @@ dependencies = [
  "drop_bomb",
  "expect-test",
  "indexmap",
- "lexical",
  "num-bigint",
  "rome_rowan",
  "rslint_errors",
@@ -1595,12 +1565,6 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -13,7 +13,6 @@ rslint_syntax = { path = "../rslint_syntax", version = "0.1" }
 rslint_lexer = { path = "../rslint_lexer", version = "0.2", features = ["highlight"] }
 rome_rowan = { path = "../rome_rowan", version = "0.0.0" }
 num-bigint = "0.4.3"
-lexical = { version = "5.2.0", features = ["radix"] }
 drop_bomb = "0.1.5"
 bitflags = "1.3.2"
 indexmap = "1.8.0"


### PR DESCRIPTION
## Summary
Number parsing is incomplete at the moment. This is the first part of on going effort to improve number parsing.

Previously rslint used the `lexical` library to parse any number into f64 without checking, and has a double parsing issue when parsing numbers with leading zeroes.

This PR only removes `lexical`, and uses
* `f64` to parse numbers with radix 10
* `i64` to parse other radix 2, 8 and 16, since JavaScript does not have floating point binary/octal/hex numbers. 
 
Correctness checking and other improvements will be submitted in other PRs.

## Test Plan
All tests pass.
