### PR TITLE
feat(rome_formatter): normalize line terminators in template literals

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -380,7 +380,7 @@ impl Formatter {
 
                 // Print the full (not trimmed) text of the token
                 FormatElement::from(Token::new_dynamic(
-                    normalize_newlines(syntax_token.text()),
+                    normalize_newlines(syntax_token.text(), true),
                     syntax_token.text_range(),
                 ))
             }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use crate::{
     concat_elements, empty_element, empty_line,
-    format_element::{normalize_newlines, Token},
+    format_element::{normalize_newlines, Token, LINE_TERMINATORS},
     format_elements, hard_line_break, if_group_breaks, if_group_fits_on_single_line,
     join_elements_hard_line, line_suffix, soft_line_break_or_space, space_token, FormatElement,
     FormatOptions, FormatResult, ToFormatElement,
@@ -380,7 +380,7 @@ impl Formatter {
 
                 // Print the full (not trimmed) text of the token
                 FormatElement::from(Token::new_dynamic(
-                    normalize_newlines(syntax_token.text(), true),
+                    normalize_newlines(syntax_token.text(), LINE_TERMINATORS).into_owned(),
                     syntax_token.text_range(),
                 ))
             }

--- a/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
@@ -12,7 +12,7 @@ impl ToFormatElement for JsTemplateChunkElement {
         formatter.format_replaced(
             &chunk,
             FormatElement::from(Token::new_dynamic(
-                normalize_newlines(chunk.text_trimmed(), false),
+                normalize_newlines(chunk.text_trimmed(), ['\r']).into_owned(),
                 chunk.text_trimmed_range(),
             )),
         )

--- a/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
@@ -1,8 +1,41 @@
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{
+    format_element::{normalize_newlines, Token},
+    FormatElement, FormatResult, Formatter, ToFormatElement,
+};
 use rslint_parser::ast::JsTemplateChunkElement;
 
 impl ToFormatElement for JsTemplateChunkElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.template_chunk_token()?)
+        // Per https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-static-semantics-trv:
+        // In template literals, the '\r' and '\r\n' line terminators are normalized to '\n'
+        let chunk = self.template_chunk_token()?;
+        formatter.format_replaced(
+            &chunk,
+            FormatElement::from(Token::new_dynamic(
+                normalize_newlines(chunk.text_trimmed(), false),
+                chunk.text_trimmed_range(),
+            )),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{format, FormatOptions};
+    use rslint_parser::parse_script;
+
+    #[test]
+    fn template_line_breaks() {
+        const CODE: &str = "
+            const CR = `\r`;
+            const LF = `\n`;
+            const CR_LF = `\r\n`;
+            const LS = `\u{2028}`;
+            const PS = `\u{2029}`;
+        ";
+
+        let tree = parse_script(CODE, 0).syntax();
+        let result = format(FormatOptions::default(), &tree).unwrap();
+        assert!(!result.into_code().contains('\r'));
     }
 }


### PR DESCRIPTION
## Summary

Per the ECMAScript specification there is no semantic difference between `\r`, `\n` and `\r\n` in template literals (they all get normalized to `\n`). This means the formatter doesn't need to preserve these and can normalize them all to `\n`, which will get replaced with an OS-appropriate line ending sequence in the printer.
