### PR TITLE
refactor(rome_formatter): change signature of `format_node`

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -121,7 +121,7 @@ impl Formatter {
     /// The parent may use [Self::format_verbatim] to insert the node content as is.
     pub fn format_node<T: AstNode + ToFormatElement>(
         &self,
-        node: T,
+        node: &T,
     ) -> FormatResult<FormatElement> {
         let leading = self.format_node_start(node.syntax());
         let trailing = self.format_node_end(node.syntax());
@@ -211,7 +211,7 @@ impl Formatter {
         let mut result = Vec::new();
 
         for node in nodes {
-            match self.format_node(node) {
+            match self.format_node(&node) {
                 Ok(formatted) => {
                     result.push(formatted);
                 }
@@ -242,7 +242,7 @@ impl Formatter {
         let last_index = list.len().saturating_sub(1);
 
         for (index, element) in list.elements().enumerate() {
-            let node = self.format_node(element.node()?)?;
+            let node = self.format_node(&element.node()?)?;
 
             // Reuse the existing trailing separator or create it if it wasn't in the
             // input source. Only print the last trailing token if the outer group breaks

--- a/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/array_assignment_pattern.rs
@@ -50,7 +50,7 @@ impl ToFormatElement for JsArrayAssignmentPatternRestElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/assignment/assignment_with_default.rs
+++ b/crates/rome_formatter/src/ts/assignment/assignment_with_default.rs
@@ -6,11 +6,11 @@ use rslint_parser::ast::JsAssignmentWithDefault;
 impl ToFormatElement for JsAssignmentWithDefault {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
             space_token(),
             formatter.format_token(&self.eq_token()?)?,
             space_token(),
-            formatter.format_node(self.default()?)?,
+            formatter.format_node(&self.default()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/assignment/computed_member_assignment.rs
+++ b/crates/rome_formatter/src/ts/assignment/computed_member_assignment.rs
@@ -4,9 +4,9 @@ use rslint_parser::ast::JsComputedMemberAssignment;
 impl ToFormatElement for JsComputedMemberAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.object()?)?,
+            formatter.format_node(&self.object()?)?,
             formatter.format_token(&self.l_brack_token()?)?,
-            formatter.format_node(self.member()?)?,
+            formatter.format_node(&self.member()?)?,
             formatter.format_token(&self.r_brack_token()?)?,
         ])
     }

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -52,12 +52,12 @@ impl ToFormatElement for JsAnyObjectAssignmentPatternMember {
 impl ToFormatElement for JsObjectAssignmentPatternShorthandProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let init_node = if let Some(node) = self.init() {
-            format_elements![space_token(), formatter.format_node(node)?]
+            format_elements![space_token(), formatter.format_node(&node)?]
         } else {
             empty_element()
         };
         Ok(format_elements![
-            formatter.format_node(self.identifier()?)?,
+            formatter.format_node(&self.identifier()?)?,
             init_node
         ])
     }
@@ -66,15 +66,15 @@ impl ToFormatElement for JsObjectAssignmentPatternShorthandProperty {
 impl ToFormatElement for JsObjectAssignmentPatternProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let init_node = if let Some(node) = self.init() {
-            format_elements![space_token(), formatter.format_node(node)?]
+            format_elements![space_token(), formatter.format_node(&node)?]
         } else {
             empty_element()
         };
         Ok(format_elements![
-            formatter.format_node(self.member()?)?,
+            formatter.format_node(&self.member()?)?,
             formatter.format_token(&self.colon_token()?)?,
             space_token(),
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
             init_node,
         ])
     }
@@ -84,7 +84,7 @@ impl ToFormatElement for JsObjectAssignmentPatternRest {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.target()?)?,
+            formatter.format_node(&self.target()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/assignment/parenthesized_assignment.rs
+++ b/crates/rome_formatter/src/ts/assignment/parenthesized_assignment.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsParenthesizedAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(self.assignment()?)?,
+            formatter.format_node(&self.assignment()?)?,
             formatter.format_token(&self.r_paren_token()?)?,
         ])
     }

--- a/crates/rome_formatter/src/ts/assignment/static_member_assignment.rs
+++ b/crates/rome_formatter/src/ts/assignment/static_member_assignment.rs
@@ -4,9 +4,9 @@ use rslint_parser::ast::JsStaticMemberAssignment;
 impl ToFormatElement for JsStaticMemberAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.object()?)?,
+            formatter.format_node(&self.object()?)?,
             formatter.format_token(&self.dot_token()?)?,
-            formatter.format_node(self.member()?)?,
+            formatter.format_node(&self.member()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/auxiliary/any_function.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/any_function.rs
@@ -24,16 +24,16 @@ impl ToFormatElement for JsAnyFunction {
         tokens.push(match self {
             JsAnyFunction::JsArrowFunctionExpression(_) => empty_element(),
             _ => match self.id()? {
-                Some(id) => format_elements![space_token(), formatter.format_node(id)?],
+                Some(id) => format_elements![space_token(), formatter.format_node(&id)?],
                 None => space_token(),
             },
         });
 
         tokens.push(match self.parameters()? {
             JsAnyArrowFunctionParameters::JsAnyBinding(binding) => {
-                format_elements![token("("), formatter.format_node(binding)?, token(")")]
+                format_elements![token("("), formatter.format_node(&binding)?, token(")")]
             }
-            JsAnyArrowFunctionParameters::JsParameters(params) => formatter.format_node(params)?,
+            JsAnyArrowFunctionParameters::JsParameters(params) => formatter.format_node(&params)?,
         });
 
         tokens.push(space_token());
@@ -43,7 +43,7 @@ impl ToFormatElement for JsAnyFunction {
             tokens.push(space_token());
         }
 
-        tokens.push(formatter.format_node(self.body()?)?);
+        tokens.push(formatter.format_node(&self.body()?)?);
 
         Ok(concat_elements(tokens))
     }

--- a/crates/rome_formatter/src/ts/auxiliary/initializer_clause.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/initializer_clause.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsInitializerClause {
         Ok(format_elements![
             formatter.format_token(&self.eq_token()?)?,
             space_token(),
-            formatter.format_node(self.expression()?)?
+            formatter.format_node(&self.expression()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/auxiliary/spread.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/spread.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsSpread {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.argument()?)?
+            formatter.format_node(&self.argument()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/binding_pattern_rest_element.rs
+++ b/crates/rome_formatter/src/ts/bindings/binding_pattern_rest_element.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsArrayBindingPatternRestElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_formatter/src/ts/bindings/binding_pattern_with_default.rs
@@ -6,11 +6,11 @@ use rslint_parser::ast::JsBindingPatternWithDefault;
 impl ToFormatElement for JsBindingPatternWithDefault {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
             space_token(),
             formatter.format_token(&self.eq_token()?)?,
             space_token(),
-            formatter.format_node(self.default()?)?
+            formatter.format_node(&self.default()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/ts/bindings/object_binding_pattern.rs
@@ -55,15 +55,15 @@ impl ToFormatElement for JsAnyObjectBindingPatternMember {
 impl ToFormatElement for JsObjectBindingPatternProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let init_node = if let Some(node) = self.init() {
-            format_elements![space_token(), formatter.format_node(node)?]
+            format_elements![space_token(), formatter.format_node(&node)?]
         } else {
             empty_element()
         };
         Ok(format_elements![
-            formatter.format_node(self.member()?)?,
+            formatter.format_node(&self.member()?)?,
             formatter.format_token(&self.colon_token()?)?,
             space_token(),
-            formatter.format_node(self.pattern()?)?,
+            formatter.format_node(&self.pattern()?)?,
             init_node,
         ])
     }
@@ -73,7 +73,7 @@ impl ToFormatElement for JsObjectBindingPatternRest {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.binding()?)?,
+            formatter.format_node(&self.binding()?)?,
         ])
     }
 }
@@ -81,12 +81,12 @@ impl ToFormatElement for JsObjectBindingPatternRest {
 impl ToFormatElement for JsObjectBindingPatternShorthandProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let init_node = if let Some(node) = self.init() {
-            format_elements![space_token(), formatter.format_node(node)?]
+            format_elements![space_token(), formatter.format_node(&node)?]
         } else {
             empty_element()
         };
         Ok(format_elements![
-            formatter.format_node(self.identifier()?)?,
+            formatter.format_node(&self.identifier()?)?,
             init_node
         ])
     }

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -7,13 +7,13 @@ use rslint_parser::ast::JsAnyClass;
 impl ToFormatElement for JsAnyClass {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let id = match self.id()? {
-            Some(id) => format_elements![space_token(), formatter.format_node(id)?],
+            Some(id) => format_elements![space_token(), formatter.format_node(&id)?],
             None => empty_element(),
         };
 
         let extends = match self.extends_clause() {
             Some(extends_clause) => {
-                format_elements![space_token(), formatter.format_node(extends_clause)?]
+                format_elements![space_token(), formatter.format_node(&extends_clause)?]
             }
             None => empty_element(),
         };

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -10,10 +10,10 @@ use rslint_parser::AstNode;
 impl ToFormatElement for JsConstructorClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.name()?)?,
-            formatter.format_node(self.parameters()?)?,
+            formatter.format_node(&self.name()?)?,
+            formatter.format_node(&self.parameters()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/extends_clause.rs
+++ b/crates/rome_formatter/src/ts/class/extends_clause.rs
@@ -8,7 +8,7 @@ impl ToFormatElement for JsExtendsClause {
         Ok(format_elements![
             formatter.format_token(&self.extends_token()?)?,
             space_token(),
-            formatter.format_node(self.super_class()?)?
+            formatter.format_node(&self.super_class()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/getter_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/getter_class_member.rs
@@ -8,11 +8,11 @@ impl ToFormatElement for JsGetterClassMember {
         Ok(format_elements![
             formatter.format_token(&self.get_token()?)?,
             space_token(),
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             formatter.format_token(&self.l_paren_token()?)?,
             formatter.format_token(&self.r_paren_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/method_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/method_class_member.rs
@@ -12,9 +12,9 @@ impl ToFormatElement for JsMethodClassMember {
             empty_element()
         };
         let star_token = formatter.format_token(&self.star_token())?;
-        let name = formatter.format_node(self.name()?)?;
-        let params = formatter.format_node(self.parameters()?)?;
-        let body = formatter.format_node(self.body()?)?;
+        let name = formatter.format_node(&self.name()?)?;
+        let params = formatter.format_node(&self.parameters()?)?;
+        let body = formatter.format_node(&self.body()?)?;
         Ok(format_elements![
             static_token,
             star_token,

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -13,7 +13,7 @@ impl ToFormatElement for JsPropertyClassMember {
         };
 
         let init = if let Some(init) = self.value() {
-            format_elements![space_token(), formatter.format_node(init)?]
+            format_elements![space_token(), formatter.format_node(&init)?]
         } else {
             empty_element()
         };
@@ -24,7 +24,7 @@ impl ToFormatElement for JsPropertyClassMember {
 
         Ok(format_elements![
             static_token,
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             init,
             semicolon
         ])

--- a/crates/rome_formatter/src/ts/class/setter_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/setter_class_member.rs
@@ -8,12 +8,12 @@ impl ToFormatElement for JsSetterClassMember {
         Ok(format_elements![
             formatter.format_token(&self.set_token()?)?,
             space_token(),
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(self.parameter()?)?,
+            formatter.format_node(&self.parameter()?)?,
             formatter.format_token(&self.r_paren_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -7,7 +7,7 @@ use rslint_parser::ast::{AstNode, AstNodeList, JsDirective, JsDirectiveList};
 pub fn format_directives(directives: JsDirectiveList, formatter: &Formatter) -> FormatElement {
     join_elements_hard_line(directives.iter().map(|directive| {
         let snapshot = formatter.snapshot();
-        let elem = match formatter.format_node(directive.clone()) {
+        let elem = match formatter.format_node(&directive) {
             Ok(result) => result,
             Err(_) => {
                 formatter.restore(snapshot);

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -25,7 +25,7 @@ impl ToFormatElement for JsArrayExpression {
                         let node = element.node()?;
                         let is_hole = matches!(node, JsAnyArrayElement::JsArrayHole(_));
 
-                        let elem = formatter.format_node(node.clone())?;
+                        let elem = formatter.format_node(&node)?;
                         let separator = if is_hole || index != last_index {
                             // If the previous element was empty or this is not the last element, always print a separator
                             if let Some(separator) = element.trailing_separator()? {

--- a/crates/rome_formatter/src/ts/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/call_expression.rs
@@ -3,9 +3,9 @@ use rslint_parser::ast::JsCallExpression;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let name = formatter.format_node(self.callee()?)?;
+        let name = formatter.format_node(&self.callee()?)?;
         let option = formatter.format_token(&self.optional_chain_token_token())?;
-        let arguments = formatter.format_node(self.arguments()?)?;
+        let arguments = formatter.format_node(&self.arguments()?)?;
 
         Ok(format_elements![name, option, arguments])
     }

--- a/crates/rome_formatter/src/ts/expressions/expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/expression.rs
@@ -107,7 +107,7 @@ impl ToFormatElement for JsParenthesizedExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(self.expression()?)?,
+            formatter.format_node(&self.expression()?)?,
             formatter.format_token(&self.r_paren_token()?)?
         ])
     }
@@ -122,10 +122,10 @@ impl ToFormatElement for JsComputedMemberExpression {
         };
 
         Ok(format_elements![
-            formatter.format_node(self.object()?)?,
+            formatter.format_node(&self.object()?)?,
             optional_chain_token,
             formatter.format_token(&self.l_brack_token()?)?,
-            formatter.format_node(self.member()?)?,
+            formatter.format_node(&self.member()?)?,
             formatter.format_token(&self.r_brack_token()?)?
         ])
     }
@@ -134,7 +134,7 @@ impl ToFormatElement for JsComputedMemberExpression {
 impl ToFormatElement for JsNewExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let arguments = if let Some(arguments) = self.arguments() {
-            formatter.format_node(arguments)?
+            formatter.format_node(&arguments)?
         } else {
             format_elements![token("("), token(")")]
         };
@@ -143,7 +143,7 @@ impl ToFormatElement for JsNewExpression {
             formatter.format_token(&self.new_token()?)?,
             // TODO handle TsTypeArgs
             space_token(),
-            formatter.format_node(self.callee()?)?,
+            formatter.format_node(&self.callee()?)?,
             arguments,
         ])
     }
@@ -161,7 +161,7 @@ impl ToFormatElement for JsUnaryExpression {
         Ok(format_elements![
             formatter.format_token(&self.operator()?)?,
             space_or_empty,
-            formatter.format_node(self.argument()?)?,
+            formatter.format_node(&self.argument()?)?,
         ])
     }
 }
@@ -169,11 +169,11 @@ impl ToFormatElement for JsUnaryExpression {
 impl ToFormatElement for JsBinaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.left()?)?,
+            formatter.format_node(&self.left()?)?,
             space_token(),
             formatter.format_token(&self.operator()?)?,
             space_token(),
-            formatter.format_node(self.right()?)?
+            formatter.format_node(&self.right()?)?
         ])
     }
 }
@@ -181,15 +181,15 @@ impl ToFormatElement for JsBinaryExpression {
 impl ToFormatElement for JsConditionalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.test()?)?,
+            formatter.format_node(&self.test()?)?,
             space_token(),
             formatter.format_token(&self.question_mark_token()?)?,
             space_token(),
-            formatter.format_node(self.consequent()?)?,
+            formatter.format_node(&self.consequent()?)?,
             space_token(),
             formatter.format_token(&self.colon_token()?)?,
             space_token(),
-            formatter.format_node(self.alternate()?)?,
+            formatter.format_node(&self.alternate()?)?,
         ])
     }
 }
@@ -197,11 +197,11 @@ impl ToFormatElement for JsConditionalExpression {
 impl ToFormatElement for JsAssignmentExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.left()?)?,
+            formatter.format_node(&self.left()?)?,
             space_token(),
             formatter.format_token(&self.operator_token()?)?,
             space_token(),
-            formatter.format_node(self.right()?)?,
+            formatter.format_node(&self.right()?)?,
         ])
     }
 }
@@ -219,7 +219,7 @@ impl ToFormatElement for NewTarget {
 impl ToFormatElement for JsYieldExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let argument = if let Some(node) = self.argument() {
-            formatter.format_node(node)?
+            formatter.format_node(&node)?
         } else {
             empty_element()
         };
@@ -242,7 +242,7 @@ impl ToFormatElement for JsYieldArgument {
         Ok(format_elements![
             star_token,
             space_token(),
-            formatter.format_node(self.expression()?)?
+            formatter.format_node(&self.expression()?)?
         ])
     }
 }
@@ -252,7 +252,7 @@ impl ToFormatElement for JsAwaitExpression {
         Ok(format_elements![
             formatter.format_token(&self.await_token()?)?,
             space_token(),
-            formatter.format_node(self.argument()?)?,
+            formatter.format_node(&self.argument()?)?,
         ])
     }
 }
@@ -260,11 +260,11 @@ impl ToFormatElement for JsAwaitExpression {
 impl ToFormatElement for JsLogicalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.left()?)?,
+            formatter.format_node(&self.left()?)?,
             space_token(),
             formatter.format_token(&self.operator()?)?,
             space_token(),
-            formatter.format_node(self.right()?)?,
+            formatter.format_node(&self.right()?)?,
         ])
     }
 }
@@ -272,11 +272,11 @@ impl ToFormatElement for JsLogicalExpression {
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.left()?)?,
+            formatter.format_node(&self.left()?)?,
             space_token(),
             formatter.format_token(&self.instanceof_token()?)?,
             space_token(),
-            formatter.format_node(self.right()?)?,
+            formatter.format_node(&self.right()?)?,
         ])
     }
 }
@@ -284,11 +284,11 @@ impl ToFormatElement for JsInstanceofExpression {
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.property()?)?,
+            formatter.format_node(&self.property()?)?,
             space_token(),
             formatter.format_token(&self.in_token()?)?,
             space_token(),
-            formatter.format_node(self.object()?)?,
+            formatter.format_node(&self.object()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/identifier_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/identifier_expression.rs
@@ -3,6 +3,6 @@ use rslint_parser::ast::JsIdentifierExpression;
 
 impl ToFormatElement for JsIdentifierExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_node(self.name()?)
+        formatter.format_node(&self.name()?)
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/sequence_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/sequence_expression.rs
@@ -7,10 +7,10 @@ use crate::{
 impl ToFormatElement for JsSequenceExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.left()?)?,
+            formatter.format_node(&self.left()?)?,
             formatter.format_token(&self.comma_token()?)?,
             space_token(),
-            formatter.format_node(self.right()?)?
+            formatter.format_node(&self.right()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/static_member_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/static_member_expression.rs
@@ -5,9 +5,9 @@ use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatEle
 impl ToFormatElement for JsStaticMemberExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.object()?)?,
+            formatter.format_node(&self.object()?)?,
             formatter.format_token(&self.operator()?)?,
-            formatter.format_node(self.member()?)?
+            formatter.format_node(&self.member()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/update_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/update_expression.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsPreUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.operator()?)?,
-            formatter.format_node(self.operand()?)?,
+            formatter.format_node(&self.operand()?)?,
         ])
     }
 }
@@ -13,7 +13,7 @@ impl ToFormatElement for JsPreUpdateExpression {
 impl ToFormatElement for JsPostUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.operand()?)?,
+            formatter.format_node(&self.operand()?)?,
             formatter.format_token(&self.operator()?)?,
         ])
     }

