### PR TITLE
ci: add `cargo check --release` to lint stage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
         run: rustup show
       - name: Cache
         uses: Swatinem/rust-cache@v1
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --all-targets --release
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,11 @@ jobs:
         run: rustup show
       - name: Cache
         uses: Swatinem/rust-cache@v1
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --all-targets --release
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Main branch is failing with release build, this PR adds release build check.

This PR is failling with 
```
no field `printed_tokens` on type `&formatter::Formatter`
```
 @leops 