### PR TITLE
feat(rome_rowan): implement DoubleEndedIterator for SyntaxTriviaPiecesIterator

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -326,7 +326,7 @@ where
             .last_trailing_trivia()
             .and_then(|prev_token| {
                 // Newline pieces can only come last in trailing trivias, skip to it directly
-                prev_token.pieces().last()?.as_newline()
+                prev_token.pieces().next_back()?.as_newline()
             })
             .is_some() as usize;
 

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -271,16 +271,10 @@ impl Formatter {
     }
 
     fn print_leading_trivia(&self, token: &SyntaxToken) -> FormatElement {
-        // False positive: the trivias need to be collected in a vector as they
-        // are iterated on in reverse order later, but SyntaxTriviaPiecesIterator
-        // doesn't implement DoubleEndedIterator (rust-lang/rust-clippy#8132)
-        #[allow(clippy::needless_collect)]
-        let pieces: Vec<_> = token.leading_trivia().pieces().collect();
-
         let mut line_count = 0;
         let mut elements = Vec::new();
 
-        for piece in pieces.into_iter().rev() {
+        for piece in token.leading_trivia().pieces().rev() {
             if let Some(comment) = piece.as_comments() {
                 let is_single_line = comment.text().trim_start().starts_with("//");
 

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -438,6 +438,18 @@ impl<L: Language> Iterator for SyntaxTriviaPiecesIterator<L> {
     }
 }
 
+impl<L: Language> DoubleEndedIterator for SyntaxTriviaPiecesIterator<L> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let (offset, trivia) = self.iter.next_back()?;
+        Some(SyntaxTriviaPiece {
+            raw: self.iter.raw.clone(),
+            offset,
+            trivia,
+            _p: PhantomData,
+        })
+    }
+}
+
 impl<L: Language> SyntaxTrivia<L> {
     /// Returns all [SyntaxTriviaPiece] of this trivia.
     ///
@@ -1691,6 +1703,7 @@ mod tests {
                 &[TriviaPiece::Whitespace(3)],
             );
         });
+
         let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
         assert_eq!(2, pieces.len());
 
@@ -1703,5 +1716,16 @@ mod tests {
         assert_eq!(TextSize::from(4), pieces[1].text_len());
         assert_eq!(TextRange::new(3.into(), 7.into()), pieces[1].text_range());
         assert!(pieces[1].as_comments().is_some());
+
+        let pieces_rev: Vec<_> = node
+            .first_leading_trivia()
+            .unwrap()
+            .pieces()
+            .rev()
+            .collect();
+
+        assert_eq!(2, pieces_rev.len());
+        assert_eq!("/**/", pieces_rev[0].text());
+        assert_eq!("\n\t ", pieces_rev[1].text());
     }
 }

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -40,6 +40,15 @@ impl GreenTokenTrivia {
         }
     }
 
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            GreenTokenTrivia::None => 0,
+            GreenTokenTrivia::Whitespace(_) => 1,
+            GreenTokenTrivia::Comment(..) => 1,
+            GreenTokenTrivia::Many(v) => v.len(),
+        }
+    }
+
     pub(crate) fn get_piece(&self, index: usize) -> Option<TriviaPiece> {
         match self {
             GreenTokenTrivia::Whitespace(l) if index == 0 => Some(TriviaPiece::Whitespace(*l)),


### PR DESCRIPTION
## Summary

Iterating over trivia pieces backward is required for a number of algorithms in the formatter, for instance when emitting leading comments or determining the indentation level of a token. This adds an implementation of DoubleEndedIterator for SyntaxTriviaPiecesIterator (and its internal iterator type) to make this process more efficient than having to collect all the pieces into a vector first