### PR TITLE
fix(rome_formatter): better comments inside blocks

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -93,14 +93,23 @@ impl Formatter {
                 drop(printed_tokens);
             }
         }
+        let open_token_trailing_trivia = self.print_trailing_trivia(open_token);
+        let close_token_leading_trivia = self.print_leading_trivia(close_token);
 
+        let open_token_trailing_trivia = if !open_token_trailing_trivia.is_empty() {
+            format_elements![open_token_trailing_trivia, hard_line_break()]
+        } else {
+            empty_element()
+        };
+        let close_token_leading_trivia = if !close_token_leading_trivia.is_empty() {
+            format_elements![hard_line_break(), close_token_leading_trivia]
+        } else {
+            empty_element()
+        };
         Ok(format_elements![
             self.print_leading_trivia(open_token),
             token(open_token.text_trimmed()),
-            content(
-                self.print_trailing_trivia(open_token),
-                self.print_leading_trivia(close_token),
-            )?,
+            content(open_token_trailing_trivia, close_token_leading_trivia,)?,
             token(close_token.text_trimmed()),
             self.print_trailing_trivia(close_token),
         ])

--- a/crates/rome_formatter/src/ts/arg_list.rs
+++ b/crates/rome_formatter/src/ts/arg_list.rs
@@ -10,11 +10,11 @@ impl ToFormatElement for JsCallArguments {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements(soft_line_break_or_space(), args_tokens),
-                    trailing
+                    close_token_leading
                 ]))
             },
             &self.r_paren_token()?,

