### PR TITLE
feat(rslint_parser): Ban template literal after optional chain

### DIFF
--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.js
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.js
@@ -1,2 +1,2 @@
-foo()?.baz[].
+foo()?.baz[].;
 BAR`b

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -3,46 +3,52 @@ JsModule {
     directives: JsDirectiveList [],
     items: JsModuleItemList [
         JsExpressionStatement {
-            expression: JsUnknownExpression {
-                items: [
-                    JsStaticMemberExpression {
-                        object: JsComputedMemberExpression {
-                            object: JsStaticMemberExpression {
-                                object: JsCallExpression {
-                                    callee: JsIdentifierExpression {
-                                        name: JsReferenceIdentifier {
-                                            value_token: IDENT@0..3 "foo" [] [],
-                                        },
-                                    },
-                                    optional_chain_token_token: missing (optional),
-                                    type_args: missing (optional),
-                                    arguments: JsCallArguments {
-                                        l_paren_token: L_PAREN@3..4 "(" [] [],
-                                        args: JsCallArgumentList [],
-                                        r_paren_token: R_PAREN@4..5 ")" [] [],
-                                    },
-                                },
-                                operator: QUESTIONDOT@5..7 "?." [] [],
-                                member: JsName {
-                                    value_token: IDENT@7..10 "baz" [] [],
+            expression: JsStaticMemberExpression {
+                object: JsComputedMemberExpression {
+                    object: JsStaticMemberExpression {
+                        object: JsCallExpression {
+                            callee: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@0..3 "foo" [] [],
                                 },
                             },
-                            optional_chain_token: missing (optional),
-                            l_brack_token: L_BRACK@10..11 "[" [] [],
-                            member: missing (required),
-                            r_brack_token: R_BRACK@11..12 "]" [] [],
+                            optional_chain_token_token: missing (optional),
+                            type_args: missing (optional),
+                            arguments: JsCallArguments {
+                                l_paren_token: L_PAREN@3..4 "(" [] [],
+                                args: JsCallArgumentList [],
+                                r_paren_token: R_PAREN@4..5 ")" [] [],
+                            },
                         },
-                        operator: DOT@12..13 "." [] [],
+                        operator: QUESTIONDOT@5..7 "?." [] [],
                         member: JsName {
-                            value_token: IDENT@13..17 "BAR" [Newline("\n")] [],
+                            value_token: IDENT@7..10 "baz" [] [],
                         },
                     },
-                    BACKTICK@17..18 "`" [] [],
+                    optional_chain_token: missing (optional),
+                    l_brack_token: L_BRACK@10..11 "[" [] [],
+                    member: missing (required),
+                    r_brack_token: R_BRACK@11..12 "]" [] [],
+                },
+                operator: DOT@12..13 "." [] [],
+                member: missing (required),
+            },
+            semicolon_token: SEMICOLON@13..14 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@14..18 "BAR" [Newline("\n")] [],
+                        },
+                    },
+                    BACKTICK@18..19 "`" [] [],
                     JsUnknown {
                         items: [
                             JsUnknownExpression {
                                 items: [
-                                    ERROR_TOKEN@18..20 "b\n" [] [],
+                                    ERROR_TOKEN@19..21 "b\n" [] [],
                                 ],
                             },
                         ],
@@ -52,44 +58,48 @@ JsModule {
             semicolon_token: missing (optional),
         },
     ],
-    eof_token: EOF@20..20 "" [] [],
+    eof_token: EOF@21..21 "" [] [],
 }
 
