### PR TITLE
fix(rslint_lexer): Invalid unicode escape sequence in tagged template literal

### DIFF
--- a/crates/rslint_errors/src/file.rs
+++ b/crates/rslint_errors/src/file.rs
@@ -82,7 +82,17 @@ where
     T: Into<usize>,
 {
     fn as_range(&self) -> Range<usize> {
-        self.start.clone().into()..self.end.clone().into()
+        let start = self.start.clone().into();
+        let end = self.end.clone().into();
+
+        debug_assert!(
+            start <= end,
+            "slice index starts at {} but ends at {}",
+            start,
+            end
+        );
+
+        start..end
     }
 }
 

--- a/crates/rslint_errors/src/file.rs
+++ b/crates/rslint_errors/src/file.rs
@@ -137,10 +137,15 @@ pub struct FileSpan {
 
 impl FileSpan {
     pub fn new(file: FileId, span: impl Span) -> Self {
-        Self {
-            file,
-            range: span.as_range(),
-        }
+        let range = span.as_range();
+        debug_assert!(
+            range.start <= range.end,
+            "slice index starts at {} but ends at {}",
+            range.start,
+            range.end
+        );
+
+        Self { file, range }
     }
 }
 

--- a/crates/rslint_errors/src/file.rs
+++ b/crates/rslint_errors/src/file.rs
@@ -82,17 +82,7 @@ where
     T: Into<usize>,
 {
     fn as_range(&self) -> Range<usize> {
-        let start = self.start.clone().into();
-        let end = self.end.clone().into();
-
-        debug_assert!(
-            start <= end,
-            "slice index starts at {} but ends at {}",
-            start,
-            end
-        );
-
-        start..end
+        self.start.clone().into()..self.end.clone().into()
     }
 }
 

--- a/crates/rslint_lexer/src/state.rs
+++ b/crates/rslint_lexer/src/state.rs
@@ -146,10 +146,6 @@ impl Context {
         matches!(self, Context::TplInternal)
     }
 
-    fn is_template(&self) -> bool {
-        matches!(self, Context::Template { .. })
-    }
-
     fn is_expr(&self) -> bool {
         matches!(
             self,

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -46,8 +46,19 @@ macro_rules! assert_lex {
             idx += 1;
         )*
 
+		if idx < tokens.len() {
+			dbg!(&tokens);
+			panic!(
+				"expected {} tokens but lexer returned {}, first unexpected token is '{:?}'",
+				idx,
+				tokens.len(),
+				tokens[idx].0.kind
+			);
+		} else {
+			assert_eq!(idx, tokens.len());
+		}
+
         assert_eq!($src, new_str, "Failed to reconstruct input");
-        assert_eq!(idx, tokens.len());
     }};
 }
 
@@ -1009,6 +1020,25 @@ fn template_escape() {
         TEMPLATE_CHUNK:10,
         BACKTICK:1
     }
+}
+
+#[test]
+fn template_invalid_escape() {
+    assert_lex! {
+        r"a`\xg`",
+        IDENT:1,
+        BACKTICK:1,
+        TEMPLATE_CHUNK:3,
+        BACKTICK:1,
+    };
+
+    assert_lex! {
+        r#"a`\u0`"#,
+        IDENT:1,
+        BACKTICK:1,
+        TEMPLATE_CHUNK:3,
+        BACKTICK:1,
+    };
 }
 
 #[test]


### PR DESCRIPTION

## Summary

Invalid unicode escape sequences are valid inside of tagged template literals, but not template literals. 

This PR suppresses the escape sequence diagnostics for tagged template literals. 

It further fixes an issue with escaped sequences where `validate_escape_sequence` progressed the current position and so did `read_str_literal`. 

It also fixes the span of a diagnostic to be a valid range (and not from pos to 1).

## Test Plan

Added new lexer tests. The `invalid_escape_sequence.js` test is now passing.