### PR TITLE
refactor(rome_formatter): new format API, part 3

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -115,24 +115,6 @@ impl Formatter {
         ])
     }
 
-    /// Recursively formats the ast node and all its children
-    ///
-    /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.
-    /// The parent may use [Self::format_verbatim] to insert the node content as is.
-    #[deprecated = "use the .format traits"]
-    pub fn format_node<T: AstNode + ToFormatElement>(
-        &self,
-        node: &T,
-    ) -> FormatResult<FormatElement> {
-        let leading = self.format_node_start(node.syntax());
-        let trailing = self.format_node_end(node.syntax());
-        Ok(format_elements![
-            leading,
-            node.to_format_element(self)?,
-            trailing,
-        ])
-    }
-
     /// Helper function that returns what should be printed before the node that work on
     /// the non-generic [SyntaxNode] to avoid unrolling the logic for every [AstNode] type.
     pub(super) fn format_node_start(&self, _node: &SyntaxNode) -> FormatElement {
@@ -145,39 +127,6 @@ impl Formatter {
     pub(super) fn format_node_end(&self, _node: &SyntaxNode) -> FormatElement {
         // TODO: Sets the marker for the end source map location, ...
         empty_element()
-    }
-
-    /// Formats the passed in token.
-    ///
-    /// May return `None` if the token wasn't present in the original source but was inserted
-    /// by the parser to "fix" a syntax error and generate a valid tree.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rome_formatter::{Formatter, token};
-    /// use rslint_parser::{SyntaxNode, T, SyntaxToken, JsLanguage, JsSyntaxKind, SyntaxTreeBuilder};
-    /// use rome_rowan::{NodeOrToken};
-    ///
-    /// let mut builder = SyntaxTreeBuilder::new();
-    /// builder.start_node(JsSyntaxKind::JS_STRING_LITERAL_EXPRESSION);
-    /// builder.token(JsSyntaxKind::JS_STRING_LITERAL, "'abc'");
-    /// builder.finish_node();
-    /// let node = builder.finish();
-    ///
-    /// let syntax_token = node.first_token().unwrap();
-    ///
-    /// let formatter = Formatter::default();
-    /// let result = formatter.format_token(&syntax_token);
-    ///
-    /// assert_eq!(Ok(token("'abc'")), result)
-    /// ```
-    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
-    pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
-    where
-        T: token::FormattableToken,
-    {
-        syntax_token.format(self)
     }
 
     /// Print out a `token` from the original source with a different `content`.
@@ -418,47 +367,4 @@ impl Formatter {
     #[cfg(not(debug_assertions))]
     /// Restore the state of the formatter to a previous snapshot
     pub fn restore(&self, _: FormatterSnapshot) {}
-}
-
-// FormattableToken needs to be public as its used in the signature of format_token,
-// part of the public API, but it should not be exposed for implementation so
-// declare it in a private module inaccessible for external consumers
-mod token {
-    use rslint_parser::SyntaxToken;
-
-    use crate::{format_element::Token, format_elements, FormatElement, FormatResult, Formatter};
-
-    pub trait FormattableToken {
-        type Output;
-        fn format(&self, formatter: &Formatter) -> FormatResult<Self::Output>;
-    }
-
-    impl FormattableToken for SyntaxToken {
-        type Output = FormatElement;
-
-        fn format(&self, formatter: &Formatter) -> FormatResult<Self::Output> {
-            cfg_if::cfg_if! {
-                if #[cfg(debug_assertions)] {
-                    assert!(formatter.printed_tokens.borrow_mut().insert(self.clone()));
-                }
-            }
-
-            Ok(format_elements![
-                formatter.print_leading_trivia(self),
-                Token::from(self),
-                formatter.print_trailing_trivia(self),
-            ])
-        }
-    }
-
-    impl FormattableToken for Option<SyntaxToken> {
-        type Output = Option<FormatElement>;
-
-        fn format(&self, formatter: &Formatter) -> FormatResult<Self::Output> {
-            match self {
-                Some(token) => Ok(Some(token.format(formatter)?)),
-                None => Ok(None),
-            }
-        }
-    }
 }

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -119,7 +119,7 @@ impl Formatter {
     ///
     /// Returns `None` if the node couldn't be formatted because of syntax errors in its sub tree.
     /// The parent may use [Self::format_verbatim] to insert the node content as is.
-    // #[deprecated = "use the .format traits"]
+    #[deprecated = "use the .format traits"]
     pub fn format_node<T: AstNode + ToFormatElement>(
         &self,
         node: &T,
@@ -172,7 +172,7 @@ impl Formatter {
     ///
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
-    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
+    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
     where
         T: token::FormattableToken,
@@ -205,7 +205,6 @@ impl Formatter {
     /// Formats each child and returns the result as a list.
     ///
     /// Returns [None] if a child couldn't be formatted.
-    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_nodes<T: AstNode + ToFormatElement>(
         &self,
         nodes: impl IntoIterator<Item = T>,

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -172,7 +172,7 @@ impl Formatter {
     ///
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
-    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
+    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
     where
         T: token::FormattableToken,

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -172,7 +172,7 @@ impl Formatter {
     ///
     /// assert_eq!(Ok(token("'abc'")), result)
     /// ```
-    #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
+    // #[deprecated = "Please use the traits available in 'crate::formatter_traits' which allow better developer experience"]
     pub fn format_token<T>(&self, syntax_token: &T) -> FormatResult<T::Output>
     where
         T: token::FormattableToken,

--- a/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/ts/assignment/object_assignment_pattern.rs
@@ -55,7 +55,7 @@ impl ToFormatElement for JsObjectAssignmentPatternShorthandProperty {
             .init()
             .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
         Ok(format_elements![
-            formatter.format_node(&self.identifier()?)?,
+            self.identifier().format(formatter)?,
             init_node
         ])
     }

--- a/crates/rome_formatter/src/ts/class/any_class.rs
+++ b/crates/rome_formatter/src/ts/class/any_class.rs
@@ -1,25 +1,24 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    block_indent, empty_element, format_elements, group_elements, join_elements_hard_line,
-    space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    block_indent, format_elements, group_elements, join_elements_hard_line, space_token,
+    FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsAnyClass;
 
 impl ToFormatElement for JsAnyClass {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let id = match self.id()? {
-            Some(id) => format_elements![space_token(), formatter.format_node(&id)?],
-            None => empty_element(),
-        };
+        let id = self
+            .id()
+            .format_with_or_empty(formatter, |id| format_elements![space_token(), id])?;
 
-        let extends = match self.extends_clause() {
-            Some(extends_clause) => {
-                format_elements![space_token(), formatter.format_node(&extends_clause)?]
-            }
-            None => empty_element(),
-        };
+        let extends = self
+            .extends_clause()
+            .format_with_or_empty(formatter, |extends_clause| {
+                format_elements![space_token(), extends_clause]
+            })?;
 
         Ok(format_elements![
-            formatter.format_token(&self.class_token()?)?,
+            self.class_token().format(formatter)?,
             id,
             extends,
             space_token(),

--- a/crates/rome_formatter/src/ts/class/static_initialization_block_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/static_initialization_block_class_member.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     block_indent, format_elements, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
@@ -6,7 +7,7 @@ use rslint_parser::ast::JsStaticInitializationBlockClassMember;
 
 impl ToFormatElement for JsStaticInitializationBlockClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let static_token = formatter.format_token(&self.static_token()?)?;
+        let static_token = self.static_token().format(formatter)?;
         let separated = formatter.format_delimited(
             &self.l_curly_token()?,
             |open_token_trailing, close_token_leading| {

--- a/crates/rome_formatter/src/ts/directives.rs
+++ b/crates/rome_formatter/src/ts/directives.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     empty_element, format_elements, hard_line_break, token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
@@ -15,10 +16,8 @@ pub fn format_directives_list(directives: JsDirectiveList, formatter: &Formatter
 impl ToFormatElement for JsDirective {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.value_token()?)?,
-            formatter
-                .format_token(&self.semicolon_token())?
-                .unwrap_or_else(|| token(";")),
+            self.value_token().format(formatter)?,
+            self.semicolon_token().format_or(formatter, || token(";"))?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/export/as_clause.rs
+++ b/crates/rome_formatter/src/ts/export/as_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,8 +6,8 @@ use rslint_parser::ast::JsExportAsClause;
 
 impl ToFormatElement for JsExportAsClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let as_token = formatter.format_token(&self.as_token()?)?;
-        let exported_name = formatter.format_node(&self.exported_name()?)?;
+        let as_token = self.as_token().format(formatter)?;
+        let exported_name = self.exported_name().format(formatter)?;
 
         Ok(format_elements![as_token, space_token(), exported_name])
     }

--- a/crates/rome_formatter/src/ts/export/default_class_clause.rs
+++ b/crates/rome_formatter/src/ts/export/default_class_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,7 +6,7 @@ use rslint_parser::ast::{JsAnyClass, JsExportDefaultClassClause};
 
 impl ToFormatElement for JsExportDefaultClassClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default_token = formatter.format_token(&self.default_token()?)?;
+        let default_token = self.default_token().format(formatter)?;
         let class = JsAnyClass::from(self.clone()).to_format_element(formatter)?;
 
         Ok(format_elements![default_token, space_token(), class])

--- a/crates/rome_formatter/src/ts/export/default_expression_clause.rs
+++ b/crates/rome_formatter/src/ts/export/default_expression_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,13 +6,9 @@ use rslint_parser::ast::JsExportDefaultExpressionClause;
 
 impl ToFormatElement for JsExportDefaultExpressionClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default_token = formatter.format_token(&self.default_token()?)?;
-        let class = formatter.format_node(&self.expression()?)?;
-        let semicolon = if let Some(semicolon) = &self.semicolon_token() {
-            formatter.format_token(semicolon)?
-        } else {
-            token(";")
-        };
+        let default_token = self.default_token().format(formatter)?;
+        let class = self.expression().format(formatter)?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
         Ok(format_elements![
             default_token,
             space_token(),

--- a/crates/rome_formatter/src/ts/export/default_function_clause.rs
+++ b/crates/rome_formatter/src/ts/export/default_function_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,7 +6,7 @@ use rslint_parser::ast::{JsAnyFunction, JsExportDefaultFunctionClause};
 
 impl ToFormatElement for JsExportDefaultFunctionClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default_token = formatter.format_token(&self.default_token()?)?;
+        let default_token = self.default_token().format(formatter)?;
         let class = JsAnyFunction::from(self.clone()).to_format_element(formatter)?;
 
         Ok(format_elements![default_token, space_token(), class])

--- a/crates/rome_formatter/src/ts/export/from_clause.rs
+++ b/crates/rome_formatter/src/ts/export/from_clause.rs
@@ -1,29 +1,27 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsExportFromClause;
 
 impl ToFormatElement for JsExportFromClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = formatter.format_token(&self.star_token()?)?;
-        let export_as = if let Some(export_as) = self.export_as() {
-            format_elements![formatter.format_node(&export_as)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let from = formatter.format_token(&self.from_token()?)?;
-        let source = formatter.format_node(&self.source()?)?;
-        let assertion = if let Some(assertion) = self.assertion() {
-            formatter.format_node(&assertion)?
-        } else {
-            empty_element()
-        };
-        let semicolon = if let Some(semicolon) = self.semicolon_token() {
-            formatter.format_token(&semicolon)?
-        } else {
-            token(";")
-        };
+        let star = self.star_token().format(formatter)?;
+
+        let export_as = self
+            .export_as()
+            .format_with_or_empty(formatter, |as_token| {
+                format_elements![as_token, space_token()]
+            })?;
+        let from = self.from_token().format(formatter)?;
+        let source = self.source().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+
         Ok(format_elements![
             star,
             space_token(),

--- a/crates/rome_formatter/src/ts/export/mod.rs
+++ b/crates/rome_formatter/src/ts/export/mod.rs
@@ -14,6 +14,7 @@ mod named_shorthand_specifier;
 mod named_specifier;
 mod variable_clause;
 
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -21,8 +22,8 @@ use rslint_parser::ast::JsExport;
 
 impl ToFormatElement for JsExport {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let export_token = formatter.format_token(&self.export_token()?)?;
-        let export_clause = formatter.format_node(&self.export_clause()?)?;
+        let export_token = self.export_token().format(formatter)?;
+        let export_clause = self.export_clause().format(formatter)?;
         Ok(format_elements![export_token, space_token(), export_clause])
     }
 }

--- a/crates/rome_formatter/src/ts/export/named_clause.rs
+++ b/crates/rome_formatter/src/ts/export/named_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatOptionalTokenAndNode;
 use crate::{
     empty_element, format_elements, group_elements, if_group_fits_on_single_line, join_elements,
     soft_block_indent, soft_line_break_or_space, space_token, token, FormatElement, FormatResult,
@@ -33,11 +34,7 @@ impl ToFormatElement for JsExportNamedClause {
             &self.r_curly_token()?,
         )?);
 
-        let semicolon = if let Some(semicolon) = self.semicolon_token() {
-            formatter.format_token(&semicolon)?
-        } else {
-            token(";")
-        };
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![list, semicolon])
     }

--- a/crates/rome_formatter/src/ts/export/named_from_clause.rs
+++ b/crates/rome_formatter/src/ts/export/named_from_clause.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     empty_element, format_elements, group_elements, if_group_fits_on_single_line, join_elements,
     soft_block_indent, soft_line_break_or_space, space_token, token, FormatElement, FormatResult,
@@ -33,18 +34,14 @@ impl ToFormatElement for JsExportNamedFromClause {
             &self.r_curly_token()?,
         )?);
 
-        let from = formatter.format_token(&self.from_token()?)?;
-        let source = formatter.format_node(&self.source()?)?;
-        let assertion = if let Some(assertion) = self.assertion() {
-            formatter.format_node(&assertion)?
-        } else {
-            empty_element()
-        };
-        let semicolon = if let Some(semicolon) = self.semicolon_token() {
-            formatter.format_token(&semicolon)?
-        } else {
-            token(";")
-        };
+        let from = self.from_token().format(formatter)?;
+        let source = self.source().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             list,

--- a/crates/rome_formatter/src/ts/export/named_from_specifier.rs
+++ b/crates/rome_formatter/src/ts/export/named_from_specifier.rs
@@ -1,22 +1,22 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsExportNamedFromSpecifier;
 
 impl ToFormatElement for JsExportNamedFromSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = if let Some(type_token) = self.type_token() {
-            format_elements![formatter.format_token(&type_token)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let export_as = if let Some(export_as) = self.export_as() {
-            format_elements![formatter.format_node(&export_as)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let source = formatter.format_node(&self.source_name()?)?;
+        let type_token = self
+            .type_token()
+            .format_with_or_empty(formatter, |type_token| {
+                format_elements![type_token, space_token()]
+            })?;
+        let export_as = self
+            .export_as()
+            .format_with_or_empty(formatter, |export_as| {
+                format_elements![export_as, space_token()]
+            })?;
+        let source = self.source_name().format(formatter)?;
 
         Ok(format_elements![type_token, export_as, source])
     }

--- a/crates/rome_formatter/src/ts/export/named_shorthand_specifier.rs
+++ b/crates/rome_formatter/src/ts/export/named_shorthand_specifier.rs
@@ -1,18 +1,17 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsExportNamedShorthandSpecifier;
 
 impl ToFormatElement for JsExportNamedShorthandSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = if let Some(type_token) = self.type_token() {
-            format_elements![formatter.format_token(&type_token)?, space_token()]
-        } else {
-            empty_element()
-        };
-
-        let name = formatter.format_node(&self.name()?)?;
+        let type_token = self
+            .type_token()
+            .format_with_or_empty(formatter, |type_token| {
+                format_elements![type_token, space_token()]
+            })?;
+        let name = self.name().format(formatter)?;
 
         Ok(format_elements![type_token, name])
     }

--- a/crates/rome_formatter/src/ts/export/named_specifier.rs
+++ b/crates/rome_formatter/src/ts/export/named_specifier.rs
@@ -1,20 +1,19 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsExportNamedSpecifier;
 
 impl ToFormatElement for JsExportNamedSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = if let Some(type_token) = self.type_token() {
-            format_elements![formatter.format_token(&type_token)?, space_token()]
-        } else {
-            empty_element()
-        };
-
-        let as_token = formatter.format_token(&self.as_token()?)?;
-        let local_name = formatter.format_node(&self.local_name()?)?;
-        let exported_name = formatter.format_node(&self.exported_name()?)?;
+        let type_token = self
+            .type_token()
+            .format_with_or_empty(formatter, |type_token| {
+                format_elements![type_token, space_token()]
+            })?;
+        let as_token = self.as_token().format(formatter)?;
+        let local_name = self.local_name().format(formatter)?;
+        let exported_name = self.exported_name().format(formatter)?;
 
         Ok(format_elements![
             type_token,

--- a/crates/rome_formatter/src/ts/export/variable_clause.rs
+++ b/crates/rome_formatter/src/ts/export/variable_clause.rs
@@ -1,14 +1,11 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsExportVariableClause;
 
 impl ToFormatElement for JsExportVariableClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let declarations = formatter.format_node(&self.declarations()?)?;
-        let semicolon = if let Some(semicolon) = self.semicolon_token() {
-            formatter.format_token(&semicolon)?
-        } else {
-            token(";")
-        };
+        let declarations = self.declarations().format(formatter)?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![declarations, semicolon])
     }

--- a/crates/rome_formatter/src/ts/expressions/identifier_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/identifier_expression.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsIdentifierExpression;
 
 impl ToFormatElement for JsIdentifierExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_node(&self.name()?)
+        self.name().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/import_meta_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/import_meta_expression.rs
@@ -1,13 +1,14 @@
 use rslint_parser::ast::ImportMeta;
 
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 impl ToFormatElement for ImportMeta {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.import_token()?)?,
-            formatter.format_token(&self.dot_token()?)?,
-            formatter.format_token(&self.meta_token()?)?
+            self.import_token().format(formatter)?,
+            self.dot_token().format(formatter)?,
+            self.meta_token().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/literal_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/literal_expression.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_element::Token, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::{
     JsAnyLiteralExpression, JsBigIntLiteralExpression, JsBooleanLiteralExpression,
@@ -24,25 +25,25 @@ impl ToFormatElement for JsStringLiteralExpression {
 
 impl ToFormatElement for JsBooleanLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }
 
 impl ToFormatElement for JsNullLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }
 
 impl ToFormatElement for JsNumberLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }
 
 impl ToFormatElement for JsBigIntLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }
 

--- a/crates/rome_formatter/src/ts/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/object_expression.rs
@@ -10,7 +10,7 @@ impl ToFormatElement for JsObjectExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let members = self.members();
 
-        let space = if members.len() == 0 {
+        let space = if members.is_empty() {
             empty_element()
         } else {
             if_group_fits_on_single_line(space_token())

--- a/crates/rome_formatter/src/ts/expressions/sequence_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/sequence_expression.rs
@@ -1,16 +1,16 @@
-use rslint_parser::ast::JsSequenceExpression;
-
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
+use rslint_parser::ast::JsSequenceExpression;
 
 impl ToFormatElement for JsSequenceExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(&self.left()?)?,
-            formatter.format_token(&self.comma_token()?)?,
+            self.left().format(formatter)?,
+            self.comma_token().format(formatter)?,
             space_token(),
-            formatter.format_node(&self.right()?)?
+            self.right().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/static_member_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/static_member_expression.rs
@@ -1,15 +1,15 @@
-use rslint_parser::ast::JsStaticMemberExpression;
-
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, group_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
+use rslint_parser::ast::JsStaticMemberExpression;
 
 impl ToFormatElement for JsStaticMemberExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(group_elements(format_elements![
-            formatter.format_node(&self.object()?)?,
-            formatter.format_token(&self.operator()?)?,
-            formatter.format_node(&self.member()?)?
+            self.object().format(formatter)?,
+            self.operator().format(formatter)?,
+            self.member().format(formatter)?,
         ]))
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/super_expression.rs
+++ b/crates/rome_formatter/src/ts/expressions/super_expression.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsSuperExpression;
 
 impl ToFormatElement for JsSuperExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.super_token()?)
+        self.super_token().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/template.rs
+++ b/crates/rome_formatter/src/ts/expressions/template.rs
@@ -1,17 +1,12 @@
-use crate::{
-    empty_element, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
-};
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
+use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsTemplate;
 
 impl ToFormatElement for JsTemplate {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let tag = if let Some(tag) = self.tag() {
-            formatter.format_node(&tag)?
-        } else {
-            empty_element()
-        };
-        let l_tick = formatter.format_token(&self.l_tick_token()?)?;
-        let r_tick = formatter.format_token(&self.r_tick_token()?)?;
+        let tag = self.tag().format_or_empty(formatter)?;
+        let l_tick = self.l_tick_token().format(formatter)?;
+        let r_tick = self.r_tick_token().format(formatter)?;
 
         Ok(format_elements![
             tag,

--- a/crates/rome_formatter/src/ts/ident.rs
+++ b/crates/rome_formatter/src/ts/ident.rs
@@ -1,9 +1,10 @@
 use rslint_parser::ast::Ident;
 
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 impl ToFormatElement for Ident {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.ident_token()?)
+        self.ident_token().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/import/assertion.rs
+++ b/crates/rome_formatter/src/ts/import/assertion.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     empty_element, format_elements, group_elements, if_group_fits_on_single_line, join_elements,
     soft_block_indent, soft_line_break_or_space, space_token, token, FormatElement, FormatResult,
@@ -8,7 +9,7 @@ use rslint_parser::AstSeparatedList;
 
 impl ToFormatElement for JsImportAssertion {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let assert_token = formatter.format_token(&self.assert_token()?)?;
+        let assert_token = self.assert_token().format(formatter)?;
         let assertions = self.assertions();
 
         let space = if assertions.is_empty() {

--- a/crates/rome_formatter/src/ts/import/assertion_entry.rs
+++ b/crates/rome_formatter/src/ts/import/assertion_entry.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -6,10 +7,10 @@ use rslint_parser::ast::JsImportAssertionEntry;
 impl ToFormatElement for JsImportAssertionEntry {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.key()?)?,
-            formatter.format_token(&self.colon_token()?)?,
+            self.key().format(formatter)?,
+            self.colon_token().format(formatter)?,
             space_token(),
-            formatter.format_token(&self.value_token()?)?,
+            self.value_token().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/import/bare_clause.rs
+++ b/crates/rome_formatter/src/ts/import/bare_clause.rs
@@ -1,17 +1,17 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsImportBareClause;
 
 impl ToFormatElement for JsImportBareClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let source = formatter.format_node(&self.source()?)?;
-        let assertion = if let Some(assertion) = self.assertion() {
-            format_elements![space_token(), formatter.format_node(&assertion)?]
-        } else {
-            empty_element()
-        };
+        let source = self.source().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
 
         Ok(format_elements![source, assertion])
     }

--- a/crates/rome_formatter/src/ts/import/default_import_specifier.rs
+++ b/crates/rome_formatter/src/ts/import/default_import_specifier.rs
@@ -1,11 +1,12 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsDefaultImportSpecifier;
 
 impl ToFormatElement for JsDefaultImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_node(&self.local_name()?)?,
-            formatter.format_token(&self.trailing_comma_token()?)?
+            self.local_name().format(formatter)?,
+            self.trailing_comma_token().format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/import/import_call_expression.rs
+++ b/crates/rome_formatter/src/ts/import/import_call_expression.rs
@@ -1,11 +1,12 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsImportCallExpression;
 
 impl ToFormatElement for JsImportCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.import_token()?)?,
-            formatter.format_node(&self.arguments()?)?,
+            self.import_token().format(formatter)?,
+            self.arguments().format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/import/import_default_clause.rs
+++ b/crates/rome_formatter/src/ts/import/import_default_clause.rs
@@ -1,19 +1,19 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsImportDefaultClause;
 
 impl ToFormatElement for JsImportDefaultClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let local_name = formatter.format_node(&self.local_name()?)?;
-        let from = formatter.format_token(&self.from_token()?)?;
-        let source = formatter.format_node(&self.source()?)?;
-        let assertions = if let Some(assertion) = self.assertion() {
-            format_elements![space_token(), formatter.format_node(&assertion)?]
-        } else {
-            empty_element()
-        };
+        let local_name = self.local_name().format(formatter)?;
+        let from = self.from_token().format(formatter)?;
+        let source = self.source().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
 
         Ok(format_elements![
             local_name,
@@ -21,7 +21,7 @@ impl ToFormatElement for JsImportDefaultClause {
             from,
             space_token(),
             source,
-            assertions
+            assertion
         ])
     }
 }

--- a/crates/rome_formatter/src/ts/import/literal_export_name.rs
+++ b/crates/rome_formatter/src/ts/import/literal_export_name.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsLiteralExportName;
 
 impl ToFormatElement for JsLiteralExportName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value()?)
+        self.value().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/import/mod.rs
+++ b/crates/rome_formatter/src/ts/import/mod.rs
@@ -17,6 +17,7 @@ mod namespace_clause;
 mod namespace_import_specifier;
 mod shorthand_named_import_specifier;
 
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -24,11 +25,9 @@ use rslint_parser::ast::JsImport;
 
 impl ToFormatElement for JsImport {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let import_token = formatter.format_token(&self.import_token()?)?;
-        let import_clause = formatter.format_node(&self.import_clause()?)?;
-        let semicolon = formatter
-            .format_token(&self.semicolon_token())?
-            .unwrap_or_else(|| token(";"));
+        let import_token = self.import_token().format(formatter)?;
+        let import_clause = self.import_clause().format(formatter)?;
+        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             import_token,

--- a/crates/rome_formatter/src/ts/import/module_source.rs
+++ b/crates/rome_formatter/src/ts/import/module_source.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsModuleSource;
 
 impl ToFormatElement for JsModuleSource {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_token(&self.value_token()?)
+        self.value_token().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/import/named_clause.rs
+++ b/crates/rome_formatter/src/ts/import/named_clause.rs
@@ -1,24 +1,25 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsImportNamedClause;
 
 impl ToFormatElement for JsImportNamedClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let source = formatter.format_node(&self.source()?)?;
-        let default = if let Some(default) = self.default_specifier() {
-            format_elements![formatter.format_node(&default)?, space_token()]
-        } else {
-            empty_element()
-        };
-        let from = formatter.format_token(&self.from_token()?)?;
-        let name = formatter.format_node(&self.named_import()?)?;
-        let assertion = if let Some(assertion) = self.assertion() {
-            format_elements![space_token(), formatter.format_node(&assertion)?]
-        } else {
-            empty_element()
-        };
+        let source = self.source().format(formatter)?;
+
+        let default = self
+            .default_specifier()
+            .format_with_or_empty(formatter, |specifier| {
+                format_elements![specifier, space_token()]
+            })?;
+        let from = self.from_token().format(formatter)?;
+        let name = self.named_import().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
         Ok(format_elements![
             default,
             name,

--- a/crates/rome_formatter/src/ts/import/named_import_specifier.rs
+++ b/crates/rome_formatter/src/ts/import/named_import_specifier.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, soft_line_break_or_space, FormatElement, FormatResult, Formatter,
     ToFormatElement,
@@ -6,9 +7,9 @@ use rslint_parser::ast::JsNamedImportSpecifier;
 
 impl ToFormatElement for JsNamedImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let name = formatter.format_node(&self.name()?)?;
-        let as_token = formatter.format_token(&self.as_token()?)?;
-        let local_name = formatter.format_node(&self.local_name()?)?;
+        let name = self.name().format(formatter)?;
+        let as_token = self.as_token().format(formatter)?;
+        let local_name = self.local_name().format(formatter)?;
 
         Ok(format_elements![
             name,

--- a/crates/rome_formatter/src/ts/import/named_import_specifiers.rs
+++ b/crates/rome_formatter/src/ts/import/named_import_specifiers.rs
@@ -9,11 +9,12 @@ use rslint_parser::AstSeparatedList;
 impl ToFormatElement for JsNamedImportSpecifiers {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let specifiers = self.specifiers();
-        let space = if specifiers.len() == 0 {
+        let space = if specifiers.is_empty() {
             empty_element()
         } else {
             if_group_fits_on_single_line(space_token())
         };
+
         Ok(group_elements(formatter.format_delimited(
             &self.l_curly_token()?,
             |leading, trailing| {

--- a/crates/rome_formatter/src/ts/import/namespace_clause.rs
+++ b/crates/rome_formatter/src/ts/import/namespace_clause.rs
@@ -1,21 +1,21 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsImportNamespaceClause;
 
 impl ToFormatElement for JsImportNamespaceClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = formatter.format_token(&self.star_token()?)?;
-        let as_token = formatter.format_token(&self.as_token()?)?;
-        let local_name = formatter.format_node(&self.local_name()?)?;
-        let source = formatter.format_node(&self.source()?)?;
-        let from = formatter.format_token(&self.from_token()?)?;
-        let assertion = if let Some(assertion) = self.assertion() {
-            format_elements![space_token(), formatter.format_node(&assertion)?]
-        } else {
-            empty_element()
-        };
+        let star = self.star_token().format(formatter)?;
+        let as_token = self.as_token().format(formatter)?;
+        let local_name = self.local_name().format(formatter)?;
+        let source = self.source().format(formatter)?;
+        let from = self.from_token().format(formatter)?;
+        let assertion = self
+            .assertion()
+            .format_with_or_empty(formatter, |assertion| {
+                format_elements![space_token(), assertion]
+            })?;
         Ok(format_elements![
             star,
             space_token(),

--- a/crates/rome_formatter/src/ts/import/namespace_import_specifier.rs
+++ b/crates/rome_formatter/src/ts/import/namespace_import_specifier.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -5,9 +6,9 @@ use rslint_parser::ast::JsNamespaceImportSpecifier;
 
 impl ToFormatElement for JsNamespaceImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = formatter.format_token(&self.star_token()?)?;
-        let as_token = formatter.format_token(&self.as_token()?)?;
-        let local_name = formatter.format_node(&self.local_name()?)?;
+        let star = self.star_token().format(formatter)?;
+        let as_token = self.as_token().format(formatter)?;
+        let local_name = self.local_name().format(formatter)?;
 
         Ok(format_elements![
             star,

--- a/crates/rome_formatter/src/ts/import/shorthand_named_import_specifier.rs
+++ b/crates/rome_formatter/src/ts/import/shorthand_named_import_specifier.rs
@@ -1,8 +1,9 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsShorthandNamedImportSpecifier;
 
 impl ToFormatElement for JsShorthandNamedImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_node(&self.local_name()?)
+        self.local_name().format(formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/parameter_list.rs
+++ b/crates/rome_formatter/src/ts/parameter_list.rs
@@ -1,7 +1,7 @@
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, group_elements, join_elements, soft_block_indent,
-    soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, group_elements, join_elements, soft_block_indent, soft_line_break_or_space,
+    space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::{JsAnyParameter, JsParameter, JsParameters, JsRestParameter};
 
@@ -38,22 +38,22 @@ impl ToFormatElement for JsAnyParameter {
 impl ToFormatElement for JsRestParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
-            formatter.format_token(&self.dotdotdot_token()?)?,
-            formatter.format_node(&self.binding()?)?
+            self.dotdotdot_token().format(formatter)?,
+            self.binding().format(formatter)?,
         ])
     }
 }
 
 impl ToFormatElement for JsParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let initializer = if let Some(initializer) = self.initializer() {
-            format_elements![space_token(), formatter.format_node(&initializer)?]
-        } else {
-            empty_element()
-        };
+        let initializer = self
+            .initializer()
+            .format_with_or_empty(formatter, |initializer| {
+                format_elements![space_token(), initializer]
+            })?;
 
         Ok(format_elements![
-            formatter.format_node(&self.binding()?)?,
+            self.binding().format(formatter)?,
             initializer
         ])
     }

--- a/crates/rome_formatter/src/ts/root/mod.rs
+++ b/crates/rome_formatter/src/ts/root/mod.rs
@@ -1,6 +1,5 @@
-use crate::{
-    empty_element, format_elements, hard_line_break, FormatElement, FormatResult, Formatter,
-};
+use crate::formatter_traits::FormatOptionalTokenAndNode;
+use crate::{format_elements, hard_line_break, FormatElement, FormatResult, Formatter};
 use rslint_parser::SyntaxToken;
 
 mod any_module_item;
@@ -11,10 +10,7 @@ pub fn format_interpreter(
     interpreter: Option<SyntaxToken>,
     formatter: &Formatter,
 ) -> FormatResult<FormatElement> {
-    let result = if let Some(interpreter) = interpreter {
-        format_elements![formatter.format_token(&interpreter)?, hard_line_break()]
-    } else {
-        empty_element()
-    };
-    Ok(result)
+    interpreter.format_with_or_empty(formatter, |element| {
+        format_elements![element, hard_line_break()]
+    })
 }

--- a/crates/rome_formatter/src/ts/root/module.rs
+++ b/crates/rome_formatter/src/ts/root/module.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::ts::directives::format_directives_list;
 use crate::ts::root::format_interpreter;
 use crate::{
@@ -12,7 +13,7 @@ impl ToFormatElement for JsModule {
         elements.push(format_interpreter(self.interpreter_token(), formatter)?);
         elements.push(format_directives_list(self.directives(), formatter));
         elements.push(formatter.format_list(self.items()));
-        elements.push(formatter.format_token(&self.eof_token()?)?);
+        elements.push(self.eof_token().format(formatter)?);
 
         Ok(format_elements![
             concat_elements(elements),

--- a/crates/rome_formatter/src/ts/root/script.rs
+++ b/crates/rome_formatter/src/ts/root/script.rs
@@ -1,3 +1,4 @@
+use crate::formatter_traits::FormatTokenAndNode;
 use crate::ts::directives::format_directives_list;
 use crate::ts::root::format_interpreter;
 use crate::{
@@ -11,7 +12,7 @@ impl ToFormatElement for JsScript {
         elements.push(format_interpreter(self.interpreter_token(), formatter)?);
         elements.push(format_directives_list(self.directives(), formatter));
         elements.push(formatter.format_list(self.statements()));
-        elements.push(formatter.format_token(&self.eof_token()?)?);
+        elements.push(self.eof_token().format(formatter)?);
 
         Ok(format_elements![
             concat_elements(elements),

--- a/crates/rome_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -16,7 +16,7 @@ export * from "hey";
 
 export * as something_bad_will_happen from "something_bad_might_not_happen";
 
-export * as something_bad_will_happen from "something_bad_might_not_happen"assert {
+export * as something_bad_will_happen from "something_bad_might_not_happen" assert {
 	"type": "json",
 	"type2": "json3",
 };


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #1996 

Finished porting the formatter to use the new API.

Doing so, it also removes two APIs that are not needed anymore:
- `formatter.format_node`
- `formatter.format_token`

The logic contained inside these two APIs have been moved inside the new traits.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Fixed an incorrect test. Existing tests should yield the same results.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
