### PR TITLE
ci: fix bench bot not creating a comment on PRs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -65,15 +65,11 @@ jobs:
           comment="${comment//$'\r'/'%0D'}"
           echo "::set-output name=comment::$comment"
 
-      - name: Get the PR number
-        id: pr-number
-        uses: kkak10/pr-number-action@v1.3
-
       - name: Write a new comment
         uses: peter-evans/create-or-update-comment@v1.4.5
         continue-on-error: true
         with:
-          issue-number: ${{ steps.pr-number.outputs.pr }}
+          issue-number: ${{ github.event.issue.number }}
           body: |
             ${{ steps.bench_comparison.outputs.comment }}
 


### PR DESCRIPTION
## Summary
Fix bench bot not creating a comment on PRs, from 
@driimus https://github.com/driimus/tools/compare/main...driimus-patch-1?diff=split in discord.
