### PR TITLE
refactor(rome_formatter): new format API, part 2

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -119,6 +119,7 @@ impl Formatter {
     ///
     /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.
     /// The parent may use [Self::format_verbatim] to insert the node content as is.
+    #[deprecated = "use the .format traits"]
     pub fn format_node<T: AstNode + ToFormatElement>(
         &self,
         node: &T,
@@ -171,7 +172,7 @@ impl Formatter {
     ///
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
-    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
+    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
     where
         T: token::FormattableToken,
@@ -179,10 +180,10 @@ impl Formatter {
         syntax_token.format(self)
     }
 
-    /// Print out a token from the original source with a different content
+    /// Print out a `token` from the original source with a different `content`.
     ///
-    /// This will print the associated trivias from the token as well as mark
-    /// it as having been consumed by the formatter
+    /// This will print the trivias that belong to `token` to `content`;
+    /// `token` is then marked as consumed by the formatter.
     pub fn format_replaced(
         &self,
         token: &SyntaxToken,

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -119,7 +119,7 @@ impl Formatter {
     ///
     /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.
     /// The parent may use [Self::format_verbatim] to insert the node content as is.
-    #[deprecated = "use the .format traits"]
+    // #[deprecated = "use the .format traits"]
     pub fn format_node<T: AstNode + ToFormatElement>(
         &self,
         node: &T,
@@ -172,7 +172,7 @@ impl Formatter {
     ///
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
-    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
+    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
     where
         T: token::FormattableToken,

--- a/crates/rome_formatter/src/formatter_traits.rs
+++ b/crates/rome_formatter/src/formatter_traits.rs
@@ -95,7 +95,7 @@ pub trait FormatOptionalTokenAndNode {
     where
         Or: FnOnce() -> FormatResult<FormatElement>,
     {
-        self.try_format_with_or(formatter, |token| Ok(token), op)
+        self.try_format_with_or(formatter, Ok, op)
     }
 
     /// If the token/node exists, it will call the first closure which will accept formatted element.

--- a/crates/rome_formatter/src/ts/auxiliary/any_function.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/any_function.rs
@@ -25,7 +25,7 @@ impl ToFormatElement for JsAnyFunction {
             _ => self.id().format_with_or(
                 formatter,
                 |id| format_elements![space_token(), id],
-                || space_token(),
+                space_token,
             )?,
         });
 

--- a/crates/rome_formatter/src/ts/class/constructor_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/constructor_class_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, join_elements, soft_block_indent, soft_line_break_or_space,
     space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -10,10 +11,10 @@ use rslint_parser::AstNode;
 impl ToFormatElement for JsConstructorClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(&self.name()?)?,
-            formatter.format_node(&self.parameters()?)?,
+            self.name().format(formatter)?,
+            self.parameters().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/extends_clause.rs
+++ b/crates/rome_formatter/src/ts/class/extends_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,9 +7,9 @@ use rslint_parser::ast::JsExtendsClause;
 impl ToFormatElement for JsExtendsClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.extends_token()?)?,
+            self.extends_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.super_class()?)?
+            self.super_class().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/getter_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/getter_class_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,13 +7,13 @@ use rslint_parser::ast::JsGetterClassMember;
 impl ToFormatElement for JsGetterClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.get_token()?)?,
+            self.get_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.name()?)?,
-            formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_token(&self.r_paren_token()?)?,
+            self.name().format(formatter)?,
+            self.l_paren_token().format(formatter)?,
+            self.r_paren_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/method_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/method_class_member.rs
@@ -1,20 +1,18 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsMethodClassMember;
 
 impl ToFormatElement for JsMethodClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let static_token = if let Some(token) = self.static_token() {
-            format_elements![formatter.format_token(&token)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let star_token = formatter.format_token(&self.star_token())?;
-        let name = formatter.format_node(&self.name()?)?;
-        let params = formatter.format_node(&self.parameters()?)?;
-        let body = formatter.format_node(&self.body()?)?;
+        let static_token = self
+            .static_token()
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let star_token = self.star_token().format_or_empty(formatter)?;
+        let name = self.name().format(formatter)?;
+        let params = self.parameters().format(formatter)?;
+        let body = self.body().format(formatter)?;
         Ok(format_elements![
             static_token,
             star_token,

--- a/crates/rome_formatter/src/ts/class/private_class_member_name.rs
+++ b/crates/rome_formatter/src/ts/class/private_class_member_name.rs
@@ -1,11 +1,12 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsPrivateClassMemberName;
 
 impl ToFormatElement for JsPrivateClassMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.hash_token()?)?,
-            formatter.format_token(&self.id_token()?)?,
+            self.hash_token().format(formatter)?,
+            self.id_token().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatOptionalTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -18,7 +18,7 @@ impl ToFormatElement for JsPropertyClassMember {
 
         Ok(format_elements![
             static_token,
-            formatter.format_node(&self.name()?)?,
+            self.name().format(formatter)?,
             init,
             semicolon
         ])

--- a/crates/rome_formatter/src/ts/class/property_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/property_class_member.rs
@@ -1,26 +1,20 @@
+use crate::formatter_traits::FormatOptionalTokenAndNode;
 use crate::{
-    empty_element, format_elements, space_token, token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsPropertyClassMember;
 
 impl ToFormatElement for JsPropertyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let static_token = if let Some(token) = self.static_token() {
-            format_elements![formatter.format_token(&token)?, space_token()]
-        } else {
-            empty_element()
-        };
+        let static_token = self
+            .static_token()
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
 
-        let init = if let Some(init) = self.value() {
-            format_elements![space_token(), formatter.format_node(&init)?]
-        } else {
-            empty_element()
-        };
+        let init = self
+            .value()
+            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
 
-        let semicolon = formatter
-            .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(";"));
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             static_token,

--- a/crates/rome_formatter/src/ts/class/setter_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/setter_class_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,14 +7,14 @@ use rslint_parser::ast::JsSetterClassMember;
 impl ToFormatElement for JsSetterClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.set_token()?)?,
+            self.set_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.name()?)?,
-            formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(&self.parameter()?)?,
-            formatter.format_token(&self.r_paren_token()?)?,
+            self.name().format(formatter)?,
+            self.l_paren_token().format(formatter)?,
+            self.parameter().format(formatter)?,
+            self.r_paren_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/array_expr.rs
+++ b/crates/rome_formatter/src/ts/expressions/array_expr.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     empty_element, format_element::join_elements_soft_line, format_elements, group_elements,
     if_group_breaks, soft_block_indent, token, FormatElement, FormatResult, Formatter,
@@ -26,14 +27,12 @@ impl ToFormatElement for JsArrayExpression {
                         let node = element.node()?;
                         let is_hole = matches!(node, JsAnyArrayElement::JsArrayHole(_));
 
-                        let elem = formatter.format_node(&node)?;
+                        let elem = node.format(formatter)?;
                         let separator = if is_hole || index != last_index {
                             // If the previous element was empty or this is not the last element, always print a separator
-                            if let Some(separator) = element.trailing_separator()? {
-                                formatter.format_token(&separator)?
-                            } else {
-                                token(",")
-                            }
+                            element
+                                .trailing_separator()
+                                .format_or(formatter, || token(";"))?
                         } else if let Some(separator) = element.trailing_separator()? {
                             formatter.format_replaced(&separator, if_group_breaks(token(",")))?
                         } else {

--- a/crates/rome_formatter/src/ts/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/call_expression.rs
@@ -1,11 +1,14 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsCallExpression;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let name = formatter.format_node(&self.callee()?)?;
-        let option = formatter.format_token(&self.optional_chain_token_token())?;
-        let arguments = formatter.format_node(&self.arguments()?)?;
+        let name = self.callee().format(formatter)?;
+        let option = self
+            .optional_chain_token_token()
+            .format_or_empty(formatter)?;
+        let arguments = self.arguments().format(formatter)?;
 
         Ok(format_elements![name, option, arguments])
     }

--- a/crates/rome_formatter/src/ts/expressions/expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/expression.rs
@@ -130,11 +130,9 @@ impl ToFormatElement for JsComputedMemberExpression {
 
 impl ToFormatElement for JsNewExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let arguments = self.arguments().format_with_or(
-            formatter,
-            |arguments| arguments,
-            || format_elements![token("("), token(")")],
-        )?;
+        let arguments = self
+            .arguments()
+            .format_or(formatter, || format_elements![token("("), token(")")])?;
 
         Ok(format_elements![
             self.new_token().format(formatter)?,

--- a/crates/rome_formatter/src/ts/expressions/regex_literal.rs
+++ b/crates/rome_formatter/src/ts/expressions/regex_literal.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsRegexLiteralExpression;
 
 impl ToFormatElement for JsRegexLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/template_element.rs
+++ b/crates/rome_formatter/src/ts/expressions/template_element.rs
@@ -1,11 +1,12 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsTemplateElement;
 
 impl ToFormatElement for JsTemplateElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let dollar_curly = formatter.format_token(&self.dollar_curly_token()?)?;
-        let expression = formatter.format_node(&self.expression()?)?;
-        let r_curly = formatter.format_token(&self.r_curly_token()?)?;
+        let dollar_curly = self.dollar_curly_token().format(formatter)?;
+        let expression = self.expression().format(formatter)?;
+        let r_curly = self.r_curly_token().format(formatter)?;
         Ok(format_elements![dollar_curly, expression, r_curly])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/update_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/update_expression.rs
@@ -1,11 +1,12 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::{JsPostUpdateExpression, JsPreUpdateExpression};
 
 impl ToFormatElement for JsPreUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.operator()?)?,
-            formatter.format_node(&self.operand()?)?,
+            self.operator().format(formatter)?,
+            self.operand().format(formatter)?,
         ])
     }
 }
@@ -13,8 +14,8 @@ impl ToFormatElement for JsPreUpdateExpression {
 impl ToFormatElement for JsPostUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(&self.operand()?)?,
-            formatter.format_token(&self.operator()?)?,
+            self.operand().format(formatter)?,
+            self.operator().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/computed_member_name.rs
+++ b/crates/rome_formatter/src/ts/object_members/computed_member_name.rs
@@ -1,12 +1,13 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsComputedMemberName;
 
 impl ToFormatElement for JsComputedMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.l_brack_token()?)?,
-            formatter.format_node(&self.expression()?)?,
-            formatter.format_token(&self.r_brack_token()?)?,
+            self.l_brack_token().format(formatter)?,
+            self.expression().format(formatter)?,
+            self.r_brack_token().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/getter_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/getter_object_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,13 +7,13 @@ use rslint_parser::ast::JsGetterObjectMember;
 impl ToFormatElement for JsGetterObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.get_token()?)?,
+            self.get_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.name()?)?,
-            formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_token(&self.r_paren_token()?)?,
+            self.name().format(formatter)?,
+            self.l_paren_token().format(formatter)?,
+            self.r_paren_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/literal_member_name.rs
+++ b/crates/rome_formatter/src/ts/object_members/literal_member_name.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsLiteralMemberName;
 
 impl ToFormatElement for JsLiteralMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value()?)
+        self.value().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/method_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/method_object_member.rs
@@ -1,31 +1,26 @@
-use rslint_parser::ast::JsMethodObjectMember;
-
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
+use rslint_parser::ast::JsMethodObjectMember;
 
 impl ToFormatElement for JsMethodObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let async_token = if let Some(token) = self.async_token() {
-            format_elements![formatter.format_token(&token)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let star_token = if let Some(token) = self.star_token() {
-            formatter.format_token(&token)?
-        } else {
-            empty_element()
-        };
+        let async_token = self
+            .async_token()
+            .format_with_or_empty(formatter, |async_token| {
+                format_elements![async_token, space_token()]
+            })?;
+        let star_token = self.star_token().format_or_empty(formatter)?;
         Ok(format_elements![
             async_token,
             star_token,
-            formatter.format_node(&self.name()?)?,
+            self.name().format(formatter)?,
             // TODO self.type_params()
-            formatter.format_node(&self.parameters()?)?,
+            self.parameters().format(formatter)?,
             // TODO self.return_type()
             space_token(),
-            formatter.format_node(&self.body()?)?,
+            self.body().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/property_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/property_object_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,9 +6,9 @@ use rslint_parser::ast::JsPropertyObjectMember;
 
 impl ToFormatElement for JsPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let key = formatter.format_node(&self.name()?)?;
-        let colon = formatter.format_token(&self.colon_token()?)?;
-        let value = formatter.format_node(&self.value()?)?;
+        let key = self.name().format(formatter)?;
+        let colon = self.colon_token().format(formatter)?;
+        let value = self.value().format(formatter)?;
         Ok(format_elements![key, colon, space_token(), value])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/setter_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/setter_object_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,14 +7,14 @@ use rslint_parser::ast::JsSetterObjectMember;
 impl ToFormatElement for JsSetterObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.set_token()?)?,
+            self.set_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.name()?)?,
-            formatter.format_token(&self.l_paren_token()?)?,
-            formatter.format_node(&self.parameter()?)?,
-            formatter.format_token(&self.r_paren_token()?)?,
+            self.name().format(formatter)?,
+            self.l_paren_token().format(formatter)?,
+            self.parameter().format(formatter)?,
+            self.r_paren_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/object_members/shorthand_property_object_member.rs
+++ b/crates/rome_formatter/src/ts/object_members/shorthand_property_object_member.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsShorthandPropertyObjectMember;
 
 impl ToFormatElement for JsShorthandPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_node(&self.name()?)
+        self.name().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/statements/block.rs
+++ b/crates/rome_formatter/src/ts/statements/block.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     block_indent, format_elements, hard_line_break, FormatElement, FormatResult, Formatter,
     ToFormatElement,
@@ -11,9 +12,9 @@ impl ToFormatElement for JsBlockStatement {
 
         if is_non_collapsable_empty_block(self) {
             Ok(format_elements![
-                formatter.format_token(&self.l_curly_token()?)?,
+                self.l_curly_token().format(formatter)?,
                 hard_line_break(),
-                formatter.format_token(&self.r_curly_token()?)?
+                self.r_curly_token().format(formatter)?
             ])
         } else {
             formatter.format_delimited(

--- a/crates/rome_formatter/src/ts/statements/break_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/break_statement.rs
@@ -1,23 +1,19 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsBreakStatement;
 
 impl ToFormatElement for JsBreakStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let label = if let Some(label_token) = self.label_token() {
-            format_elements![space_token(), formatter.format_token(&label_token)?]
-        } else {
-            empty_element()
-        };
+        let label = self
+            .label_token()
+            .format_with_or_empty(formatter, |label| format_elements![space_token(), label])?;
 
-        let semicolon = formatter
-            .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(";"));
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
-            formatter.format_token(&self.break_token()?)?,
+            self.break_token().format(formatter)?,
             label,
             semicolon,
         ])

--- a/crates/rome_formatter/src/ts/statements/continue_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/continue_statement.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatOptionalTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -13,7 +13,7 @@ impl ToFormatElement for JsContinueStatement {
         let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
-            formatter.format_token(&self.continue_token()?)?,
+            self.continue_token().format(formatter)?,
             label,
             semicolon
         ])

--- a/crates/rome_formatter/src/ts/statements/debugger_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/debugger_statement.rs
@@ -1,13 +1,12 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsDebuggerStatement;
 
 impl ToFormatElement for JsDebuggerStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.debugger_token()?)?,
-            formatter
-                .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(";"))
+            self.debugger_token().format(formatter)?,
+            self.semicolon_token().format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/do_while_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, group_elements, soft_block_indent, space_token, token, FormatElement,
     FormatResult, Formatter, ToFormatElement,
