### PR TITLE
ci: benchmark with bot comment

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,3 +71,89 @@ jobs:
           command: test
           args: --workspace --verbose
 
+  bench:
+    name: bench
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+       os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+
+      - name: Fetch Main Branch
+        run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main
+
+      - name: Install toolchain
+        run: rustup show
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install critcmp
+        run: cargo install critcmp
+
+      - name: Compile
+        run: cargo build --release --locked -p xtask
+
+      - name: Run Bench on PR Branch
+        run: cargo run -p xtask --release -- coverage-libs --save-baseline pr
+
+      - name: Checkout Main Branch
+        run: git checkout main
+
+      - name: Run Bench on Main Branch
+        run: cargo run -p xtask --release -- coverage-libs --save-baseline main
+
+      - name: Compare Bench Results on ${{ matrix.os }}
+        if: github.event_name == 'pull_request'
+        id: bench_comparison
+        shell: bash
+        run: |
+          echo "### Bench results on ${{ matrix.os }}\n\`\`\`" > output
+          critcmp main pr >> output
+          echo "\`\`\`" >> output
+          cat output
+          comment="$(cat output)"
+          comment="${comment//'%'/'%25'}"
+          comment="${comment//$'\n'/'%0A'}"
+          comment="${comment//$'\r'/'%0D'}"
+          echo "::set-output name=comment::$comment"
+
+      - name: Get the PR number
+        if: github.event_name == 'pull_request'
+        id: pr-number
+        uses: kkak10/pr-number-action@v1.3
+
+      - name: Find Previous Comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v1.3.0
+        id: previous-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body-includes: Bench results on ${{ matrix.os }}
+
+      - name: Update existing comment
+        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.previous-comment.outputs.comment-id }}
+          body: |
+            ${{ steps.bench_comparison.outputs.comment }}
+          edit-mode: replace
+
+      - name: Write a new comment
+        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body: |
+            ${{ steps.bench_comparison.outputs.comment }}
+
+      - name: Remove Criterion Artifact
+        run: rm -rf ./target/criterion

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -69,7 +69,8 @@ fn main() -> Result<()> {
                 .opt_value_from_str("--criterion")
                 .unwrap()
                 .unwrap_or(true);
-            xtask::libs::run(filter, criterion);
+            let baseline: Option<String> = args.opt_value_from_str("--save-baseline").unwrap();
+            xtask::libs::run(filter, criterion, baseline);
             Ok(())
         }
         _ => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -61,6 +61,12 @@ fn main() -> Result<()> {
             Ok(())
         }
         "coverage-libs" => {
+            // on pr branch, run
+            // git checkout main
+            // cargo run -p xtask --release -- coverage-libs --save-baseline main
+            // git checkout -
+            // cargo run -p xtask --release -- coverage-libs --save-baseline pr
+            // critcmp main pr # (cargo install critcmp)
             let filter: String = args
                 .opt_value_from_str("--filter")
                 .unwrap()


### PR DESCRIPTION
This PR adds 
* criterion groups, which enables throughput
* the `--save-baseline` option from criterion, which enables [critcmp](https://github.com/BurntSushi/critcmp) tool for comparing results
* ci pipeline with bot comment

Use Case:
```
on pr branch, run
git checkout main
cargo run -p xtask --release -- coverage-libs --save-baseline main
git checkout -
cargo run -p xtask --release -- coverage-libs --save-baseline pr
critcmp main pr # (cargo install critcmp)
```

Output using the `remove-lexical` branch
```
group                                 main                                    pr
-----                                 ----                                    --
parser/compiler.js                    1.05    98.1±26.02ms    10.7 MB/sec     1.00     93.4±7.47ms    11.2 MB/sec
parser/d3.min.js                      1.09    57.7±10.50ms     4.5 MB/sec     1.00     52.9±1.59ms     5.0 MB/sec
parser/dojo.js                        1.13      4.8±0.96ms    14.4 MB/sec     1.00      4.2±0.30ms    16.3 MB/sec
parser/jquery.min.js                  1.16     20.5±4.63ms     4.0 MB/sec     1.00     17.6±0.55ms     4.7 MB/sec
parser/pixi.min.js                    1.00    72.3±15.58ms     6.1 MB/sec     1.02     73.7±9.94ms     6.0 MB/sec
parser/react-dom.production.min.js    1.00     22.3±1.95ms     5.2 MB/sec     1.04     23.2±4.56ms     5.0 MB/sec
parser/react.production.min.js        1.05  1096.7±295.86µs     5.6 MB/sec    1.00  1049.1±237.49µs     5.9 MB/sec
parser/tex-chtml-full.js              1.08   154.9±21.43ms     5.9 MB/sec     1.00   143.9±22.96ms     6.3 MB/sec
parser/three.min.js                   1.00    81.6±11.86ms     7.2 MB/sec     1.10    90.2±19.85ms     6.5 MB/sec
parser/vue.global.prod.js             1.09     28.7±6.39ms     4.2 MB/sec     1.00     26.3±0.88ms     4.6 MB/sec
```

The 1.xx column is the percentage difference, larger means worse. 
For example jquery is 16% slower on main. And the pr branch performs better overall.

To reduce noise, I have increased the measurement time duration to 10 seconds, this should give us more stable result, especially on the CI.

Note, I'm on a fork so no bot comment on this PR, and we need the `--save-baseline` commit in main first in order for this to have an affect. 