### PR TITLE
fix(rslint_parser): Fix `do-while` optional semi

### DIFF
--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -1254,7 +1254,10 @@ fn parse_do_statement(p: &mut Parser) -> ParsedSyntax {
 
     // test do-while-asi
     // do do do ; while (x) while (x) while (x) x = 39;
-    if !parenthesized_expression(p) {
+    // do do ; while (x); while (x) x = 39
+    if parenthesized_expression(p) {
+        optional_semi(p);
+    } else {
         let end_range = p.cur_tok().end();
         semi(p, start..end_range);
     }

--- a/crates/rslint_parser/test_data/inline/ok/do-while-asi.js
+++ b/crates/rslint_parser/test_data/inline/ok/do-while-asi.js
@@ -1,1 +1,2 @@
 do do do ; while (x) while (x) while (x) x = 39;
+do do ; while (x); while (x) x = 39

--- a/crates/rslint_parser/test_data/inline/ok/do-while-asi.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do-while-asi.rast
@@ -53,14 +53,53 @@ JsModule {
             },
             semicolon_token: SEMICOLON@47..48 ";" [] [],
         },
+        JsDoWhileStatement {
+            do_token: DO_KW@48..52 "do" [Newline("\n")] [Whitespace(" ")],
+            body: JsDoWhileStatement {
+                do_token: DO_KW@52..55 "do" [] [Whitespace(" ")],
+                body: JsEmptyStatement {
+                    semicolon_token: SEMICOLON@55..57 ";" [] [Whitespace(" ")],
+                },
+                while_token: WHILE_KW@57..63 "while" [] [Whitespace(" ")],
+                l_paren_token: L_PAREN@63..64 "(" [] [],
+                test: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@64..65 "x" [] [],
+                    },
+                },
+                r_paren_token: R_PAREN@65..66 ")" [] [],
+                semicolon_token: SEMICOLON@66..68 ";" [] [Whitespace(" ")],
+            },
+            while_token: WHILE_KW@68..74 "while" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@74..75 "(" [] [],
+            test: JsIdentifierExpression {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@75..76 "x" [] [],
+                },
+            },
+            r_paren_token: R_PAREN@76..78 ")" [] [Whitespace(" ")],
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsAssignmentExpression {
+                left: JsIdentifierAssignment {
+                    name_token: IDENT@78..80 "x" [] [Whitespace(" ")],
+                },
+                operator_token: EQ@80..82 "=" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@82..84 "39" [] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
     ],
-    eof_token: EOF@48..49 "" [Newline("\n")] [],
+    eof_token: EOF@84..85 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..49
+0: JS_MODULE@0..85
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..48
+  2: JS_MODULE_ITEM_LIST@0..84
     0: JS_DO_WHILE_STATEMENT@0..41
       0: DO_KW@0..3 "do" [] [Whitespace(" ")]
       1: JS_DO_WHILE_STATEMENT@3..31
@@ -98,4 +137,32 @@ JsModule {
         2: JS_NUMBER_LITERAL_EXPRESSION@45..47
           0: JS_NUMBER_LITERAL@45..47 "39" [] []
       1: SEMICOLON@47..48 ";" [] []
-  3: EOF@48..49 "" [Newline("\n")] []
+    2: JS_DO_WHILE_STATEMENT@48..78
+      0: DO_KW@48..52 "do" [Newline("\n")] [Whitespace(" ")]
+      1: JS_DO_WHILE_STATEMENT@52..68
+        0: DO_KW@52..55 "do" [] [Whitespace(" ")]
+        1: JS_EMPTY_STATEMENT@55..57
+          0: SEMICOLON@55..57 ";" [] [Whitespace(" ")]
+        2: WHILE_KW@57..63 "while" [] [Whitespace(" ")]
+        3: L_PAREN@63..64 "(" [] []
+        4: JS_IDENTIFIER_EXPRESSION@64..65
+          0: JS_REFERENCE_IDENTIFIER@64..65
+            0: IDENT@64..65 "x" [] []
+        5: R_PAREN@65..66 ")" [] []
+        6: SEMICOLON@66..68 ";" [] [Whitespace(" ")]
+      2: WHILE_KW@68..74 "while" [] [Whitespace(" ")]
+      3: L_PAREN@74..75 "(" [] []
+      4: JS_IDENTIFIER_EXPRESSION@75..76
+        0: JS_REFERENCE_IDENTIFIER@75..76
+          0: IDENT@75..76 "x" [] []
+      5: R_PAREN@76..78 ")" [] [Whitespace(" ")]
+      6: (empty)
+    3: JS_EXPRESSION_STATEMENT@78..84
+      0: JS_ASSIGNMENT_EXPRESSION@78..84
+        0: JS_IDENTIFIER_ASSIGNMENT@78..80
+          0: IDENT@78..80 "x" [] [Whitespace(" ")]
+        1: EQ@80..82 "=" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@82..84
+          0: JS_NUMBER_LITERAL@82..84 "39" [] []
+      1: (empty)
+  3: EOF@84..85 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -80,9 +80,6 @@ JsModule {
                 value_token: TRUE_KW@72..76 "true" [] [],
             },
             r_paren_token: R_PAREN@76..77 ")" [] [],
-            semicolon_token: missing (optional),
-        },
-        JsEmptyStatement {
             semicolon_token: SEMICOLON@77..78 ";" [] [],
         },
         JsVariableStatement {
@@ -202,7 +199,7 @@ JsModule {
         0: TRUE_KW@30..34 "true" [] []
       5: R_PAREN@34..35 ")" [] []
       6: (empty)
-    1: JS_DO_WHILE_STATEMENT@35..77
+    1: JS_DO_WHILE_STATEMENT@35..78
       0: DO_KW@35..39 "do" [Newline("\n")] [Whitespace(" ")]
       1: JS_BLOCK_STATEMENT@39..65
         0: L_CURLY@39..40 "{" [] []
@@ -231,10 +228,8 @@ JsModule {
       4: JS_BOOLEAN_LITERAL_EXPRESSION@72..76
         0: TRUE_KW@72..76 "true" [] []
       5: R_PAREN@76..77 ")" [] []
-      6: (empty)
-    2: JS_EMPTY_STATEMENT@77..78
-      0: SEMICOLON@77..78 ";" [] []
-    3: JS_VARIABLE_STATEMENT@78..89
+      6: SEMICOLON@77..78 ";" [] []
+    2: JS_VARIABLE_STATEMENT@78..89
       0: JS_VARIABLE_DECLARATIONS@78..88
         0: LET_KW@78..83 "let" [Newline("\n")] [Whitespace(" ")]
         1: JS_VARIABLE_DECLARATION_LIST@83..88
@@ -248,7 +243,7 @@ JsModule {
               1: JS_NUMBER_LITERAL_EXPRESSION@87..88
                 0: JS_NUMBER_LITERAL@87..88 "1" [] []
       1: SEMICOLON@88..89 ";" [] []
-    4: JS_DO_WHILE_STATEMENT@89..140
+    3: JS_DO_WHILE_STATEMENT@89..140
       0: DO_KW@89..92 "do" [Newline("\n")] []
       1: JS_DO_WHILE_STATEMENT@92..124
         0: DO_KW@92..96 "do" [Newline("\n")] [Whitespace(" ")]


### PR DESCRIPTION

## Summary
#1954 fixed the ASI rule for `do...while` statements so that it no longer errors if the semicolon is missing after the `do ...while ()`.

However, the parser should still eat the semi in case one is present.

Fixes the parse errors with `d3.min.js`

## Test Plan

Adds a new test with an optional semi.
