### PR TITLE
fix(rslint_lexer): Fix lexing of regex literals

### DIFF
--- a/crates/rslint_lexer/src/state.rs
+++ b/crates/rslint_lexer/src/state.rs
@@ -59,8 +59,9 @@ impl LexerState {
             }
 
             T![function] => {
+                // Needed to lex function fn() {}/1/;
                 if self.expr_allowed
-                    && ctx_is_brace_block(
+                    && !ctx_is_brace_block(
                         &self.ctx,
                         self.prev,
                         self.had_linebreak,

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -931,6 +931,34 @@ fn regex() {
 }
 
 #[test]
+fn regex_after_fn() {
+    assert_lex! {
+        "function fn() {}/1/;",
+        FUNCTION_KW:8,
+        WHITESPACE:1,
+        IDENT:2,
+        L_PAREN:1,
+        R_PAREN:1,
+        WHITESPACE:1,
+        L_CURLY:1,
+        R_CURLY:1,
+        JS_REGEX_LITERAL:3,
+        SEMICOLON:1
+    };
+}
+
+#[test]
+fn regex_await() {
+    assert_lex! {
+        "await /x.y/g;",
+        AWAIT_KW:5,
+        WHITESPACE:1,
+        JS_REGEX_LITERAL:6,
+        SEMICOLON:1,
+    }
+}
+
+#[test]
 fn division() {
     assert_lex! {
         "var a = 5 / 6",

--- a/crates/rslint_syntax/src/generated.rs
+++ b/crates/rslint_syntax/src/generated.rs
@@ -450,8 +450,10 @@ impl JsSyntaxKind {
             BANG | L_PAREN | L_BRACK | L_CURLY | SEMICOLON | COMMA | COLON | QUESTION | PLUS2
             | MINUS2 | TILDE | CASE_KW | DEFAULT_KW | DO_KW | ELSE_KW | RETURN_KW | THROW_KW
             | NEW_KW | EXTENDS_KW | YIELD_KW | IN_KW | TYPEOF_KW | VOID_KW | DELETE_KW | PLUSEQ
-            | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ | AMP2 | PIPE2
-            | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS => true,
+            | INSTANCEOF_KW | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ
+            | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS | AWAIT_KW => {
+                true
+            }
             _ => false,
         }
     }


### PR DESCRIPTION

## Summary

Fixes the remaining 262 tests that incorrectly fail parsing a valid program containing a regex literal.
The lexer uses the `in_expr` state to determine whatever a regexp is valid. This requires, that the lexer correctly tracks in which places an expression is valid. This hasn't been the case for

```
{

}
function // <- smt
```

and some keywords that I added to `before_expr` list.

## Test Plan

Added additional tests to the lexer
