### PR TITLE
refactor(error): use thiserror to implement the Error trait on FormatError and SyntaxError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ dependencies = [
  "rome_rowan",
  "rslint_parser",
  "tests_macros",
+ "thiserror",
 ]
 
 [[package]]
@@ -1308,6 +1309,7 @@ dependencies = [
  "rslint_lexer",
  "rslint_syntax",
  "tests_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/rome_formatter/Cargo.toml
+++ b/crates/rome_formatter/Cargo.toml
@@ -11,6 +11,7 @@ rome_rowan = { path = "../rome_rowan" }
 rome_path = { version = "0.0.0", path = "../rome_path" }
 rome_core = { version = "0.0.0", path = "../rome_core" }
 cfg-if = "1.0.0"
+thiserror = "1.0.30"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -68,6 +68,7 @@ pub use printer::PrinterOptions;
 use rome_core::App;
 use rome_path::RomePath;
 use std::str::FromStr;
+use thiserror::Error;
 
 /// This trait should be implemented on each node/value that should have a formatted representation
 pub trait ToFormatElement {
@@ -77,16 +78,19 @@ pub trait ToFormatElement {
 /// Public return type of the formatter
 pub type FormatResult<F> = Result<F, FormatError>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 /// Series of errors encountered during formatting
 pub enum FormatError {
     /// Node is missing and it should be required for a correct formatting
+    #[error("missing required child")]
     MissingRequiredChild,
 
     /// In case our formatter doesn't know how to format a certain language
+    #[error("language is not supported")]
     UnsupportedLanguage,
 
     /// When the ability to format the current file has been turned off on purpose
+    #[error("formatting capability is disabled")]
     CapabilityDisabled,
 }
 

--- a/crates/rslint_parser/Cargo.toml
+++ b/crates/rslint_parser/Cargo.toml
@@ -17,6 +17,7 @@ drop_bomb = "0.1.5"
 bitflags = "1.3.2"
 indexmap = "1.8.0"
 cfg-if = "1.0.0"
+thiserror = "1.0.30"
 
 [dev-dependencies]
 tests_macros = { path = "../tests_macros" }

--- a/crates/rslint_parser/src/ast.rs
+++ b/crates/rslint_parser/src/ast.rs
@@ -12,10 +12,10 @@ mod ts_ext;
 mod union_ext;
 
 use crate::{syntax_node::*, util::SyntaxNodeExt, JsSyntaxKind, SyntaxList, TextRange};
-use std::error::Error;
 use std::fmt::{Debug, Formatter};
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
+use thiserror::Error;
 
 pub use self::{expr_ext::*, generated::nodes::*, stmt_ext::*, ts_ext::*};
 
@@ -327,20 +327,11 @@ impl<N: AstNode> FusedIterator for AstSeparatedListNodesIterator<N> {}
 /// Specific result used when navigating nodes using AST APIs
 pub type SyntaxResult<ResultType> = Result<ResultType, SyntaxError>;
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Error)]
 pub enum SyntaxError {
     /// Error thrown when a mandatory node is not found
+    #[error("missing required child")]
     MissingRequiredChild(SyntaxNode),
-}
-
-impl Error for SyntaxError {}
-
-impl std::fmt::Display for SyntaxError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SyntaxError::MissingRequiredChild(_) => write!(f, "missing required child"),
-        }
-    }
 }
 
 mod support {


### PR DESCRIPTION
## Summary

Use the procedural `Error` macro from the `thiserror` crate to automatically derive the `std::error::Error` and `std::fmt::Display` trait for the `FormatError` and `SyntaxError` types
