### PR TITLE
chor: TS Conformance expected errors

### DIFF
--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use crate::runner::{TestCase, TestRunOutcome, TestSuite};
 
 const BASE_PATH: &str = "xtask/coverage/Typescript/tests";
+const REFERENCE_PATH: &str = "xtask/coverage/Typescript/tests/baselines/reference";
 
 #[derive(Debug)]
 struct TypeScriptTestCase {
@@ -25,9 +26,7 @@ impl TestCase for TypeScriptTestCase {
         let syntax = Syntax::default().typescript();
         let r = parse(self.code(), 0, syntax);
 
-        let error_reference_file = Path::new(BASE_PATH)
-            .join("baselines")
-            .join("reference")
+        let error_reference_file = Path::new(REFERENCE_PATH)
             .join(self.path.with_extension("errors.txt").file_name().unwrap());
 
         let expected_errors = error_reference_file.exists();
@@ -56,6 +55,10 @@ impl TestSuite for TypeScriptTestSuite {
     }
 
     fn is_test(&self, path: &Path) -> bool {
+        if path.starts_with(REFERENCE_PATH) {
+            return false;
+        }
+
         match path.extension() {
             None => false,
             Some(ext) => ext == "ts",

--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -25,8 +25,19 @@ impl TestCase for TypeScriptTestCase {
         let syntax = Syntax::default().typescript();
         let r = parse(self.code(), 0, syntax);
 
+        let error_reference_file = Path::new(BASE_PATH)
+            .join("baselines")
+            .join("reference")
+            .join(self.path.with_extension("errors.txt").file_name().unwrap());
+
+        let expected_errors = error_reference_file.exists();
+
         match r.ok() {
-            Err(errors) => TestRunOutcome::IncorrectlyErrored { errors, syntax },
+            Err(errors) if !expected_errors => {
+                TestRunOutcome::IncorrectlyErrored { errors, syntax }
+            }
+            Err(_) => TestRunOutcome::Passed(syntax),
+            _ if expected_errors => TestRunOutcome::IncorrectlyPassed(syntax),
             _ => TestRunOutcome::Passed(syntax),
         }
     }

--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::runner::{TestCase, TestRunOutcome, TestSuite};
 
-const BASE_PATH: &str = "xtask/coverage/Typescript/tests";
+const CASES_PATH: &str = "xtask/coverage/Typescript/tests/cases";
 const REFERENCE_PATH: &str = "xtask/coverage/Typescript/tests/baselines/reference";
 
 #[derive(Debug)]
@@ -15,7 +15,7 @@ struct TypeScriptTestCase {
 
 impl TestCase for TypeScriptTestCase {
     fn path(&self) -> &Path {
-        self.path.strip_prefix(BASE_PATH).unwrap()
+        self.path.strip_prefix(CASES_PATH).unwrap()
     }
 
     fn code(&self) -> &str {
@@ -51,14 +51,10 @@ impl TestSuite for TypeScriptTestSuite {
     }
 
     fn base_path(&self) -> &str {
-        BASE_PATH
+        CASES_PATH
     }
 
     fn is_test(&self, path: &Path) -> bool {
-        if path.starts_with(REFERENCE_PATH) {
-            return false;
-        }
-
         match path.extension() {
             None => false,
             Some(ext) => ext == "ts",


### PR DESCRIPTION
The `baselines/reference` directory contains the expected outcome for every test.

Extend the TypeScript test case runner to check the reference directory to determine whether a test is expected to fail or not.