-0: JS_MODULE@0..20
+0: JS_MODULE@0..21
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..20
-    0: JS_EXPRESSION_STATEMENT@0..20
-      0: JS_UNKNOWN_EXPRESSION@0..20
-        0: JS_STATIC_MEMBER_EXPRESSION@0..17
-          0: JS_COMPUTED_MEMBER_EXPRESSION@0..12
-            0: JS_STATIC_MEMBER_EXPRESSION@0..10
-              0: JS_CALL_EXPRESSION@0..5
-                0: JS_IDENTIFIER_EXPRESSION@0..3
-                  0: JS_REFERENCE_IDENTIFIER@0..3
-                    0: IDENT@0..3 "foo" [] []
-                1: (empty)
-                2: (empty)
-                3: JS_CALL_ARGUMENTS@3..5
-                  0: L_PAREN@3..4 "(" [] []
-                  1: JS_CALL_ARGUMENT_LIST@4..4
-                  2: R_PAREN@4..5 ")" [] []
-              1: QUESTIONDOT@5..7 "?." [] []
-              2: JS_NAME@7..10
-                0: IDENT@7..10 "baz" [] []
-            1: (empty)
-            2: L_BRACK@10..11 "[" [] []
-            3: (empty)
-            4: R_BRACK@11..12 "]" [] []
-          1: DOT@12..13 "." [] []
-          2: JS_NAME@13..17
-            0: IDENT@13..17 "BAR" [Newline("\n")] []
-        1: BACKTICK@17..18 "`" [] []
-        2: JS_UNKNOWN@18..20
-          0: JS_UNKNOWN_EXPRESSION@18..20
-            0: ERROR_TOKEN@18..20 "b\n" [] []
+  2: JS_MODULE_ITEM_LIST@0..21
+    0: JS_EXPRESSION_STATEMENT@0..14
+      0: JS_STATIC_MEMBER_EXPRESSION@0..13
+        0: JS_COMPUTED_MEMBER_EXPRESSION@0..12
+          0: JS_STATIC_MEMBER_EXPRESSION@0..10
+            0: JS_CALL_EXPRESSION@0..5
+              0: JS_IDENTIFIER_EXPRESSION@0..3
+                0: JS_REFERENCE_IDENTIFIER@0..3
+                  0: IDENT@0..3 "foo" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_CALL_ARGUMENTS@3..5
+                0: L_PAREN@3..4 "(" [] []
+                1: JS_CALL_ARGUMENT_LIST@4..4
+                2: R_PAREN@4..5 ")" [] []
+            1: QUESTIONDOT@5..7 "?." [] []
+            2: JS_NAME@7..10
+              0: IDENT@7..10 "baz" [] []
+          1: (empty)
+          2: L_BRACK@10..11 "[" [] []
+          3: (empty)
+          4: R_BRACK@11..12 "]" [] []
+        1: DOT@12..13 "." [] []
+        2: (empty)
+      1: SEMICOLON@13..14 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@14..21
+      0: JS_UNKNOWN_EXPRESSION@14..21
+        0: JS_IDENTIFIER_EXPRESSION@14..18
+          0: JS_REFERENCE_IDENTIFIER@14..18
+            0: IDENT@14..18 "BAR" [Newline("\n")] []
+        1: BACKTICK@18..19 "`" [] []
+        2: JS_UNKNOWN@19..21
+          0: JS_UNKNOWN_EXPRESSION@19..21
+            0: ERROR_TOKEN@19..21 "b\n" [] []
       1: (empty)
-  3: EOF@20..20 "" [] []
+  3: EOF@21..21 "" [] []
 --
 error: unterminated template literal
   ┌─ subscripts_err.js:3:1
@@ -101,8 +111,15 @@ error: unterminated template literal
 error[SyntaxError]: expected an expression but instead found ']'
   ┌─ subscripts_err.js:1:12
   │
-1 │ foo()?.baz[].
+1 │ foo()?.baz[].;
   │            ^ Expected an expression here
+
+--
+error[SyntaxError]: expected an identifier but instead found ';'
+  ┌─ subscripts_err.js:1:14
+  │
+1 │ foo()?.baz[].;
+  │              ^ Expected an identifier here
 
 --
 error[SyntaxError]: Invalid template literal
@@ -114,5 +131,5 @@ error[SyntaxError]: Invalid template literal
   │ └^
 
 --
