### PR TITLE
feat(rome_formatter): add a baseline version of range formatting

### DIFF
--- a/crates/rome_formatter/src/cst.rs
+++ b/crates/rome_formatter/src/cst.rs
@@ -12,7 +12,8 @@ use rslint_parser::ast::{
     JsStatementList, JsStringLiteralExpression, JsSwitchStatement, JsTryStatement,
     JsUnknownAssignment, JsUnknownBinding, JsUnknownExpression, JsUnknownImportAssertionEntry,
     JsUnknownMember, JsUnknownNamedImportSpecifier, JsUnknownParameter, JsUnknownStatement,
-    JsVariableDeclaration, JsVariableStatement, JsWhileStatement, JsWithStatement,
+    JsVariableDeclaration, JsVariableDeclarations, JsVariableStatement, JsWhileStatement,
+    JsWithStatement,
 };
 use rslint_parser::{AstNode, JsSyntaxKind, SyntaxNode};
 
@@ -202,6 +203,9 @@ impl ToFormatElement for SyntaxNode {
                 JsStatementList::cast(self.clone()).unwrap(),
                 formatter,
             )),
+            JsSyntaxKind::JS_VARIABLE_DECLARATIONS => JsVariableDeclarations::cast(self.clone())
+                .unwrap()
+                .to_format_element(formatter),
 
             _ => todo!(
                 "Implement formatting for the {:?} syntax kind.",

--- a/crates/rome_formatter/src/cst.rs
+++ b/crates/rome_formatter/src/cst.rs
@@ -1,4 +1,4 @@
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{ts::format_statements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::{
     JsArrayBindingPattern, JsArrayExpression, JsArrowFunctionExpression, JsBlockStatement,
     JsBooleanLiteralExpression, JsCallArguments, JsCallExpression, JsCaseClause, JsCatchClause,
@@ -9,10 +9,10 @@ use rslint_parser::ast::{
     JsNullLiteralExpression, JsNumberLiteralExpression, JsObjectExpression, JsParameters,
     JsPropertyClassMember, JsPropertyObjectMember, JsReturnStatement, JsScript,
     JsSequenceExpression, JsSetterClassMember, JsShorthandPropertyObjectMember, JsSpread,
-    JsStringLiteralExpression, JsSwitchStatement, JsTryStatement, JsUnknownAssignment,
-    JsUnknownBinding, JsUnknownExpression, JsUnknownImportAssertionEntry, JsUnknownMember,
-    JsUnknownNamedImportSpecifier, JsUnknownParameter, JsUnknownStatement, JsVariableDeclaration,
-    JsVariableStatement, JsWhileStatement, JsWithStatement,
+    JsStatementList, JsStringLiteralExpression, JsSwitchStatement, JsTryStatement,
+    JsUnknownAssignment, JsUnknownBinding, JsUnknownExpression, JsUnknownImportAssertionEntry,
+    JsUnknownMember, JsUnknownNamedImportSpecifier, JsUnknownParameter, JsUnknownStatement,
+    JsVariableDeclaration, JsVariableStatement, JsWhileStatement, JsWithStatement,
 };
 use rslint_parser::{AstNode, JsSyntaxKind, SyntaxNode};
 
@@ -197,6 +197,11 @@ impl ToFormatElement for SyntaxNode {
                     .unwrap()
                     .to_format_element(formatter)
             }
+
+            JsSyntaxKind::JS_STATEMENT_LIST => Ok(format_statements(
+                JsStatementList::cast(self.clone()).unwrap(),
+                formatter,
+            )),
 
             _ => todo!(
                 "Implement formatting for the {:?} syntax kind.",

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -33,7 +33,7 @@ pub fn empty_element() -> FormatElement {
 ///   token("b"),
 /// ]);
 ///
-/// assert_eq!("a,b", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("a,b", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 /// See [soft_line_break_or_space] if you want to insert a space between the elements if the enclosing
 /// [Group] fits on a single line.
@@ -53,7 +53,7 @@ pub fn empty_element() -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).code());
+/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).as_code());
 /// ```
 #[inline]
 pub const fn soft_line_break() -> FormatElement {
@@ -76,7 +76,7 @@ pub const fn soft_line_break() -> FormatElement {
 ///   hard_line_break()
 /// ]);
 ///
-/// assert_eq!("a,\nb\n", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("a,\nb\n", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub const fn hard_line_break() -> FormatElement {
@@ -98,7 +98,7 @@ pub const fn hard_line_break() -> FormatElement {
 ///   empty_line()
 /// ]);
 ///
-/// assert_eq!("a,\n\nb\n\n", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("a,\n\nb\n\n", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub const fn empty_line() -> FormatElement {
@@ -119,7 +119,7 @@ pub const fn empty_line() -> FormatElement {
 ///   token("b"),
 /// ]);
 ///
-/// assert_eq!("a, b", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("a, b", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 ///
 /// The printer breaks the lines if the enclosing [Group] doesn't fit on a single line:
@@ -137,7 +137,7 @@ pub const fn empty_line() -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).code());
+/// assert_eq!("a long word,\nso that the group doesn't fit on a single line", format_element(&elements, options).as_code());
 /// ```
 #[inline]
 pub const fn soft_line_break_or_space() -> FormatElement {
@@ -157,7 +157,7 @@ pub const fn soft_line_break_or_space() -> FormatElement {
 /// use rome_formatter::{token, format_element, FormatOptions};
 /// let elements = token("Hello World");
 ///
-/// assert_eq!("Hello World", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("Hello World", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 ///
 /// Printing a string literal as a literal requires that the string literal is properly escaped and
@@ -169,7 +169,7 @@ pub const fn soft_line_break_or_space() -> FormatElement {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = token("\"Hello\\tWorld\"");
 ///
-/// assert_eq!(r#""Hello\tWorld""#, format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!(r#""Hello\tWorld""#, format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub const fn token(text: &'static str) -> FormatElement {
@@ -189,7 +189,7 @@ pub const fn token(text: &'static str) -> FormatElement {
 ///
 /// let elements = format_elements![token("a"), line_suffix(token("c")), token("b")];
 ///
-/// assert_eq!("abc", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("abc", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
@@ -206,7 +206,7 @@ pub fn line_suffix(element: impl Into<FormatElement>) -> FormatElement {
 /// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
 /// let elements = format_elements![token("a"), space_token(), token("b")];
 ///
-/// assert_eq!("a b", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("a b", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub const fn space_token() -> FormatElement {
@@ -221,7 +221,7 @@ pub const fn space_token() -> FormatElement {
 /// use rome_formatter::{concat_elements, FormatElement, space_token, token, format_element, FormatOptions};
 /// let expr = concat_elements(vec![token("a"), space_token(), token("+"), space_token(), token("b")]);
 ///
-/// assert_eq!("a + b", format_element(&expr, FormatOptions::default()).code())
+/// assert_eq!("a + b", format_element(&expr, FormatOptions::default()).as_code())
 /// ```
 pub fn concat_elements<I>(elements: I) -> FormatElement
 where
@@ -265,7 +265,7 @@ where
 /// let separator = concat_elements(vec![token(","), space_token()]);
 /// let elements = join_elements(separator, vec![token("1"), token("2"), token("3"), token("4")]);
 ///
-/// assert_eq!("1, 2, 3, 4", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("1, 2, 3, 4", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 #[inline]
 pub fn join_elements<TSep, I>(separator: TSep, elements: I) -> FormatElement
@@ -385,7 +385,7 @@ where
 ///
 /// assert_eq!(
 ///   "switch {\n\tdefault:\n\t\tbreak;\n}",
-///   format_element(&block, FormatOptions::default()).code()
+///   format_element(&block, FormatOptions::default()).as_code()
 /// );
 /// ```
 #[inline]
@@ -420,7 +420,7 @@ pub fn indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///   "{\n\tlet a = 10;\n\tlet c = a + 5;\n}",
-///   format_element(&block, FormatOptions::default()).code()
+///   format_element(&block, FormatOptions::default()).as_code()
 /// );
 /// ```
 #[inline]
@@ -463,7 +463,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///  ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("[\n\t'First string',\n\t'second string',\n]", format_element(&elements, options).code());
+/// assert_eq!("[\n\t'First string',\n\t'second string',\n]", format_element(&elements, options).as_code());
 /// ```
 ///
 /// Doesn't change the formatting if the enclosing [Group] fits on a single line
@@ -482,7 +482,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// assert_eq!(
 ///   "[5, 10]",
-///   format_element(&elements, FormatOptions::default()).code()
+///   format_element(&elements, FormatOptions::default()).as_code()
 /// );
 /// ```
 ///
@@ -528,7 +528,7 @@ pub fn soft_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   token("]"),
 /// ]);
 ///
-/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 ///
 /// The printer breaks the [Group] over multiple lines if its content doesn't fit on a single line
@@ -552,7 +552,7 @@ pub fn soft_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   ..FormatOptions::default()
 /// };
 ///
-/// assert_eq!("[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]", format_element(&elements, options).code());
+/// assert_eq!("[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]", format_element(&elements, options).as_code());
 /// ```
 #[inline]
 pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
@@ -591,7 +591,7 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   ]),
 ///   token("]"),
 /// ]);
-/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("[1, 2, 3]", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 ///
 /// Prints the trailing comma for the last array element if the [Group] doesn't fit on a single line
@@ -614,7 +614,7 @@ pub fn group_elements<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// let options = FormatOptions { line_width: 20, ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
-///   format_element(&elements, options).code()
+///   format_element(&elements, options).as_code()
 /// );
 /// ```
 #[inline]
@@ -654,7 +654,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   ]),
 ///   token("]"),
 /// ]);
-/// assert_eq!("[1, 2, 3,]", format_element(&elements, FormatOptions::default()).code());
+/// assert_eq!("[1, 2, 3,]", format_element(&elements, FormatOptions::default()).as_code());
 /// ```
 ///
 /// Omits the trailing comma for the last array element if the [Group] doesn't fit on a single line
@@ -677,7 +677,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// let options = FormatOptions { line_width: 20, ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3\n]",
-///   format_element(&elements, options).code()
+///   format_element(&elements, options).as_code()
 /// );
 /// ```
 #[inline]
@@ -850,17 +850,16 @@ impl Token {
     }
 
     /// Create a token from a dynamic string and a range of the input source
-    pub(crate) fn new_dynamic(text: &str, source: TextRange) -> Self {
-        const LINE_SEPARATOR: char = '\u{2028}';
-        const PARAGRAPH_SEPARATOR: char = '\u{2029}';
-        Self::Dynamic {
-            // Normalize all line terminators to "\n" since its
-            // the only line break type supported by the printer
-            text: text
-                .replace("\r\n", "\n")
-                .replace(&['\r', LINE_SEPARATOR, PARAGRAPH_SEPARATOR], "\n"),
-            source,
+    pub(crate) fn new_dynamic(text: String, source: TextRange) -> Self {
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                for line_break in text.matches(&['\r', LINE_SEPARATOR, PARAGRAPH_SEPARATOR]) {
+                    panic!("The content '{}' contains an unsupported {:?} line terminator character but string tokens must only use line feeds '\\n' as line separator. Use '\\n' instead of '\\r' and '\\r\\n' to insert a line break in strings.", text, line_break);
+                }
+            }
         }
+
+        Self::Dynamic { text, source }
     }
 
     /// Get the range of the input source covered by this token,
@@ -924,13 +923,26 @@ impl<L: Language> From<SyntaxToken<L>> for Token {
 
 impl<'a, L: Language> From<&'a SyntaxToken<L>> for Token {
     fn from(token: &'a SyntaxToken<L>) -> Self {
-        Self::new_dynamic(token.text_trimmed(), token.text_trimmed_range())
+        Self::new_dynamic(token.text_trimmed().into(), token.text_trimmed_range())
     }
+}
+
+const LINE_SEPARATOR: char = '\u{2028}';
+const PARAGRAPH_SEPARATOR: char = '\u{2029}';
+
+/// Normalize all line terminators in the text to "\n" since
+/// its the only line break type supported by the printer
+pub(crate) fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n")
+        .replace(&['\r', LINE_SEPARATOR, PARAGRAPH_SEPARATOR], "\n")
 }
 
 impl<L: Language> From<SyntaxTriviaPieceComments<L>> for Token {
     fn from(trivia: SyntaxTriviaPieceComments<L>) -> Self {
-        Self::new_dynamic(trivia.text().trim(), trivia.text_range())
+        Self::new_dynamic(
+            normalize_newlines(trivia.text().trim()),
+            trivia.text_range(),
+        )
     }
 }
 

--- a/crates/rome_formatter/src/format_elements.rs
+++ b/crates/rome_formatter/src/format_elements.rs
@@ -33,13 +33,13 @@
 ///   space_token(),
 ///   token("}")
 /// ];
-/// assert_eq!(r#"foo: { bar: lorem }"#, format_element(&element, FormatOptions::default()).code());
+/// assert_eq!(r#"foo: { bar: lorem }"#, format_element(&element, FormatOptions::default()).as_code());
 /// ```
 /// Or you can also create single element:
 /// ```
 /// use rome_formatter::{format_elements, format_element, FormatOptions, token};
 /// let element = format_elements![token("single")];
-/// assert_eq!(r#"single"#, format_element(&element, FormatOptions::default()).code());
+/// assert_eq!(r#"single"#, format_element(&element, FormatOptions::default()).as_code());
 /// ```
 #[macro_export]
 macro_rules! format_elements {

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -4,8 +4,9 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 
 use crate::{
-    concat_elements, empty_element, empty_line, format_element::Token, format_elements,
-    hard_line_break, if_group_breaks, if_group_fits_on_single_line, line_suffix,
+    concat_elements, empty_element, empty_line,
+    format_element::{normalize_newlines, Token},
+    format_elements, hard_line_break, if_group_breaks, if_group_fits_on_single_line, line_suffix,
     soft_line_break_or_space, space_token, FormatElement, FormatOptions, FormatResult,
     ToFormatElement,
 };
@@ -349,7 +350,10 @@ impl Formatter {
                 }
 
                 // Print the full (not trimmed) text of the token
-                Token::new_dynamic(syntax_token.text(), syntax_token.text_range()).into()
+                FormatElement::from(Token::new_dynamic(
+                    normalize_newlines(syntax_token.text()),
+                    syntax_token.text_range(),
+                ))
             }
         }))
     }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -3,11 +3,10 @@ use std::cell::RefCell;
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
 
-use crate::printer::Printer;
 use crate::{
     concat_elements, empty_element, empty_line, format_element::Token, format_elements,
     hard_line_break, if_group_breaks, if_group_fits_on_single_line, line_suffix,
-    soft_line_break_or_space, space_token, FormatElement, FormatOptions, FormatResult, Formatted,
+    soft_line_break_or_space, space_token, FormatElement, FormatOptions, FormatResult,
     ToFormatElement,
 };
 use rome_rowan::SyntaxElement;
@@ -44,7 +43,7 @@ impl Formatter {
     }
 
     /// Formats a CST
-    pub fn format_root(self, root: &SyntaxNode) -> FormatResult<Formatted> {
+    pub(crate) fn format_root(self, root: &SyntaxNode) -> FormatResult<FormatElement> {
         let element = self.format_syntax_node(root)?;
 
         cfg_if::cfg_if! {
@@ -60,8 +59,7 @@ impl Formatter {
             }
         }
 
-        let printer = Printer::new(self.options);
-        Ok(printer.print(&element))
+        Ok(element)
     }
 
     fn format_syntax_node(&self, node: &SyntaxNode) -> FormatResult<FormatElement> {

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -104,7 +104,7 @@ impl From<SyntaxError> for FormatError {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum IndentStyle {
     /// Tab
     Tab,
@@ -131,7 +131,7 @@ impl FromStr for IndentStyle {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct FormatOptions {
     /// The indent style
     pub indent_style: IndentStyle,
@@ -183,6 +183,14 @@ impl Formatted {
         }
     }
 
+    fn empty() -> Self {
+        Self {
+            code: String::new(),
+            range: None,
+            sourcemap: Vec::new(),
+        }
+    }
+
     /// Range of the input source file covered by this formatted code,
     /// or None if the entire file is covered in this instance
     pub fn range(&self) -> Option<TextRange> {
@@ -206,7 +214,8 @@ impl Formatted {
 ///
 /// It returns a [Formatted] result, which the user can use to override a file.
 pub fn format(options: FormatOptions, syntax: &SyntaxNode) -> FormatResult<Formatted> {
-    Formatter::new(options).format_root(syntax)
+    let element = Formatter::new(options).format_root(syntax)?;
+    Ok(Printer::new(options).print(&element))
 }
 
 /// Formats a range withing a JavaScript file
@@ -218,7 +227,124 @@ pub fn format_range(
     root: &SyntaxNode,
     range: TextRange,
 ) -> FormatResult<Formatted> {
-    let formatted = format(options, root)?;
+    // Find the tokens corresponding to the start and end of the range
+    let mut start_token = None;
+    let mut end_token = None;
+
+    for token in root.descendants_tokens() {
+        let range = token.text_range();
+
+        if start_token.is_none() && range.contains_inclusive(range.start()) {
+            start_token = Some(token.clone());
+        }
+
+        if end_token.is_none() && range.contains_inclusive(range.end()) {
+            end_token = Some(token);
+        }
+
+        if start_token.is_some() && end_token.is_some() {
+            break;
+        }
+    }
+
+    // If not token were found, this means the input node was empty
+    // or the formatting function was not passed the root SyntaxNode
+    // for the file: default to the first and last token in the root
+    // node or exit early with an empty result if no such token exists
+    let start_token = match start_token {
+        Some(token) => token,
+        None => match root.first_token() {
+            Some(token) => token,
+            // root node is empty
+            None => return Ok(Formatted::empty()),
+        },
+    };
+    let end_token = match end_token {
+        Some(token) => token,
+        None => match root.last_token() {
+            Some(token) => token,
+            // root node is empty
+            None => return Ok(Formatted::empty()),
+        },
+    };
+
+    // Find the lowest common ancestor node for the start and end token
+    // by building the path to the root node from both tokens and
+    // iterating along the two paths at once to find the first divergence
+    let mut start_to_root = Vec::new();
+    let mut end_to_root = Vec::new();
+
+    let mut cursor = start_token.parent();
+    while let Some(node) = cursor {
+        cursor = node.parent();
+        start_to_root.push(node);
+    }
+
+    let mut cursor = end_token.parent();
+    while let Some(node) = cursor {
+        cursor = node.parent();
+        end_to_root.push(node);
+    }
+
+    let mut iter = start_to_root
+        .into_iter()
+        .rev()
+        .zip(end_to_root.into_iter().rev())
+        .peekable();
+
+    let mut common_root = None;
+    while let Some((lhs, rhs)) = iter.peek() {
+        if lhs != rhs {
+            break;
+        }
+
+        common_root = iter.next().map(|(node, _)| node);
+    }
+
+    // Logically this should always return at least the root node,
+    // fallback to said node just in case
+    let common_root = common_root.as_ref().unwrap_or(root);
+
+    // Determine the initial indentation level for the printer by inspecting the trivias
+    // of each token from the first token of the common root towards the start of the file
+    let tokens = std::iter::successors(common_root.first_token(), |token| token.prev_token());
+
+    // From the iterator on tokens, build an iterator on trivia pieces (once again the iterator is
+    // reversed, starting from the last trailing trivia towards the first leading trivia)
+    let trivias = tokens.flat_map(|token| {
+        // We need to build up the trivia pieces into a vector as SyntaxTriviaPieceIterator does
+        // not support reverse iteration, but we're only interested in newline and whitespace
+        #[allow(clippy::needless_collect)]
+        let pieces: Vec<_> = token
+            .leading_trivia()
+            .pieces()
+            .chain(token.trailing_trivia().pieces())
+            .filter(|piece| piece.as_newline().is_some() || piece.as_whitespace().is_some())
+            .collect();
+        pieces.into_iter().rev()
+    });
+
+    // Finally run the iterator until a newline trivia is found, and get the last whitespace trivia before it
+    let last_whitespace = trivias.map_while(|piece| piece.as_whitespace()).last();
+    let initial_indent = match last_whitespace {
+        Some(trivia) => {
+            // This logic is based on the formatting options passed in
+            // the be user (or the editor) as we do not have any kind
+            // of identation type detection yet. Unfortunately this
+            // may not actually match the current content of the file
+            let length = trivia.text().len() as u16;
+            match options.indent_style {
+                IndentStyle::Tab => length,
+                IndentStyle::Space(width) => length / u16::from(width),
+            }
+        }
+        // No whitespace was found between the start of the range
+        // and the start of the file
+        None => 0,
+    };
+
+    let element = Formatter::new(options).format_root(common_root)?;
+    let formatted = Printer::new(options).print_with_indent(&element, initial_indent);
 
     // This finds the closests marker to the beginning of the source
     // starting before or at said starting point, and the closest
@@ -255,11 +381,10 @@ pub fn format_range(
         }
     }
 
-    // If no start or end were found this means either the input was empty,
-    // or the edge of the formatting range was near the edge of the input
-    // and no marker was emitted before the start (or after the end) of the
-    // formatting range: in this case the start/end marker default to the
-    // start/end of the input
+    // If no start or end were found this means the edge of the formatting
+    // range was near the edge of the input and no marker was emitted before
+    // the start (or after the end) of the formatting range: in this case
+    // the start/end marker default to the start/end of the input
     let (start_source, start_dest) = match range_start {
         Some((start_marker, _)) => (start_marker.source, start_marker.dest),
         None => (TextSize::from(0), TextSize::from(0)),
@@ -306,6 +431,8 @@ pub fn format_file_and_save(rome_path: &mut RomePath, options: FormatOptions, ap
 
 #[cfg(test)]
 mod tests {
+    use crate::IndentStyle;
+
     use super::{format_range, FormatOptions};
 
     use rome_rowan::{TextRange, TextSize};
@@ -314,30 +441,49 @@ mod tests {
     #[test]
     fn test_range_formatting() {
         let input = "
-        
-        func(     /* comment */
-        );
-        
-        let array =
-            [ 1
-        , 2];
-        
-        const no_format    =    () => {};
+while(
+    true
+) {
+    function func() {
+    func(     /* comment */
+    );
+    
+    let array =
+        [ 1
+    , 2];
 
-        ";
+    }
 
-        let range_start = TextSize::try_from(input.find("let").unwrap()).unwrap();
+    function func2()
+    {
+
+    const no_format    =    () => {};
+
+    }
+}
+";
+
+        let range_start = TextSize::try_from(input.find("let").unwrap() - 1).unwrap();
         let range_end = TextSize::try_from(input.find("const").unwrap()).unwrap();
 
         let tree = parse_script(input, 0);
         let result = format_range(
-            FormatOptions::default(),
+            FormatOptions {
+                indent_style: IndentStyle::Space(4),
+                ..FormatOptions::default()
+            },
             &tree.syntax(),
             TextRange::new(range_start, range_end),
         );
 
         let result = result.expect("range formatting failed");
-        assert_eq!(result.range(), Some(TextRange::new(range_start, range_end)));
-        assert_eq!(result.code(), "let array = [1, 2];\n\n");
+        assert_eq!(
+            result.range(),
+            Some(TextRange::new(range_start + TextSize::from(1), range_end))
+        );
+        assert_eq!(
+            result.code(),
+            "let array = [1, 2];\n    }\n\n    function func2() {\n        "
+        );
     }
 }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -41,7 +41,7 @@
 //!     let key_value = KeyValue { key: "lorem", value: "ipsum" };
 //!     let element = key_value.to_format_element(&Formatter::default()).unwrap();
 //!     let result = format_element(&element, FormatOptions::default());
-//!     assert_eq!(result.code(), "lorem => ipsum");
+//!     assert_eq!(result.as_code(), "lorem => ipsum");
 //! }
 //!
 //! ```

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -99,10 +99,18 @@ impl<'a> Printer<'a> {
     }
 
     /// Prints the passed in element as well as all its content
-    pub fn print(mut self, element: &'a FormatElement) -> Formatted {
+    pub fn print(self, element: &'a FormatElement) -> Formatted {
+        self.print_with_indent(element, 0)
+    }
+
+    pub(crate) fn print_with_indent(
+        mut self,
+        element: &'a FormatElement,
+        indent: u16,
+    ) -> Formatted {
         let mut queue = ElementCallQueue::new();
 
-        queue.enqueue(PrintElementCall::new(element, PrintElementArgs::default()));
+        queue.enqueue(PrintElementCall::new(element, PrintElementArgs { indent }));
 
         while let Some(print_element_call) = queue.dequeue() {
             queue.extend(self.print_element(print_element_call.element, print_element_call.args));

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -103,6 +103,8 @@ impl<'a> Printer<'a> {
         self.print_with_indent(element, 0)
     }
 
+    /// Prints the passed in element as well as all its content,
+    /// starting at the specified indentation level
     pub(crate) fn print_with_indent(
         mut self,
         element: &'a FormatElement,
@@ -516,7 +518,7 @@ mod tests {
             token("\"d\""),
         ]));
 
-        assert_eq!(r#"["a", "b", "c", "d"]"#, result.code())
+        assert_eq!(r#"["a", "b", "c", "d"]"#, result.as_code())
     }
 
     #[test]
@@ -544,7 +546,7 @@ mod tests {
     c
   b
 a"#,
-            print_element(element).code()
+            print_element(element).as_code()
         )
     }
 
@@ -561,7 +563,7 @@ a"#,
 two lines`,
   "b",
 ]"#,
-            result.code()
+            result.as_code()
         )
     }
 
@@ -583,7 +585,7 @@ two lines`,
 
         assert_eq!(
             "function main() {\r\n\tlet x = `This is a multiline\r\nstring`;\r\n}\r\n",
-            result.code()
+            result.as_code()
         );
     }
 
@@ -611,7 +613,7 @@ two lines`,
   "d",
   ["0123456789", "0123456789", "0123456789", "0123456789", "0123456789"],
 ]"#,
-            result.code()
+            result.as_code()
         );
     }
 
@@ -631,7 +633,7 @@ two lines`,
             token("'d'"),
         ]));
 
-        assert_eq!("[\n\t'a',\n\t\'b',\n\t\'c',\n\t'd',\n]", result.code());
+        assert_eq!("[\n\t'a',\n\t\'b',\n\t\'c',\n\t'd',\n]", result.as_code());
     }
 
     fn create_array_element(items: Vec<FormatElement>) -> FormatElement {

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -20,7 +20,7 @@ impl ToFormatElement for JsPropertyClassMember {
 
         let semicolon = formatter
             .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(';'));
+            .unwrap_or_else(|| token(";"));
 
         Ok(format_elements![
             static_token,

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -28,7 +28,7 @@ impl ToFormatElement for JsDirective {
             formatter.format_token(&self.value_token()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';')),
+                .unwrap_or_else(|| token(";")),
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/literal_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/literal_expression.rs
@@ -1,4 +1,4 @@
-use crate::{token, FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{format_element::Token, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::{
     JsAnyLiteralExpression, JsBigIntLiteralExpression, JsBooleanLiteralExpression,
     JsNullLiteralExpression, JsNumberLiteralExpression, JsStringLiteralExpression,
@@ -13,12 +13,12 @@ impl ToFormatElement for JsStringLiteralExpression {
         let content = if quoted.starts_with('\'') {
             let s = &quoted[1..quoted.len() - 1];
             let s = format!("\"{}\"", s);
-            token(s)
+            Token::new_dynamic(&s, value_token.text_trimmed_range())
         } else {
-            token(quoted)
+            Token::from(&value_token)
         };
 
-        formatter.format_replaced(&value_token, content)
+        formatter.format_replaced(&value_token, content.into())
     }
 }
 

--- a/crates/rome_formatter/src/ts/expressions/literal_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/literal_expression.rs
@@ -13,7 +13,7 @@ impl ToFormatElement for JsStringLiteralExpression {
         let content = if quoted.starts_with('\'') {
             let s = &quoted[1..quoted.len() - 1];
             let s = format!("\"{}\"", s);
-            Token::new_dynamic(&s, value_token.text_trimmed_range())
+            Token::new_dynamic(s, value_token.text_trimmed_range())
         } else {
             Token::from(&value_token)
         };

--- a/crates/rome_formatter/src/ts/mod.rs
+++ b/crates/rome_formatter/src/ts/mod.rs
@@ -19,13 +19,13 @@ mod unknown;
 mod test {
     use rslint_parser::parse_script;
 
-    use crate::Formatter;
+    use crate::{format, FormatOptions};
 
     #[test]
     fn arrow_function() {
         let src = "let v = (value  , second_value) =>    true";
         let tree = parse_script(src, 0);
-        let result = Formatter::default().format_root(&tree.syntax()).unwrap();
+        let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
             "let v = (value, second_value) => true;
@@ -38,7 +38,7 @@ mod test {
         let src = r#"function foo() { return 'something' }"#;
 
         let tree = parse_script(src, 0);
-        let result = Formatter::default().format_root(&tree.syntax()).unwrap();
+        let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
             r#"function foo() {
@@ -52,7 +52,7 @@ mod test {
     fn array() {
         let src = r#"let users = [   'john', 'chandler', true ]"#;
         let tree = parse_script(src, 0);
-        let result = Formatter::default().format_root(&tree.syntax()).unwrap();
+        let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
             r#"let users = ["john", "chandler", true];
@@ -65,7 +65,7 @@ mod test {
         let src = r#"let a1 = [{}, {}];
 "#;
         let tree = parse_script(src, 0);
-        let result = Formatter::default().format_root(&tree.syntax()).unwrap();
+        let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
             result.code(),
             r#"let a1 = [{}, {}];

--- a/crates/rome_formatter/src/ts/mod.rs
+++ b/crates/rome_formatter/src/ts/mod.rs
@@ -15,6 +15,8 @@ mod statements;
 mod template;
 mod unknown;
 
+pub(crate) use statements::format_statements;
+
 #[cfg(test)]
 mod test {
     use rslint_parser::parse_script;
@@ -27,7 +29,7 @@ mod test {
         let tree = parse_script(src, 0);
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
-            result.code(),
+            result.as_code(),
             "let v = (value, second_value) => true;
 "
         );
@@ -40,7 +42,7 @@ mod test {
         let tree = parse_script(src, 0);
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
-            result.code(),
+            result.as_code(),
             r#"function foo() {
 	return "something";
 }
@@ -54,7 +56,7 @@ mod test {
         let tree = parse_script(src, 0);
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
-            result.code(),
+            result.as_code(),
             r#"let users = ["john", "chandler", true];
 "#
         );
@@ -67,7 +69,7 @@ mod test {
         let tree = parse_script(src, 0);
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         assert_eq!(
-            result.code(),
+            result.as_code(),
             r#"let a1 = [{}, {}];
 "#
         );

--- a/crates/rome_formatter/src/ts/statements/break_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/break_statement.rs
@@ -14,7 +14,7 @@ impl ToFormatElement for JsBreakStatement {
 
         let semicolon = formatter
             .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(';'));
+            .unwrap_or_else(|| token(";"));
 
         Ok(format_elements![
             formatter.format_token(&self.break_token()?)?,

--- a/crates/rome_formatter/src/ts/statements/continue_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/continue_statement.rs
@@ -14,7 +14,7 @@ impl ToFormatElement for JsContinueStatement {
 
         let semicolon = formatter
             .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(';'));
+            .unwrap_or_else(|| token(";"));
 
         Ok(format_elements![
             formatter.format_token(&self.continue_token()?)?,

--- a/crates/rome_formatter/src/ts/statements/debugger_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/debugger_statement.rs
@@ -7,7 +7,7 @@ impl ToFormatElement for JsDebuggerStatement {
             formatter.format_token(&self.debugger_token()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';'))
+                .unwrap_or_else(|| token(";"))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -24,7 +24,7 @@ impl ToFormatElement for JsDoWhileStatement {
             )?),
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';'))
+                .unwrap_or_else(|| token(";"))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/expression_statement.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsExpressionStatement {
             formatter.format_node(self.expression()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';'))
+                .unwrap_or_else(|| token(";"))
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/return_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/return_statement.rs
@@ -15,7 +15,7 @@ impl ToFormatElement for JsReturnStatement {
         tokens.push(
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';')),
+                .unwrap_or_else(|| token(";")),
         );
 
         Ok(concat_elements(tokens))

--- a/crates/rome_formatter/src/ts/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/throw_statement.rs
@@ -10,7 +10,7 @@ impl ToFormatElement for JsThrowStatement {
 
         let semicolon = formatter
             .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(';'));
+            .unwrap_or_else(|| token(";"));
 
         Ok(format_elements![
             throw_token,

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -14,7 +14,7 @@ impl ToFormatElement for JsVariableStatement {
             formatter.format_node(self.declarations()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(';')),
+                .unwrap_or_else(|| token(";")),
         ])
     }
 }

--- a/crates/rome_formatter/tests/spec_test.rs
+++ b/crates/rome_formatter/tests/spec_test.rs
@@ -48,7 +48,7 @@ pub fn run(spec_input_file: &str, _: &str, file_type: &str) {
         let input = fs::read_to_string(file_path).unwrap();
         let result = formatted_result.unwrap();
         // we ignore the error for now
-        let snapshot = format!("# Input\n{}\n---\n# Output\n{}", input, result.code());
+        let snapshot = format!("# Input\n{}\n---\n# Output\n{}", input, result.as_code());
 
         insta::with_settings!({
             prepend_module_to_snapshot => false,

--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -1,6 +1,6 @@
 use lspower::lsp::{
-    CodeActionProviderCapability, OneOf, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind,
+    CodeActionProviderCapability, DocumentOnTypeFormattingOptions, OneOf, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind,
 };
 
 pub(crate) fn server_capabilities() -> ServerCapabilities {
@@ -9,6 +9,10 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
         document_range_formatting_provider: Some(OneOf::Left(true)),
+        document_on_type_formatting_provider: Some(DocumentOnTypeFormattingOptions {
+            first_trigger_character: String::from("}"),
+            more_trigger_character: Some(vec![String::from("]"), String::from(")")]),
+        }),
         ..Default::default()
     }
 }

--- a/crates/rome_lsp/src/capabilities.rs
+++ b/crates/rome_lsp/src/capabilities.rs
@@ -8,6 +8,7 @@ pub(crate) fn server_capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
+        document_range_formatting_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -1,8 +1,8 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use lspower::lsp::*;
 use rome_analyze::FileId;
 use rome_formatter::{FormatOptions, IndentStyle};
-use rslint_parser::{parse_script, TextRange};
+use rslint_parser::{parse_script, TextRange, TokenAtOffset};
 
 use crate::line_index::{self, LineCol};
 
@@ -60,9 +60,75 @@ pub(crate) fn format_range(params: FormatRangeParams) -> Result<Vec<TextEdit>> {
     };
 
     let format_range = TextRange::new(start_index, end_index);
-    let formatted = rome_formatter::format_range(options, &tree, format_range)
-        // TODO: impl Error for FormatError
-        .unwrap();
+    let formatted = rome_formatter::format_range(options, &tree, format_range)?;
+
+    // Recalculate the actual range that was reformatted from the formatter result
+    let formatted_range = match formatted.range() {
+        Some(range) => {
+            let start_loc = line_index.line_col(range.start());
+            let end_loc = line_index.line_col(range.end());
+            Range {
+                start: Position {
+                    line: start_loc.line,
+                    character: start_loc.col,
+                },
+                end: Position {
+                    line: end_loc.line,
+                    character: end_loc.col,
+                },
+            }
+        }
+        None => Range {
+            start: Position::default(),
+            end: Position {
+                line: line_index.newlines.len().try_into()?,
+                character: 0,
+            },
+        },
+    };
+
+    Ok(vec![TextEdit {
+        range: formatted_range,
+        new_text: formatted.into_code(),
+    }])
+}
+
+pub(crate) struct FormatOnTypeParams<'input> {
+    pub(crate) text: &'input str,
+    pub(crate) file_id: FileId,
+    pub(crate) indent_style: IndentStyle,
+    pub(crate) position: Position,
+}
+
+pub(crate) fn format_on_type(params: FormatOnTypeParams) -> Result<Vec<TextEdit>> {
+    let tree = parse_script(params.text, params.file_id).syntax();
+
+    let line_index = line_index::LineIndex::new(params.text);
+    let offset = line_index.offset(LineCol {
+        line: params.position.line,
+        col: params.position.character,
+    });
+
+    let token = match tree.token_at_offset(offset) {
+        // File is empty, do nothing
+        TokenAtOffset::None => return Ok(vec![]),
+        TokenAtOffset::Single(token) => token,
+        // The cursor should be right after the closing character that was just typed,
+        // select the previous token as the correct one
+        TokenAtOffset::Between(token, _) => token,
+    };
+
+    let root_node = match token.parent() {
+        Some(node) => node,
+        None => bail!("found a token with no parent"),
+    };
+
+    let options = FormatOptions {
+        indent_style: params.indent_style,
+        line_width: 80,
+    };
+
+    let formatted = rome_formatter::format_node(options, &root_node)?;
 
     // Recalculate the actual range that was reformatted from the formatter result
     let formatted_range = match formatted.range() {

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use lspower::lsp::*;
 use rome_analyze::FileId;
 use rome_formatter::{FormatOptions, Formatter, IndentStyle};
-use rslint_parser::parse_script;
+use rslint_parser::{parse_script, TextRange};
 
-use crate::line_index;
+use crate::line_index::{self, LineCol};
 
 pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
     let tree = parse_script(text, file_id).syntax();
@@ -33,4 +33,65 @@ pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
 
     let edits = vec![TextEdit { range, new_text }];
     Ok(edits)
+}
+
+pub(crate) struct FormatRangeParams<'input> {
+    pub(crate) text: &'input str,
+    pub(crate) file_id: FileId,
+    pub(crate) indent_style: IndentStyle,
+    pub(crate) range: Range,
+}
+
+pub(crate) fn format_range(params: FormatRangeParams) -> Result<Vec<TextEdit>> {
+    let tree = parse_script(params.text, params.file_id).syntax();
+
+    let line_index = line_index::LineIndex::new(params.text);
+    let start_index = line_index.offset(LineCol {
+        line: params.range.start.line,
+        col: params.range.start.character,
+    });
+    let end_index = line_index.offset(LineCol {
+        line: params.range.end.line,
+        col: params.range.end.character,
+    });
+
+    let options = FormatOptions {
+        indent_style: params.indent_style,
+        line_width: 80,
+    };
+
+    let format_range = TextRange::new(start_index, end_index);
+    let formatted = rome_formatter::format_range(options, &tree, format_range)
+        // TODO: impl Error for FormatError
+        .unwrap();
+
+    // Recalculate the actual range that was reformatted from the formatter result
+    let formatted_range = match formatted.range() {
+        Some(range) => {
+            let start_loc = line_index.line_col(range.start());
+            let end_loc = line_index.line_col(range.end());
+            Range {
+                start: Position {
+                    line: start_loc.line,
+                    character: start_loc.col,
+                },
+                end: Position {
+                    line: end_loc.line,
+                    character: end_loc.col,
+                },
+            }
+        }
+        None => Range {
+            start: Position::default(),
+            end: Position {
+                line: line_index.newlines.len().try_into()?,
+                character: 0,
+            },
+        },
+    };
+
+    Ok(vec![TextEdit {
+        range: formatted_range,
+        new_text: formatted.into_code(),
+    }])
 }

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -14,11 +14,7 @@ pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
         line_width: 80,
     };
 
-    let new_text = rome_formatter::format(options, &tree)
-        // TODO: impl Error for FormatError
-        .unwrap()
-        .code()
-        .to_string();
+    let new_text = rome_formatter::format(options, &tree)?.into_code();
 
     let num_lines: u32 = line_index::LineIndex::new(text).newlines.len().try_into()?;
 

--- a/crates/rome_lsp/src/handlers.rs
+++ b/crates/rome_lsp/src/handlers.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use lspower::lsp::*;
 use rome_analyze::FileId;
-use rome_formatter::{FormatOptions, Formatter, IndentStyle};
+use rome_formatter::{FormatOptions, IndentStyle};
 use rslint_parser::{parse_script, TextRange};
 
 use crate::line_index::{self, LineCol};
@@ -14,8 +14,7 @@ pub fn format(text: &str, file_id: FileId) -> Result<Vec<TextEdit>> {
         line_width: 80,
     };
 
-    let new_text = Formatter::new(options)
-        .format_root(&tree)
+    let new_text = rome_formatter::format(options, &tree)
         // TODO: impl Error for FormatError
         .unwrap()
         .code()

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -4,6 +4,7 @@ use lspower::jsonrpc::Result;
 use lspower::lsp::*;
 use lspower::{Client, LanguageServer, LspService, Server};
 use rome_analyze::{AnalysisServer, FileId, Signal, TextAction};
+use rome_formatter::IndentStyle;
 use rslint_parser::TextRange;
 use tokio::io::{Stdin, Stdout};
 use tokio::sync::Mutex;
@@ -11,7 +12,7 @@ use tracing::{debug, error, trace, trace_span, Instrument};
 
 use crate::capabilities::server_capabilities;
 use crate::documents::{Document, DocumentStore};
-use crate::handlers;
+use crate::handlers::{self, FormatRangeParams};
 use crate::line_index::LineIndex;
 use crate::url_interner::UrlInterner;
 use crate::utils::{self, text_action_to_lsp};
@@ -248,6 +249,52 @@ impl LanguageServer for LSPServer {
                 None
             }
         };
+        Ok(opt)
+    }
+
+    async fn range_formatting(
+        &self,
+        params: DocumentRangeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let url = params.text_document.uri.clone();
+        trace!("Formatting: {:?}", url);
+
+        let file_id;
+        let text;
+        {
+            let mut state = self.state.lock().await;
+            file_id = state.url_interner.intern(url);
+            text = state.text_documents.get(&file_id).unwrap().text.clone();
+        }
+
+        let handle = tokio::spawn(async move {
+            handlers::format_range(FormatRangeParams {
+                text: text.as_ref(),
+                file_id,
+                indent_style: if params.options.insert_spaces {
+                    IndentStyle::Space(params.options.tab_size as u8)
+                } else {
+                    IndentStyle::Tab
+                },
+                range: params.range,
+            })
+        });
+
+        // TODO: Clean up this error handling
+        let opt = match handle.await {
+            Ok(res) => match res {
+                Ok(edits) => Some(edits),
+                Err(e) => {
+                    error!("Error while formatting: {}", e);
+                    None
+                }
+            },
+            Err(e) => {
+                error!("Error while joining thread: {}", e);
+                None
+            }
+        };
+
         Ok(opt)
     }
 


### PR DESCRIPTION
## Summary

This is an initial implementation of the range formatting API. It works by tracking the location of tokens between the input and output of the formatter, and use that information to remap the location of the formatting range from the source document to the result and slice the resulting code accordingly. I consider this an initial baseline implementation since it still reformats the entire document: the next step would be to find the lowest common ancestor for the start and end of the formatting range and reformat only that node, with the printer initialized to the correct indentation level.

This change introduce a layout modification of the `Token` type in the formatter: I added source location information alongside the text content, and took the opportunity to change its type from a struct to an enum and allow the text content to be static string in addition to a heap allocated one. This removes the need for an allocation in the common case of dynamically constructed tokens (eg. `token(",")`) at no additional memory cost (relative to adding a `source: Option<TextRange>` field to the existing `Token` struct) and makes differentiating the tokens created from the input source (with range information) and the ones created by the formatter easier. I also included the normalization of newline characters at token creations, all the line terminators supported in ECMAScript are now represented as "\n" in tokens.

Fixes #2009
