### PR TITLE
fix(rslint_lexer): Fix regex not being parsed after the await keyword

### DIFF
--- a/crates/rslint_syntax/src/generated.rs
+++ b/crates/rslint_syntax/src/generated.rs
@@ -449,9 +449,11 @@ impl JsSyntaxKind {
         match self {
             BANG | L_PAREN | L_BRACK | L_CURLY | SEMICOLON | COMMA | COLON | QUESTION | PLUS2
             | MINUS2 | TILDE | CASE_KW | DEFAULT_KW | DO_KW | ELSE_KW | RETURN_KW | THROW_KW
-            | NEW_KW | EXTENDS_KW | YIELD_KW | IN_KW | TYPEOF_KW | VOID_KW | DELETE_KW | PLUSEQ
-            | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ | AMP2 | PIPE2
-            | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS => true,
+            | NEW_KW | EXTENDS_KW | YIELD_KW | AWAIT_KW | IN_KW | TYPEOF_KW | VOID_KW
+            | DELETE_KW | PLUSEQ | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ
+            | PERCENTEQ | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS => {
+                true
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary

Fixed the lexer not parsing regex after the `await` keyword.

The lexer tried to read the `slash` token in this line (inside `read_slash` function:
```
            _ if self.state.expr_allowed => self.read_regex(),
```

`self.state.expr_allowed` is returned from `is_before_expr`, which didn't include the `await` keyword. 


## Test Plan
Local output
| Test result | `main` count | This PR count | Difference |
| :---------: | :----------: | :-----------: | :--------: |
| Total | 45250 | 45250 | 0 |
| Passed | 44103 | 44121 | ✅ ⏫ **+18** |
| Failed | 1146 | 1128 | ✅ ⏬ **-18** |
| Panics | 1 | 1 | 0 |
| Coverage | 97.47% | 97.50% | **+0.04%** |

<details><summary><b>:tada: Fixed (18):</b></summary>

```
xtask/coverage/test262/test/language/module-code/top-level-await/await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/block-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/export-class-decl-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/export-dflt-assign-expr-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/export-dft-class-decl-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/export-lex-decl-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/export-var-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/for-await-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/for-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/for-in-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/for-of-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/if-block-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/if-expr-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/top-level-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/try-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/typeof-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/void-await-expr-regexp.js
xtask/coverage/test262/test/language/module-code/top-level-await/syntax/while-await-expr-regexp.js
```
</details>