### PR TITLE
feat(rslint_parser): Add `parse` method

### DIFF
--- a/crates/rome_analyze/src/analysis_server.rs
+++ b/crates/rome_analyze/src/analysis_server.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use rslint_parser::{parse_text, AstNode, SyntaxNode, TextRange};
+use rslint_parser::{parse_script, AstNode, SyntaxNode, TextRange};
 use tracing::trace;
 
 use crate::{
@@ -35,7 +35,7 @@ impl AnalysisServer {
         let text = self
             .get_file_text(file_id)
             .expect("File contents missing while parsing");
-        parse_text(&text, file_id).syntax()
+        parse_script(&text, file_id).syntax()
     }
 
     pub fn suppressions(&self, file_id: FileId) -> Suppressions {

--- a/crates/rome_core/src/file_handlers/javascript.rs
+++ b/crates/rome_core/src/file_handlers/javascript.rs
@@ -4,21 +4,6 @@ use std::fmt::Debug;
 #[derive(Debug, PartialEq, Eq)]
 pub struct JsFileHandler;
 
-/// Features that belong to a single file
-#[derive(Debug)]
-pub struct JsFileFeatures {
-    /// Whether the file is executed as a script
-    pub script: bool,
-    /// Whether the file is executed as a module
-    pub module: bool,
-    /// Whether the TS grammar is supported
-    pub typescript: bool,
-    /// Whether the JSX syntax is supported
-    pub jsx: bool,
-    /// Whether the TSX syntax is supported
-    pub tsx: bool,
-}
-
 impl ExtensionHandler for JsFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {
@@ -37,46 +22,5 @@ impl ExtensionHandler for JsFileHandler {
 
     fn may_use_tabs(&self) -> bool {
         true
-    }
-}
-
-impl Default for JsFileFeatures {
-    fn default() -> Self {
-        Self {
-            module: true,
-            script: false,
-            jsx: false,
-            tsx: false,
-            typescript: false,
-        }
-    }
-}
-
-impl JsFileFeatures {
-    /// Mark the file as module
-    pub fn module(mut self) -> Self {
-        self.module = true;
-        self.script = false;
-        self
-    }
-
-    /// Mark the file as a script
-    ///
-    /// With this, most of the other features are turned off
-    pub fn script(mut self) -> Self {
-        self.script = true;
-        self.module = false;
-        self.typescript = false;
-        self.tsx = false;
-        self.jsx = false;
-        self
-    }
-
-    /// Enables TypeScript
-    pub fn typescript(mut self) -> Self {
-        self.script = false;
-        self.module = true;
-        self.typescript = true;
-        self
     }
 }

--- a/crates/rome_core/src/file_handlers/json.rs
+++ b/crates/rome_core/src/file_handlers/json.rs
@@ -2,9 +2,6 @@ use super::{ExtensionHandler, Mime};
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct JsonFileHandler;
 
-#[derive(Default)]
-pub struct JsonFileFeatures {}
-
 impl ExtensionHandler for JsonFileHandler {
     fn capabilities(&self) -> super::Capabilities {
         super::Capabilities {

--- a/crates/rome_core/src/file_handlers/unknown.rs
+++ b/crates/rome_core/src/file_handlers/unknown.rs
@@ -1,4 +1,5 @@
 use super::ExtensionHandler;
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct UnknownFileHandler {}
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -55,7 +55,7 @@ mod intersperse;
 mod printer;
 mod ts;
 pub use formatter::Formatter;
-use rslint_parser::{parse_module, SyntaxError, SyntaxNode};
+use rslint_parser::{parse, Syntax, SyntaxError, SyntaxNode};
 
 pub use format_element::{
     block_indent, concat_elements, empty_element, group_elements, hard_line_break, if_group_breaks,
@@ -64,10 +64,8 @@ pub use format_element::{
 };
 pub use printer::Printer;
 pub use printer::PrinterOptions;
-use rome_core::file_handlers::javascript::JsFileFeatures;
 use rome_core::App;
 use rome_path::RomePath;
-use rslint_parser::parse_text;
 use std::str::FromStr;
 
 /// This trait should be implemented on each node/value that should have a formatted representation
@@ -183,13 +181,9 @@ pub fn format_element(element: &FormatElement, options: FormatOptions) -> Format
 pub fn format_file_and_save(rome_path: &mut RomePath, options: FormatOptions, app: &App) {
     let result = if app.can_format(rome_path) {
         let buffer = rome_path.get_buffer_from_file();
-        let features = JsFileFeatures::default().module();
-        let parsed_result = if features.module {
-            parse_module(buffer.as_str(), 0).syntax()
-        } else {
-            parse_text(buffer.as_str(), 0).syntax()
-        };
-        Some(format(options, &parsed_result))
+        let syntax = Syntax::default().module();
+        let root = parse(buffer.as_str(), 0, syntax).syntax();
+        Some(format(options, &root))
     } else {
         None
     };

--- a/crates/rome_formatter/src/ts/mod.rs
+++ b/crates/rome_formatter/src/ts/mod.rs
@@ -17,14 +17,14 @@ mod unknown;
 
 #[cfg(test)]
 mod test {
-    use rslint_parser::parse_text;
+    use rslint_parser::parse_script;
 
     use crate::Formatter;
 
     #[test]
     fn arrow_function() {
         let src = "let v = (value  , second_value) =>    true";
-        let tree = parse_text(src, 0);
+        let tree = parse_script(src, 0);
         let result = Formatter::default().format_root(&tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
@@ -37,7 +37,7 @@ mod test {
     fn function_block() {
         let src = r#"function foo() { return 'something' }"#;
 
-        let tree = parse_text(src, 0);
+        let tree = parse_script(src, 0);
         let result = Formatter::default().format_root(&tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
@@ -51,7 +51,7 @@ mod test {
     #[test]
     fn array() {
         let src = r#"let users = [   'john', 'chandler', true ]"#;
-        let tree = parse_text(src, 0);
+        let tree = parse_script(src, 0);
         let result = Formatter::default().format_root(&tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
@@ -64,7 +64,7 @@ mod test {
     fn poc() {
         let src = r#"let a1 = [{}, {}];
 "#;
-        let tree = parse_text(src, 0);
+        let tree = parse_script(src, 0);
         let result = Formatter::default().format_root(&tree.syntax()).unwrap();
         assert_eq!(
             result.code(),

--- a/crates/rome_formatter/tests/spec_test.rs
+++ b/crates/rome_formatter/tests/spec_test.rs
@@ -1,8 +1,7 @@
-use rome_core::file_handlers::javascript::JsFileFeatures;
 use rome_core::App;
 use rome_formatter::{format, FormatOptions};
 use rome_path::RomePath;
-use rslint_parser::{parse_module, parse_text};
+use rslint_parser::{parse, Syntax};
 use std::fs;
 use std::path::Path;
 
@@ -37,19 +36,14 @@ pub fn run(spec_input_file: &str, _: &str, file_type: &str) {
     let mut rome_path = RomePath::new(file_path);
     if app.can_format(&rome_path) {
         let buffer = rome_path.get_buffer_from_file();
-        let features = if file_type == "module" {
-            JsFileFeatures::default().module()
+        let syntax = if file_type == "module" {
+            Syntax::default().module()
         } else {
-            JsFileFeatures::default().script()
+            Syntax::default()
         };
 
-        let parsed_result = if features.module {
-            parse_module(buffer.as_str(), 0).syntax()
-        } else {
-            parse_text(buffer.as_str(), 0).syntax()
-        };
-
-        let formatted_result = format(FormatOptions::default(), &parsed_result);
+        let root = parse(buffer.as_str(), 0, syntax).syntax();
+        let formatted_result = format(FormatOptions::default(), &root);
         let file_name = spec_input_file.file_name().unwrap().to_str().unwrap();
         let input = fs::read_to_string(file_path).unwrap();
         let result = formatted_result.unwrap();

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use lspower::lsp::*;
 use rome_analyze::FileId;
 use rome_formatter::{FormatOptions, Formatter, IndentStyle};
-use rslint_parser::parse_text;
+use rslint_parser::parse_script;
 
 use crate::line_index;
 
 pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
-    let tree = parse_text(text, file_id).syntax();
+    let tree = parse_script(text, file_id).syntax();
 
     let options = FormatOptions {
         indent_style: IndentStyle::Tab,

--- a/crates/rslint_parser/src/ast/stmt_ext.rs
+++ b/crates/rslint_parser/src/ast/stmt_ext.rs
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn var_decl_let_token() {
-        let parsed = parse_text("/* */let a = 5;", 0).tree();
+        let parsed = parse_script("/* */let a = 5;", 0).tree();
         let var_decl = parsed
             .statements()
             .iter()
@@ -54,7 +54,7 @@ mod tests {
 
     #[test]
     fn is_var_check() {
-        let root = parse_text("var a = 5;", 0).syntax();
+        let root = parse_script("var a = 5;", 0).syntax();
         let var_decl = root
             .descendants()
             .find_map(ast::JsVariableDeclarations::cast);

--- a/crates/rslint_parser/src/numbers.rs
+++ b/crates/rslint_parser/src/numbers.rs
@@ -45,13 +45,13 @@ pub fn parse_js_big_int(num: &str) -> Option<BigInt> {
 mod tests {
     use crate::{
         ast::{JsAnyExpression, JsAnyLiteralExpression},
-        parse_expr,
+        parse_expression,
     };
     use num_bigint::ToBigInt;
 
     macro_rules! assert_float {
         ($literal:literal, $value:expr) => {
-            let parsed = parse_expr($literal, 0);
+            let parsed = parse_expression($literal, 0);
             match parsed.tree().expression().unwrap() {
                 JsAnyExpression::JsAnyLiteralExpression(
                     JsAnyLiteralExpression::JsNumberLiteralExpression(literal),
@@ -68,7 +68,7 @@ mod tests {
 
     macro_rules! assert_bigint {
         ($literal:literal, $value:expr) => {
-            let parsed = parse_expr($literal, 0);
+            let parsed = parse_expression($literal, 0);
             match parsed.tree().expression().unwrap() {
                 JsAnyExpression::JsAnyLiteralExpression(
                     JsAnyLiteralExpression::JsBigIntLiteralExpression(literal),

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -52,6 +52,8 @@ fn parser_missing_smoke_test() {
 
 fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
     let res = catch_unwind(|| {
+        // Files containing a // SCRIPT comment are parsed as script and not as module
+        // This is needed to test features that are restricted in strict mode.
         let syntax = if text.contains("// SCRIPT") {
             Syntax::default()
         } else if text.contains("// TYPESCRIPT") {
@@ -59,9 +61,6 @@ fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
         } else {
             Syntax::default().module()
         };
-
-        // Files containing a // SCRIPT comment are parsed as script and not as module
-        // This is needed to test features that are restricted in strict mode.
 
         let parse = parse(text, 0, syntax);
 

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::ast::{JsAnyRoot, JsCallArguments};
-use crate::{parse_module, parse_text, AstNode, Parse, ParserError, SyntaxNode, SyntaxToken};
+use crate::{parse, parse_module, AstNode, Parse, ParserError, Syntax, SyntaxNode, SyntaxToken};
 use expect_test::expect_file;
 use rome_rowan::TextSize;
 use rslint_errors::file::SimpleFile;
@@ -52,13 +52,18 @@ fn parser_missing_smoke_test() {
 
 fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
     let res = catch_unwind(|| {
+        let syntax = if text.contains("// SCRIPT") {
+            Syntax::default()
+        } else if text.contains("// TYPESCRIPT") {
+            Syntax::default().typescript()
+        } else {
+            Syntax::default().module()
+        };
+
         // Files containing a // SCRIPT comment are parsed as script and not as module
         // This is needed to test features that are restricted in strict mode.
-        let parse = if text.contains("// SCRIPT") {
-            parse_text(text, 0).cast::<JsAnyRoot>().unwrap()
-        } else {
-            parse_module(text, 0).cast::<JsAnyRoot>().unwrap()
-        };
+
+        let parse = parse(text, 0, syntax);
 
         assert_eq!(
             parse.syntax().to_string(),

--- a/crates/rslint_parser/src/util.rs
+++ b/crates/rslint_parser/src/util.rs
@@ -49,10 +49,10 @@ pub trait SyntaxNodeExt {
     /// # Examples
     ///
     /// ```
-    /// use rslint_parser::{SyntaxNodeExt, parse_expr};
+    /// use rslint_parser::{SyntaxNodeExt, parse_expression};
     ///
-    /// let left = parse_expr("foo. bar", 0).syntax();
-    /// let right = parse_expr("foo.bar", 0).syntax();
+    /// let left = parse_expression("foo. bar", 0).syntax();
+    /// let right = parse_expression("foo.bar", 0).syntax();
     ///
     /// assert!(left.lexical_eq(&right));
     ///

--- a/xtask/src/coverage/typescript.rs
+++ b/xtask/src/coverage/typescript.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::coverage::{FailReason, Outcome, TestResult};
 use colored::Colorize;
-use rslint_parser::parse_text;
+use rslint_parser::{parse, Syntax};
 use walkdir::{DirEntry, WalkDir};
 use yastl::Pool;
 
@@ -79,7 +79,7 @@ pub fn run_ts(
             }
             let code = code.unwrap();
             let result = std::panic::catch_unwind(|| {
-                let r = parse_text(&code, 0);
+                let r = parse(&code, 0, Syntax::default().typescript());
 
                 if is_detailed && show_rast {
                     println!("{:#?}", r.syntax());

--- a/xtask/src/libs/mod.rs
+++ b/xtask/src/libs/mod.rs
@@ -113,13 +113,13 @@ pub fn run(filter: String, criterion: bool, baseline: Option<String>) {
                     group.throughput(criterion::Throughput::Bytes(code.len() as u64));
                     group.bench_function(&id, |b| {
                         b.iter(|| {
-                            let _ = criterion::black_box(rslint_parser::parse_text(code, 0));
+                            let _ = criterion::black_box(rslint_parser::parse_module(code, 0));
                         })
                     });
                     group.finish();
                 } else {
                     //warmup
-                    rslint_parser::parse_text(code, 0);
+                    rslint_parser::parse_module(code, 0);
                 }
 
                 let result = benchmark_lib(&id, code);


### PR DESCRIPTION
## Summary

Adds a method that allows parsing a file with the provided syntax. This is useful because in many cases all we want to do is to parse the root of a program and enable certain syntax features. 

It's likely that the `Syntax` struct will change in the future. It's just what already existed.

This PR also adds a way to run TypeScript codegen tests by writing `// TYPESCRIPT`. We probably want to have a more elaborated approach of doing this in the codegen but it unblocks me from working on parsing typescript types. 

## Test Plan

`cargo test`
