### PR TITLE
feat(rome_formatter): format_verbatim and unknown nodes

### DIFF
--- a/crates/rome_formatter/src/cst.rs
+++ b/crates/rome_formatter/src/cst.rs
@@ -9,7 +9,9 @@ use rslint_parser::ast::{
     JsNullLiteralExpression, JsNumberLiteralExpression, JsObjectExpression, JsParameters,
     JsPropertyClassMember, JsPropertyObjectMember, JsReturnStatement, JsScript,
     JsSequenceExpression, JsSetterClassMember, JsShorthandPropertyObjectMember, JsSpread,
-    JsStringLiteralExpression, JsSwitchStatement, JsTryStatement, JsVariableDeclaration,
+    JsStringLiteralExpression, JsSwitchStatement, JsTryStatement, JsUnknownAssignment,
+    JsUnknownBinding, JsUnknownExpression, JsUnknownImportAssertionEntry, JsUnknownMember,
+    JsUnknownNamedImportSpecifier, JsUnknownParameter, JsUnknownStatement, JsVariableDeclaration,
     JsVariableStatement, JsWhileStatement, JsWithStatement,
 };
 use rslint_parser::{AstNode, JsSyntaxKind, SyntaxNode};
@@ -162,6 +164,35 @@ impl ToFormatElement for SyntaxNode {
             JsSyntaxKind::JS_PROPERTY_CLASS_MEMBER => JsPropertyClassMember::cast(self.clone())
                 .unwrap()
                 .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_BINDING => JsUnknownBinding::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_MEMBER => JsUnknownMember::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_STATEMENT => JsUnknownStatement::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_EXPRESSION => JsUnknownExpression::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_ASSIGNMENT => JsUnknownAssignment::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+            JsSyntaxKind::JS_UNKNOWN_PARAMETER => JsUnknownParameter::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
+
+            JsSyntaxKind::JS_UNKNOWN_IMPORT_ASSERTION_ENTRY => {
+                JsUnknownImportAssertionEntry::cast(self.clone())
+                    .unwrap()
+                    .to_format_element(formatter)
+            }
+            JsSyntaxKind::JS_UNKNOWN_NAMED_IMPORT_SPECIFIER => {
+                JsUnknownNamedImportSpecifier::cast(self.clone())
+                    .unwrap()
+                    .to_format_element(formatter)
+            }
 
             _ => todo!(
                 "Implement formatting for the {:?} syntax kind.",

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -109,7 +109,7 @@ impl Formatter {
     /// Recursively formats the ast node and all its children
     ///
     /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.
-    /// The parent may use `format_raw` to insert the node content as is.
+    /// The parent may use [Self::format_verbatim] to insert the node content as is.
     pub fn format_node<T: AstNode + ToFormatElement>(
         &self,
         node: T,
@@ -356,12 +356,12 @@ impl Formatter {
     ///
     /// You may be inclined to call `node.text` directly. However, using `text` doesn't track the nodes
     ///nor its children source mapping information, resulting in incorrect source maps for this subtree.
-    pub fn format_raw(&self, node: &SyntaxNode) -> FormatElement {
+    pub fn format_verbatim(&self, node: &SyntaxNode) -> FormatElement {
         concat_elements(node.children_with_tokens().map(|child| match child {
             SyntaxElement::Node(child_node) => {
                 // TODO: Add source map markers before/after node as well as any additional elements that
                 // need to be tracked for every node.
-                self.format_raw(&child_node)
+                self.format_verbatim(&child_node)
             }
             SyntaxElement::Token(syntax_token) => {
                 cfg_if::cfg_if! {

--- a/crates/rome_formatter/src/ts/assignment/any_assignment.rs
+++ b/crates/rome_formatter/src/ts/assignment/any_assignment.rs
@@ -1,5 +1,6 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyAssignment;
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -16,7 +17,9 @@ impl ToFormatElement for JsAnyAssignment {
             JsAnyAssignment::JsParenthesizedAssignment(parenthesized_assignment) => {
                 parenthesized_assignment.to_format_element(formatter)
             }
-            JsAnyAssignment::JsUnknownAssignment(_) => todo!(),
+            JsAnyAssignment::JsUnknownAssignment(unknown_assignment) => {
+                Ok(formatter.format_verbatim(unknown_assignment.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/assignment/any_assignment.rs
+++ b/crates/rome_formatter/src/ts/assignment/any_assignment.rs
@@ -1,6 +1,5 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyAssignment;
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -18,7 +17,7 @@ impl ToFormatElement for JsAnyAssignment {
                 parenthesized_assignment.to_format_element(formatter)
             }
             JsAnyAssignment::JsUnknownAssignment(unknown_assignment) => {
-                Ok(formatter.format_verbatim(unknown_assignment.syntax()))
+                unknown_assignment.to_format_element(formatter)
             }
         }
     }

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -8,6 +8,7 @@ use rslint_parser::ast::{
     JsObjectAssignmentPatternProperty, JsObjectAssignmentPatternRest,
     JsObjectAssignmentPatternShorthandProperty,
 };
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -42,7 +43,9 @@ impl ToFormatElement for JsAnyObjectAssignmentPatternMember {
             JsAnyObjectAssignmentPatternMember::JsObjectAssignmentPatternRest(
                 object_assignment_pattern_rest,
             ) => object_assignment_pattern_rest.to_format_element(formatter),
-            JsAnyObjectAssignmentPatternMember::JsUnknownAssignment(_) => todo!(),
+            JsAnyObjectAssignmentPatternMember::JsUnknownAssignment(unknown_assignment) => {
+                Ok(formatter.format_verbatim(unknown_assignment.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -8,7 +8,6 @@ use rslint_parser::ast::{
     JsObjectAssignmentPatternProperty, JsObjectAssignmentPatternRest,
     JsObjectAssignmentPatternShorthandProperty,
 };
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -44,7 +43,7 @@ impl ToFormatElement for JsAnyObjectAssignmentPatternMember {
                 object_assignment_pattern_rest,
             ) => object_assignment_pattern_rest.to_format_element(formatter),
             JsAnyObjectAssignmentPatternMember::JsUnknownAssignment(unknown_assignment) => {
-                Ok(formatter.format_verbatim(unknown_assignment.syntax()))
+                unknown_assignment.to_format_element(formatter)
             }
         }
     }

--- a/crates/rome_formatter/src/ts/bindings/any_binding.rs
+++ b/crates/rome_formatter/src/ts/bindings/any_binding.rs
@@ -1,11 +1,14 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyBinding;
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyBinding {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         match self {
             JsAnyBinding::JsIdentifierBinding(single) => single.to_format_element(formatter),
-            JsAnyBinding::JsUnknownBinding(_) => todo!(),
+            JsAnyBinding::JsUnknownBinding(unknown_binding) => {
+                Ok(formatter.format_verbatim(unknown_binding.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/any_binding.rs
+++ b/crates/rome_formatter/src/ts/bindings/any_binding.rs
@@ -1,13 +1,12 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyBinding;
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyBinding {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         match self {
             JsAnyBinding::JsIdentifierBinding(single) => single.to_format_element(formatter),
             JsAnyBinding::JsUnknownBinding(unknown_binding) => {
-                Ok(formatter.format_verbatim(unknown_binding.syntax()))
+                unknown_binding.to_format_element(formatter)
             }
         }
     }

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -7,6 +7,7 @@ use rslint_parser::ast::{
     JsAnyObjectBindingPatternMember, JsObjectBindingPattern, JsObjectBindingPatternProperty,
     JsObjectBindingPatternRest, JsObjectBindingPatternShorthandProperty,
 };
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -45,7 +46,9 @@ impl ToFormatElement for JsAnyObjectBindingPatternMember {
             JsAnyObjectBindingPatternMember::JsIdentifierBinding(identifier_binding) => {
                 identifier_binding.to_format_element(formatter)
             }
-            JsAnyObjectBindingPatternMember::JsUnknownBinding(_) => todo!(),
+            JsAnyObjectBindingPatternMember::JsUnknownBinding(unknown_binding) => {
+                Ok(formatter.format_verbatim(unknown_binding.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -7,7 +7,6 @@ use rslint_parser::ast::{
     JsAnyObjectBindingPatternMember, JsObjectBindingPattern, JsObjectBindingPatternProperty,
     JsObjectBindingPatternRest, JsObjectBindingPatternShorthandProperty,
 };
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -47,7 +46,7 @@ impl ToFormatElement for JsAnyObjectBindingPatternMember {
                 identifier_binding.to_format_element(formatter)
             }
             JsAnyObjectBindingPatternMember::JsUnknownBinding(unknown_binding) => {
-                Ok(formatter.format_verbatim(unknown_binding.syntax()))
+                unknown_binding.to_format_element(formatter)
             }
         }
     }

--- a/crates/rome_formatter/src/ts/class/class_member.rs
+++ b/crates/rome_formatter/src/ts/class/class_member.rs
@@ -1,5 +1,6 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyClassMember;
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -16,7 +17,9 @@ impl ToFormatElement for JsAnyClassMember {
             }
             JsAnyClassMember::JsGetterClassMember(getter) => getter.to_format_element(formatter),
             JsAnyClassMember::JsSetterClassMember(setter) => setter.to_format_element(formatter),
-            JsAnyClassMember::JsUnknownMember(_) => todo!(),
+            JsAnyClassMember::JsUnknownMember(unknown_member) => {
+                Ok(formatter.format_verbatim(unknown_member.syntax()))
+            }
             JsAnyClassMember::TsIndexSignature(_) => todo!(),
             JsAnyClassMember::JsStaticInitializationBlockClassMember(_) => todo!(),
         }

--- a/crates/rome_formatter/src/ts/class/class_member.rs
+++ b/crates/rome_formatter/src/ts/class/class_member.rs
@@ -1,6 +1,5 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyClassMember;
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -18,7 +17,7 @@ impl ToFormatElement for JsAnyClassMember {
             JsAnyClassMember::JsGetterClassMember(getter) => getter.to_format_element(formatter),
             JsAnyClassMember::JsSetterClassMember(setter) => setter.to_format_element(formatter),
             JsAnyClassMember::JsUnknownMember(unknown_member) => {
-                Ok(formatter.format_verbatim(unknown_member.syntax()))
+                unknown_member.to_format_element(formatter)
             }
             JsAnyClassMember::TsIndexSignature(_) => todo!(),
             JsAnyClassMember::JsStaticInitializationBlockClassMember(_) => todo!(),

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -5,6 +5,7 @@ use crate::{
 use rslint_parser::ast::{
     JsAnyConstructorParameter, JsConstructorClassMember, JsConstructorParameters,
 };
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsConstructorClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -42,7 +43,9 @@ impl ToFormatElement for JsAnyConstructorParameter {
             JsAnyConstructorParameter::JsParameter(parameter) => {
                 parameter.to_format_element(formatter)
             }
-            JsAnyConstructorParameter::JsUnknownParameter(_) => todo!(),
+            JsAnyConstructorParameter::JsUnknownParameter(unknown_parameter) => {
+                Ok(formatter.format_verbatim(unknown_parameter.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -14,7 +14,7 @@ pub fn format_directives(directives: JsDirectiveList, formatter: &Formatter) -> 
                 Err(_) => {
                     formatter.restore(snapshot);
                     formatter
-                        .format_raw(directive.syntax())
+                        .format_verbatim(directive.syntax())
                         .trim_start()
                         .trim_end()
                 }

--- a/crates/rome_formatter/src/ts/expressions/expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/expression.rs
@@ -8,7 +8,7 @@ use rslint_parser::ast::{
     JsInstanceofExpression, JsLogicalExpression, JsNewExpression, JsParenthesizedExpression,
     JsThisExpression, JsUnaryExpression, JsYieldArgument, JsYieldExpression, NewTarget,
 };
-use rslint_parser::{token_set, AstNode, T};
+use rslint_parser::{token_set, T};
 
 impl ToFormatElement for JsAnyExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -83,7 +83,7 @@ impl ToFormatElement for JsAnyExpression {
                 post_update_expression.to_format_element(formatter)
             }
             JsAnyExpression::JsUnknownExpression(unknown_expression) => {
-                Ok(formatter.format_verbatim(unknown_expression.syntax()))
+                unknown_expression.to_format_element(formatter)
             }
             JsAnyExpression::JsLogicalExpression(logical_expression) => {
                 logical_expression.to_format_element(formatter)

--- a/crates/rome_formatter/src/ts/expressions/expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/expression.rs
@@ -8,7 +8,7 @@ use rslint_parser::ast::{
     JsInstanceofExpression, JsLogicalExpression, JsNewExpression, JsParenthesizedExpression,
     JsThisExpression, JsUnaryExpression, JsYieldArgument, JsYieldExpression, NewTarget,
 };
-use rslint_parser::{token_set, T};
+use rslint_parser::{token_set, AstNode, T};
 
 impl ToFormatElement for JsAnyExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -82,7 +82,9 @@ impl ToFormatElement for JsAnyExpression {
             JsAnyExpression::JsPostUpdateExpression(post_update_expression) => {
                 post_update_expression.to_format_element(formatter)
             }
-            JsAnyExpression::JsUnknownExpression(_) => todo!(),
+            JsAnyExpression::JsUnknownExpression(unknown_expression) => {
+                Ok(formatter.format_verbatim(unknown_expression.syntax()))
+            }
             JsAnyExpression::JsLogicalExpression(logical_expression) => {
                 logical_expression.to_format_element(formatter)
             }

--- a/crates/rome_formatter/src/ts/mod.rs
+++ b/crates/rome_formatter/src/ts/mod.rs
@@ -13,6 +13,7 @@ mod parameter_list;
 mod script;
 mod statements;
 mod template;
+mod unknown;
 
 #[cfg(test)]
 mod test {

--- a/crates/rome_formatter/src/ts/object_members/object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/object_member.rs
@@ -1,6 +1,5 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyObjectMember;
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -18,7 +17,7 @@ impl ToFormatElement for JsAnyObjectMember {
                 method_object_member.to_format_element(formatter)
             }
             JsAnyObjectMember::JsUnknownMember(unknown_member) => {
-                Ok(formatter.format_verbatim(unknown_member.syntax()))
+                unknown_member.to_format_element(formatter)
             }
         }
     }

--- a/crates/rome_formatter/src/ts/object_members/object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/object_member.rs
@@ -1,5 +1,6 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsAnyObjectMember;
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsAnyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -16,7 +17,9 @@ impl ToFormatElement for JsAnyObjectMember {
             JsAnyObjectMember::JsMethodObjectMember(method_object_member) => {
                 method_object_member.to_format_element(formatter)
             }
-            JsAnyObjectMember::JsUnknownMember(_) => todo!(),
+            JsAnyObjectMember::JsUnknownMember(unknown_member) => {
+                Ok(formatter.format_verbatim(unknown_member.syntax()))
+            }
         }
     }
 }

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -4,6 +4,7 @@ use crate::{
     ToFormatElement,
 };
 use rslint_parser::ast::{JsAnyParameter, JsParameter, JsParameters, JsRestParameter};
+use rslint_parser::AstNode;
 
 impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -27,7 +28,9 @@ impl ToFormatElement for JsAnyParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         match self {
             JsAnyParameter::JsParameter(parameter) => parameter.to_format_element(formatter),
-            JsAnyParameter::JsUnknownParameter(_) => todo!(),
+            JsAnyParameter::JsUnknownParameter(unknown_parameter) => {
+                Ok(formatter.format_verbatim(unknown_parameter.syntax()))
+            }
             JsAnyParameter::JsRestParameter(binding) => binding.to_format_element(formatter),
         }
     }

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -4,7 +4,6 @@ use crate::{
     ToFormatElement,
 };
 use rslint_parser::ast::{JsAnyParameter, JsParameter, JsParameters, JsRestParameter};
-use rslint_parser::AstNode;
 
 impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -29,7 +28,7 @@ impl ToFormatElement for JsAnyParameter {
         match self {
             JsAnyParameter::JsParameter(parameter) => parameter.to_format_element(formatter),
             JsAnyParameter::JsUnknownParameter(unknown_parameter) => {
-                Ok(formatter.format_verbatim(unknown_parameter.syntax()))
+                unknown_parameter.to_format_element(formatter)
             }
             JsAnyParameter::JsRestParameter(binding) => binding.to_format_element(formatter),
         }

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -34,7 +34,10 @@ pub fn format_statements(stmts: JsStatementList, formatter: &Formatter) -> Forma
                 Ok(result) => result,
                 Err(_) => {
                     formatter.restore(snapshot);
-                    formatter.format_raw(stmt.syntax()).trim_start().trim_end()
+                    formatter
+                        .format_verbatim(stmt.syntax())
+                        .trim_start()
+                        .trim_end()
                 }
             }
         }),

--- a/crates/rome_formatter/src/ts/statements/statement.rs
+++ b/crates/rome_formatter/src/ts/statements/statement.rs
@@ -57,7 +57,7 @@ impl ToFormatElement for JsAnyStatement {
             JsAnyStatement::JsClassStatement(statement) => statement.to_format_element(formatter),
             JsAnyStatement::JsVariableStatement(decl) => decl.to_format_element(formatter),
             JsAnyStatement::JsUnknownStatement(unknown_statement) => {
-                Ok(formatter.format_raw(unknown_statement.syntax()))
+                Ok(formatter.format_verbatim(unknown_statement.syntax()))
             }
             JsAnyStatement::JsTryFinallyStatement(try_finally) => {
                 try_finally.to_format_element(formatter)

--- a/crates/rome_formatter/src/ts/statements/statement.rs
+++ b/crates/rome_formatter/src/ts/statements/statement.rs
@@ -1,5 +1,5 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::{ast::JsAnyStatement, AstNode};
+use rslint_parser::ast::JsAnyStatement;
 
 impl ToFormatElement for JsAnyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -57,7 +57,7 @@ impl ToFormatElement for JsAnyStatement {
             JsAnyStatement::JsClassStatement(statement) => statement.to_format_element(formatter),
             JsAnyStatement::JsVariableStatement(decl) => decl.to_format_element(formatter),
             JsAnyStatement::JsUnknownStatement(unknown_statement) => {
-                Ok(formatter.format_verbatim(unknown_statement.syntax()))
+                unknown_statement.to_format_element(formatter)
             }
             JsAnyStatement::JsTryFinallyStatement(try_finally) => {
                 try_finally.to_format_element(formatter)

--- a/crates/rome_formatter/src/ts/unknown/assignment.rs
+++ b/crates/rome_formatter/src/ts/unknown/assignment.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownAssignment;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownAssignment {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/binding.rs
+++ b/crates/rome_formatter/src/ts/unknown/binding.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownBinding;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownBinding {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/expression.rs
+++ b/crates/rome_formatter/src/ts/unknown/expression.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownExpression;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownExpression {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/import_assertion_entry.rs
+++ b/crates/rome_formatter/src/ts/unknown/import_assertion_entry.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownImportAssertionEntry;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownImportAssertionEntry {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/member.rs
+++ b/crates/rome_formatter/src/ts/unknown/member.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownMember;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownMember {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/mod.rs
+++ b/crates/rome_formatter/src/ts/unknown/mod.rs
@@ -1,0 +1,8 @@
+mod assignment;
+mod binding;
+mod expression;
+mod import_assertion_entry;
+mod member;
+mod named_import_specifier;
+mod parameter;
+mod statement;

--- a/crates/rome_formatter/src/ts/unknown/named_import_specifier.rs
+++ b/crates/rome_formatter/src/ts/unknown/named_import_specifier.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownNamedImportSpecifier;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownNamedImportSpecifier {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/parameter.rs
+++ b/crates/rome_formatter/src/ts/unknown/parameter.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownParameter;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownParameter {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}

--- a/crates/rome_formatter/src/ts/unknown/statement.rs
+++ b/crates/rome_formatter/src/ts/unknown/statement.rs
@@ -1,0 +1,9 @@
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsUnknownStatement;
+use rslint_parser::AstNode;
+
+impl ToFormatElement for JsUnknownStatement {
+    fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        Ok(formatter.format_verbatim(self.syntax()))
+    }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #1726 

This PR:
- changes the API `format_raw` to `format_verbatim`
- implements all `Unknown*` nodes we have in the formatter so far. While we wait on a decision on to attempt to format them, they all do call the API `format_verbatim`
- implements `ToFormatElement` for all `Unknown*` nodes
- adds formatting of `Unknown*` nodes to `cst.rs`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