-foo()?.baz[].
+foo()?.baz[].;
 BAR`b

--- a/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.js
+++ b/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.js
@@ -1,0 +1,3 @@
+obj.val?.prop`template`
+obj.val?.[expr]`template`
+obj.func?.(args)`template`

--- a/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.rast
@@ -1,0 +1,210 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsStaticMemberExpression {
+                        object: JsStaticMemberExpression {
+                            object: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@0..3 "obj" [] [],
+                                },
+                            },
+                            operator: DOT@3..4 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@4..7 "val" [] [],
+                            },
+                        },
+                        operator: QUESTIONDOT@7..9 "?." [] [],
+                        member: JsName {
+                            value_token: IDENT@9..13 "prop" [] [],
+                        },
+                    },
+                    BACKTICK@13..14 "`" [] [],
+                    TemplateElementList [
+                        TemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@14..22 "template" [] [],
+                        },
+                    ],
+                    BACKTICK@22..23 "`" [] [],
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsComputedMemberExpression {
+                        object: JsStaticMemberExpression {
+                            object: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@23..27 "obj" [Newline("\n")] [],
+                                },
+                            },
+                            operator: DOT@27..28 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@28..31 "val" [] [],
+                            },
+                        },
+                        optional_chain_token: QUESTIONDOT@31..33 "?." [] [],
+                        l_brack_token: L_BRACK@33..34 "[" [] [],
+                        member: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@34..38 "expr" [] [],
+                            },
+                        },
+                        r_brack_token: R_BRACK@38..39 "]" [] [],
+                    },
+                    BACKTICK@39..40 "`" [] [],
+                    TemplateElementList [
+                        TemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@40..48 "template" [] [],
+                        },
+                    ],
+                    BACKTICK@48..49 "`" [] [],
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsUnknownExpression {
+                items: [
+                    JsCallExpression {
+                        callee: JsStaticMemberExpression {
+                            object: JsIdentifierExpression {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@49..53 "obj" [Newline("\n")] [],
+                                },
+                            },
+                            operator: DOT@53..54 "." [] [],
+                            member: JsName {
+                                value_token: IDENT@54..58 "func" [] [],
+                            },
+                        },
+                        optional_chain_token_token: QUESTIONDOT@58..60 "?." [] [],
+                        type_args: missing (optional),
+                        arguments: JsCallArguments {
+                            l_paren_token: L_PAREN@60..61 "(" [] [],
+                            args: JsCallArgumentList [
+                                JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@61..65 "args" [] [],
+                                    },
+                                },
+                            ],
+                            r_paren_token: R_PAREN@65..66 ")" [] [],
+                        },
+                    },
+                    BACKTICK@66..67 "`" [] [],
+                    TemplateElementList [
+                        TemplateChunkElement {
+                            template_chunk_token: TEMPLATE_CHUNK@67..75 "template" [] [],
+                        },
+                    ],
+                    BACKTICK@75..76 "`" [] [],
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@76..77 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..77
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..76
+    0: JS_EXPRESSION_STATEMENT@0..23
+      0: JS_UNKNOWN_EXPRESSION@0..23
+        0: JS_STATIC_MEMBER_EXPRESSION@0..13
+          0: JS_STATIC_MEMBER_EXPRESSION@0..7
+            0: JS_IDENTIFIER_EXPRESSION@0..3
+              0: JS_REFERENCE_IDENTIFIER@0..3
+                0: IDENT@0..3 "obj" [] []
+            1: DOT@3..4 "." [] []
+            2: JS_NAME@4..7
+              0: IDENT@4..7 "val" [] []
+          1: QUESTIONDOT@7..9 "?." [] []
+          2: JS_NAME@9..13
+            0: IDENT@9..13 "prop" [] []
+        1: BACKTICK@13..14 "`" [] []
+        2: TEMPLATE_ELEMENT_LIST@14..22
+          0: TEMPLATE_CHUNK_ELEMENT@14..22
+            0: TEMPLATE_CHUNK@14..22 "template" [] []
+        3: BACKTICK@22..23 "`" [] []
+      1: (empty)
+    1: JS_EXPRESSION_STATEMENT@23..49
+      0: JS_UNKNOWN_EXPRESSION@23..49
+        0: JS_COMPUTED_MEMBER_EXPRESSION@23..39
+          0: JS_STATIC_MEMBER_EXPRESSION@23..31
+            0: JS_IDENTIFIER_EXPRESSION@23..27
+              0: JS_REFERENCE_IDENTIFIER@23..27
+                0: IDENT@23..27 "obj" [Newline("\n")] []
+            1: DOT@27..28 "." [] []
+            2: JS_NAME@28..31
+              0: IDENT@28..31 "val" [] []
+          1: QUESTIONDOT@31..33 "?." [] []
+          2: L_BRACK@33..34 "[" [] []
+          3: JS_IDENTIFIER_EXPRESSION@34..38
+            0: JS_REFERENCE_IDENTIFIER@34..38
+              0: IDENT@34..38 "expr" [] []
+          4: R_BRACK@38..39 "]" [] []
+        1: BACKTICK@39..40 "`" [] []
+        2: TEMPLATE_ELEMENT_LIST@40..48
+          0: TEMPLATE_CHUNK_ELEMENT@40..48
+            0: TEMPLATE_CHUNK@40..48 "template" [] []
+        3: BACKTICK@48..49 "`" [] []
+      1: (empty)
+    2: JS_EXPRESSION_STATEMENT@49..76
+      0: JS_UNKNOWN_EXPRESSION@49..76
+        0: JS_CALL_EXPRESSION@49..66
+          0: JS_STATIC_MEMBER_EXPRESSION@49..58
+            0: JS_IDENTIFIER_EXPRESSION@49..53
+              0: JS_REFERENCE_IDENTIFIER@49..53
+                0: IDENT@49..53 "obj" [Newline("\n")] []
+            1: DOT@53..54 "." [] []
+            2: JS_NAME@54..58
+              0: IDENT@54..58 "func" [] []
+          1: QUESTIONDOT@58..60 "?." [] []
+          2: (empty)
+          3: JS_CALL_ARGUMENTS@60..66
+            0: L_PAREN@60..61 "(" [] []
+            1: JS_CALL_ARGUMENT_LIST@61..65
+              0: JS_IDENTIFIER_EXPRESSION@61..65
+                0: JS_REFERENCE_IDENTIFIER@61..65
+                  0: IDENT@61..65 "args" [] []
+            2: R_PAREN@65..66 ")" [] []
+        1: BACKTICK@66..67 "`" [] []
+        2: TEMPLATE_ELEMENT_LIST@67..75
+          0: TEMPLATE_CHUNK_ELEMENT@67..75
+            0: TEMPLATE_CHUNK@67..75 "template" [] []
+        3: BACKTICK@75..76 "`" [] []
+      1: (empty)
+  3: EOF@76..77 "" [Newline("\n")] []
+--
+error[SyntaxError]: Tagged template expressions are not permitted in an optional chain.
+  ┌─ template_after_optional_chain.js:1:1
+  │
+1 │ obj.val?.prop`template`
+  │ ^^^^^^^^^^^^^^^^^^^^^^^
+
+--
+error[SyntaxError]: Tagged template expressions are not permitted in an optional chain.
+  ┌─ template_after_optional_chain.js:2:1
+  │
+2 │ obj.val?.[expr]`template`
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+--
+error[SyntaxError]: Tagged template expressions are not permitted in an optional chain.
+  ┌─ template_after_optional_chain.js:3:1
+  │
+3 │ obj.func?.(args)`template`
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+--
+obj.val?.prop`template`
+obj.val?.[expr]`template`
+obj.func?.(args)`template`


### PR DESCRIPTION
## Summary
Template string is not allowed to be passed to tail position of optional chain.


## Test Plan
### Test262 comparison coverage results on ubuntu-latest
| Test result | `main` count | This PR count | Difference |
| :---------: | :----------: | :-----------: | :--------: |
| Total | 44951 | 44951 | 0 |
| Passed | 43841 | 43845 | ✅ ⏫ **+4** |
| Failed | 1109 | 1105 | ✅ ⏬ **-4** |
| Panics | 1 | 1 | 0 |
| Coverage | 97.53% | 97.54% | **+0.01%** |

<details><summary><b>:tada: Fixed (4):</b></summary>

```
xtask/src/coverage/test262/test/language/expressions/optional-chaining/early-errors-tail-position-null-optchain-template-string-esi.js
xtask/src/coverage/test262/test/language/expressions/optional-chaining/early-errors-tail-position-null-optchain-template-string.js
xtask/src/coverage/test262/test/language/expressions/optional-chaining/early-errors-tail-position-optchain-template-string-esi.js
xtask/src/coverage/test262/test/language/expressions/optional-chaining/early-errors-tail-position-optchain-template-string.js
```
</details>