### PR TITLE
feat: add a macro for executing an expression on all AST node types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 crates/rslint_parser/test_data/**/*.js text eol=lf
+xtask/js.ungram text eol=lf

--- a/crates/rome_formatter/src/cst.rs
+++ b/crates/rome_formatter/src/cst.rs
@@ -3,14 +3,12 @@ use rslint_parser::{map_syntax_node, SyntaxNode};
 
 impl ToFormatElement for SyntaxNode {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        map_syntax_node!(
-            self.clone(),
-            node => node.to_format_element(formatter),
-            _ => Ok(formatter.format_verbatim(self))
-        )
+        map_syntax_node!(self.clone(), node => node.to_format_element(formatter))
     }
 }
 
+// Temporary macro providing a default implementation of ToFormatElement to
+// the node types currently missing one as part of #1997
 macro_rules! impl_format_verbatim {
     ( $( $node:ident, )* ) => {
         $( impl $crate::ToFormatElement for ::rslint_parser::ast::$node {

--- a/crates/rome_formatter/src/cst.rs
+++ b/crates/rome_formatter/src/cst.rs
@@ -1,347 +1,148 @@
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::ast::{
-    ImportMeta, JsArrayBindingPattern, JsArrayExpression, JsArrowFunctionExpression,
-    JsBlockStatement, JsBooleanLiteralExpression, JsCallArguments, JsCallExpression, JsCaseClause,
-    JsCatchClause, JsClassStatement, JsConstructorParameters, JsContinueStatement,
-    JsDebuggerStatement, JsDefaultClause, JsDefaultImportSpecifier, JsDoWhileStatement,
-    JsEmptyStatement, JsExport, JsExportAsClause, JsExportClassClause, JsExportDefaultClassClause,
-    JsExportDefaultExpressionClause, JsExportDefaultFunctionClause, JsExportFromClause,
-    JsExportFunctionClause, JsExportNamedClause, JsExportNamedFromClause,
-    JsExportNamedFromSpecifier, JsExportNamedShorthandSpecifier, JsExportNamedSpecifier,
-    JsExportVariableClause, JsExpressionStatement, JsFinallyClause, JsForInStatement,
-    JsForStatement, JsFunctionStatement, JsGetterClassMember, JsIdentifierBinding,
-    JsIdentifierExpression, JsIfStatement, JsImport, JsImportAssertion, JsImportAssertionEntry,
-    JsImportBareClause, JsImportCallExpression, JsImportDefaultClause, JsImportNamedClause,
-    JsImportNamespaceClause, JsLabeledStatement, JsLiteralExportName, JsModule, JsModuleSource,
-    JsNamedImportSpecifier, JsNamedImportSpecifiers, JsNamespaceImportSpecifier,
-    JsNullLiteralExpression, JsNumberLiteralExpression, JsObjectExpression, JsParameters,
-    JsPropertyClassMember, JsPropertyObjectMember, JsReturnStatement, JsScript,
-    JsSequenceExpression, JsSetterClassMember, JsShorthandNamedImportSpecifier,
-    JsShorthandPropertyObjectMember, JsSpread, JsStatementList,
-    JsStaticInitializationBlockClassMember, JsStringLiteralExpression, JsSwitchStatement,
-    JsTemplate, JsTemplateChunkElement, JsTemplateElement, JsTryStatement, JsUnknownAssignment,
-    JsUnknownBinding, JsUnknownExpression, JsUnknownImportAssertionEntry, JsUnknownMember,
-    JsUnknownNamedImportSpecifier, JsUnknownParameter, JsUnknownStatement, JsVariableDeclaration,
-    JsVariableDeclarations, JsVariableStatement, JsWhileStatement, JsWithStatement,
-};
-use rslint_parser::{AstNode, JsSyntaxKind, SyntaxNode};
+use rslint_parser::{map_syntax_node, SyntaxNode};
 
 impl ToFormatElement for SyntaxNode {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        match self.kind() {
-            JsSyntaxKind::JS_ARRAY_EXPRESSION => JsArrayExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {
-                JsArrowFunctionExpression::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_BOOLEAN_LITERAL_EXPRESSION => {
-                JsBooleanLiteralExpression::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_STRING_LITERAL_EXPRESSION => {
-                JsStringLiteralExpression::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_IDENTIFIER_BINDING => JsIdentifierBinding::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_NULL_LITERAL_EXPRESSION => JsNullLiteralExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION => {
-                JsNumberLiteralExpression::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_IDENTIFIER_EXPRESSION => JsIdentifierExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_PARAMETERS => JsParameters::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SCRIPT => JsScript::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_MODULE => JsModule::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SPREAD => JsSpread::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_VARIABLE_STATEMENT => JsVariableStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_VARIABLE_DECLARATION => JsVariableDeclaration::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_FUNCTION_STATEMENT => JsFunctionStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SEQUENCE_EXPRESSION => JsSequenceExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_BLOCK_STATEMENT => JsBlockStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPRESSION_STATEMENT => JsExpressionStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_RETURN_STATEMENT => JsReturnStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IF_STATEMENT => JsIfStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_FOR_STATEMENT => JsForStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EMPTY_STATEMENT => JsEmptyStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SHORTHAND_PROPERTY_OBJECT_MEMBER => {
-                JsShorthandPropertyObjectMember::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_OBJECT_EXPRESSION => JsObjectExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_WHILE_STATEMENT => JsWhileStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_DO_WHILE_STATEMENT => JsDoWhileStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SWITCH_STATEMENT => JsSwitchStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_DEFAULT_CLAUSE => JsDefaultClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CASE_CLAUSE => JsCaseClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CONTINUE_STATEMENT => JsContinueStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_LABELED_STATEMENT => JsLabeledStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_TRY_STATEMENT => JsTryStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_FINALLY_CLAUSE => JsFinallyClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CATCH_CLAUSE => JsCatchClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_WITH_STATEMENT => JsWithStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_DEBUGGER_STATEMENT => JsDebuggerStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_FOR_IN_STATEMENT => JsForInStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_ARRAY_BINDING_PATTERN => JsArrayBindingPattern::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CALL_EXPRESSION => JsCallExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CALL_ARGUMENTS => JsCallArguments::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER => JsPropertyObjectMember::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CLASS_STATEMENT => JsClassStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_CONSTRUCTOR_PARAMETERS => JsConstructorParameters::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_GETTER_CLASS_MEMBER => JsGetterClassMember::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SETTER_CLASS_MEMBER => JsSetterClassMember::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_PROPERTY_CLASS_MEMBER => JsPropertyClassMember::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_DEFAULT_IMPORT_SPECIFIER => {
-                JsDefaultImportSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_UNKNOWN_BINDING => JsUnknownBinding::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_UNKNOWN_MEMBER => JsUnknownMember::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_UNKNOWN_STATEMENT => JsUnknownStatement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_UNKNOWN_EXPRESSION => JsUnknownExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_UNKNOWN_ASSIGNMENT => JsUnknownAssignment::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_UNKNOWN_PARAMETER => JsUnknownParameter::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-
-            JsSyntaxKind::JS_UNKNOWN_IMPORT_ASSERTION_ENTRY => {
-                JsUnknownImportAssertionEntry::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_UNKNOWN_NAMED_IMPORT_SPECIFIER => {
-                JsUnknownNamedImportSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER => {
-                JsStaticInitializationBlockClassMember::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_TEMPLATE => JsTemplate::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-
-            JsSyntaxKind::JS_TEMPLATE_ELEMENT => JsTemplateElement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_TEMPLATE_CHUNK_ELEMENT => JsTemplateChunkElement::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT => JsImport::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_BARE_CLAUSE => JsImportBareClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_MODULE_SOURCE => JsModuleSource::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_ASSERTION => JsImportAssertion::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_NAMED_CLAUSE => JsImportNamedClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_STATEMENT_LIST => {
-                Ok(formatter.format_list(JsStatementList::cast(self.clone()).unwrap()))
-            }
-            JsSyntaxKind::JS_VARIABLE_DECLARATIONS => JsVariableDeclarations::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_ASSERTION_ENTRY => JsImportAssertionEntry::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-
-            JsSyntaxKind::JS_IMPORT_CALL_EXPRESSION => JsImportCallExpression::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_DEFAULT_CLAUSE => JsImportDefaultClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_LITERAL_EXPORT_NAME => JsLiteralExportName::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_IMPORT_NAMESPACE_CLAUSE => JsImportNamespaceClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_NAMESPACE_IMPORT_SPECIFIER => {
-                JsNamespaceImportSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER => JsNamedImportSpecifier::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIERS => JsNamedImportSpecifiers::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_SHORTHAND_NAMED_IMPORT_SPECIFIER => {
-                JsShorthandNamedImportSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::IMPORT_META => ImportMeta::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT => JsExport::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_CLASS_CLAUSE => JsExportClassClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_DEFAULT_CLASS_CLAUSE => {
-                JsExportDefaultClassClause::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_EXPORT_FUNCTION_CLAUSE => JsExportFunctionClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_DEFAULT_FUNCTION_CLAUSE => {
-                JsExportDefaultFunctionClause::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_EXPORT_VARIABLE_CLAUSE => JsExportVariableClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE => {
-                JsExportDefaultExpressionClause::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_EXPORT_FROM_CLAUSE => JsExportFromClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-
-            JsSyntaxKind::JS_EXPORT_AS_CLAUSE => JsExportAsClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_NAMED_CLAUSE => JsExportNamedClause::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_NAMED_SPECIFIER => JsExportNamedSpecifier::cast(self.clone())
-                .unwrap()
-                .to_format_element(formatter),
-            JsSyntaxKind::JS_EXPORT_NAMED_SHORTHAND_SPECIFIER => {
-                JsExportNamedShorthandSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_EXPORT_NAMED_FROM_CLAUSE => {
-                JsExportNamedFromClause::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-            JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER => {
-                JsExportNamedFromSpecifier::cast(self.clone())
-                    .unwrap()
-                    .to_format_element(formatter)
-            }
-
-            _ => todo!(
-                "Implement formatting for the {:?} syntax kind.",
-                self.kind()
-            ),
-        }
+        map_syntax_node!(
+            self.clone(),
+            node => node.to_format_element(formatter),
+            _ => Ok(formatter.format_verbatim(self))
+        )
     }
+}
+
+macro_rules! impl_format_verbatim {
+    ( $( $node:ident, )* ) => {
+        $( impl $crate::ToFormatElement for ::rslint_parser::ast::$node {
+            fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+                Ok(formatter.format_verbatim(::rslint_parser::AstNode::syntax(self)))
+            }
+        } )*
+    };
+}
+
+impl_format_verbatim! {
+    // Nodes
+    JsExpressionSnipped,
+    TsAnyType,
+    TsArrayType,
+    TsAsExpression,
+    TsBigIntLiteralType,
+    TsBigintType,
+    TsBooleanLiteralType,
+    TsBooleanType,
+    TsCallSignatureObjectTypeMember,
+    TsConditionalType,
+    TsConstructSignatureObjectTypeMember,
+    TsConstructorParam,
+    TsConstructorType,
+    TsDefaultTypeClause,
+    TsEnum,
+    TsEnumMember,
+    TsExprWithTypeArgs,
+    TsExternalModuleRef,
+    TsFunctionType,
+    TsGetterSignatureObjectTypeMember,
+    TsIdentifierBinding,
+    TsImplementsClause,
+    TsImportEqualsDecl,
+    TsImportType,
+    TsImportTypeQualifier,
+    TsIndexSignatureObjectTypeMember,
+    TsIndexSignatureParameter,
+    TsIndexedAccessType,
+    TsInferType,
+    TsIntersectionType,
+    TsMappedType,
+    TsMappedTypeAsClause,
+    TsMappedTypeOptionalModifierClause,
+    TsMappedTypeReadonlyModifierClause,
+    TsMethodSignatureObjectTypeMember,
+    TsNamedTupleTypeElement,
+    TsNeverType,
+    TsNonNull,
+    TsNonPrimitiveType,
+    TsNullLiteralType,
+    TsNumberLiteralType,
+    TsNumberType,
+    TsObjectType,
+    TsOptionalTupleTypeElement,
+    TsParenthesizedType,
+    TsPropertySignatureObjectTypeMember,
+    TsQualifiedName,
+    TsReferenceType,
+    TsRestTupleTypeElement,
+    TsReturnTypeAnnotation,
+    TsSetterSignatureObjectTypeMember,
+    TsStringLiteralType,
+    TsStringType,
+    TsSymbolType,
+    TsTemplateChunkElement,
+    TsTemplateElement,
+    TsTemplateLiteralType,
+    TsThisType,
+    TsTupleType,
+    TsTypeAlias,
+    TsTypeAnnotation,
+    TsTypeArguments,
+    TsTypeAssertionExpression,
+    TsTypeConstraintClause,
+    TsTypeOperatorType,
+    TsTypeParameter,
+    TsTypeParameterName,
+    TsTypeParameters,
+    TsTypePredicate,
+    TsTypeofType,
+    TsUndefinedType,
+    TsUnionType,
+    TsUnknownType,
+    TsVoidType,
+    // Unknown
+    JsUnknown,
+    // Separated Lists
+    JsArrayAssignmentPatternElementList,
+    JsArrayBindingPatternElementList,
+    JsArrayElementList,
+    JsCallArgumentList,
+    JsConstructorParameterList,
+    JsExportNamedFromSpecifierList,
+    JsExportNamedSpecifierList,
+    JsImportAssertionEntryList,
+    JsNamedImportSpecifierList,
+    JsObjectAssignmentPatternPropertyList,
+    JsObjectBindingPatternPropertyList,
+    JsObjectMemberList,
+    JsParameterList,
+    JsVariableDeclarationList,
+    TsIntersectionTypeElementList,
+    TsAnyObjectTypeMember,
+    TsAnyTemplateElement,
+    TsTupleTypeElementList,
+    TsTypeArgumentList,
+    TsTypeList,
+    TsTypeParameterList,
+    TsUnionTypeVariantList,
+}
+
+// Non-separated lists
+macro_rules! impl_format_list {
+    ( $( $node:ident, )* ) => {
+        $( impl $crate::ToFormatElement for ::rslint_parser::ast::$node {
+            fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+                Ok(formatter.format_list(self.clone()))
+            }
+        } )*
+    };
+}
+
+impl_format_list! {
+    JsClassMemberList,
+    JsDirectiveList,
+    JsModuleItemList,
+    JsStatementList,
+    JsSwitchCaseList,
+    JsTemplateElementList,
+    TsEnumMemberList,
+    TsObjectTypeMemberList,
+    TsTemplateElementList,
 }

--- a/crates/rslint_parser/src/ast/generated.rs
+++ b/crates/rslint_parser/src/ast/generated.rs
@@ -2,3 +2,5 @@
 pub(super) mod nodes;
 #[rustfmt::skip]
 pub(super) mod syntax_factory;
+#[rustfmt::skip]
+pub mod macros;

--- a/crates/rslint_parser/src/ast/generated/macros.rs
+++ b/crates/rslint_parser/src/ast/generated/macros.rs
@@ -1,0 +1,1186 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+#[macro_export]
+macro_rules! map_syntax_node {
+    ($ node : expr , $ pattern : pat => $ body : expr , $ fallback : pat => $ default : expr) => {
+        match $node {
+            node => match $crate::SyntaxNode::kind(&node) {
+                $crate::JsSyntaxKind::IDENT => {
+                    let $pattern = unsafe { $crate::ast::Ident::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::IMPORT_META => {
+                    let $pattern = unsafe { $crate::ast::ImportMeta::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_ASSIGNMENT_PATTERN => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsArrayAssignmentPattern::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsArrayAssignmentPatternRestElement::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_BINDING_PATTERN => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsArrayBindingPattern::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_REST_ELEMENT => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsArrayBindingPatternRestElement::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsArrayExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_HOLE => {
+                    let $pattern = unsafe { $crate::ast::JsArrayHole::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsArrowFunctionExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsAssignmentExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ASSIGNMENT_WITH_DEFAULT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsAssignmentWithDefault::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_AWAIT_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsAwaitExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BIG_INT_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsBigIntLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BINARY_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsBinaryExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BINDING_PATTERN_WITH_DEFAULT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsBindingPatternWithDefault::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BLOCK_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsBlockStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BOOLEAN_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsBooleanLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_BREAK_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsBreakStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CALL_ARGUMENTS => {
+                    let $pattern = unsafe { $crate::ast::JsCallArguments::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CALL_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsCallExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CASE_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsCaseClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CATCH_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsCatchClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CATCH_DECLARATION => {
+                    let $pattern = unsafe { $crate::ast::JsCatchDeclaration::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CLASS_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsClassExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CLASS_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsClassStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsComputedMemberAssignment::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsComputedMemberExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_COMPUTED_MEMBER_NAME => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsComputedMemberName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsConditionalExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CONSTRUCTOR_CLASS_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsConstructorClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CONSTRUCTOR_PARAMETERS => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsConstructorParameters::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CONTINUE_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsContinueStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DEBUGGER_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsDebuggerStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DEFAULT_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsDefaultClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DEFAULT_IMPORT_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsDefaultImportSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DIRECTIVE => {
+                    let $pattern = unsafe { $crate::ast::JsDirective::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DO_WHILE_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsDoWhileStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ELSE_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsElseClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EMPTY_CLASS_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::JsEmptyClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EMPTY_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsEmptyStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT => {
+                    let $pattern = unsafe { $crate::ast::JsExport::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_AS_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsExportAsClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_CLASS_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsExportClassClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_DEFAULT_CLASS_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportDefaultClassClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsExportDefaultExpressionClause::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_DEFAULT_FUNCTION_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportDefaultFunctionClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_FROM_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsExportFromClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_FUNCTION_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportFunctionClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsExportNamedClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_FROM_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportNamedFromClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportNamedFromSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_SHORTHAND_SPECIFIER => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsExportNamedShorthandSpecifier::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportNamedSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_VARIABLE_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportVariableClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPRESSION_SNIPPED => {
+                    let $pattern = unsafe { $crate::ast::JsExpressionSnipped::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPRESSION_STATEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExpressionStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXTENDS_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsExtendsClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FINALLY_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsFinallyClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FOR_IN_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsForInStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FOR_OF_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsForOfStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FOR_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsForStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FOR_VARIABLE_DECLARATION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsForVariableDeclaration::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FUNCTION_BODY => {
+                    let $pattern = unsafe { $crate::ast::JsFunctionBody::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FUNCTION_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsFunctionExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_FUNCTION_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsFunctionStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_GETTER_CLASS_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::JsGetterClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_GETTER_OBJECT_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsGetterObjectMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsIdentifierAssignment::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IDENTIFIER_BINDING => {
+                    let $pattern = unsafe { $crate::ast::JsIdentifierBinding::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IDENTIFIER_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsIdentifierExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IF_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsIfStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT => {
+                    let $pattern = unsafe { $crate::ast::JsImport::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_ASSERTION => {
+                    let $pattern = unsafe { $crate::ast::JsImportAssertion::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_ASSERTION_ENTRY => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsImportAssertionEntry::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_BARE_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsImportBareClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_CALL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsImportCallExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_DEFAULT_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsImportDefaultClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_NAMED_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsImportNamedClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_NAMESPACE_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsImportNamespaceClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IN_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsInExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_INITIALIZER_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::JsInitializerClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_INSTANCEOF_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsInstanceofExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_LABELED_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsLabeledStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_LITERAL_EXPORT_NAME => {
+                    let $pattern = unsafe { $crate::ast::JsLiteralExportName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_LITERAL_MEMBER_NAME => {
+                    let $pattern = unsafe { $crate::ast::JsLiteralMemberName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_LOGICAL_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsLogicalExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_METHOD_CLASS_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::JsMethodClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_METHOD_OBJECT_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsMethodObjectMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_MODULE => {
+                    let $pattern = unsafe { $crate::ast::JsModule::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_MODULE_SOURCE => {
+                    let $pattern = unsafe { $crate::ast::JsModuleSource::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NAME => {
+                    let $pattern = unsafe { $crate::ast::JsName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNamedImportSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIERS => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNamedImportSpecifiers::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NAMESPACE_IMPORT_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNamespaceImportSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NEW_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsNewExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NULL_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNullLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NUMBER_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNumberLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsObjectAssignmentPattern::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsObjectAssignmentPatternProperty::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_REST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsObjectAssignmentPatternRest::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_SHORTHAND_PROPERTY => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsObjectAssignmentPatternShorthandProperty::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_BINDING_PATTERN => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsObjectBindingPattern::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsObjectBindingPatternProperty::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_REST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsObjectBindingPatternRest::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsObjectBindingPatternShorthandProperty::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsObjectExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PARAMETER => {
+                    let $pattern = unsafe { $crate::ast::JsParameter::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PARAMETERS => {
+                    let $pattern = unsafe { $crate::ast::JsParameters::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PARENTHESIZED_ASSIGNMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsParenthesizedAssignment::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsParenthesizedExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_POST_UPDATE_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsPostUpdateExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsPreUpdateExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PRIVATE_CLASS_MEMBER_NAME => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsPrivateClassMemberName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PRIVATE_NAME => {
+                    let $pattern = unsafe { $crate::ast::JsPrivateName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PROPERTY_CLASS_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsPropertyClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsPropertyObjectMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_REFERENCE_IDENTIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsReferenceIdentifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_REGEX_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsRegexLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_REST_PARAMETER => {
+                    let $pattern = unsafe { $crate::ast::JsRestParameter::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_RETURN_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsReturnStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SCRIPT => {
+                    let $pattern = unsafe { $crate::ast::JsScript::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SEQUENCE_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsSequenceExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SETTER_CLASS_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::JsSetterClassMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SETTER_OBJECT_MEMBER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsSetterObjectMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SHORTHAND_NAMED_IMPORT_SPECIFIER => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsShorthandNamedImportSpecifier::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SHORTHAND_PROPERTY_OBJECT_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsShorthandPropertyObjectMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SPREAD => {
+                    let $pattern = unsafe { $crate::ast::JsSpread::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsStaticInitializationBlockClassMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsStaticMemberAssignment::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsStaticMemberExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_STRING_LITERAL_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsStringLiteralExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SUPER_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsSuperExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SWITCH_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsSwitchStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TEMPLATE => {
+                    let $pattern = unsafe { $crate::ast::JsTemplate::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TEMPLATE_CHUNK_ELEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsTemplateChunkElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TEMPLATE_ELEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsTemplateElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_THIS_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsThisExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_THROW_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsThrowStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TRY_FINALLY_STATEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsTryFinallyStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TRY_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsTryStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNARY_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsUnaryExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_VARIABLE_DECLARATION => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsVariableDeclaration::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_VARIABLE_DECLARATIONS => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsVariableDeclarations::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_VARIABLE_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsVariableStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_WHILE_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsWhileStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_WITH_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsWithStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_YIELD_ARGUMENT => {
+                    let $pattern = unsafe { $crate::ast::JsYieldArgument::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_YIELD_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsYieldExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::NEW_TARGET => {
+                    let $pattern = unsafe { $crate::ast::NewTarget::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_ANY_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsAnyType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_ARRAY_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsArrayType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_AS_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::TsAsExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_BIG_INT_LITERAL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsBigIntLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_BIGINT_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsBigintType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_BOOLEAN_LITERAL_TYPE => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsBooleanLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_BOOLEAN_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsBooleanType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_CALL_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsCallSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_CONDITIONAL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsConditionalType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_CONSTRUCT_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsConstructSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_CONSTRUCTOR_PARAM => {
+                    let $pattern = unsafe { $crate::ast::TsConstructorParam::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_CONSTRUCTOR_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsConstructorType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_DEFAULT_TYPE_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::TsDefaultTypeClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_ENUM => {
+                    let $pattern = unsafe { $crate::ast::TsEnum::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_ENUM_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::TsEnumMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_EXPR_WITH_TYPE_ARGS => {
+                    let $pattern = unsafe { $crate::ast::TsExprWithTypeArgs::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_EXTERNAL_MODULE_REF => {
+                    let $pattern = unsafe { $crate::ast::TsExternalModuleRef::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_FUNCTION_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsFunctionType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_GETTER_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsGetterSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_IDENTIFIER_BINDING => {
+                    let $pattern = unsafe { $crate::ast::TsIdentifierBinding::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_IMPLEMENTS_CLAUSE => {
+                    let $pattern = unsafe { $crate::ast::TsImplementsClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_IMPORT_EQUALS_DECL => {
+                    let $pattern = unsafe { $crate::ast::TsImportEqualsDecl::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_IMPORT_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsImportType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_IMPORT_TYPE_QUALIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsImportTypeQualifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INDEX_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsIndexSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INDEX_SIGNATURE_PARAMETER => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsIndexSignatureParameter::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INDEXED_ACCESS_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsIndexedAccessType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INFER_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsInferType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INTERSECTION_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsIntersectionType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_MAPPED_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsMappedType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_MAPPED_TYPE_AS_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsMappedTypeAsClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_MAPPED_TYPE_OPTIONAL_MODIFIER_CLAUSE => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsMappedTypeOptionalModifierClause::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_MAPPED_TYPE_READONLY_MODIFIER_CLAUSE => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsMappedTypeReadonlyModifierClause::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_METHOD_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsMethodSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NAMED_TUPLE_TYPE_ELEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsNamedTupleTypeElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NEVER_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsNeverType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NON_NULL => {
+                    let $pattern = unsafe { $crate::ast::TsNonNull::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NON_PRIMITIVE_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsNonPrimitiveType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NULL_LITERAL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsNullLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NUMBER_LITERAL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsNumberLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_NUMBER_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsNumberType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_OBJECT_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsObjectType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_OPTIONAL_TUPLE_TYPE_ELEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsOptionalTupleTypeElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_PARENTHESIZED_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsParenthesizedType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_PROPERTY_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsPropertySignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_QUALIFIED_NAME => {
+                    let $pattern = unsafe { $crate::ast::TsQualifiedName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_REFERENCE_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsReferenceType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_REST_TUPLE_TYPE_ELEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsRestTupleTypeElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_RETURN_TYPE_ANNOTATION => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsReturnTypeAnnotation::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_SETTER_SIGNATURE_OBJECT_TYPE_MEMBER => {
+                    let $pattern = unsafe {
+                        $crate::ast::TsSetterSignatureObjectTypeMember::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_STRING_LITERAL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsStringLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_STRING_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsStringType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_SYMBOL_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsSymbolType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TEMPLATE_CHUNK_ELEMENT => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTemplateChunkElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TEMPLATE_ELEMENT => {
+                    let $pattern = unsafe { $crate::ast::TsTemplateElement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TEMPLATE_LITERAL_TYPE => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTemplateLiteralType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_THIS_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsThisType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TUPLE_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsTupleType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_ALIAS => {
+                    let $pattern = unsafe { $crate::ast::TsTypeAlias::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_ANNOTATION => {
+                    let $pattern = unsafe { $crate::ast::TsTypeAnnotation::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_ARGUMENTS => {
+                    let $pattern = unsafe { $crate::ast::TsTypeArguments::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_ASSERTION_EXPRESSION => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTypeAssertionExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_CONSTRAINT_CLAUSE => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTypeConstraintClause::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_OPERATOR_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsTypeOperatorType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_PARAMETER => {
+                    let $pattern = unsafe { $crate::ast::TsTypeParameter::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_PARAMETER_NAME => {
+                    let $pattern = unsafe { $crate::ast::TsTypeParameterName::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_PARAMETERS => {
+                    let $pattern = unsafe { $crate::ast::TsTypeParameters::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_PREDICATE => {
+                    let $pattern = unsafe { $crate::ast::TsTypePredicate::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPEOF_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsTypeofType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_UNDEFINED_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsUndefinedType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_UNION_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsUnionType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_UNKNOWN_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsUnknownType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_VOID_TYPE => {
+                    let $pattern = unsafe { $crate::ast::TsVoidType::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN => {
+                    let $pattern = unsafe { $crate::ast::JsUnknown::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_ASSIGNMENT => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownAssignment::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_BINDING => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownBinding::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_EXPRESSION => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownExpression::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_IMPORT_ASSERTION_ENTRY => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsUnknownImportAssertionEntry::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_MEMBER => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownMember::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_NAMED_IMPORT_SPECIFIER => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsUnknownNamedImportSpecifier::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_PARAMETER => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownParameter::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_UNKNOWN_STATEMENT => {
+                    let $pattern = unsafe { $crate::ast::JsUnknownStatement::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsArrayAssignmentPatternElementList::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsArrayBindingPatternElementList::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_ARRAY_ELEMENT_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsArrayElementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CALL_ARGUMENT_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsCallArgumentList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CLASS_MEMBER_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsClassMemberList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_CONSTRUCTOR_PARAMETER_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsConstructorParameterList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_DIRECTIVE_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsDirectiveList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_FROM_SPECIFIER_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportNamedFromSpecifierList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_EXPORT_NAMED_SPECIFIER_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsExportNamedSpecifierList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_IMPORT_ASSERTION_ENTRY_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsImportAssertionEntryList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_MODULE_ITEM_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsModuleItemList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsNamedImportSpecifierList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsObjectAssignmentPatternPropertyList::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST => {
+                    let $pattern = unsafe {
+                        $crate::ast::JsObjectBindingPatternPropertyList::new_unchecked(node)
+                    };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_OBJECT_MEMBER_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsObjectMemberList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_PARAMETER_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsParameterList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_STATEMENT_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsStatementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_SWITCH_CASE_LIST => {
+                    let $pattern = unsafe { $crate::ast::JsSwitchCaseList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_TEMPLATE_ELEMENT_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsTemplateElementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::JS_VARIABLE_DECLARATION_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::JsVariableDeclarationList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_ENUM_MEMBER_LIST => {
+                    let $pattern = unsafe { $crate::ast::TsEnumMemberList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_INTERSECTION_TYPE_ELEMENT_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsIntersectionTypeElementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_OBJECT_TYPE_MEMBER_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsObjectTypeMemberList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TEMPLATE_ELEMENT_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTemplateElementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TUPLE_TYPE_ELEMENT_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsTupleTypeElementList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_ARGUMENT_LIST => {
+                    let $pattern = unsafe { $crate::ast::TsTypeArgumentList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_LIST => {
+                    let $pattern = unsafe { $crate::ast::TsTypeList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_TYPE_PARAMETER_LIST => {
+                    let $pattern = unsafe { $crate::ast::TsTypeParameterList::new_unchecked(node) };
+                    $body
+                }
+                $crate::JsSyntaxKind::TS_UNION_TYPE_VARIANT_LIST => {
+                    let $pattern =
+                        unsafe { $crate::ast::TsUnionTypeVariantList::new_unchecked(node) };
+                    $body
+                }
+                $fallback => $default,
+            },
+        }
+    };
+}

--- a/crates/rslint_parser/src/ast/generated/macros.rs
+++ b/crates/rslint_parser/src/ast/generated/macros.rs
@@ -1,7 +1,30 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#[doc = r" Reconstruct an AstNode from a SyntaxNode"]
+#[doc = r""]
+#[doc = r" This macros performs a match over the [kind](SyntaxNode::kind)"]
+#[doc = r" of the provided [SyntaxNode] and constructs the appropriate"]
+#[doc = r" AstNode type for it, then execute the provided expression over it."]
+#[doc = r""]
+#[doc = r" The macro accepts an optional fallback branch wich defaults to"]
+#[doc = r" `unreachable!()` as the only SyntaxKind variants not covered by"]
+#[doc = r" this macro are token kinds that should not be used to construct"]
+#[doc = r" a SyntaxNode."]
+#[doc = r""]
+#[doc = r" # Examples"]
+#[doc = r""]
+#[doc = r" ```ignore"]
+#[doc = r" map_syntax_node!(syntax_node, node => node.format())"]
+#[doc = r" ```"]
+#[doc = r""]
+#[doc = r" ```ignore"]
+#[doc = r#" map_syntax_node!(syntax_node, node => Ok(node.format()), _ => Err("invalid node kind"))"#]
+#[doc = r" ```"]
 #[macro_export]
 macro_rules! map_syntax_node {
+    ($ node : expr , $ pattern : pat => $ body : expr) => {
+$crate :: map_syntax_node ! ($node , $pattern => $body , _ => unreachable ! ())
+    };
     ($ node : expr , $ pattern : pat => $ body : expr , $ fallback : pat => $ default : expr) => {
         match $node {
             node => match $crate::SyntaxNode::kind(&node) {

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -12,6 +12,13 @@ pub struct Ident {
     pub(crate) syntax: SyntaxNode,
 }
 impl Ident {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn ident_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -21,6 +28,13 @@ pub struct ImportMeta {
     pub(crate) syntax: SyntaxNode,
 }
 impl ImportMeta {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -36,6 +50,13 @@ pub struct JsArrayAssignmentPattern {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayAssignmentPattern {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -51,6 +72,13 @@ pub struct JsArrayAssignmentPatternRestElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayAssignmentPatternRestElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -63,6 +91,13 @@ pub struct JsArrayBindingPattern {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayBindingPattern {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -78,6 +113,13 @@ pub struct JsArrayBindingPatternRestElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayBindingPatternRestElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -90,6 +132,13 @@ pub struct JsArrayExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrayExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -102,12 +151,27 @@ impl JsArrayExpression {
 pub struct JsArrayHole {
     pub(crate) syntax: SyntaxNode,
 }
-impl JsArrayHole {}
+impl JsArrayHole {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+}
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsArrowFunctionExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsArrowFunctionExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn type_parameters(&self) -> Option<TsTypeParameters> {
         support::node(&self.syntax, 1usize)
@@ -130,6 +194,13 @@ pub struct JsAssignmentExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsAssignmentExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<JsAnyAssignmentPattern> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -145,6 +216,13 @@ pub struct JsAssignmentWithDefault {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsAssignmentWithDefault {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn pattern(&self) -> SyntaxResult<JsAnyAssignmentPattern> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -160,6 +238,13 @@ pub struct JsAwaitExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsAwaitExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn await_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -172,6 +257,13 @@ pub struct JsBigIntLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBigIntLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -181,6 +273,13 @@ pub struct JsBinaryExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBinaryExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -196,6 +295,13 @@ pub struct JsBindingPatternWithDefault {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBindingPatternWithDefault {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn pattern(&self) -> SyntaxResult<JsAnyBindingPattern> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -211,6 +317,13 @@ pub struct JsBlockStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBlockStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -224,6 +337,13 @@ pub struct JsBooleanLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBooleanLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -233,6 +353,13 @@ pub struct JsBreakStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsBreakStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn break_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -244,6 +371,13 @@ pub struct JsCallArguments {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsCallArguments {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -257,6 +391,13 @@ pub struct JsCallExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsCallExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -273,6 +414,13 @@ pub struct JsCaseClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsCaseClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn case_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -289,6 +437,13 @@ pub struct JsCatchClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsCatchClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn catch_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -302,6 +457,13 @@ pub struct JsCatchDeclaration {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsCatchDeclaration {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -317,6 +479,13 @@ pub struct JsClassExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsClassExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -341,6 +510,13 @@ pub struct JsClassStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsClassStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -365,6 +541,13 @@ pub struct JsComputedMemberAssignment {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberAssignment {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -383,6 +566,13 @@ pub struct JsComputedMemberExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -404,6 +594,13 @@ pub struct JsComputedMemberName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsComputedMemberName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -419,6 +616,13 @@ pub struct JsConditionalExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsConditionalExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn test(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -440,6 +644,13 @@ pub struct JsConstructorClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn access_modifier(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
         support::required_node(&self.syntax, 1usize)
@@ -459,6 +670,13 @@ pub struct JsConstructorParameters {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsConstructorParameters {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -472,6 +690,13 @@ pub struct JsContinueStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsContinueStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn continue_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -483,6 +708,13 @@ pub struct JsDebuggerStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsDebuggerStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn debugger_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -493,6 +725,13 @@ pub struct JsDefaultClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsDefaultClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn default_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -506,6 +745,13 @@ pub struct JsDefaultImportSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsDefaultImportSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -518,6 +764,13 @@ pub struct JsDirective {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsDirective {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -528,6 +781,13 @@ pub struct JsDoWhileStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsDoWhileStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn do_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -553,6 +813,13 @@ pub struct JsElseClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsElseClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn else_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -565,6 +832,13 @@ pub struct JsEmptyClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsEmptyClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -574,6 +848,13 @@ pub struct JsEmptyStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsEmptyStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -583,6 +864,13 @@ pub struct JsExport {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExport {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn export_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -595,6 +883,13 @@ pub struct JsExportAsClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportAsClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -607,6 +902,13 @@ pub struct JsExportClassClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportClassClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn class_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -631,6 +933,13 @@ pub struct JsExportDefaultClassClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportDefaultClassClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn default_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -658,6 +967,13 @@ pub struct JsExportDefaultExpressionClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportDefaultExpressionClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn default_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -671,6 +987,13 @@ pub struct JsExportDefaultFunctionClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportDefaultFunctionClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn default_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -698,6 +1021,13 @@ pub struct JsExportFromClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportFromClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -716,6 +1046,13 @@ pub struct JsExportFunctionClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportFunctionClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -740,6 +1077,13 @@ pub struct JsExportNamedClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportNamedClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -754,6 +1098,13 @@ pub struct JsExportNamedFromClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportNamedFromClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -777,6 +1128,13 @@ pub struct JsExportNamedFromSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportNamedFromSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn source_name(&self) -> SyntaxResult<JsLiteralExportName> {
         support::required_node(&self.syntax, 1usize)
@@ -788,6 +1146,13 @@ pub struct JsExportNamedShorthandSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportNamedShorthandSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn name(&self) -> SyntaxResult<JsReferenceIdentifier> {
         support::required_node(&self.syntax, 1usize)
@@ -798,6 +1163,13 @@ pub struct JsExportNamedSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportNamedSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn local_name(&self) -> SyntaxResult<JsReferenceIdentifier> {
         support::required_node(&self.syntax, 1usize)
@@ -814,6 +1186,13 @@ pub struct JsExportVariableClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExportVariableClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn declarations(&self) -> SyntaxResult<JsVariableDeclarations> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -824,6 +1203,13 @@ pub struct JsExpressionSnipped {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExpressionSnipped {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -836,6 +1222,13 @@ pub struct JsExpressionStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExpressionStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -846,6 +1239,13 @@ pub struct JsExtendsClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsExtendsClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -858,6 +1258,13 @@ pub struct JsFinallyClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsFinallyClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn finally_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -870,6 +1277,13 @@ pub struct JsForInStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsForInStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -897,6 +1311,13 @@ pub struct JsForOfStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsForOfStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -925,6 +1346,13 @@ pub struct JsForStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsForStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn for_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -952,6 +1380,13 @@ pub struct JsForVariableDeclaration {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsForVariableDeclaration {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn kind_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -964,6 +1399,13 @@ pub struct JsFunctionBody {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionBody {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -978,6 +1420,13 @@ pub struct JsFunctionExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -1002,6 +1451,13 @@ pub struct JsFunctionStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsFunctionStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn function_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -1026,6 +1482,13 @@ pub struct JsGetterClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn access_modifier(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn abstract_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 2usize) }
@@ -1051,6 +1514,13 @@ pub struct JsGetterObjectMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsGetterObjectMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1073,6 +1543,13 @@ pub struct JsIdentifierAssignment {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsIdentifierAssignment {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1082,6 +1559,13 @@ pub struct JsIdentifierBinding {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsIdentifierBinding {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1091,6 +1575,13 @@ pub struct JsIdentifierExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsIdentifierExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<JsReferenceIdentifier> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1100,6 +1591,13 @@ pub struct JsIfStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsIfStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn if_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1122,6 +1620,13 @@ pub struct JsImport {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImport {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1135,6 +1640,13 @@ pub struct JsImportAssertion {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportAssertion {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn assert_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1151,6 +1663,13 @@ pub struct JsImportAssertionEntry {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportAssertionEntry {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn key(&self) -> SyntaxResult<SyntaxToken> { support::required_token(&self.syntax, 0usize) }
     pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -1164,6 +1683,13 @@ pub struct JsImportBareClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportBareClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn source(&self) -> SyntaxResult<JsModuleSource> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1174,6 +1700,13 @@ pub struct JsImportCallExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportCallExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1186,6 +1719,13 @@ pub struct JsImportDefaultClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportDefaultClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1202,6 +1742,13 @@ pub struct JsImportNamedClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportNamedClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn default_specifier(&self) -> Option<JsDefaultImportSpecifier> {
         support::node(&self.syntax, 0usize)
     }
@@ -1221,6 +1768,13 @@ pub struct JsImportNamespaceClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsImportNamespaceClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1243,6 +1797,13 @@ pub struct JsInExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsInExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn property(&self) -> SyntaxResult<JsAnyInProperty> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1258,6 +1819,13 @@ pub struct JsInitializerClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsInitializerClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1270,6 +1838,13 @@ pub struct JsInstanceofExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsInstanceofExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1285,6 +1860,13 @@ pub struct JsLabeledStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsLabeledStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn label_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1300,6 +1882,13 @@ pub struct JsLiteralExportName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsLiteralExportName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1309,6 +1898,13 @@ pub struct JsLiteralMemberName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsLiteralMemberName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1318,6 +1914,13 @@ pub struct JsLogicalExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsLogicalExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1333,6 +1936,13 @@ pub struct JsMethodClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn access_modifier(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn abstract_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 2usize) }
@@ -1359,6 +1969,13 @@ pub struct JsMethodObjectMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsMethodObjectMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
@@ -1380,6 +1997,13 @@ pub struct JsModule {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsModule {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn interpreter_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn directives(&self) -> JsDirectiveList { support::list(&self.syntax, 1usize) }
     pub fn items(&self) -> JsModuleItemList { support::list(&self.syntax, 2usize) }
@@ -1392,6 +2016,13 @@ pub struct JsModuleSource {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsModuleSource {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1401,6 +2032,13 @@ pub struct JsName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1410,6 +2048,13 @@ pub struct JsNamedImportSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNamedImportSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<JsLiteralExportName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1425,6 +2070,13 @@ pub struct JsNamedImportSpecifiers {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNamedImportSpecifiers {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1438,6 +2090,13 @@ pub struct JsNamespaceImportSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNamespaceImportSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1453,6 +2112,13 @@ pub struct JsNewExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNewExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1467,6 +2133,13 @@ pub struct JsNullLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNullLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1476,6 +2149,13 @@ pub struct JsNumberLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsNumberLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1485,6 +2165,13 @@ pub struct JsObjectAssignmentPattern {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectAssignmentPattern {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1500,6 +2187,13 @@ pub struct JsObjectAssignmentPatternProperty {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectAssignmentPatternProperty {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn member(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1516,6 +2210,13 @@ pub struct JsObjectAssignmentPatternRest {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectAssignmentPatternRest {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1528,6 +2229,13 @@ pub struct JsObjectAssignmentPatternShorthandProperty {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectAssignmentPatternShorthandProperty {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn identifier(&self) -> SyntaxResult<JsAnyAssignment> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1538,6 +2246,13 @@ pub struct JsObjectBindingPattern {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectBindingPattern {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1553,6 +2268,13 @@ pub struct JsObjectBindingPatternProperty {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectBindingPatternProperty {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn member(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1569,6 +2291,13 @@ pub struct JsObjectBindingPatternRest {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectBindingPatternRest {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1581,6 +2310,13 @@ pub struct JsObjectBindingPatternShorthandProperty {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectBindingPatternShorthandProperty {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn identifier(&self) -> SyntaxResult<JsAnyBinding> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1591,6 +2327,13 @@ pub struct JsObjectExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsObjectExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1604,6 +2347,13 @@ pub struct JsParameter {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsParameter {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn binding(&self) -> SyntaxResult<JsAnyBindingPattern> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1617,6 +2367,13 @@ pub struct JsParameters {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsParameters {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1630,6 +2387,13 @@ pub struct JsParenthesizedAssignment {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsParenthesizedAssignment {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1645,6 +2409,13 @@ pub struct JsParenthesizedExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsParenthesizedExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1660,6 +2431,13 @@ pub struct JsPostUpdateExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPostUpdateExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operand(&self) -> SyntaxResult<JsAnyAssignment> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1672,6 +2450,13 @@ pub struct JsPreUpdateExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPreUpdateExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1684,6 +2469,13 @@ pub struct JsPrivateClassMemberName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPrivateClassMemberName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn hash_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1696,6 +2488,13 @@ pub struct JsPrivateName {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPrivateName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn hash_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1708,6 +2507,13 @@ pub struct JsPropertyClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn declare_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn access_modifier(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 2usize) }
@@ -1729,6 +2535,13 @@ pub struct JsPropertyObjectMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsPropertyObjectMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1744,6 +2557,13 @@ pub struct JsReferenceIdentifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsReferenceIdentifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1753,6 +2573,13 @@ pub struct JsRegexLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsRegexLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1762,6 +2589,13 @@ pub struct JsRestParameter {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsRestParameter {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1774,6 +2608,13 @@ pub struct JsReturnStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsReturnStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn return_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1785,6 +2626,13 @@ pub struct JsScript {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsScript {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn interpreter_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn directives(&self) -> JsDirectiveList { support::list(&self.syntax, 1usize) }
     pub fn statements(&self) -> JsStatementList { support::list(&self.syntax, 2usize) }
@@ -1797,6 +2645,13 @@ pub struct JsSequenceExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSequenceExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1812,6 +2667,13 @@ pub struct JsSetterClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn access_modifier(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn abstract_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 2usize) }
@@ -1839,6 +2701,13 @@ pub struct JsSetterObjectMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSetterObjectMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1863,6 +2732,13 @@ pub struct JsShorthandNamedImportSpecifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsShorthandNamedImportSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1872,6 +2748,13 @@ pub struct JsShorthandPropertyObjectMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsShorthandPropertyObjectMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<JsReferenceIdentifier> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1881,6 +2764,13 @@ pub struct JsSpread {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSpread {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1893,6 +2783,13 @@ pub struct JsStaticInitializationBlockClassMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticInitializationBlockClassMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn static_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1909,6 +2806,13 @@ pub struct JsStaticMemberAssignment {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberAssignment {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1922,6 +2826,13 @@ pub struct JsStaticMemberExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsStaticMemberExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -1935,6 +2846,13 @@ pub struct JsStringLiteralExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsStringLiteralExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn value_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1944,6 +2862,13 @@ pub struct JsSuperExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSuperExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn super_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1953,6 +2878,13 @@ pub struct JsSwitchStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsSwitchStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn switch_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -1978,6 +2910,13 @@ pub struct JsTemplate {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsTemplate {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn tag(&self) -> Option<JsAnyExpression> { support::node(&self.syntax, 0usize) }
     pub fn type_arguments(&self) -> Option<TsTypeArguments> { support::node(&self.syntax, 1usize) }
     pub fn l_tick_token(&self) -> SyntaxResult<SyntaxToken> {
@@ -1993,6 +2932,13 @@ pub struct JsTemplateChunkElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsTemplateChunkElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn template_chunk_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2002,6 +2948,13 @@ pub struct JsTemplateElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsTemplateElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dollar_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2017,6 +2970,13 @@ pub struct JsThisExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsThisExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn this_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2026,6 +2986,13 @@ pub struct JsThrowStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsThrowStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn throw_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2039,6 +3006,13 @@ pub struct JsTryFinallyStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsTryFinallyStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2055,6 +3029,13 @@ pub struct JsTryStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsTryStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn try_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2070,6 +3051,13 @@ pub struct JsUnaryExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsUnaryExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2082,6 +3070,13 @@ pub struct JsVariableDeclaration {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclaration {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn id(&self) -> SyntaxResult<JsAnyBindingPattern> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2096,6 +3091,13 @@ pub struct JsVariableDeclarations {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableDeclarations {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn kind(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2106,6 +3108,13 @@ pub struct JsVariableStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsVariableStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn declarations(&self) -> SyntaxResult<JsVariableDeclarations> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2116,6 +3125,13 @@ pub struct JsWhileStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsWhileStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn while_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2137,6 +3153,13 @@ pub struct JsWithStatement {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsWithStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn with_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2158,6 +3181,13 @@ pub struct JsYieldArgument {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsYieldArgument {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 1usize)
@@ -2168,6 +3198,13 @@ pub struct JsYieldExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl JsYieldExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn yield_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2178,6 +3215,13 @@ pub struct NewTarget {
     pub(crate) syntax: SyntaxNode,
 }
 impl NewTarget {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2193,6 +3237,13 @@ pub struct TsAnyType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsAnyType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn any_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2202,6 +3253,13 @@ pub struct TsArrayType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsArrayType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn element_type(&self) -> SyntaxResult<TsType> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2217,6 +3275,13 @@ pub struct TsAsExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsAsExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn expression(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2230,6 +3295,13 @@ pub struct TsBigIntLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsBigIntLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn literal_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2240,6 +3312,13 @@ pub struct TsBigintType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsBigintType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn bigint_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2249,6 +3328,13 @@ pub struct TsBooleanLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsBooleanLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn literal(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2258,6 +3344,13 @@ pub struct TsBooleanType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsBooleanType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn boolean_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2267,6 +3360,13 @@ pub struct TsCallSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsCallSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_parameters(&self) -> Option<TsTypeParameters> {
         support::node(&self.syntax, 0usize)
     }
@@ -2283,6 +3383,13 @@ pub struct TsConditionalType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsConditionalType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn check_type(&self) -> SyntaxResult<TsType> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2308,6 +3415,13 @@ pub struct TsConstructSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2327,6 +3441,13 @@ pub struct TsConstructorParam {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructorParam {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn accessibility(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn readonly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 1usize) }
     pub fn binding(&self) -> SyntaxResult<JsAnyBindingPattern> {
@@ -2342,6 +3463,13 @@ pub struct TsConstructorType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsConstructorType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn abstract_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn new_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2364,6 +3492,13 @@ pub struct TsDefaultTypeClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsDefaultTypeClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2374,6 +3509,13 @@ pub struct TsEnum {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsEnum {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn enum_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2392,6 +3534,13 @@ pub struct TsEnumMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsEnumMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn ident(&self) -> SyntaxResult<Ident> { support::required_node(&self.syntax, 0usize) }
     pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2405,6 +3554,13 @@ pub struct TsExprWithTypeArgs {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsExprWithTypeArgs {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn item(&self) -> SyntaxResult<TsAnyName> { support::required_node(&self.syntax, 0usize) }
     pub fn type_arguments(&self) -> Option<TsTypeArguments> { support::node(&self.syntax, 1usize) }
 }
@@ -2413,6 +3569,13 @@ pub struct TsExternalModuleRef {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsExternalModuleRef {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn require_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2431,6 +3594,13 @@ pub struct TsFunctionType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsFunctionType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_parameters(&self) -> Option<TsTypeParameters> {
         support::node(&self.syntax, 0usize)
     }
@@ -2449,6 +3619,13 @@ pub struct TsGetterSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsGetterSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn get_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2471,6 +3648,13 @@ pub struct TsIdentifierBinding {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsIdentifierBinding {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2480,6 +3664,13 @@ pub struct TsImplementsClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsImplementsClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn implements_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2490,6 +3681,13 @@ pub struct TsImportEqualsDecl {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsImportEqualsDecl {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2510,6 +3708,13 @@ pub struct TsImportType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsImportType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn typeof_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn import_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2532,6 +3737,13 @@ pub struct TsImportTypeQualifier {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsImportTypeQualifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2542,6 +3754,13 @@ pub struct TsIndexSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsIndexSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn readonly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2562,6 +3781,13 @@ pub struct TsIndexSignatureParameter {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsIndexSignatureParameter {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn binding(&self) -> SyntaxResult<JsIdentifierBinding> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2574,6 +3800,13 @@ pub struct TsIndexedAccessType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsIndexedAccessType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object_type(&self) -> SyntaxResult<TsType> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2592,6 +3825,13 @@ pub struct TsInferType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsInferType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn infer_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2604,6 +3844,13 @@ pub struct TsIntersectionType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsIntersectionType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn leading_separator_token_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 0usize)
     }
@@ -2614,6 +3861,13 @@ pub struct TsMappedType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2648,6 +3902,13 @@ pub struct TsMappedTypeAsClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeAsClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2658,6 +3919,13 @@ pub struct TsMappedTypeOptionalModifierClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeOptionalModifierClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2670,6 +3938,13 @@ pub struct TsMappedTypeReadonlyModifierClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsMappedTypeReadonlyModifierClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2682,6 +3957,13 @@ pub struct TsMethodSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsMethodSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2704,6 +3986,13 @@ pub struct TsNamedTupleTypeElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNamedTupleTypeElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn name(&self) -> SyntaxResult<JsName> { support::required_node(&self.syntax, 1usize) }
     pub fn question_mark_token(&self) -> Option<SyntaxToken> {
@@ -2719,6 +4008,13 @@ pub struct TsNeverType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNeverType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn never_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2728,6 +4024,13 @@ pub struct TsNonNull {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNonNull {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn expr(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -2740,6 +4043,13 @@ pub struct TsNonPrimitiveType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNonPrimitiveType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn object_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2749,6 +4059,13 @@ pub struct TsNullLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNullLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn literal_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2758,6 +4075,13 @@ pub struct TsNumberLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNumberLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn minus_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn literal_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2768,6 +4092,13 @@ pub struct TsNumberType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsNumberType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn number_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2777,6 +4108,13 @@ pub struct TsObjectType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsObjectType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2790,6 +4128,13 @@ pub struct TsOptionalTupleTypeElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsOptionalTupleTypeElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn ty(&self) -> SyntaxResult<TsType> { support::required_node(&self.syntax, 0usize) }
     pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2800,6 +4145,13 @@ pub struct TsParenthesizedType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsParenthesizedType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_paren_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2813,6 +4165,13 @@ pub struct TsPropertySignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsPropertySignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn readonly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 1usize)
@@ -2830,6 +4189,13 @@ pub struct TsQualifiedName {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsQualifiedName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn left(&self) -> SyntaxResult<TsAnyName> { support::required_node(&self.syntax, 0usize) }
     pub fn dot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
@@ -2841,6 +4207,13 @@ pub struct TsReferenceType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsReferenceType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<TsAnyName> { support::required_node(&self.syntax, 0usize) }
     pub fn type_arguments(&self) -> Option<TsTypeArguments> { support::node(&self.syntax, 1usize) }
 }
@@ -2849,6 +4222,13 @@ pub struct TsRestTupleTypeElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsRestTupleTypeElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dotdotdot_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2859,6 +4239,13 @@ pub struct TsReturnTypeAnnotation {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsReturnTypeAnnotation {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2871,6 +4258,13 @@ pub struct TsSetterSignatureObjectTypeMember {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsSetterSignatureObjectTypeMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn set_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2893,6 +4287,13 @@ pub struct TsStringLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsStringLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn literal_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2902,6 +4303,13 @@ pub struct TsStringType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsStringType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn string_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2911,6 +4319,13 @@ pub struct TsSymbolType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsSymbolType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn symbol_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2920,6 +4335,13 @@ pub struct TsTemplateChunkElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateChunkElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn template_chunk_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2929,6 +4351,13 @@ pub struct TsTemplateElement {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateElement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn dollar_curly_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2942,6 +4371,13 @@ pub struct TsTemplateLiteralType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTemplateLiteralType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_tick_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2955,6 +4391,13 @@ pub struct TsThisType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsThisType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn this_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2964,6 +4407,13 @@ pub struct TsTupleType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTupleType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_brack_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2977,6 +4427,13 @@ pub struct TsTypeAlias {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeAlias {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn type_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -2997,6 +4454,13 @@ pub struct TsTypeAnnotation {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeAnnotation {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn colon_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3007,6 +4471,13 @@ pub struct TsTypeArguments {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeArguments {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3022,6 +4493,13 @@ pub struct TsTypeAssertionExpression {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeAssertionExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3038,6 +4516,13 @@ pub struct TsTypeConstraintClause {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeConstraintClause {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn extends_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3048,6 +4533,13 @@ pub struct TsTypeOperatorType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeOperatorType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3058,6 +4550,13 @@ pub struct TsTypeParameter {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParameter {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn name(&self) -> SyntaxResult<TsTypeParameterName> {
         support::required_node(&self.syntax, 0usize)
     }
@@ -3071,6 +4570,13 @@ pub struct TsTypeParameterName {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParameterName {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn ident_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3080,6 +4586,13 @@ pub struct TsTypeParameters {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeParameters {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn l_angle_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3093,6 +4606,13 @@ pub struct TsTypePredicate {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypePredicate {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn asserts_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn parameter_name(&self) -> SyntaxResult<TsAnyTypePredicateParameterName> {
         support::required_node(&self.syntax, 1usize)
@@ -3107,6 +4627,13 @@ pub struct TsTypeofType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsTypeofType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn typeof_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3119,6 +4646,13 @@ pub struct TsUndefinedType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsUndefinedType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn undefined_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3128,6 +4662,13 @@ pub struct TsUnionType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsUnionType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn leading_separator_token_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 0usize)
     }
@@ -3138,6 +4679,13 @@ pub struct TsUnknownType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsUnknownType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn unknown_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -3147,6 +4695,13 @@ pub struct TsVoidType {
     pub(crate) syntax: SyntaxNode,
 }
 impl TsVoidType {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn void_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
@@ -15945,6 +17500,13 @@ pub struct JsUnknown {
     syntax: SyntaxNode,
 }
 impl JsUnknown {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknown {
@@ -15976,6 +17538,13 @@ pub struct JsUnknownAssignment {
     syntax: SyntaxNode,
 }
 impl JsUnknownAssignment {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownAssignment {
@@ -16007,6 +17576,13 @@ pub struct JsUnknownBinding {
     syntax: SyntaxNode,
 }
 impl JsUnknownBinding {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownBinding {
@@ -16038,6 +17614,13 @@ pub struct JsUnknownExpression {
     syntax: SyntaxNode,
 }
 impl JsUnknownExpression {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownExpression {
@@ -16069,6 +17652,13 @@ pub struct JsUnknownImportAssertionEntry {
     syntax: SyntaxNode,
 }
 impl JsUnknownImportAssertionEntry {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownImportAssertionEntry {
@@ -16100,6 +17690,13 @@ pub struct JsUnknownMember {
     syntax: SyntaxNode,
 }
 impl JsUnknownMember {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownMember {
@@ -16131,6 +17728,13 @@ pub struct JsUnknownNamedImportSpecifier {
     syntax: SyntaxNode,
 }
 impl JsUnknownNamedImportSpecifier {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownNamedImportSpecifier {
@@ -16162,6 +17766,13 @@ pub struct JsUnknownParameter {
     syntax: SyntaxNode,
 }
 impl JsUnknownParameter {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownParameter {
@@ -16193,6 +17804,13 @@ pub struct JsUnknownStatement {
     syntax: SyntaxNode,
 }
 impl JsUnknownStatement {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
 impl AstNode for JsUnknownStatement {
@@ -16222,6 +17840,19 @@ impl From<JsUnknownStatement> for SyntaxElement {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsArrayAssignmentPatternElementList {
     syntax_list: SyntaxList,
+}
+impl JsArrayAssignmentPatternElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsArrayAssignmentPatternElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST }
@@ -16259,6 +17890,19 @@ impl IntoIterator for &JsArrayAssignmentPatternElementList {
 pub struct JsArrayBindingPatternElementList {
     syntax_list: SyntaxList,
 }
+impl JsArrayBindingPatternElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsArrayBindingPatternElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayBindingPatternElementList> {
@@ -16294,6 +17938,19 @@ impl IntoIterator for &JsArrayBindingPatternElementList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsArrayElementList {
     syntax_list: SyntaxList,
+}
+impl JsArrayElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsArrayElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_ARRAY_ELEMENT_LIST }
@@ -16331,6 +17988,19 @@ impl IntoIterator for &JsArrayElementList {
 pub struct JsCallArgumentList {
     syntax_list: SyntaxList,
 }
+impl JsCallArgumentList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsCallArgumentList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_CALL_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsCallArgumentList> {
@@ -16366,6 +18036,19 @@ impl IntoIterator for &JsCallArgumentList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsClassMemberList {
     syntax_list: SyntaxList,
+}
+impl JsClassMemberList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsClassMemberList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_CLASS_MEMBER_LIST }
@@ -16403,6 +18086,19 @@ impl IntoIterator for JsClassMemberList {
 pub struct JsConstructorParameterList {
     syntax_list: SyntaxList,
 }
+impl JsConstructorParameterList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsConstructorParameterList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsConstructorParameterList> {
@@ -16438,6 +18134,19 @@ impl IntoIterator for &JsConstructorParameterList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsDirectiveList {
     syntax_list: SyntaxList,
+}
+impl JsDirectiveList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsDirectiveList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_DIRECTIVE_LIST }
@@ -16475,6 +18184,19 @@ impl IntoIterator for JsDirectiveList {
 pub struct JsExportNamedFromSpecifierList {
     syntax_list: SyntaxList,
 }
+impl JsExportNamedFromSpecifierList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsExportNamedFromSpecifierList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsExportNamedFromSpecifierList> {
@@ -16510,6 +18232,19 @@ impl IntoIterator for &JsExportNamedFromSpecifierList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsExportNamedSpecifierList {
     syntax_list: SyntaxList,
+}
+impl JsExportNamedSpecifierList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsExportNamedSpecifierList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SPECIFIER_LIST }
@@ -16547,6 +18282,19 @@ impl IntoIterator for &JsExportNamedSpecifierList {
 pub struct JsImportAssertionEntryList {
     syntax_list: SyntaxList,
 }
+impl JsImportAssertionEntryList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsImportAssertionEntryList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION_ENTRY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsImportAssertionEntryList> {
@@ -16582,6 +18330,19 @@ impl IntoIterator for &JsImportAssertionEntryList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsModuleItemList {
     syntax_list: SyntaxList,
+}
+impl JsModuleItemList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsModuleItemList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_MODULE_ITEM_LIST }
@@ -16619,6 +18380,19 @@ impl IntoIterator for JsModuleItemList {
 pub struct JsNamedImportSpecifierList {
     syntax_list: SyntaxList,
 }
+impl JsNamedImportSpecifierList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsNamedImportSpecifierList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsNamedImportSpecifierList> {
@@ -16654,6 +18428,19 @@ impl IntoIterator for &JsNamedImportSpecifierList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsObjectAssignmentPatternPropertyList {
     syntax_list: SyntaxList,
+}
+impl JsObjectAssignmentPatternPropertyList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsObjectAssignmentPatternPropertyList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST }
@@ -16693,6 +18480,19 @@ impl IntoIterator for &JsObjectAssignmentPatternPropertyList {
 pub struct JsObjectBindingPatternPropertyList {
     syntax_list: SyntaxList,
 }
+impl JsObjectBindingPatternPropertyList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsObjectBindingPatternPropertyList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectBindingPatternPropertyList> {
@@ -16728,6 +18528,19 @@ impl IntoIterator for &JsObjectBindingPatternPropertyList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsObjectMemberList {
     syntax_list: SyntaxList,
+}
+impl JsObjectMemberList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsObjectMemberList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_OBJECT_MEMBER_LIST }
@@ -16765,6 +18578,19 @@ impl IntoIterator for &JsObjectMemberList {
 pub struct JsParameterList {
     syntax_list: SyntaxList,
 }
+impl JsParameterList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsParameterList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsParameterList> {
@@ -16800,6 +18626,19 @@ impl IntoIterator for &JsParameterList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsStatementList {
     syntax_list: SyntaxList,
+}
+impl JsStatementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsStatementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_STATEMENT_LIST }
@@ -16837,6 +18676,19 @@ impl IntoIterator for JsStatementList {
 pub struct JsSwitchCaseList {
     syntax_list: SyntaxList,
 }
+impl JsSwitchCaseList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsSwitchCaseList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_SWITCH_CASE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsSwitchCaseList> {
@@ -16872,6 +18724,19 @@ impl IntoIterator for JsSwitchCaseList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsTemplateElementList {
     syntax_list: SyntaxList,
+}
+impl JsTemplateElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for JsTemplateElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_TEMPLATE_ELEMENT_LIST }
@@ -16909,6 +18774,19 @@ impl IntoIterator for JsTemplateElementList {
 pub struct JsVariableDeclarationList {
     syntax_list: SyntaxList,
 }
+impl JsVariableDeclarationList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for JsVariableDeclarationList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsVariableDeclarationList> {
@@ -16944,6 +18822,19 @@ impl IntoIterator for &JsVariableDeclarationList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct TsEnumMemberList {
     syntax_list: SyntaxList,
+}
+impl TsEnumMemberList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for TsEnumMemberList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_ENUM_MEMBER_LIST }
@@ -16981,6 +18872,19 @@ impl IntoIterator for TsEnumMemberList {
 pub struct TsIntersectionTypeElementList {
     syntax_list: SyntaxList,
 }
+impl TsIntersectionTypeElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for TsIntersectionTypeElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_INTERSECTION_TYPE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsIntersectionTypeElementList> {
@@ -17016,6 +18920,19 @@ impl IntoIterator for &TsIntersectionTypeElementList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct TsObjectTypeMemberList {
     syntax_list: SyntaxList,
+}
+impl TsObjectTypeMemberList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for TsObjectTypeMemberList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_OBJECT_TYPE_MEMBER_LIST }
@@ -17053,6 +18970,19 @@ impl IntoIterator for TsObjectTypeMemberList {
 pub struct TsTemplateElementList {
     syntax_list: SyntaxList,
 }
+impl TsTemplateElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for TsTemplateElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTemplateElementList> {
@@ -17088,6 +19018,19 @@ impl IntoIterator for TsTemplateElementList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct TsTupleTypeElementList {
     syntax_list: SyntaxList,
+}
+impl TsTupleTypeElementList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for TsTupleTypeElementList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_TUPLE_TYPE_ELEMENT_LIST }
@@ -17125,6 +19068,19 @@ impl IntoIterator for &TsTupleTypeElementList {
 pub struct TsTypeArgumentList {
     syntax_list: SyntaxList,
 }
+impl TsTypeArgumentList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for TsTypeArgumentList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_TYPE_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeArgumentList> {
@@ -17160,6 +19116,19 @@ impl IntoIterator for &TsTypeArgumentList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct TsTypeList {
     syntax_list: SyntaxList,
+}
+impl TsTypeList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for TsTypeList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_TYPE_LIST }
@@ -17197,6 +19166,19 @@ impl IntoIterator for &TsTypeList {
 pub struct TsTypeParameterList {
     syntax_list: SyntaxList,
 }
+impl TsTypeParameterList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
+}
 impl AstNode for TsTypeParameterList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_TYPE_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeParameterList> {
@@ -17232,6 +19214,19 @@ impl IntoIterator for &TsTypeParameterList {
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct TsUnionTypeVariantList {
     syntax_list: SyntaxList,
+}
+impl TsUnionTypeVariantList {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self {
+            syntax_list: syntax.into_list(),
+        }
+    }
 }
 impl AstNode for TsUnionTypeVariantList {
     fn can_cast(kind: JsSyntaxKind) -> bool { kind == TS_UNION_TYPE_VARIANT_LIST }

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -10,6 +10,7 @@ use super::{
 use crate::generate_syntax_factory::generate_syntax_factory;
 use crate::kinds_src::{AstListSeparatorConfiguration, AstListSrc, TokenKind};
 use crate::{
+    generate_macros::generate_macros,
     generate_nodes::generate_nodes,
     generate_syntax_kinds::generate_syntax_kinds,
     kinds_src::{AstEnumSrc, AstNodeSrc, KINDS_SRC},
@@ -39,6 +40,10 @@ pub fn generate_ast(mode: Mode) -> Result<()> {
     let syntax_factory_file = project_root().join(crate::SYNTAX_FACTORY);
     let contents = generate_syntax_factory(&ast)?;
     update(syntax_factory_file.as_path(), &contents, mode)?;
+
+    let ast_macros_file = project_root().join(crate::AST_MACROS);
+    let contents = generate_macros(&ast)?;
+    update(ast_macros_file.as_path(), &contents, mode)?;
 
     Ok(())
 }

--- a/xtask/codegen/src/generate_macros.rs
+++ b/xtask/codegen/src/generate_macros.rs
@@ -33,8 +33,32 @@ pub fn generate_macros(ast: &AstSrc) -> Result<String> {
         .collect();
 
     let ast = quote! {
+        /// Reconstruct an AstNode from a SyntaxNode
+        ///
+        /// This macros performs a match over the [kind](SyntaxNode::kind)
+        /// of the provided [SyntaxNode] and constructs the appropriate
+        /// AstNode type for it, then execute the provided expression over it.
+        ///
+        /// The macro accepts an optional fallback branch wich defaults to
+        /// `unreachable!()` as the only SyntaxKind variants not covered by
+        /// this macro are token kinds that should not be used to construct
+        /// a SyntaxNode.
+        ///
+        /// # Examples
+        ///
+        /// ```ignore
+        /// map_syntax_node!(syntax_node, node => node.format())
+        /// ```
+        ///
+        /// ```ignore
+        /// map_syntax_node!(syntax_node, node => Ok(node.format()), _ => Err("invalid node kind"))
+        /// ```
         #[macro_export]
         macro_rules! map_syntax_node {
+            ($node:expr, $pattern:pat => $body:expr) => {
+                $crate::map_syntax_node!( $node, $pattern => $body, _ => unreachable!() )
+            };
+
             ($node:expr, $pattern:pat => $body:expr, $fallback:pat => $default:expr) => {
                 match $node {
                     node => match $crate::SyntaxNode::kind(&node) {

--- a/xtask/codegen/src/generate_macros.rs
+++ b/xtask/codegen/src/generate_macros.rs
@@ -1,0 +1,50 @@
+use super::kinds_src::AstSrc;
+use crate::{to_upper_snake_case, Result};
+use quote::{format_ident, quote};
+
+pub fn generate_macros(ast: &AstSrc) -> Result<String> {
+    let match_arms: Vec<_> = ast
+        .nodes
+        .iter()
+        .map(|node| {
+            let name = format_ident!("{}", node.name);
+            let node_kind = format_ident!("{}", to_upper_snake_case(&node.name));
+            (name, node_kind)
+        })
+        .chain(ast.unknowns.iter().map(|node_name| {
+            let name = format_ident!("{}", node_name);
+            let node_kind = format_ident!("{}", to_upper_snake_case(node_name));
+            (name, node_kind)
+        }))
+        .chain(ast.lists().map(|(node_name, _)| {
+            let name = format_ident!("{}", node_name);
+            let node_kind = format_ident!("{}", to_upper_snake_case(node_name));
+            (name, node_kind)
+        }))
+        .map(|(name, node_kind)| {
+            quote! {
+                $crate::JsSyntaxKind::#node_kind => {
+                    // SAFETY: The call to new_unchecked is guarded by matching on node.kind()
+                    let $pattern = unsafe { $crate::ast::#name::new_unchecked(node) };
+                    $body
+                }
+            }
+        })
+        .collect();
+
+    let ast = quote! {
+        #[macro_export]
+        macro_rules! map_syntax_node {
+            ($node:expr, $pattern:pat => $body:expr, $fallback:pat => $default:expr) => {
+                match $node {
+                    node => match $crate::SyntaxNode::kind(&node) {
+                        #( #match_arms, )*
+                        $fallback => $default
+                    }
+                }
+            };
+        }
+    };
+
+    xtask::reformat(ast)
+}

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -114,6 +114,16 @@ pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
                     }
 
                     impl #name {
+                        /// Create an AstNode from a SyntaxNode without checking its kind
+                        ///
+                        /// # Safety
+                        /// This function must be guarded with a call to [AstNode::can_cast]
+                        /// or a match on [SyntaxNode::kind]
+                        #[inline]
+                        pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+                            Self { syntax }
+                        }
+
                         #(#methods)*
                     }
 
@@ -415,6 +425,16 @@ pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
             }
 
             impl #name {
+                /// Create an AstNode from a SyntaxNode without checking its kind
+                ///
+                /// # Safety
+                /// This function must be guarded with a call to [AstNode::can_cast]
+                /// or a match on [SyntaxNode::kind]
+                #[inline]
+                pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+                    Self { syntax }
+                }
+
                 pub fn items(&self) -> SyntaxElementChildren {
                     support::elements(&self.syntax)
                 }
@@ -465,6 +485,18 @@ pub fn generate_nodes(ast: &AstSrc) -> Result<String> {
         let element_type = format_ident!("{}", list.element_name);
 
         let node_impl = quote! {
+            impl #list_name {
+                /// Create an AstNode from a SyntaxNode without checking its kind
+                ///
+                /// # Safety
+                /// This function must be guarded with a call to [AstNode::can_cast]
+                /// or a match on [SyntaxNode::kind]
+                #[inline]
+                pub unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+                    Self { syntax_list: syntax.into_list() }
+                }
+            }
+
             impl AstNode for #list_name {
                 fn can_cast(kind: JsSyntaxKind) -> bool {
                     kind == #list_kind

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //!
 mod ast;
+mod generate_macros;
 mod generate_nodes;
 mod generate_syntax_factory;
 mod generate_syntax_kinds;
@@ -20,6 +21,7 @@ pub use self::unicode::generate_tables;
 const SYNTAX_KINDS: &str = "crates/rslint_syntax/src/generated.rs";
 const AST_NODES: &str = "crates/rslint_parser/src/ast/generated/nodes.rs";
 const SYNTAX_FACTORY: &str = "crates/rslint_parser/src/ast/generated/syntax_factory.rs";
+const AST_MACROS: &str = "crates/rslint_parser/src/ast/generated/macros.rs";
 
 /// A helper to update file on disk if it has changed.
 /// With verify = false,


### PR DESCRIPTION
## Summary

This PR adds a `map_syntax_node` macro with the following syntax: `map_syntax_node!(<SyntaxNode expression>, <AstNode> => <expression>, <JsSyntaxKind> => <expression>)`. The macros expands to a match on the kind of the SyntaxNode in the first argument, and for each JsSyntaxKind that implements AstNode duplicates the second argument as a match branch that casts the SyntaxNode to the appropriate AstNode type before executing the expression. For all JsSyntaxKind that do not implement AstNode the third argument is expanded as a fallback branch in the match expression.

As it stands this is only used to implement `ToFormatElement` for `SyntaxNode`, but I chose to implement this as a macro so that it can be eventually leveraged in other algorithms that implement a tree traversal and may need to "cast" a SyntaxNode into all possible AstNode types.