@@ -7,24 +8,22 @@ use rslint_parser::ast::JsDoWhileStatement;
 impl ToFormatElement for JsDoWhileStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.do_token()?)?,
+            self.do_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?,
+            self.body().format(formatter)?,
             space_token(),
-            formatter.format_token(&self.while_token()?)?,
+            self.while_token().format(formatter)?,
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(&self.test()?)?,
+                    self.test().format(formatter)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
-            formatter
-                .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(";"))
+            self.semicolon_token().format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/expression_statement.rs
@@ -1,14 +1,12 @@
-use rslint_parser::ast::JsExpressionStatement;
-
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsExpressionStatement;
 
 impl ToFormatElement for JsExpressionStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(&self.expression()?)?,
-            formatter
-                .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(";"))
+            self.expression().format(formatter)?,
+            self.semicolon_token().format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_in_statement.rs
@@ -1,5 +1,6 @@
 use rslint_parser::ast::{JsAnyForInOrOfInitializer, JsForInStatement, JsForVariableDeclaration};
 
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
     FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -7,11 +8,11 @@ use crate::{
 
 impl ToFormatElement for JsForInStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let for_token = formatter.format_token(&self.for_token()?)?;
-        let initializer = formatter.format_node(&self.initializer()?)?;
-        let in_token = formatter.format_token(&self.in_token()?)?;
-        let expression = formatter.format_node(&self.expression()?)?;
-        let body = formatter.format_node(&self.body()?)?;
+        let for_token = self.for_token().format(formatter)?;
+        let initializer = self.initializer().format(formatter)?;
+        let in_token = self.in_token().format(formatter)?;
+        let expression = self.expression().format(formatter)?;
+        let body = self.body().format(formatter)?;
 
         Ok(format_elements![
             for_token,
@@ -53,9 +54,9 @@ impl ToFormatElement for JsAnyForInOrOfInitializer {
 impl ToFormatElement for JsForVariableDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.kind_token()?)?,
+            self.kind_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.declaration()?)?
+            self.declaration().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -1,5 +1,6 @@
 use rslint_parser::ast::JsForOfStatement;
 
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
     FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -7,11 +8,11 @@ use crate::{
 
 impl ToFormatElement for JsForOfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let for_token = formatter.format_token(&self.for_token()?)?;
-        let initializer = formatter.format_node(&self.initializer()?)?;
-        let of_token = formatter.format_token(&self.of_token()?)?;
-        let expression = formatter.format_node(&self.expression()?)?;
-        let body = formatter.format_node(&self.body()?)?;
+        let for_token = self.for_token().format(formatter)?;
+        let initializer = self.initializer().format(formatter)?;
+        let of_token = self.of_token().format(formatter)?;
+        let expression = self.expression().format(formatter)?;
+        let body = self.body().format(formatter)?;
 
         Ok(format_elements![
             for_token,

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -1,7 +1,7 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
+    Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{JsElseClause, JsIfStatement};
 

--- a/crates/rome_formatter/src/ts/statements/if_stmt.rs
+++ b/crates/rome_formatter/src/ts/statements/if_stmt.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
     FormatResult, Formatter, ToFormatElement,
@@ -6,22 +7,22 @@ use rslint_parser::ast::{JsElseClause, JsIfStatement};
 
 impl ToFormatElement for JsIfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let formatted_else_clause = if let Some(else_clause) = self.else_clause() {
-            format_elements![space_token(), formatter.format_node(&else_clause)?]
-        } else {
-            empty_element()
-        };
+        let else_caluse = self
+            .else_clause()
+            .format_with_or_empty(formatter, |else_clause| {
+                format_elements![space_token(), else_clause]
+            })?;
 
         Ok(format_elements![
             group_elements(format_elements![
-                formatter.format_token(&self.if_token()?)?,
+                self.if_token().format(formatter)?,
                 space_token(),
                 group_elements(formatter.format_delimited(
                     &self.l_paren_token()?,
                     |open_token_trailing, close_token_leading| Ok(soft_block_indent(
                         format_elements![
                             open_token_trailing,
-                            formatter.format_node(&self.test()?)?,
+                            self.test().format(formatter)?,
                             close_token_leading
                         ]
                     )),
@@ -29,8 +30,8 @@ impl ToFormatElement for JsIfStatement {
                 )?),
                 space_token(),
             ]),
-            formatter.format_node(&self.consequent()?)?,
-            formatted_else_clause
+            self.consequent().format(formatter)?,
+            else_caluse
         ])
     }
 }
@@ -38,9 +39,9 @@ impl ToFormatElement for JsIfStatement {
 impl ToFormatElement for JsElseClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.else_token()?)?,
+            self.else_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.alternate()?)?,
+            self.alternate().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/label_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/label_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,9 +6,9 @@ use rslint_parser::ast::JsLabeledStatement;
 
 impl ToFormatElement for JsLabeledStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let label = formatter.format_token(&self.label_token()?)?;
-        let colon = formatter.format_token(&self.colon_token()?)?;
-        let statement = formatter.format_node(&self.body()?)?;
+        let label = self.label_token().format(formatter)?;
+        let colon = self.colon_token().format(formatter)?;
+        let statement = self.body().format(formatter)?;
 
         Ok(format_elements![label, colon, space_token(), statement])
     }

--- a/crates/rome_formatter/src/ts/statements/return_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/return_statement.rs
@@ -1,21 +1,22 @@
 use crate::formatter_traits::FormatOptionalTokenAndNode;
 use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
-    concat_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsReturnStatement;
 
 impl ToFormatElement for JsReturnStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let mut tokens = vec![self.return_token().format(formatter)?];
+        let return_token = self.return_token().format(formatter)?;
 
-        if let Some(argument) = self.argument() {
-            tokens.push(space_token());
-            tokens.push(argument.format(formatter)?);
-        }
+        let argument = self
+            .argument()
+            .format_with_or_empty(formatter, |argument| {
+                format_elements![space_token(), argument]
+            })?;
 
-        tokens.push(self.semicolon_token().format_or(formatter, || token(";"))?);
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
-        Ok(concat_elements(tokens))
+        Ok(format_elements![return_token, argument, semicolon])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/switch_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{block_indent, FormatResult};
 use crate::{
     format_element::indent, format_elements, group_elements, hard_line_break,
@@ -9,13 +10,13 @@ use rslint_parser::ast::{JsAnySwitchClause, JsCaseClause, JsDefaultClause, JsSwi
 impl ToFormatElement for JsSwitchStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.switch_token()?)?,
+            self.switch_token().format(formatter)?,
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(&self.discriminant()?)?,
+                    self.discriminant().format(formatter)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
@@ -55,8 +56,8 @@ impl ToFormatElement for JsAnySwitchClause {
 
 impl ToFormatElement for JsDefaultClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default = formatter.format_token(&self.default_token()?)?;
-        let colon = formatter.format_token(&self.colon_token()?)?;
+        let default = self.default_token().format(formatter)?;
+        let colon = self.colon_token().format(formatter)?;
         let statements = formatter.format_list(self.consequent());
 
         Ok(format_elements![
@@ -71,11 +72,9 @@ impl ToFormatElement for JsDefaultClause {
 
 impl ToFormatElement for JsCaseClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let case_word = formatter.format_token(&self.case_token()?)?;
-        let colon = formatter.format_token(&self.colon_token()?)?;
-
-        let test = formatter.format_node(&self.test()?)?;
-
+        let case_word = self.case_token().format(formatter)?;
+        let colon = self.colon_token().format(formatter)?;
+        let test = self.test().format(formatter)?;
         let cons = formatter.format_list(self.consequent());
 
         Ok(format_elements![

--- a/crates/rome_formatter/src/ts/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/throw_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,12 +6,9 @@ use rslint_parser::ast::JsThrowStatement;
 
 impl ToFormatElement for JsThrowStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let throw_token = formatter.format_token(&self.throw_token()?)?;
-        let exception = formatter.format_node(&self.argument()?)?;
-
-        let semicolon = formatter
-            .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(";"));
+        let throw_token = self.throw_token().format(formatter)?;
+        let exception = self.argument().format(formatter)?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             throw_token,

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -1,7 +1,7 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
+    Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{
     JsCatchClause, JsCatchDeclaration, JsFinallyClause, JsTryFinallyStatement, JsTryStatement,

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
     FormatResult, Formatter, ToFormatElement,
@@ -12,49 +12,53 @@ impl ToFormatElement for JsTryStatement {
         Ok(format_elements![
             self.try_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?,
+            self.body().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.catch_clause()?)?
+            self.catch_clause().format(formatter)?,
         ])
     }
 }
 
 impl ToFormatElement for JsTryFinallyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let formatted_catch_clause = if let Some(catch_clause) = self.catch_clause() {
-            format_elements![space_token(), formatter.format_node(&catch_clause)?]
-        } else {
-            empty_element()
-        };
+        let formatted_catch_clause = self
+            .catch_clause()
+            .format_with_or_empty(formatter, |catch_clause| {
+                format_elements![space_token(), catch_clause]
+            })?;
 
         Ok(format_elements![
             self.try_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?,
+            self.body().format(formatter)?,
             formatted_catch_clause,
             space_token(),
-            formatter.format_node(&self.finally_clause()?)?
+            self.finally_clause().format(formatter)?
         ])
     }
 }
 
 impl ToFormatElement for JsCatchClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        if let Some(declaration) = self.declaration() {
-            Ok(format_elements![
-                self.catch_token().format(formatter)?,
-                space_token(),
-                formatter.format_node(&declaration)?,
-                space_token(),
-                formatter.format_node(&self.body()?)?
-            ])
-        } else {
-            Ok(format_elements![
-                self.catch_token().format(formatter)?,
-                space_token(),
-                formatter.format_node(&self.body()?)?
-            ])
-        }
+        self.declaration().try_format_with_or(
+            formatter,
+            |declaration| {
+                Ok(format_elements![
+                    self.catch_token().format(formatter)?,
+                    space_token(),
+                    declaration,
+                    space_token(),
+                    self.body().format(formatter)?
+                ])
+            },
+            || {
+                Ok(format_elements![
+                    self.catch_token().format(formatter)?,
+                    space_token(),
+                    self.body().format(formatter)?
+                ])
+            },
+        )
     }
 }
 
@@ -65,7 +69,7 @@ impl ToFormatElement for JsCatchDeclaration {
             |open_token_trailing, close_token_leading| {
                 Ok(soft_block_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(&self.binding()?)?,
+                    self.binding().format(formatter)?,
                     close_token_leading,
                 ]))
             },
@@ -79,7 +83,7 @@ impl ToFormatElement for JsFinallyClause {
         Ok(format_elements![
             self.finally_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/try_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/try_statement.rs
@@ -40,7 +40,7 @@ impl ToFormatElement for JsTryFinallyStatement {
 
 impl ToFormatElement for JsCatchClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.declaration().try_format_with_or(
+        self.declaration().format_with_or(
             formatter,
             |declaration| {
                 Ok(format_elements![

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -28,14 +28,11 @@ impl ToFormatElement for JsVariableDeclarations {
             .enumerate()
             .map(|(index, element)| {
                 let node = element.node().format(formatter)?;
-                let separator = element.trailing_separator().try_format_with_or(
+                let separator = element.trailing_separator().format_with_or(
                     formatter,
                     |separator| {
-                        // SAFETY: it's fine to do a double unwrap because both checks on Result and Option
-                        // are already done inside the traits.
-                        let token = element.trailing_separator().unwrap().unwrap();
                         if index == last_index {
-                            formatter.format_replaced(&token, empty_element())
+                            Ok(empty_element())
                         } else {
                             Ok(separator)
                         }

--- a/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/variable_declaration_statement.rs
@@ -30,11 +30,12 @@ impl ToFormatElement for JsVariableDeclarations {
                 let node = element.node().format(formatter)?;
                 let separator = element.trailing_separator().try_format_with_or(
                     formatter,
-                    |separator, token| {
+                    |separator| {
+                        // SAFETY: it's fine to do a double unwrap because both checks on Result and Option
+                        // are already done inside the traits.
+                        let token = element.trailing_separator().unwrap().unwrap();
                         if index == last_index {
-                            // SAFETY: it's fine to do a double unwrap because both checks on Result and Option
-                            // are already done inside the traits.
-                            formatter.format_replaced(&token.unwrap().unwrap(), empty_element())
+                            formatter.format_replaced(&token, empty_element())
                         } else {
                             Ok(separator)
                         }

--- a/crates/rome_formatter/src/ts/statements/while_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/while_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
     Formatter, ToFormatElement,
@@ -7,19 +8,19 @@ use rslint_parser::ast::JsWhileStatement;
 impl ToFormatElement for JsWhileStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.while_token()?)?,
+            self.while_token().format(formatter)?,
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(&self.test()?)?,
+                    self.test().format(formatter)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/statements/with_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/with_statement.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
     Formatter, ToFormatElement,
@@ -7,19 +8,19 @@ use rslint_parser::ast::JsWithStatement;
 impl ToFormatElement for JsWithStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.with_token()?)?,
+            self.with_token().format(formatter)?,
             space_token(),
             group_elements(formatter.format_delimited(
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
                     open_token_trailing,
-                    formatter.format_node(&self.object()?)?,
+                    self.object().format(formatter)?,
                     close_token_leading,
                 ])),
                 &self.r_paren_token()?,
             )?),
             space_token(),
-            formatter.format_node(&self.body()?)?
+            self.body().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js
@@ -14,6 +14,8 @@ class Foo extends Boar {
 
 	}
 
+	* generator (){}
+
 	lorem() {
 		return "ipsum";
 	}

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
@@ -21,6 +21,8 @@ class Foo extends Boar {
 
 	}
 
+	* generator (){}
+
 	lorem() {
 		return "ipsum";
 	}
@@ -65,6 +67,8 @@ class Foo extends Boar {
 	get g() {}
 
 	set gg(a) {}
+
+	*generator() {}
 
 	lorem() {
 		return "ipsum";


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #1996 

This PR refactors more code to use the new format API. 

While doing so, I encountered new edge cases, because of that I created new APIs for these cases:
- `try_format_with_or` which allow the use of the try operator inside the closures
- `try_format_with` which allow the use of the try operator inside the closures

I've also fixed some bug in the process.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing tests should not break

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
