### PR TITLE
chore(git): add .vs to the list of ignored IDE directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Profile-*.json
 # Editor configuration
 .vscode
 .idea
+.vs
 # Release artifacts
 **/target
 # Ignore test files that contributors could create locally


### PR DESCRIPTION
## Summary

Visual Studio creates a .vs directory when opening the repo with it (for instance to run a profiling session), but much like other editors we don't want that to be committed