--- a/crates/rome_formatter/src/ts/import/mod.rs
+++ b/crates/rome_formatter/src/ts/import/mod.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsImportCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.import_token()?)?,
-            formatter.format_node(self.arguments()?)?,
+            formatter.format_node(&self.arguments()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/computed_member_name.rs
+++ b/crates/rome_formatter/src/ts/object_members/computed_member_name.rs
@@ -5,7 +5,7 @@ impl ToFormatElement for JsComputedMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.l_brack_token()?)?,
-            formatter.format_node(self.expression()?)?,
+            formatter.format_node(&self.expression()?)?,
             formatter.format_token(&self.r_brack_token()?)?,
         ])
     }

--- a/crates/rome_formatter/src/ts/object_members/getter_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/getter_object_member.rs
@@ -8,11 +8,11 @@ impl ToFormatElement for JsGetterObjectMember {
         Ok(format_elements![
             formatter.format_token(&self.get_token()?)?,
             space_token(),
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             formatter.format_token(&self.l_paren_token()?)?,
             formatter.format_token(&self.r_paren_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/method_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/method_object_member.rs
@@ -20,12 +20,12 @@ impl ToFormatElement for JsMethodObjectMember {
         Ok(format_elements![
             async_token,
             star_token,
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             // TODO self.type_params()
-            formatter.format_node(self.parameters()?)?,
+            formatter.format_node(&self.parameters()?)?,
             // TODO self.return_type()
             space_token(),
-            formatter.format_node(self.body()?)?,
+            formatter.format_node(&self.body()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/property_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/property_object_member.rs
@@ -5,9 +5,9 @@ use rslint_parser::ast::JsPropertyObjectMember;
 
 impl ToFormatElement for JsPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let key = formatter.format_node(self.name()?)?;
+        let key = formatter.format_node(&self.name()?)?;
         let colon = formatter.format_token(&self.colon_token()?)?;
-        let value = formatter.format_node(self.value()?)?;
+        let value = formatter.format_node(&self.value()?)?;
         Ok(format_elements![key, colon, space_token(), value])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/setter_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/setter_object_member.rs
@@ -8,12 +8,12 @@ impl ToFormatElement for JsSetterObjectMember {
         Ok(format_elements![
             formatter.format_token(&self.set_token()?)?,
             space_token(),
-            formatter.format_node(self.name()?)?,
+            formatter.format_node(&self.name()?)?,
             formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(self.parameter()?)?,
+            formatter.format_node(&self.parameter()?)?,
             formatter.format_token(&self.r_paren_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/shorthand_property_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/shorthand_property_object_member.rs
@@ -3,6 +3,6 @@ use rslint_parser::ast::JsShorthandPropertyObjectMember;
 
 impl ToFormatElement for JsShorthandPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_node(self.name()?)
+        formatter.format_node(&self.name()?)
     }
 }

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -39,7 +39,7 @@ impl ToFormatElement for JsRestParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
             formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(self.binding()?)?
+            formatter.format_node(&self.binding()?)?
         ])
     }
 }
@@ -47,13 +47,13 @@ impl ToFormatElement for JsRestParameter {
 impl ToFormatElement for JsParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let initializer = if let Some(initializer) = self.initializer() {
-            format_elements![space_token(), formatter.format_node(initializer)?]
+            format_elements![space_token(), formatter.format_node(&initializer)?]
         } else {
             empty_element()
         };
 
         Ok(format_elements![
-            formatter.format_node(self.binding()?)?,
+            formatter.format_node(&self.binding()?)?,
             initializer
         ])
     }

--- a/crates/rome_formatter/src/ts/root/mod.rs
+++ b/crates/rome_formatter/src/ts/root/mod.rs
@@ -10,7 +10,7 @@ mod script;
 pub fn format_module_item_list(list: JsModuleItemList, formatter: &Formatter) -> FormatElement {
     join_elements_hard_line(list.iter().map(|module_item| {
         let snapshot = formatter.snapshot();
-        let elem = match formatter.format_node(module_item.clone()) {
+        let elem = match formatter.format_node(&module_item) {
             Ok(result) => result,
             Err(_) => {
                 formatter.restore(snapshot);

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -9,7 +9,7 @@ impl ToFormatElement for JsDoWhileStatement {
         Ok(format_elements![
             formatter.format_token(&self.do_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?,
+            formatter.format_node(&self.body()?)?,
             space_token(),
             formatter.format_token(&self.while_token()?)?,
             space_token(),
@@ -17,7 +17,7 @@ impl ToFormatElement for JsDoWhileStatement {
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(self.test()?)?,
+                    formatter.format_node(&self.test()?)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,

--- a/crates/rome_formatter/src/ts/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/expression_statement.rs
@@ -5,7 +5,7 @@ use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFo
 impl ToFormatElement for JsExpressionStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.expression()?)?,
+            formatter.format_node(&self.expression()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
                 .unwrap_or_else(|| token(';'))

--- a/crates/rome_formatter/src/ts/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_in_statement.rs
@@ -8,10 +8,10 @@ use crate::{
 impl ToFormatElement for JsForInStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let for_token = formatter.format_token(&self.for_token()?)?;
-        let initializer = formatter.format_node(self.initializer()?)?;
+        let initializer = formatter.format_node(&self.initializer()?)?;
         let in_token = formatter.format_token(&self.in_token()?)?;
-        let expression = formatter.format_node(self.expression()?)?;
-        let body = formatter.format_node(self.body()?)?;
+        let expression = formatter.format_node(&self.expression()?)?;
+        let body = formatter.format_node(&self.body()?)?;
 
         Ok(format_elements![
             for_token,
@@ -55,7 +55,7 @@ impl ToFormatElement for JsForVariableDeclaration {
         Ok(format_elements![
             formatter.format_token(&self.kind_token()?)?,
             space_token(),
-            formatter.format_node(self.declaration()?)?
+            formatter.format_node(&self.declaration()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -8,10 +8,10 @@ use crate::{
 impl ToFormatElement for JsForOfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let for_token = formatter.format_token(&self.for_token()?)?;
-        let initializer = formatter.format_node(self.initializer()?)?;
+        let initializer = formatter.format_node(&self.initializer()?)?;
         let of_token = formatter.format_token(&self.of_token()?)?;
-        let expression = formatter.format_node(self.expression()?)?;
-        let body = formatter.format_node(self.body()?)?;
+        let expression = formatter.format_node(&self.expression()?)?;
+        let body = formatter.format_node(&self.body()?)?;
 
         Ok(format_elements![
             for_token,

--- a/crates/rome_formatter/src/ts/statements/for_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/for_stmt.rs
@@ -10,21 +10,21 @@ impl ToFormatElement for JsForStatement {
             if self.initializer().is_some() || self.test().is_some() || self.update().is_some() {
                 let mut inner = vec![];
                 if let Some(init) = self.initializer() {
-                    inner.push(formatter.format_node(init)?);
+                    inner.push(formatter.format_node(&init)?);
                 }
 
                 inner.push(formatter.format_token(&self.first_semi_token()?)?);
                 inner.push(soft_line_break_or_space());
 
                 if let Some(test) = self.test() {
-                    inner.push(formatter.format_node(test)?);
+                    inner.push(formatter.format_node(&test)?);
                 }
 
                 inner.push(formatter.format_token(&self.second_semi_token()?)?);
                 inner.push(soft_line_break_or_space());
 
                 if let Some(update) = self.update() {
-                    inner.push(formatter.format_node(update)?);
+                    inner.push(formatter.format_node(&update)?);
                 }
 
                 concat_elements(inner)
@@ -46,7 +46,7 @@ impl ToFormatElement for JsForStatement {
                 &self.r_paren_token()?,
             )?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ]))
     }
 }

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -7,7 +7,7 @@ use rslint_parser::ast::{JsElseClause, JsIfStatement};
 impl ToFormatElement for JsIfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let formatted_else_clause = if let Some(else_clause) = self.else_clause() {
-            format_elements![space_token(), formatter.format_node(else_clause)?]
+            format_elements![space_token(), formatter.format_node(&else_clause)?]
         } else {
             empty_element()
         };
@@ -20,14 +20,14 @@ impl ToFormatElement for JsIfStatement {
                     &self.l_paren_token()?,
                     |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
                         open_token_trailing,
-                        formatter.format_node(self.test()?)?,
+                        formatter.format_node(&self.test()?)?,
                         close_token_leading
                     ])),
                     &self.r_paren_token()?,
                 )?),
                 space_token(),
             ]),
-            formatter.format_node(self.consequent()?)?,
+            formatter.format_node(&self.consequent()?)?,
             formatted_else_clause
         ])
     }
@@ -38,7 +38,7 @@ impl ToFormatElement for JsElseClause {
         Ok(format_elements![
             formatter.format_token(&self.else_token()?)?,
             space_token(),
-            formatter.format_node(self.alternate()?)?,
+            formatter.format_node(&self.alternate()?)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/label_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/label_statement.rs
@@ -7,7 +7,7 @@ impl ToFormatElement for JsLabeledStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let label = formatter.format_token(&self.label_token()?)?;
         let colon = formatter.format_token(&self.colon_token()?)?;
-        let statement = formatter.format_node(self.body()?)?;
+        let statement = formatter.format_node(&self.body()?)?;
 
         Ok(format_elements![label, colon, space_token(), statement])
     }

--- a/crates/rome_formatter/src/ts/statements/mod.rs
+++ b/crates/rome_formatter/src/ts/statements/mod.rs
@@ -28,7 +28,7 @@ mod with_statement;
 pub fn format_statements(stmts: JsStatementList, formatter: &Formatter) -> FormatElement {
     join_elements_hard_line(stmts.iter().map(|stmt| {
         let snapshot = formatter.snapshot();
-        let elem = match formatter.format_node(stmt.clone()) {
+        let elem = match formatter.format_node(&stmt) {
             Ok(result) => result,
             Err(_) => {
                 formatter.restore(snapshot);

--- a/crates/rome_formatter/src/ts/statements/return_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/return_statement.rs
@@ -9,7 +9,7 @@ impl ToFormatElement for JsReturnStatement {
 
         if let Some(argument) = self.argument() {
             tokens.push(space_token());
-            tokens.push(formatter.format_node(argument)?);
+            tokens.push(formatter.format_node(&argument)?);
         }
 
         tokens.push(

--- a/crates/rome_formatter/src/ts/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/switch_statement.rs
@@ -15,7 +15,7 @@ impl ToFormatElement for JsSwitchStatement {
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(self.discriminant()?)?,
+                    formatter.format_node(&self.discriminant()?)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
@@ -74,7 +74,7 @@ impl ToFormatElement for JsCaseClause {
         let case_word = formatter.format_token(&self.case_token()?)?;
         let colon = formatter.format_token(&self.colon_token()?)?;
 
-        let test = formatter.format_node(self.test()?)?;
+        let test = formatter.format_node(&self.test()?)?;
 
         let cons = format_statements(self.consequent(), formatter);
 

--- a/crates/rome_formatter/src/ts/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/throw_statement.rs
@@ -6,7 +6,7 @@ use rslint_parser::ast::JsThrowStatement;
 impl ToFormatElement for JsThrowStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let throw_token = formatter.format_token(&self.throw_token()?)?;
-        let exception = formatter.format_node(self.argument()?)?;
+        let exception = formatter.format_node(&self.argument()?)?;
 
         let semicolon = formatter
             .format_token(&self.semicolon_token())?

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -11,9 +11,9 @@ impl ToFormatElement for JsTryStatement {
         Ok(format_elements![
             formatter.format_token(&self.try_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?,
+            formatter.format_node(&self.body()?)?,
             space_token(),
-            formatter.format_node(self.catch_clause()?)?
+            formatter.format_node(&self.catch_clause()?)?
         ])
     }
 }
@@ -21,7 +21,7 @@ impl ToFormatElement for JsTryStatement {
 impl ToFormatElement for JsTryFinallyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let formatted_catch_clause = if let Some(catch_clause) = self.catch_clause() {
-            format_elements![space_token(), formatter.format_node(catch_clause)?]
+            format_elements![space_token(), formatter.format_node(&catch_clause)?]
         } else {
             empty_element()
         };
@@ -29,10 +29,10 @@ impl ToFormatElement for JsTryFinallyStatement {
         Ok(format_elements![
             formatter.format_token(&self.try_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?,
+            formatter.format_node(&self.body()?)?,
             formatted_catch_clause,
             space_token(),
-            formatter.format_node(self.finally_clause()?)?
+            formatter.format_node(&self.finally_clause()?)?
         ])
     }
 }
@@ -43,15 +43,15 @@ impl ToFormatElement for JsCatchClause {
             Ok(format_elements![
                 formatter.format_token(&self.catch_token()?)?,
                 space_token(),
-                formatter.format_node(declaration)?,
+                formatter.format_node(&declaration)?,
                 space_token(),
-                formatter.format_node(self.body()?)?
+                formatter.format_node(&self.body()?)?
             ])
         } else {
             Ok(format_elements![
                 formatter.format_token(&self.catch_token()?)?,
                 space_token(),
-                formatter.format_node(self.body()?)?
+                formatter.format_node(&self.body()?)?
             ])
         }
     }
@@ -64,7 +64,7 @@ impl ToFormatElement for JsCatchDeclaration {
             |open_token_trailing, close_token_leading| {
                 Ok(soft_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(self.binding()?)?,
+                    formatter.format_node(&self.binding()?)?,
                     close_token_leading,
                 ]))
             },
@@ -78,7 +78,7 @@ impl ToFormatElement for JsFinallyClause {
         Ok(format_elements![
             formatter.format_token(&self.finally_token()?)?,
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -11,7 +11,7 @@ use rslint_parser::{
 impl ToFormatElement for JsVariableStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(self.declarations()?)?,
+            formatter.format_node(&self.declarations()?)?,
             formatter
                 .format_token(&self.semicolon_token())?
                 .unwrap_or_else(|| token(';')),
@@ -28,7 +28,7 @@ impl ToFormatElement for JsVariableDeclarations {
             .elements()
             .enumerate()
             .map(|(index, element)| {
-                let node = formatter.format_node(element.node()?)?;
+                let node = formatter.format_node(&element.node()?)?;
                 let separator = if let Some(separator) = element.trailing_separator()? {
                     if index == last_index {
                         formatter.format_replaced(&separator, empty_element())?
@@ -70,13 +70,13 @@ impl ToFormatElement for JsVariableDeclarations {
 impl ToFormatElement for JsVariableDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let initializer = if let Some(initializer) = self.initializer() {
-            format_elements![space_token(), formatter.format_node(initializer)?]
+            format_elements![space_token(), formatter.format_node(&initializer)?]
         } else {
             empty_element()
         };
 
         Ok(format_elements![
-            formatter.format_node(self.id()?)?,
+            formatter.format_node(&self.id()?)?,
             initializer
         ])
     }

--- a/crates/rome_formatter/src/ts/statements/while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/while_statement.rs
@@ -13,13 +13,13 @@ impl ToFormatElement for JsWhileStatement {
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(self.test()?)?,
+                    formatter.format_node(&self.test()?)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/with_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/with_statement.rs
@@ -13,13 +13,13 @@ impl ToFormatElement for JsWithStatement {
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(self.object()?)?,
+                    formatter.format_node(&self.object()?)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
             space_token(),
-            formatter.format_node(self.body()?)?
+            formatter.format_node(&self.body()?)?
         ])
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR changes the signature for `formatter.format_node` to accepting a reference to the node instead the node itself.

This change will unlock some utilities that will be added to #2012 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI, it should not break anything.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
