### PR TITLE
fix(coverage): Fix [raw, module] flag combination of t262

### DIFF
--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -120,7 +120,7 @@ pub fn run_test_file(file: TestFile) -> TestResult {
     let TestFile { code, meta, path } = file;
 
     if meta.flags.contains(&TestFlag::OnlyStrict) {
-        let (code, res) = exec_test(code, !meta.flags.contains(&TestFlag::Raw), false);
+        let (code, res) = exec_test(code, true, false);
         let fail = passed(res, meta);
         let outcome = extract_outcome(&fail);
         TestResult {

--- a/xtask/src/coverage/mod.rs
+++ b/xtask/src/coverage/mod.rs
@@ -120,17 +120,7 @@ pub fn run_test_file(file: TestFile) -> TestResult {
     let TestFile { code, meta, path } = file;
 
     if meta.flags.contains(&TestFlag::OnlyStrict) {
-        let (code, res) = exec_test(code, true, false);
-        let fail = passed(res, meta);
-        let outcome = extract_outcome(&fail);
-        TestResult {
-            fail,
-            path,
-            code,
-            outcome,
-        }
-    } else if meta.flags.contains(&TestFlag::NoStrict) || meta.flags.contains(&TestFlag::Raw) {
-        let (code, res) = exec_test(code, false, false);
+        let (code, res) = exec_test(code, !meta.flags.contains(&TestFlag::Raw), false);
         let fail = passed(res, meta);
         let outcome = extract_outcome(&fail);
         TestResult {
@@ -141,6 +131,16 @@ pub fn run_test_file(file: TestFile) -> TestResult {
         }
     } else if meta.flags.contains(&TestFlag::Module) {
         let (code, res) = exec_test(code, false, true);
+        let fail = passed(res, meta);
+        let outcome = extract_outcome(&fail);
+        TestResult {
+            fail,
+            path,
+            code,
+            outcome,
+        }
+    } else if meta.flags.contains(&TestFlag::NoStrict) || meta.flags.contains(&TestFlag::Raw) {
+        let (code, res) = exec_test(code, false, false);
         let fail = passed(res, meta);
         let outcome = extract_outcome(&fail);
         TestResult {
@@ -263,8 +263,8 @@ enum ExecRes {
     ParserPanic(Box<dyn Any + Send + 'static>),
 }
 
-fn exec_test(mut code: String, strict: bool, module: bool) -> (String, ExecRes) {
-    if strict {
+fn exec_test(mut code: String, append_use_strict: bool, module: bool) -> (String, ExecRes) {
+    if append_use_strict {
         code.insert_str(0, "\"use strict\";\n");
     }
 


### PR DESCRIPTION

## Summary

> `raw` The test source code must not be modified in any way, files from the harness/ directory must not be evaluated, and the test must be executed just once (in non-strict mode, only).

But there are a few tests with flags `[raw, module]`. It's important that we parse these as modules. The `raw` flag has no effect because modules are "strict" by default.  

