### PR TITLE
chore: change vscode extension name and version

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "rome-dev",
+	"name": "rome",
 	"publisher": "rome",
-	"displayName": "Rome Dev",
-	"description": "Rome LSP Dev Client",
-	"version": "0.0.1",
+	"displayName": "Rome",
+	"description": "Rome LSP VS Code Extension",
+	"version": "0.0.4",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",
@@ -22,7 +22,7 @@
 	},
 	"contributes": {
 		"configuration": {
-			"title": "Rome Dev",
+			"title": "Rome",
 			"properties": {
 				"rome.lspBin": {
 					"type": "string",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(_context: ExtensionContext) {
 
 	client = new LanguageClient(
 		'rome_lsp',
-		'Language Server Rome',
+		'Rome',
 		serverOptions,
 		clientOptions
 	);


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

When I added a new extension locally for `rome_lsp`, I used the `rome-dev` name and had the word "Dev" all over the place so that I wouldn't mix it up with the published version. This changes the name to match what's on the marketplace and updates the version to `"0.0.4"`.

Although I noticed that the extension name is `vscode-rome` in the `archived-js` branch and I don't remember why that's the case or if we should do the same thing here. @sebmck?

@leops Also, feel free to close this PR if its easier to incorporate these changes into your #1995 PR.