### PR TITLE
ci: enable longpaths on github actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -25,6 +25,14 @@ jobs:
     steps:
       - name: Checkout PR Branch
         uses: actions/checkout@v2
+        with:
+          submodules: false
+
+      - name: Support longpaths
+        run: git config core.longpaths true
+        
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
 
       - name: Fetch Main Branch
         run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,12 @@ jobs:
     name: format
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Support longpaths
+        run: git config core.longpaths true
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install toolchain

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Support longpaths
+        run: git config core.longpaths true
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install toolchain

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Checkout PR Branch
         uses: actions/checkout@v2
         with:
+          submodules: false
+
+      - name: Support longpaths
+        run: git config core.longpaths true
+
+      - name: Checkout PR Branch
+        uses: actions/checkout@v2
+        with:
           submodules: recursive
 
       - name: Fetch Main Branch


### PR DESCRIPTION
FIx github action to enable long paths.
More details at: https://github.com/rome/tools/pull/1982
