### PR TITLE
fix(rslint_parser): mark optional type parameters is alias statement

### DIFF
--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -4482,8 +4482,8 @@ impl TsTypeAliasStatement {
     pub fn binding_identifier(&self) -> SyntaxResult<TsIdentifierBinding> {
         support::required_node(&self.syntax, 1usize)
     }
-    pub fn type_parameters(&self) -> SyntaxResult<TsTypeParameters> {
-        support::required_node(&self.syntax, 2usize)
+    pub fn type_parameters(&self) -> Option<TsTypeParameters> {
+        support::node(&self.syntax, 2usize)
     }
     pub fn eq_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 3usize)
@@ -11834,7 +11834,7 @@ impl std::fmt::Debug for TsTypeAliasStatement {
             )
             .field(
                 "type_parameters",
-                &support::DebugSyntaxResult(self.type_parameters()),
+                &support::DebugOptionalElement(self.type_parameters()),
             )
             .field("eq_token", &support::DebugSyntaxResult(self.eq_token()))
             .field("ty", &support::DebugSyntaxResult(self.ty()))

--- a/crates/rslint_parser/test_data/inline/ok/ts_array_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_array_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsArrayType {
                 element_type: TsStringType {
@@ -23,7 +23,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@38..40 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@40..42 "=" [] [Whitespace(" ")],
             ty: TsArrayType {
                 element_type: TsObjectType {

--- a/crates/rslint_parser/test_data/inline/ok/ts_call_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_call_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -37,7 +37,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@44..46 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@46..48 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@48..50 "{" [] [Whitespace(" ")],
@@ -94,7 +94,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@75..77 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@77..79 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@79..81 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_conditional_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_conditional_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsNumberType {
                 number_token: NUMBER_KW@23..29 "number" [] [],
@@ -19,7 +19,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@36..38 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
             ty: TsConditionalType {
                 check_type: TsStringType {
@@ -45,7 +45,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@86..88 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@88..90 "=" [] [Whitespace(" ")],
             ty: TsConditionalType {
                 check_type: TsReferenceType {

--- a/crates/rslint_parser/test_data/inline/ok/ts_construct_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_construct_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -38,7 +38,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@48..50 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@52..54 "{" [] [Whitespace(" ")],
@@ -92,7 +92,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@88..90 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@90..92 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@92..94 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_constructor_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_constructor_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsConstructorType {
                 abstract_token: missing (optional),
@@ -58,7 +58,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@65..67 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@67..69 "=" [] [Whitespace(" ")],
             ty: TsConstructorType {
                 abstract_token: ABSTRACT_KW@69..78 "abstract" [] [Whitespace(" ")],
@@ -109,7 +109,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@120..122 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@122..124 "=" [] [Whitespace(" ")],
             ty: TsConstructorType {
                 abstract_token: missing (optional),
@@ -186,7 +186,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@162..164 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@164..166 "=" [] [Whitespace(" ")],
             ty: TsConstructorType {
                 abstract_token: ABSTRACT_KW@166..175 "abstract" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_function_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_function_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -28,7 +28,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@42..44 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@44..46 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -63,7 +63,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@74..76 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@76..78 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -98,7 +98,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@107..109 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@109..111 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -137,7 +137,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@133..135 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@135..137 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -173,7 +173,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@158..160 "F" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@160..162 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -212,7 +212,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@183..185 "G" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@185..187 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: TsTypeParameters {
@@ -287,7 +287,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@221..223 "H" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@223..225 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -329,7 +329,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@255..257 "I" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@257..259 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/ts_getter_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_getter_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -37,7 +37,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@48..50 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@52..54 "{" [] [Whitespace(" ")],
@@ -62,7 +62,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@122..124 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@124..126 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@126..128 "{" [] [Whitespace(" ")],
@@ -96,7 +96,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@149..151 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@151..153 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@153..155 "{" [] [Whitespace(" ")],
@@ -125,7 +125,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@174..176 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@176..178 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@178..180 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_import_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_import_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsImportType {
                 typeof_token: TYPEOF_KW@23..30 "typeof" [] [Whitespace(" ")],
@@ -24,7 +24,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@51..53 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@53..55 "=" [] [Whitespace(" ")],
             ty: TsImportType {
                 typeof_token: missing (optional),
@@ -41,7 +41,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@76..78 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@78..80 "=" [] [Whitespace(" ")],
             ty: TsImportType {
                 typeof_token: TYPEOF_KW@80..87 "typeof" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_index_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_index_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -45,7 +45,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@52..54 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@54..56 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@56..58 "{" [] [Whitespace(" ")],
@@ -83,7 +83,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@120..122 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@122..124 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@124..126 "{" [] [Whitespace(" ")],
@@ -118,7 +118,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@145..147 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@147..149 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@149..151 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_indexed_access_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_indexed_access_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsIndexedAccessType {
                 object_type: TsStringType {
@@ -26,7 +26,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@44..46 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@46..48 "=" [] [Whitespace(" ")],
             ty: TsArrayType {
                 element_type: TsIndexedAccessType {

--- a/crates/rslint_parser/test_data/inline/ok/ts_inferred_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_inferred_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsInferType {
                 infer_token: INFER_KW@23..29 "infer" [] [Whitespace(" ")],
@@ -22,7 +22,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@37..39 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@39..41 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@41..43 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_intersection_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_intersection_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsIntersectionType {
                 leading_separator_token_token: missing (optional),
@@ -28,7 +28,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@45..47 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@47..49 "=" [] [Whitespace(" ")],
             ty: TsIntersectionType {
                 leading_separator_token_token: AMP@49..51 "&" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_literal_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_literal_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsNumberLiteralType {
                 minus_token: missing (optional),
@@ -20,7 +20,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@31..33 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@33..35 "=" [] [Whitespace(" ")],
             ty: TsNumberLiteralType {
                 minus_token: MINUS@35..36 "-" [] [],
@@ -33,7 +33,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@44..46 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@46..48 "=" [] [Whitespace(" ")],
             ty: TsBigIntLiteralType {
                 minus_token: missing (optional),
@@ -46,7 +46,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@57..59 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@59..61 "=" [] [Whitespace(" ")],
             ty: TsBigIntLiteralType {
                 minus_token: MINUS@61..62 "-" [] [],
@@ -59,7 +59,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@71..73 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@73..75 "=" [] [Whitespace(" ")],
             ty: TsStringLiteralType {
                 literal_token: JS_STRING_LITERAL@75..82 "\"abvcd\"" [] [],
@@ -71,7 +71,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@89..91 "F" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@91..93 "=" [] [Whitespace(" ")],
             ty: TsBooleanLiteralType {
                 literal: TRUE_KW@93..97 "true" [] [],
@@ -83,7 +83,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@104..106 "G" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@106..108 "=" [] [Whitespace(" ")],
             ty: TsBooleanLiteralType {
                 literal: FALSE_KW@108..113 "false" [] [],
@@ -95,7 +95,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@120..122 "H" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@122..124 "=" [] [Whitespace(" ")],
             ty: TsNullLiteralType {
                 literal_token: NULL_KW@124..128 "null" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_mapped_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_mapped_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsMappedType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_object_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_object_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -50,7 +50,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@54..56 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@56..58 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@58..60 "{" [] [Whitespace(" ")],
@@ -93,7 +93,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@89..91 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@91..93 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@93..95 "{" [] [Whitespace(" ")],
@@ -150,7 +150,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@135..137 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@137..139 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@139..140 "{" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_parenthesized_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_parenthesized_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsParenthesizedType {
                 l_paren_token: L_PAREN@23..24 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_predefined_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_predefined_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsAnyType {
                 any_token: ANY_KW@23..26 "any" [] [],
@@ -19,7 +19,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@32..34 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@34..36 "=" [] [Whitespace(" ")],
             ty: TsNumberType {
                 number_token: NUMBER_KW@36..42 "number" [] [],
@@ -31,7 +31,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@49..51 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@51..53 "=" [] [Whitespace(" ")],
             ty: TsNonPrimitiveType {
                 object_token: OBJECT_KW@53..59 "object" [] [],
@@ -43,7 +43,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@66..68 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@68..70 "=" [] [Whitespace(" ")],
             ty: TsBooleanType {
                 boolean_token: BOOLEAN_KW@70..77 "boolean" [] [],
@@ -55,7 +55,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@84..86 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@86..88 "=" [] [Whitespace(" ")],
             ty: TsBigintType {
                 bigint_token: BIGINT_KW@88..94 "bigint" [] [],
@@ -67,7 +67,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@101..103 "F" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@103..105 "=" [] [Whitespace(" ")],
             ty: TsStringType {
                 string_token: STRING_KW@105..111 "string" [] [],
@@ -79,7 +79,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@118..120 "G" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@120..122 "=" [] [Whitespace(" ")],
             ty: TsSymbolType {
                 symbol_token: SYMBOL_KW@122..128 "symbol" [] [],
@@ -91,7 +91,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@135..137 "H" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@137..139 "=" [] [Whitespace(" ")],
             ty: TsVoidType {
                 void_token: VOID_KW@139..143 "void" [] [],
@@ -103,7 +103,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@150..152 "I" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@152..154 "=" [] [Whitespace(" ")],
             ty: TsUndefinedType {
                 undefined_token: UNDEFINED_KW@154..163 "undefined" [] [],
@@ -115,7 +115,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@170..172 "J" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@172..174 "=" [] [Whitespace(" ")],
             ty: TsNullLiteralType {
                 literal_token: NULL_KW@174..178 "null" [] [],
@@ -127,7 +127,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@185..187 "K" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@187..189 "=" [] [Whitespace(" ")],
             ty: TsNeverType {
                 never_token: NEVER_KW@189..194 "never" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_property_or_method_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_property_or_method_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -55,7 +55,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@57..59 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@59..61 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@61..63 "{" [] [Whitespace(" ")],
@@ -103,7 +103,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@93..95 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@95..97 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@97..99 "{" [] [Whitespace(" ")],
@@ -179,7 +179,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@146..148 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@148..150 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@150..152 "{" [] [Whitespace(" ")],
@@ -222,7 +222,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@196..198 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@198..200 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@200..202 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_reference_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_reference_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsNonPrimitiveType {
                 object_token: OBJECT_KW@23..29 "object" [] [],
@@ -19,7 +19,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@36..38 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@38..40 "=" [] [Whitespace(" ")],
             ty: TsStringType {
                 string_token: STRING_KW@40..46 "string" [] [],
@@ -31,7 +31,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@53..55 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@55..57 "=" [] [Whitespace(" ")],
             ty: TsReferenceType {
                 name: JsReferenceIdentifier {
@@ -46,7 +46,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@65..67 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@67..69 "=" [] [Whitespace(" ")],
             ty: TsReferenceType {
                 name: TsQualifiedName {
@@ -67,7 +67,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@79..81 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@81..83 "=" [] [Whitespace(" ")],
             ty: TsReferenceType {
                 name: TsQualifiedName {

--- a/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -44,7 +44,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@48..50 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@52..54 "{" [] [Whitespace(" ")],
@@ -94,7 +94,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@82..84 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@84..86 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@86..88 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_setter_signature_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_setter_signature_member.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -44,7 +44,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@49..51 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@51..53 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@53..55 "{" [] [Whitespace(" ")],
@@ -76,7 +76,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@124..126 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@126..128 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@128..130 "{" [] [Whitespace(" ")],
@@ -114,7 +114,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@144..146 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@146..148 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@148..150 "{" [] [Whitespace(" ")],
@@ -143,7 +143,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@169..171 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@171..173 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@173..175 "{" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_template_literal_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_template_literal_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsTemplateLiteralType {
                 l_tick_token: BACKTICK@23..24 "`" [] [],
@@ -25,7 +25,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@35..37 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@37..39 "=" [] [Whitespace(" ")],
             ty: TsTemplateLiteralType {
                 l_tick_token: BACKTICK@39..40 "`" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_this_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_this_type.rast
@@ -37,7 +37,7 @@ JsModule {
                                 binding_identifier: TsIdentifierBinding {
                                     name_token: IDENT@52..54 "A" [] [Whitespace(" ")],
                                 },
-                                type_parameters: missing (required),
+                                type_parameters: missing (optional),
                                 eq_token: EQ@54..56 "=" [] [Whitespace(" ")],
                                 ty: TsThisType {
                                     this_token: THIS_KW@56..60 "this" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_tuple_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_tuple_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@23..24 "[" [] [],
@@ -33,7 +33,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@50..52 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@52..54 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@54..55 "[" [] [],
@@ -83,7 +83,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@90..92 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@92..94 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@94..95 "[" [] [],
@@ -137,7 +137,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@135..137 "D" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@137..139 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@139..140 "[" [] [],
@@ -163,7 +163,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@157..159 "E" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@159..161 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@161..162 "[" [] [],
@@ -188,7 +188,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@180..182 "F" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@182..184 "=" [] [Whitespace(" ")],
             ty: TsTupleType {
                 l_brack_token: L_BRACK@184..185 "[" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_operator.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_operator.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsObjectType {
                 l_curly_token: L_CURLY@23..25 "{" [] [Whitespace(" ")],
@@ -50,7 +50,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@54..56 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@56..58 "=" [] [Whitespace(" ")],
             ty: TsTypeOperatorType {
                 operator_token: KEYOF_KW@58..64 "keyof" [] [Whitespace(" ")],
@@ -68,7 +68,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@72..74 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@74..76 "=" [] [Whitespace(" ")],
             ty: TsTypeOperatorType {
                 operator_token: READONLY_KW@76..85 "readonly" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_predicate.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_predicate.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -44,7 +44,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@48..50 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@50..52 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),
@@ -81,7 +81,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@85..93 "asserts" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@93..95 "=" [] [Whitespace(" ")],
             ty: TsStringType {
                 string_token: STRING_KW@95..101 "string" [] [],
@@ -93,7 +93,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@108..110 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@110..112 "=" [] [Whitespace(" ")],
             ty: TsFunctionType {
                 type_parameters: missing (optional),

--- a/crates/rslint_parser/test_data/inline/ok/ts_typeof_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_typeof_type.rast
@@ -28,7 +28,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@35..37 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@37..39 "=" [] [Whitespace(" ")],
             ty: TsTypeofType {
                 typeof_token: TYPEOF_KW@39..46 "typeof" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_union_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_union_type.rast
@@ -7,7 +7,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@19..21 "A" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
                 leading_separator_token_token: missing (optional),
@@ -28,7 +28,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@45..47 "B" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@47..49 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
                 leading_separator_token_token: PIPE@49..51 "|" [] [Whitespace(" ")],
@@ -56,7 +56,7 @@ JsModule {
             binding_identifier: TsIdentifierBinding {
                 name_token: IDENT@73..75 "C" [] [Whitespace(" ")],
             },
-            type_parameters: missing (required),
+            type_parameters: missing (optional),
             eq_token: EQ@75..77 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
                 leading_separator_token_token: missing (optional),

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1497,7 +1497,7 @@ TsReferenceType =
 TsTypeAliasStatement =
 	'type'
 	binding_identifier: TsIdentifierBinding
-	type_parameters: TsTypeParameters
+	type_parameters: TsTypeParameters?
 	'='
 	ty: TsType
 	';'?


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a small bug in our grammar. Now the `type_parameters` in `TsTypeAliasStatement` are marked as optional.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

We already have tests for these cases. I updated the current RAST files

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