--- a/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
@@ -12,11 +12,11 @@ impl ToFormatElement for JsArrayAssignmentPattern {
         let elements = formatter.format_separated(self.elements(), || token(","))?;
         Ok(group_elements(formatter.format_delimited(
             &self.l_brack_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements(soft_line_break_or_space(), elements),
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_brack_token()?,

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -14,13 +14,13 @@ impl ToFormatElement for JsObjectAssignmentPattern {
         let properties = formatter.format_separated(self.properties(), || token(","))?;
         Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(format_elements![
                     space_token(),
                     soft_indent(format_elements![
-                        leading,
+                        open_token_trailing,
                         join_elements(soft_line_break_or_space(), properties),
-                        trailing
+                        close_token_leading
                     ]),
                     space_token(),
                 ])

--- a/crates/rome_formatter/src/ts/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/function_body.rs
@@ -9,11 +9,11 @@ impl ToFormatElement for JsFunctionBody {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         formatter.format_delimited(
             &self.l_curly_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(block_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     format_statements(self.statements(), formatter),
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_curly_token()?,

--- a/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/array_binding_pattern.rs
@@ -10,11 +10,11 @@ impl ToFormatElement for JsArrayBindingPattern {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_brack_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements(soft_line_break_or_space(), elements),
-                    trailing
+                    close_token_leading
                 ]))
             },
             &self.r_brack_token()?,

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -14,13 +14,13 @@ impl ToFormatElement for JsObjectBindingPattern {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(format_elements![
                     space_token(),
                     soft_indent(format_elements![
-                        leading,
+                        open_token_trailing,
                         join_elements(soft_line_break_or_space(), properties),
-                        trailing,
+                        close_token_leading,
                     ]),
                     space_token(),
                 ])

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -1,6 +1,6 @@
 use crate::{
-    block_indent, empty_element, format_elements, group_elements, hard_line_break,
-    join_elements_hard_line, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    block_indent, empty_element, format_elements, group_elements, join_elements_hard_line,
+    space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsAnyClass;
 

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -1,6 +1,6 @@
 use crate::{
-    block_indent, empty_element, format_elements, group_elements, join_elements_hard_line,
-    space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    block_indent, empty_element, format_elements, group_elements, hard_line_break,
+    join_elements_hard_line, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsAnyClass;
 
@@ -25,15 +25,15 @@ impl ToFormatElement for JsAnyClass {
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_curly_token()?,
-                |leading, trailing| {
+                |open_token_trailing, close_token_leading| {
                     Ok(block_indent(format_elements![
-                        leading,
+                        open_token_trailing,
                         join_elements_hard_line(
                             self.members()
                                 .into_iter()
                                 .zip(formatter.format_nodes(self.members())?)
                         ),
-                        trailing,
+                        close_token_leading,
                     ]))
                 },
                 &self.r_curly_token()?

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -24,11 +24,11 @@ impl ToFormatElement for JsConstructorParameters {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements(soft_line_break_or_space(), params),
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_paren_token()?,

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -13,7 +13,7 @@ impl ToFormatElement for JsArrayExpression {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_brack_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 // Specifically do not use format_separated as array expressions need
                 // separators inserted after empty expressions regardless of the
                 // formatting since this makes a semantic difference
@@ -44,9 +44,9 @@ impl ToFormatElement for JsArrayExpression {
                     .collect::<FormatResult<Vec<_>>>()?;
 
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements_soft_line(results),
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_brack_token()?,

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -1,7 +1,7 @@
 use crate::format_element::join_elements_soft_line;
 use crate::{
-    empty_element, format_elements, group_elements, if_group_fits_on_single_line, soft_indent,
-    space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    empty_element, format_elements, group_elements, hard_line_break, if_group_fits_on_single_line,
+    soft_indent, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsObjectExpression;
 use rslint_parser::AstSeparatedList;
@@ -18,13 +18,13 @@ impl ToFormatElement for JsObjectExpression {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 let members = formatter.format_separated(members, || token(","))?;
 
                 Ok(format_elements!(
                     space.clone(),
                     soft_indent(format_elements![
-                        leading,
+                        open_token_trailing,
                         join_elements_soft_line(
                             self.members()
                                 .elements()
@@ -32,7 +32,7 @@ impl ToFormatElement for JsObjectExpression {
                                 .map(|node| node.node().unwrap())
                                 .zip(members)
                         ),
-                        trailing
+                        close_token_leading
                     ]),
                     space,
                 ))

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -1,7 +1,7 @@
 use crate::format_element::join_elements_soft_line;
 use crate::{
-    empty_element, format_elements, group_elements, hard_line_break, if_group_fits_on_single_line,
-    soft_indent, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    empty_element, format_elements, group_elements, if_group_fits_on_single_line, soft_indent,
+    space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsObjectExpression;
 use rslint_parser::AstSeparatedList;

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -11,11 +11,11 @@ impl ToFormatElement for JsParameters {
 
         Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     join_elements(soft_line_break_or_space(), param_tokens),
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_paren_token()?,

--- a/crates/rome_formatter/src/ts/statements/block.rs
+++ b/crates/rome_formatter/src/ts/statements/block.rs
@@ -20,7 +20,13 @@ impl ToFormatElement for JsBlockStatement {
         } else {
             formatter.format_delimited(
                 &self.l_curly_token()?,
-                |leading, trailing| Ok(block_indent(format_elements![leading, stmts, trailing])),
+                |open_token_trailing, close_token_leading| {
+                    Ok(block_indent(format_elements![
+                        open_token_trailing,
+                        stmts,
+                        close_token_leading
+                    ]))
+                },
                 &self.r_curly_token()?,
             )
         }
@@ -31,7 +37,18 @@ impl ToFormatElement for JsBlockStatement {
 // * empty block: same line `{}`,
 // * empty block that is the 'cons' or 'alt' of an if statement: two lines `{\n}`
 // * non empty block: put each stmt on its own line: `{\nstmt1;\nstmt2;\n}`
+// * non empty block with comments (trailing comments on {, or leading comments on })
 fn is_non_collapsable_empty_block(block: &JsBlockStatement) -> bool {
+    if block
+        .l_curly_token()
+        .map_or_else(|_| false, |token| token.has_trailing_comments())
+        || block
+            .r_curly_token()
+            .map_or_else(|_| false, |token| token.has_leading_comments())
+    {
+        return false;
+    }
+
     if !block.statements().is_empty() {
         return false;
     }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -15,10 +15,10 @@ impl ToFormatElement for JsDoWhileStatement {
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(soft_indent(format_elements![
-                    leading,
+                |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
+                    open_token_trailing,
                     formatter.format_node(self.test()?)?,
-                    trailing,
+                    close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),

--- a/crates/rome_formatter/src/ts/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_in_statement.rs
@@ -18,15 +18,17 @@ impl ToFormatElement for JsForInStatement {
             space_token(),
             formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
-                    leading,
-                    initializer,
-                    soft_line_break_or_space(),
-                    in_token,
-                    soft_line_break_or_space(),
-                    expression,
-                    trailing,
-                ]))),
+                |open_token_trailing, close_token_leading| Ok(group_elements(soft_indent(
+                    format_elements![
+                        open_token_trailing,
+                        initializer,
+                        soft_line_break_or_space(),
+                        in_token,
+                        soft_line_break_or_space(),
+                        expression,
+                        close_token_leading,
+                    ]
+                ))),
                 &self.r_paren_token()?
             )?,
             space_token(),

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -18,15 +18,17 @@ impl ToFormatElement for JsForOfStatement {
             space_token(),
             formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
-                    leading,
-                    initializer,
-                    soft_line_break_or_space(),
-                    of_token,
-                    soft_line_break_or_space(),
-                    expression,
-                    trailing,
-                ]))),
+                |open_token_trailing, close_token_leading| Ok(group_elements(soft_indent(
+                    format_elements![
+                        open_token_trailing,
+                        initializer,
+                        soft_line_break_or_space(),
+                        of_token,
+                        soft_line_break_or_space(),
+                        expression,
+                        close_token_leading,
+                    ]
+                ))),
                 &self.r_paren_token()?
             )?,
             space_token(),

--- a/crates/rome_formatter/src/ts/statements/for_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/for_stmt.rs
@@ -40,9 +40,9 @@ impl ToFormatElement for JsForStatement {
             space_token(),
             formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(group_elements(soft_indent(format_elements![
-                    leading, inner, trailing
-                ]))),
+                |open_token_trailing, close_token_leading| Ok(group_elements(soft_indent(
+                    format_elements![open_token_trailing, inner, close_token_leading]
+                ))),
                 &self.r_paren_token()?,
             )?,
             space_token(),

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -18,10 +18,10 @@ impl ToFormatElement for JsIfStatement {
                 space_token(),
                 group_elements(formatter.format_delimited(
                     &self.l_paren_token()?,
-                    |leading, trailing| Ok(soft_indent(format_elements![
-                        leading,
+                    |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
+                        open_token_trailing,
                         formatter.format_node(self.test()?)?,
-                        trailing
+                        close_token_leading
                     ])),
                     &self.r_paren_token()?,
                 )?),

--- a/crates/rome_formatter/src/ts/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/switch_statement.rs
@@ -13,25 +13,25 @@ impl ToFormatElement for JsSwitchStatement {
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(soft_indent(format_elements![
-                    leading,
+                |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
+                    open_token_trailing,
                     formatter.format_node(self.discriminant()?)?,
-                    trailing,
+                    close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_curly_token()?,
-                |leading, trailing| {
+                |open_token_trailing, close_token_leading| {
                     Ok(block_indent(format_elements![
-                        leading,
+                        open_token_trailing,
                         join_elements_hard_line(
                             self.cases()
                                 .into_iter()
                                 .zip(formatter.format_nodes(self.cases())?)
                         ),
-                        trailing,
+                        close_token_leading,
                     ]))
                 },
                 &self.r_curly_token()?

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -61,11 +61,11 @@ impl ToFormatElement for JsCatchDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(group_elements(formatter.format_delimited(
             &self.l_paren_token()?,
-            |leading, trailing| {
+            |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
-                    leading,
+                    open_token_trailing,
                     formatter.format_node(self.binding()?)?,
-                    trailing,
+                    close_token_leading,
                 ]))
             },
             &self.r_paren_token()?,

--- a/crates/rome_formatter/src/ts/statements/while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/while_statement.rs
@@ -11,10 +11,10 @@ impl ToFormatElement for JsWhileStatement {
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(soft_indent(format_elements![
-                    leading,
+                |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
+                    open_token_trailing,
                     formatter.format_node(self.test()?)?,
-                    trailing,
+                    close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),

--- a/crates/rome_formatter/src/ts/statements/with_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/with_statement.rs
@@ -11,10 +11,10 @@ impl ToFormatElement for JsWithStatement {
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
-                |leading, trailing| Ok(soft_indent(format_elements![
-                    leading,
+                |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
+                    open_token_trailing,
                     formatter.format_node(self.object()?)?,
-                    trailing,
+                    close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),

--- a/crates/rome_formatter/tests/spec_tests.rs
+++ b/crates/rome_formatter/tests/spec_tests.rs
@@ -4,11 +4,11 @@ mod formatter {
 
     mod js_module {
         use crate::spec_test;
-        tests_macros::gen_tests! {"tests/specs/js/module/**.js", spec_test::run, "module"}
+        tests_macros::gen_tests! {"tests/specs/js/module/**/**/*.js", spec_test::run, "module"}
     }
 
     mod js_script {
         use crate::spec_test;
-        tests_macros::gen_tests! {"tests/specs/js/script/**.js", spec_test::run, "script"}
+        tests_macros::gen_tests! {"tests/specs/js/script/**/**/*.js", spec_test::run, "script"}
     }
 }

--- a/crates/rome_formatter/tests/specs/js/module/class/class_comments.js
+++ b/crates/rome_formatter/tests/specs/js/module/class/class_comments.js
@@ -1,0 +1,7 @@
+class A extends B { // leading comment
+    constructor() {
+        super();
+    }
+
+    // trailing comment
+}

--- a/crates/rome_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -1,0 +1,24 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 57
+expression: class_comments.js
+
+---
+# Input
+class A extends B { // leading comment
+    constructor() {
+        super();
+    }
+
+    // trailing comment
+}
+---
+# Output
+class A extends B {
+	// leading comment
+	constructor() {
+		super();
+	}
+	// trailing comment
+}
+

--- a/crates/rome_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 63
+assertion_line: 57
 expression: comments.js
 
 ---
@@ -57,7 +57,9 @@ statement(); // inline
 // import {
 //     func, // trailing comma removal
 // } from 'module';
-expression( /* block comment */ );
+expression(
+	/* block comment */
+);
 
 expression(
 	/* block comment */
@@ -77,16 +79,28 @@ expression(
 
 expression("something" /** something **/ );
 
-expression( /** something **/ "something");
+expression(
+	/** something **/
+	"something",
+);
 
 expression(
 	/** something **/
 	"something",
 );
 
-const array0 = [ /*0*/ ];
-const array1 = [ /*0*/ , /*1*/ ];
-const array2 = [ /*0*/ , /*1*/ , /*2*/ ];
+const array0 = [
+	/*0*/
+];
+const array1 = [
+	/*0*/
+	, /*1*/
+];
+const array2 = [
+	/*0*/
+	, /*1*/
+	, /*2*/
+];
 
 /* block comment */
 statement();

--- a/crates/rome_formatter/tests/specs/js/module/function/function_comments.js
+++ b/crates/rome_formatter/tests/specs/js/module/function/function_comments.js
@@ -5,8 +5,13 @@ function a() { // trailing comment
  /** leading comment **/   }
 
 
-function a() // leading comment
+function b() // leading comment
 { // trailing
 
 
 }
+
+
+function c( //some comment
+    foo, bar,
+) {}

--- a/crates/rome_formatter/tests/specs/js/module/function/function_comments.js
+++ b/crates/rome_formatter/tests/specs/js/module/function/function_comments.js
@@ -1,0 +1,12 @@
+function a() { // trailing comment
+    let a = 2;
+
+
+ /** leading comment **/   }
+
+
+function a() // leading comment
+{ // trailing
+
+
+}

--- a/crates/rome_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -12,11 +12,16 @@ function a() { // trailing comment
  /** leading comment **/   }
 
 
-function a() // leading comment
+function b() // leading comment
 { // trailing
 
 
 }
+
+
+function c( //some comment
+    foo, bar,
+) {}
 ---
 # Output
 function a() {
@@ -25,7 +30,13 @@ function a() {
 	/** leading comment **/
 }
 
-function a() { // leading comment
+function b() { // leading comment
 	// trailing
 }
+
+function c(
+	//some comment
+	foo,
+	bar,
+) {}
 

--- a/crates/rome_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 57
+expression: function_comments.js
+
+---
+# Input
+function a() { // trailing comment
+    let a = 2;
+
+
+ /** leading comment **/   }
+
+
+function a() // leading comment
+{ // trailing
+
+
+}
+---
+# Output
+function a() {
+	// trailing comment
+	let a = 2;
+	/** leading comment **/
+}
+
+function a() { // leading comment
+	// trailing
+}
+

--- a/crates/rome_formatter/tests/specs/js/module/object/object_comments.js
+++ b/crates/rome_formatter/tests/specs/js/module/object/object_comments.js
@@ -1,0 +1,4 @@
+let a = { // leading comment
+    "type": "bar"
+    // trailing comment
+}

--- a/crates/rome_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 57
+expression: object_comments.js
+
+---
+# Input
+let a = { // leading comment
+    "type": "bar"
+    // trailing comment
+}
+---
+# Output
+let a = {
+	// leading comment
+	"type": "bar",
+	// trailing comment
+};
+

--- a/crates/rome_formatter/tests/specs/js/module/statement/do_while.js
+++ b/crates/rome_formatter/tests/specs/js/module/statement/do_while.js
@@ -3,3 +3,10 @@ var foo = 4
 }
 
 while (something)
+
+
+do { // trailing
+    var foo = 4
+}
+
+while (something)

--- a/crates/rome_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 43
+assertion_line: 57
 expression: do_while.js
 
 ---
@@ -11,9 +11,20 @@ var foo = 4
 
 while (something)
 
+
+do { // trailing
+    var foo = 4
+}
+
+while (something)
 ---
 # Output
 do {
+	var foo = 4;
+} while (something);
+
+do {
+	// trailing
 	var foo = 4;
 } while (something);
 

--- a/crates/rome_formatter/tests/specs/js/module/statement/for_in.js
+++ b/crates/rome_formatter/tests/specs/js/module/statement/for_in.js
@@ -2,3 +2,6 @@ for (a in b) {}
 
 for (aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks in aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 }
+
+for (a in b) { // trailing
+     }

--- a/crates/rome_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 43
+assertion_line: 57
 expression: for_in.js
 
 ---
@@ -10,6 +10,8 @@ for (a in b) {}
 for (aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks in aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 }
 
+for (a in b) { // trailing
+     }
 ---
 # Output
 for (a in b) {}
@@ -19,4 +21,8 @@ for (
 	in
 	aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks
 ) {}
+
+for (a in b) {
+	// trailing
+}
 

--- a/crates/rome_formatter/tests/specs/js/module/statement/if_else.js
+++ b/crates/rome_formatter/tests/specs/js/module/statement/if_else.js
@@ -49,3 +49,10 @@ if (true) {
 
 }
 
+if (true) {
+	// trailing
+
+} else { // trailing
+
+}
+

--- a/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 43
+assertion_line: 57
 expression: if_else.js
 
 ---
@@ -56,6 +56,13 @@ if (true) {
 
 }
 
+if (true) {
+	// trailing
+
+} else { // trailing
+
+}
+
 
 ---
 # Output
@@ -98,5 +105,11 @@ if (
 }
 
 if (true) {
+}
+
+if (true) {
+	// trailing
+} else {
+	// trailing
 }
 

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -981,7 +981,7 @@ impl<L: Language> SyntaxToken<L> {
     pub fn has_trailing_comments(&self) -> bool {
         let mut has_comments = false;
         for piece in self.trailing_trivia().pieces() {
-            if let Some(_) = piece.as_comments() {
+            if piece.as_comments().is_some() {
                 has_comments = true;
                 break;
             }
@@ -994,7 +994,7 @@ impl<L: Language> SyntaxToken<L> {
     pub fn has_leading_comments(&self) -> bool {
         let mut has_comments = false;
         for piece in self.leading_trivia().pieces() {
-            if let Some(_) = piece.as_comments() {
+            if piece.as_comments().is_some() {
                 has_comments = true;
                 break;
             }

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -976,6 +976,32 @@ impl<L: Language> SyntaxToken<L> {
             _p: PhantomData,
         }
     }
+
+    /// Checks if the current token has trailing comments
+    pub fn has_trailing_comments(&self) -> bool {
+        let mut has_comments = false;
+        for piece in self.trailing_trivia().pieces() {
+            if let Some(_) = piece.as_comments() {
+                has_comments = true;
+                break;
+            }
+        }
+
+        has_comments
+    }
+
+    /// Checks if the current token has leading comments
+    pub fn has_leading_comments(&self) -> bool {
+        let mut has_comments = false;
+        for piece in self.leading_trivia().pieces() {
+            if let Some(_) = piece.as_comments() {
+                has_comments = true;
+                break;
+            }
+        }
+
+        has_comments
+    }
 }
 
 impl<L: Language> SyntaxElement<L> {

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -16,7 +16,6 @@ let [a, b] = [1, 2];
     "#;
 
     let module = parse_module(src, 0);
-
     assert_errors_are_absent(
         module.errors(),
         Path::new("parser_smoke_test"),


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #2006 

I found a small bug inside the `format_delimited` of the formatter, where some comments were appended in some weird way.

While I was starting to fix this from the implementation side, I found out out that I was repeating myself, so I decided to bring the solution inside the `format_delimited` function. 

The trailing comments of the open token are followed by a hard line break, the leading comments of the close token are preceded by a hard line break.

There was a small case where I needed to check if a token has some comments, so I also added two new API to `rome_rowan` to check that.

Also, I applied a small renaming to `|leading, trailing|` inside the code. I did this because this naming choice created a confusion where I thought `leading` was the leading comment that belonged to the block, while in reality it's the trailing comment that belongs to the open token. As Rust doesn't support named parameters, I wanted to chose a better name to avoid confusions (if it happened to me, it can happen to everyone)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Created new test cases to cover the new changes

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
