### PR TITLE
feat(rslint_parser): Type parameters

### DIFF
--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -2001,7 +2001,9 @@ impl JsMethodObjectMember {
     pub fn name(&self) -> SyntaxResult<JsAnyObjectMemberName> {
         support::required_node(&self.syntax, 2usize)
     }
-    pub fn type_params(&self) -> Option<TsTypeParameters> { support::node(&self.syntax, 3usize) }
+    pub fn type_parameters(&self) -> Option<TsTypeParameters> {
+        support::node(&self.syntax, 3usize)
+    }
     pub fn parameters(&self) -> SyntaxResult<JsParameters> {
         support::required_node(&self.syntax, 4usize)
     }
@@ -8063,8 +8065,8 @@ impl std::fmt::Debug for JsMethodObjectMember {
             )
             .field("name", &support::DebugSyntaxResult(self.name()))
             .field(
-                "type_params",
-                &support::DebugOptionalElement(self.type_params()),
+                "type_parameters",
+                &support::DebugOptionalElement(self.type_parameters()),
             )
             .field("parameters", &support::DebugSyntaxResult(self.parameters()))
             .field(

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -655,14 +655,11 @@ impl JsConstructorClassMember {
     pub fn name(&self) -> SyntaxResult<JsLiteralMemberName> {
         support::required_node(&self.syntax, 1usize)
     }
-    pub fn type_parameters(&self) -> Option<TsTypeParameters> {
-        support::node(&self.syntax, 2usize)
-    }
     pub fn parameters(&self) -> SyntaxResult<JsConstructorParameters> {
-        support::required_node(&self.syntax, 3usize)
+        support::required_node(&self.syntax, 2usize)
     }
     pub fn body(&self) -> SyntaxResult<JsFunctionBody> {
-        support::required_node(&self.syntax, 4usize)
+        support::required_node(&self.syntax, 3usize)
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -6063,10 +6060,6 @@ impl std::fmt::Debug for JsConstructorClassMember {
                 &support::DebugOptionalElement(self.access_modifier()),
             )
             .field("name", &support::DebugSyntaxResult(self.name()))
-            .field(
-                "type_parameters",
-                &support::DebugOptionalElement(self.type_parameters()),
-            )
             .field("parameters", &support::DebugSyntaxResult(self.parameters()))
             .field("body", &support::DebugSyntaxResult(self.body()))
             .finish()

--- a/crates/rslint_parser/src/ast/generated/syntax_factory.rs
+++ b/crates/rslint_parser/src/ast/generated/syntax_factory.rs
@@ -1073,7 +1073,7 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_CONSTRUCTOR_CLASS_MEMBER => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<5usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
                     if matches!(element.kind(), T![private] | T![protected] | T![public]) {
@@ -1084,13 +1084,6 @@ impl SyntaxFactory for JsSyntaxFactory {
                 slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsLiteralMemberName::can_cast(element.kind()) {
-                        slots.mark_present();
-                        current_element = elements.next();
-                    }
-                }
-                slots.next_slot();
-                if let Some(element) = &current_element {
-                    if TsTypeParameters::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -582,8 +582,8 @@ fn parse_class_member_impl(
                     // test_err ts_getter_setter_type_parameters
                     // // TYPESCRIPT
                     // class Test {
-                    //   get a<A>(): A {}
-                    // 	 set a<A>(value: A) {}
+                    //  get a<A>(): A {}
+                    //  set a<A>(value: A) {}
                     // }
                     if let Present(type_parameters) = parse_ts_type_parameters(p) {
                         p.error(

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -268,6 +268,9 @@ pub(crate) fn parse_assignment_expression_or_higher(
 ) -> ParsedSyntax {
     if p.at(T![<]) && is_nth_at_identifier(p, 1) {
         let res = try_parse(p, |p| {
+            // test ts_arrow_function_type_parameters
+            // // TYPESCRIPT
+            // let a = <A, B extends A, C = string>(a: A, b: B, c: C) => "hello";
             let type_parameters =
                 parse_ts_type_parameters(p).exclusive_for(p, TypeScript, |p, parameters| {
                     ts_only_syntax_error(p, "type parameters", parameters.range(p).as_range())

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -53,6 +53,7 @@ use rslint_syntax::{JsSyntaxKind, T};
 // test ts_function_statement
 // // TYPESCRIPT
 // function test(a: string, b?: number, c="default") {}
+// function test2<A, B extends A, C = A>(a: A, b: B, c: C) {}
 //
 // test_err ts_optional_pattern_parameter
 // // TYPESCRIPT
@@ -330,8 +331,8 @@ pub(super) fn parse_arrow_function(
     let parameters = parse_arrow_function_parameters(p, flags);
 
     if parameters.kind() == Some(JS_PARAMETERS) {
-        TypeScript
-            .parse_exclusive_syntax(p, parse_ts_return_type_annotation, |p, annotation| {
+        parse_ts_return_type_annotation(p)
+            .exclusive_for(p, TypeScript, |p, annotation| {
                 ts_only_syntax_error(p, "return type annotation", annotation.range(p).as_range())
             })
             .ok();

--- a/crates/rslint_parser/src/syntax/js_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/js_parse_error.rs
@@ -1,5 +1,5 @@
 use crate::parser::{expected_any, expected_node, ToDiagnostic};
-use crate::Parser;
+use crate::{CompletedMarker, Parser};
 use rslint_errors::Diagnostic;
 use std::ops::Range;
 
@@ -195,4 +195,33 @@ pub(crate) fn expected_property_or_signature(p: &Parser, range: Range<usize>) ->
 pub(crate) fn ts_only_syntax_error(p: &Parser, syntax: &str, range: Range<usize>) -> Diagnostic {
     p.err_builder(&format!("{} are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.", syntax))
 		.primary(range, "TypeScript only syntax")
+}
+
+pub(crate) fn ts_accessor_type_parameters_error(
+    p: &Parser,
+    type_parameters: &CompletedMarker,
+) -> Diagnostic {
+    p.err_builder("An accessor cannot have type parameters")
+        .primary(type_parameters.range(p), "")
+}
+
+pub(crate) fn ts_constructor_type_parameters_error(
+    p: &Parser,
+    type_parameters: &CompletedMarker,
+) -> Diagnostic {
+    p.err_builder("constructors cannot have type parameters")
+        .primary(type_parameters.range(p), "")
+}
+
+pub(crate) fn accessor_readonly_error(p: &Parser, readonly_range: &Range<usize>) -> Diagnostic {
+    p.err_builder("getters and setters cannot be readonly")
+        .primary(readonly_range, "")
+}
+
+pub(crate) fn ts_set_accessor_return_type_error(
+    p: &Parser,
+    type_annotation: &CompletedMarker,
+) -> Diagnostic {
+    p.err_builder("A 'set' accessor cannot have a return type annotation.")
+        .primary(type_annotation.range(p), "")
 }

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -8,14 +8,13 @@ use crate::syntax::expr::{
     parse_reference_identifier, ExpressionContext,
 };
 use crate::syntax::function::{
-    parse_formal_parameter, parse_function_body, parse_parameter_list,
-    parse_ts_type_annotation_or_error, ParameterContext,
+    parse_formal_parameter, parse_function_body, parse_parameter_list, ParameterContext,
 };
 use crate::syntax::js_parse_error;
 use crate::syntax::js_parse_error::ts_only_syntax_error;
 use crate::syntax::typescript::{parse_ts_return_type_annotation, parse_ts_type_parameters};
 use crate::JsSyntaxFeature::TypeScript;
-use crate::{ParseRecovery, ParseSeparatedList, Parser, SyntaxFeature};
+use crate::{ParseRecovery, ParseSeparatedList, Parser};
 use rslint_errors::Span;
 use rslint_syntax::JsSyntaxKind::*;
 use rslint_syntax::{JsSyntaxKind, T};
@@ -432,6 +431,14 @@ fn parse_method_object_member(p: &mut Parser) -> ParsedSyntax {
 
     Present(m.complete(p, JS_METHOD_OBJECT_MEMBER))
 }
+
+// test ts_method_object_member_body
+// // TYPESCRIPT
+// ({
+//     x<A>(maybeA: any): maybeA is A { return true },
+//     y(a: string): string { return "string"; },
+//     async *id<R>(param: Promise<R>): AsyncIterableIterator<R> { yield await param },
+// })
 
 /// Parses the body of a method object member starting right after the member name.
 fn parse_method_object_member_body(p: &mut Parser, flags: SignatureFlags) {

--- a/crates/rslint_parser/test_data/inline/err/class_constructor_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_constructor_parameter.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@10..21 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@21..22 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -68,8 +67,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@10..21
             0: IDENT@10..21 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@21..35
+          2: JS_CONSTRUCTOR_PARAMETERS@21..35
             0: L_PAREN@21..22 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@22..33
               0: JS_UNKNOWN_PARAMETER@22..33
@@ -81,7 +79,7 @@ JsModule {
                   2: (empty)
                   3: (empty)
             2: R_PAREN@33..35 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@35..38
+          3: JS_FUNCTION_BODY@35..38
             0: L_CURLY@35..36 "{" [] []
             1: JS_DIRECTIVE_LIST@36..36
             2: JS_STATEMENT_LIST@36..36

--- a/crates/rslint_parser/test_data/inline/err/class_constructor_parameter_readonly.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_constructor_parameter_readonly.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@10..21 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@21..22 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -68,8 +67,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@10..21
             0: IDENT@10..21 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@21..34
+          2: JS_CONSTRUCTOR_PARAMETERS@21..34
             0: L_PAREN@21..22 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@22..32
               0: JS_UNKNOWN_PARAMETER@22..32
@@ -81,7 +79,7 @@ JsModule {
                   2: (empty)
                   3: (empty)
             2: R_PAREN@32..34 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@34..37
+          3: JS_FUNCTION_BODY@34..37
             0: L_CURLY@34..35 "{" [] []
             1: JS_DIRECTIVE_LIST@35..35
             2: JS_STATEMENT_LIST@35..35

--- a/crates/rslint_parser/test_data/inline/err/js_constructor_parameter_reserved_names.rast
+++ b/crates/rslint_parser/test_data/inline/err/js_constructor_parameter_reserved_names.rast
@@ -17,7 +17,6 @@ JsScript {
                     name: JsLiteralMemberName {
                         value: IDENT@20..31 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@31..32 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -96,8 +95,7 @@ JsScript {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@20..31
             0: IDENT@20..31 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@31..70
+          2: JS_CONSTRUCTOR_PARAMETERS@31..70
             0: L_PAREN@31..32 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@32..68
               0: JS_FORMAL_PARAMETER@32..40
@@ -128,7 +126,7 @@ JsScript {
                 2: (empty)
                 3: (empty)
             2: R_PAREN@68..70 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@70..73
+          3: JS_FUNCTION_BODY@70..73
             0: L_CURLY@70..71 "{" [] []
             1: JS_DIRECTIVE_LIST@71..71
             2: JS_STATEMENT_LIST@71..71

--- a/crates/rslint_parser/test_data/inline/err/ts_constructor_this_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_constructor_this_parameter.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@24..35 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@35..36 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -60,14 +59,13 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@24..35
             0: IDENT@24..35 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@35..42
+          2: JS_CONSTRUCTOR_PARAMETERS@35..42
             0: L_PAREN@35..36 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@36..40
               0: JS_UNKNOWN_PARAMETER@36..40
                 0: THIS_KW@36..40 "this" [] []
             2: R_PAREN@40..42 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@42..45
+          3: JS_FUNCTION_BODY@42..45
             0: L_CURLY@42..43 "{" [] []
             1: JS_DIRECTIVE_LIST@43..43
             2: JS_STATEMENT_LIST@43..43

--- a/crates/rslint_parser/test_data/inline/err/ts_constructor_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_constructor_type_parameters.js
@@ -1,0 +1,2 @@
+// TYPESCRIPT
+class A { constructor<A>(b) {} }

--- a/crates/rslint_parser/test_data/inline/err/ts_constructor_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_constructor_type_parameters.rast
@@ -1,0 +1,113 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..22 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@22..24 "{" [] [Whitespace(" ")],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        JsLiteralMemberName {
+                            value: IDENT@24..35 "constructor" [] [],
+                        },
+                        TsTypeParameters {
+                            l_angle_token: L_ANGLE@35..36 "<" [] [],
+                            items: TsTypeParameterList [
+                                TsTypeParameter {
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@36..37 "A" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                    default: missing (optional),
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@37..38 ">" [] [],
+                        },
+                        JsConstructorParameters {
+                            l_paren_token: L_PAREN@38..39 "(" [] [],
+                            parameters: JsConstructorParameterList [
+                                JsFormalParameter {
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@39..40 "b" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    type_annotation: missing (optional),
+                                    initializer: missing (optional),
+                                },
+                            ],
+                            r_paren_token: R_PAREN@40..42 ")" [] [Whitespace(" ")],
+                        },
+                        JsFunctionBody {
+                            l_curly_token: L_CURLY@42..43 "{" [] [],
+                            directives: JsDirectiveList [],
+                            statements: JsStatementList [],
+                            r_curly_token: R_CURLY@43..45 "}" [] [Whitespace(" ")],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@45..46 "}" [] [],
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..47
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..46
+    0: JS_CLASS_STATEMENT@0..46
+      0: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@20..22
+        0: IDENT@20..22 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: (empty)
+      5: L_CURLY@22..24 "{" [] [Whitespace(" ")]
+      6: JS_CLASS_MEMBER_LIST@24..45
+        0: JS_UNKNOWN_MEMBER@24..45
+          0: JS_LITERAL_MEMBER_NAME@24..35
+            0: IDENT@24..35 "constructor" [] []
+          1: TS_TYPE_PARAMETERS@35..38
+            0: L_ANGLE@35..36 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@36..37
+              0: TS_TYPE_PARAMETER@36..37
+                0: TS_TYPE_PARAMETER_NAME@36..37
+                  0: IDENT@36..37 "A" [] []
+                1: (empty)
+                2: (empty)
+            2: R_ANGLE@37..38 ">" [] []
+          2: JS_CONSTRUCTOR_PARAMETERS@38..42
+            0: L_PAREN@38..39 "(" [] []
+            1: JS_CONSTRUCTOR_PARAMETER_LIST@39..40
+              0: JS_FORMAL_PARAMETER@39..40
+                0: JS_IDENTIFIER_BINDING@39..40
+                  0: IDENT@39..40 "b" [] []
+                1: (empty)
+                2: (empty)
+                3: (empty)
+            2: R_PAREN@40..42 ")" [] [Whitespace(" ")]
+          3: JS_FUNCTION_BODY@42..45
+            0: L_CURLY@42..43 "{" [] []
+            1: JS_DIRECTIVE_LIST@43..43
+            2: JS_STATEMENT_LIST@43..43
+            3: R_CURLY@43..45 "}" [] [Whitespace(" ")]
+      7: R_CURLY@45..46 "}" [] []
+  3: EOF@46..47 "" [Newline("\n")] []
+--
+error[SyntaxError]: constructors cannot have type parameters
+  ┌─ ts_constructor_type_parameters.js:2:22
+  │
+2 │ class A { constructor<A>(b) {} }
+  │                      ^^^
+
+--
+// TYPESCRIPT
+class A { constructor<A>(b) {} }

--- a/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.js
@@ -1,5 +1,5 @@
 // TYPESCRIPT
 class Test {
-  get a<A>(): A {}
-	 set a<A>(value: A) {}
+ get a<A>(): A {}
+ set a<A>(value: A) {}
 }

--- a/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.js
@@ -1,0 +1,5 @@
+// TYPESCRIPT
+class Test {
+  get a<A>(): A {}
+	 set a<A>(value: A) {}
+}

--- a/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
@@ -175,14 +175,14 @@ JsModule {
       7: R_CURLY@67..69 "}" [Newline("\n")] []
   3: EOF@69..70 "" [Newline("\n")] []
 --
-error[SyntaxError]: An accessor can not have type parameters
+error[SyntaxError]: An accessor cannot have type parameters
   ┌─ ts_getter_setter_type_parameters.js:3:7
   │
 3 │  get a<A>(): A {}
   │       ^^^
 
 --
-error[SyntaxError]: An accessor can not have type parameters
+error[SyntaxError]: An accessor cannot have type parameters
   ┌─ ts_getter_setter_type_parameters.js:4:7
   │
 4 │  set a<A>(value: A) {}

--- a/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
@@ -1,0 +1,196 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..25 "Test" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@25..26 "{" [] [],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        GET_KW@26..33 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                        JsLiteralMemberName {
+                            value: IDENT@33..34 "a" [] [],
+                        },
+                        TsTypeParameters {
+                            l_angle_token: L_ANGLE@34..35 "<" [] [],
+                            items: TsTypeParameterList [
+                                TsTypeParameter {
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@35..36 "A" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                    default: missing (optional),
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@36..37 ">" [] [],
+                        },
+                        L_PAREN@37..38 "(" [] [],
+                        R_PAREN@38..39 ")" [] [],
+                        TsTypeAnnotation {
+                            colon_token: COLON@39..41 ":" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@41..43 "A" [] [Whitespace(" ")],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                        JsFunctionBody {
+                            l_curly_token: L_CURLY@43..44 "{" [] [],
+                            directives: JsDirectiveList [],
+                            statements: JsStatementList [],
+                            r_curly_token: R_CURLY@44..45 "}" [] [],
+                        },
+                    ],
+                },
+                JsUnknownMember {
+                    items: [
+                        SET_KW@45..52 "set" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                        JsLiteralMemberName {
+                            value: IDENT@52..53 "a" [] [],
+                        },
+                        TsTypeParameters {
+                            l_angle_token: L_ANGLE@53..54 "<" [] [],
+                            items: TsTypeParameterList [
+                                TsTypeParameter {
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@54..55 "A" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                    default: missing (optional),
+                                },
+                            ],
+                            r_angle_token: R_ANGLE@55..56 ">" [] [],
+                        },
+                        L_PAREN@56..57 "(" [] [],
+                        JsFormalParameter {
+                            binding: JsIdentifierBinding {
+                                name_token: IDENT@57..62 "value" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@62..64 ":" [] [Whitespace(" ")],
+                                ty: TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@64..65 "A" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                            },
+                            initializer: missing (optional),
+                        },
+                        R_PAREN@65..67 ")" [] [Whitespace(" ")],
+                        JsFunctionBody {
+                            l_curly_token: L_CURLY@67..68 "{" [] [],
+                            directives: JsDirectiveList [],
+                            statements: JsStatementList [],
+                            r_curly_token: R_CURLY@68..69 "}" [] [],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@69..71 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@71..72 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..72
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..71
+    0: JS_CLASS_STATEMENT@0..71
+      0: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@20..25
+        0: IDENT@20..25 "Test" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: (empty)
+      5: L_CURLY@25..26 "{" [] []
+      6: JS_CLASS_MEMBER_LIST@26..69
+        0: JS_UNKNOWN_MEMBER@26..45
+          0: GET_KW@26..33 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
+          1: JS_LITERAL_MEMBER_NAME@33..34
+            0: IDENT@33..34 "a" [] []
+          2: TS_TYPE_PARAMETERS@34..37
+            0: L_ANGLE@34..35 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@35..36
+              0: TS_TYPE_PARAMETER@35..36
+                0: TS_TYPE_PARAMETER_NAME@35..36
+                  0: IDENT@35..36 "A" [] []
+                1: (empty)
+                2: (empty)
+            2: R_ANGLE@36..37 ">" [] []
+          3: L_PAREN@37..38 "(" [] []
+          4: R_PAREN@38..39 ")" [] []
+          5: TS_TYPE_ANNOTATION@39..43
+            0: COLON@39..41 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@41..43
+              0: JS_REFERENCE_IDENTIFIER@41..43
+                0: IDENT@41..43 "A" [] [Whitespace(" ")]
+              1: (empty)
+          6: JS_FUNCTION_BODY@43..45
+            0: L_CURLY@43..44 "{" [] []
+            1: JS_DIRECTIVE_LIST@44..44
+            2: JS_STATEMENT_LIST@44..44
+            3: R_CURLY@44..45 "}" [] []
+        1: JS_UNKNOWN_MEMBER@45..69
+          0: SET_KW@45..52 "set" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
+          1: JS_LITERAL_MEMBER_NAME@52..53
+            0: IDENT@52..53 "a" [] []
+          2: TS_TYPE_PARAMETERS@53..56
+            0: L_ANGLE@53..54 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@54..55
+              0: TS_TYPE_PARAMETER@54..55
+                0: TS_TYPE_PARAMETER_NAME@54..55
+                  0: IDENT@54..55 "A" [] []
+                1: (empty)
+                2: (empty)
+            2: R_ANGLE@55..56 ">" [] []
+          3: L_PAREN@56..57 "(" [] []
+          4: JS_FORMAL_PARAMETER@57..65
+            0: JS_IDENTIFIER_BINDING@57..62
+              0: IDENT@57..62 "value" [] []
+            1: (empty)
+            2: TS_TYPE_ANNOTATION@62..65
+              0: COLON@62..64 ":" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@64..65
+                0: JS_REFERENCE_IDENTIFIER@64..65
+                  0: IDENT@64..65 "A" [] []
+                1: (empty)
+            3: (empty)
+          5: R_PAREN@65..67 ")" [] [Whitespace(" ")]
+          6: JS_FUNCTION_BODY@67..69
+            0: L_CURLY@67..68 "{" [] []
+            1: JS_DIRECTIVE_LIST@68..68
+            2: JS_STATEMENT_LIST@68..68
+            3: R_CURLY@68..69 "}" [] []
+      7: R_CURLY@69..71 "}" [Newline("\n")] []
+  3: EOF@71..72 "" [Newline("\n")] []
+--
+error[SyntaxError]: An accessor can not have type parameters
+  ┌─ ts_getter_setter_type_parameters.js:3:8
+  │
+3 │   get a<A>(): A {}
+  │        ^^^
+
+--
+error[SyntaxError]: An accessor can not have type parameters
+  ┌─ ts_getter_setter_type_parameters.js:4:8
+  │
+4 │      set a<A>(value: A) {}
+  │           ^^^
+
+--
+// TYPESCRIPT
+class Test {
+  get a<A>(): A {}
+	 set a<A>(value: A) {}
+}

--- a/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_getter_setter_type_parameters.rast
@@ -14,99 +14,99 @@ JsModule {
             members: JsClassMemberList [
                 JsUnknownMember {
                     items: [
-                        GET_KW@26..33 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")],
+                        GET_KW@26..32 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsLiteralMemberName {
-                            value: IDENT@33..34 "a" [] [],
+                            value: IDENT@32..33 "a" [] [],
                         },
                         TsTypeParameters {
-                            l_angle_token: L_ANGLE@34..35 "<" [] [],
+                            l_angle_token: L_ANGLE@33..34 "<" [] [],
                             items: TsTypeParameterList [
                                 TsTypeParameter {
                                     name: TsTypeParameterName {
-                                        ident_token: IDENT@35..36 "A" [] [],
+                                        ident_token: IDENT@34..35 "A" [] [],
                                     },
                                     constraint: missing (optional),
                                     default: missing (optional),
                                 },
                             ],
-                            r_angle_token: R_ANGLE@36..37 ">" [] [],
+                            r_angle_token: R_ANGLE@35..36 ">" [] [],
                         },
-                        L_PAREN@37..38 "(" [] [],
-                        R_PAREN@38..39 ")" [] [],
+                        L_PAREN@36..37 "(" [] [],
+                        R_PAREN@37..38 ")" [] [],
                         TsTypeAnnotation {
-                            colon_token: COLON@39..41 ":" [] [Whitespace(" ")],
+                            colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
                             ty: TsReferenceType {
                                 name: JsReferenceIdentifier {
-                                    value_token: IDENT@41..43 "A" [] [Whitespace(" ")],
+                                    value_token: IDENT@40..42 "A" [] [Whitespace(" ")],
                                 },
                                 type_arguments: missing (optional),
                             },
                         },
                         JsFunctionBody {
-                            l_curly_token: L_CURLY@43..44 "{" [] [],
+                            l_curly_token: L_CURLY@42..43 "{" [] [],
                             directives: JsDirectiveList [],
                             statements: JsStatementList [],
-                            r_curly_token: R_CURLY@44..45 "}" [] [],
+                            r_curly_token: R_CURLY@43..44 "}" [] [],
                         },
                     ],
                 },
                 JsUnknownMember {
                     items: [
-                        SET_KW@45..52 "set" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")],
+                        SET_KW@44..50 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsLiteralMemberName {
-                            value: IDENT@52..53 "a" [] [],
+                            value: IDENT@50..51 "a" [] [],
                         },
                         TsTypeParameters {
-                            l_angle_token: L_ANGLE@53..54 "<" [] [],
+                            l_angle_token: L_ANGLE@51..52 "<" [] [],
                             items: TsTypeParameterList [
                                 TsTypeParameter {
                                     name: TsTypeParameterName {
-                                        ident_token: IDENT@54..55 "A" [] [],
+                                        ident_token: IDENT@52..53 "A" [] [],
                                     },
                                     constraint: missing (optional),
                                     default: missing (optional),
                                 },
                             ],
-                            r_angle_token: R_ANGLE@55..56 ">" [] [],
+                            r_angle_token: R_ANGLE@53..54 ">" [] [],
                         },
-                        L_PAREN@56..57 "(" [] [],
+                        L_PAREN@54..55 "(" [] [],
                         JsFormalParameter {
                             binding: JsIdentifierBinding {
-                                name_token: IDENT@57..62 "value" [] [],
+                                name_token: IDENT@55..60 "value" [] [],
                             },
                             question_mark_token: missing (optional),
                             type_annotation: TsTypeAnnotation {
-                                colon_token: COLON@62..64 ":" [] [Whitespace(" ")],
+                                colon_token: COLON@60..62 ":" [] [Whitespace(" ")],
                                 ty: TsReferenceType {
                                     name: JsReferenceIdentifier {
-                                        value_token: IDENT@64..65 "A" [] [],
+                                        value_token: IDENT@62..63 "A" [] [],
                                     },
                                     type_arguments: missing (optional),
                                 },
                             },
                             initializer: missing (optional),
                         },
-                        R_PAREN@65..67 ")" [] [Whitespace(" ")],
+                        R_PAREN@63..65 ")" [] [Whitespace(" ")],
                         JsFunctionBody {
-                            l_curly_token: L_CURLY@67..68 "{" [] [],
+                            l_curly_token: L_CURLY@65..66 "{" [] [],
                             directives: JsDirectiveList [],
                             statements: JsStatementList [],
-                            r_curly_token: R_CURLY@68..69 "}" [] [],
+                            r_curly_token: R_CURLY@66..67 "}" [] [],
                         },
                     ],
                 },
             ],
-            r_curly_token: R_CURLY@69..71 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@67..69 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@71..72 "" [Newline("\n")] [],
+    eof_token: EOF@69..70 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..72
+0: JS_MODULE@0..70
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..71
-    0: JS_CLASS_STATEMENT@0..71
+  2: JS_MODULE_ITEM_LIST@0..69
+    0: JS_CLASS_STATEMENT@0..69
       0: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
       1: JS_IDENTIFIER_BINDING@20..25
         0: IDENT@20..25 "Test" [] [Whitespace(" ")]
@@ -114,83 +114,83 @@ JsModule {
       3: (empty)
       4: (empty)
       5: L_CURLY@25..26 "{" [] []
-      6: JS_CLASS_MEMBER_LIST@26..69
-        0: JS_UNKNOWN_MEMBER@26..45
-          0: GET_KW@26..33 "get" [Newline("\n"), Whitespace("  ")] [Whitespace(" ")]
-          1: JS_LITERAL_MEMBER_NAME@33..34
-            0: IDENT@33..34 "a" [] []
-          2: TS_TYPE_PARAMETERS@34..37
-            0: L_ANGLE@34..35 "<" [] []
-            1: TS_TYPE_PARAMETER_LIST@35..36
-              0: TS_TYPE_PARAMETER@35..36
-                0: TS_TYPE_PARAMETER_NAME@35..36
-                  0: IDENT@35..36 "A" [] []
+      6: JS_CLASS_MEMBER_LIST@26..67
+        0: JS_UNKNOWN_MEMBER@26..44
+          0: GET_KW@26..32 "get" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: JS_LITERAL_MEMBER_NAME@32..33
+            0: IDENT@32..33 "a" [] []
+          2: TS_TYPE_PARAMETERS@33..36
+            0: L_ANGLE@33..34 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@34..35
+              0: TS_TYPE_PARAMETER@34..35
+                0: TS_TYPE_PARAMETER_NAME@34..35
+                  0: IDENT@34..35 "A" [] []
                 1: (empty)
                 2: (empty)
-            2: R_ANGLE@36..37 ">" [] []
-          3: L_PAREN@37..38 "(" [] []
-          4: R_PAREN@38..39 ")" [] []
-          5: TS_TYPE_ANNOTATION@39..43
-            0: COLON@39..41 ":" [] [Whitespace(" ")]
-            1: TS_REFERENCE_TYPE@41..43
-              0: JS_REFERENCE_IDENTIFIER@41..43
-                0: IDENT@41..43 "A" [] [Whitespace(" ")]
+            2: R_ANGLE@35..36 ">" [] []
+          3: L_PAREN@36..37 "(" [] []
+          4: R_PAREN@37..38 ")" [] []
+          5: TS_TYPE_ANNOTATION@38..42
+            0: COLON@38..40 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@40..42
+              0: JS_REFERENCE_IDENTIFIER@40..42
+                0: IDENT@40..42 "A" [] [Whitespace(" ")]
               1: (empty)
-          6: JS_FUNCTION_BODY@43..45
-            0: L_CURLY@43..44 "{" [] []
-            1: JS_DIRECTIVE_LIST@44..44
-            2: JS_STATEMENT_LIST@44..44
-            3: R_CURLY@44..45 "}" [] []
-        1: JS_UNKNOWN_MEMBER@45..69
-          0: SET_KW@45..52 "set" [Newline("\n"), Whitespace("\t ")] [Whitespace(" ")]
-          1: JS_LITERAL_MEMBER_NAME@52..53
-            0: IDENT@52..53 "a" [] []
-          2: TS_TYPE_PARAMETERS@53..56
-            0: L_ANGLE@53..54 "<" [] []
-            1: TS_TYPE_PARAMETER_LIST@54..55
-              0: TS_TYPE_PARAMETER@54..55
-                0: TS_TYPE_PARAMETER_NAME@54..55
-                  0: IDENT@54..55 "A" [] []
+          6: JS_FUNCTION_BODY@42..44
+            0: L_CURLY@42..43 "{" [] []
+            1: JS_DIRECTIVE_LIST@43..43
+            2: JS_STATEMENT_LIST@43..43
+            3: R_CURLY@43..44 "}" [] []
+        1: JS_UNKNOWN_MEMBER@44..67
+          0: SET_KW@44..50 "set" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
+          1: JS_LITERAL_MEMBER_NAME@50..51
+            0: IDENT@50..51 "a" [] []
+          2: TS_TYPE_PARAMETERS@51..54
+            0: L_ANGLE@51..52 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@52..53
+              0: TS_TYPE_PARAMETER@52..53
+                0: TS_TYPE_PARAMETER_NAME@52..53
+                  0: IDENT@52..53 "A" [] []
                 1: (empty)
                 2: (empty)
-            2: R_ANGLE@55..56 ">" [] []
-          3: L_PAREN@56..57 "(" [] []
-          4: JS_FORMAL_PARAMETER@57..65
-            0: JS_IDENTIFIER_BINDING@57..62
-              0: IDENT@57..62 "value" [] []
+            2: R_ANGLE@53..54 ">" [] []
+          3: L_PAREN@54..55 "(" [] []
+          4: JS_FORMAL_PARAMETER@55..63
+            0: JS_IDENTIFIER_BINDING@55..60
+              0: IDENT@55..60 "value" [] []
             1: (empty)
-            2: TS_TYPE_ANNOTATION@62..65
-              0: COLON@62..64 ":" [] [Whitespace(" ")]
-              1: TS_REFERENCE_TYPE@64..65
-                0: JS_REFERENCE_IDENTIFIER@64..65
-                  0: IDENT@64..65 "A" [] []
+            2: TS_TYPE_ANNOTATION@60..63
+              0: COLON@60..62 ":" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@62..63
+                0: JS_REFERENCE_IDENTIFIER@62..63
+                  0: IDENT@62..63 "A" [] []
                 1: (empty)
             3: (empty)
-          5: R_PAREN@65..67 ")" [] [Whitespace(" ")]
-          6: JS_FUNCTION_BODY@67..69
-            0: L_CURLY@67..68 "{" [] []
-            1: JS_DIRECTIVE_LIST@68..68
-            2: JS_STATEMENT_LIST@68..68
-            3: R_CURLY@68..69 "}" [] []
-      7: R_CURLY@69..71 "}" [Newline("\n")] []
-  3: EOF@71..72 "" [Newline("\n")] []
+          5: R_PAREN@63..65 ")" [] [Whitespace(" ")]
+          6: JS_FUNCTION_BODY@65..67
+            0: L_CURLY@65..66 "{" [] []
+            1: JS_DIRECTIVE_LIST@66..66
+            2: JS_STATEMENT_LIST@66..66
+            3: R_CURLY@66..67 "}" [] []
+      7: R_CURLY@67..69 "}" [Newline("\n")] []
+  3: EOF@69..70 "" [Newline("\n")] []
 --
 error[SyntaxError]: An accessor can not have type parameters
-  ┌─ ts_getter_setter_type_parameters.js:3:8
+  ┌─ ts_getter_setter_type_parameters.js:3:7
   │
-3 │   get a<A>(): A {}
-  │        ^^^
+3 │  get a<A>(): A {}
+  │       ^^^
 
 --
 error[SyntaxError]: An accessor can not have type parameters
-  ┌─ ts_getter_setter_type_parameters.js:4:8
+  ┌─ ts_getter_setter_type_parameters.js:4:7
   │
-4 │      set a<A>(value: A) {}
-  │           ^^^
+4 │  set a<A>(value: A) {}
+  │       ^^^
 
 --
 // TYPESCRIPT
 class Test {
-  get a<A>(): A {}
-	 set a<A>(value: A) {}
+ get a<A>(): A {}
+ set a<A>(value: A) {}
 }

--- a/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.js
@@ -1,0 +1,2 @@
+// TYPESCRIPT
+({ get a<A>(): A {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
@@ -98,7 +98,7 @@ JsModule {
       1: SEMICOLON@36..37 ";" [] []
   3: EOF@37..38 "" [Newline("\n")] []
 --
-error[SyntaxError]: An accessor can not have type parameters
+error[SyntaxError]: An accessor cannot have type parameters
   ┌─ ts_object_getter_type_parameters.js:2:9
   │
 2 │ ({ get a<A>(): A {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
@@ -1,0 +1,109 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] [],
+                expression: JsObjectExpression {
+                    l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                    members: JsObjectMemberList [
+                        JsUnknownMember {
+                            items: [
+                                GET_KW@17..21 "get" [] [Whitespace(" ")],
+                                JsLiteralMemberName {
+                                    value: IDENT@21..22 "a" [] [],
+                                },
+                                TsTypeParameters {
+                                    l_angle_token: L_ANGLE@22..23 "<" [] [],
+                                    items: TsTypeParameterList [
+                                        TsTypeParameter {
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@23..24 "A" [] [],
+                                            },
+                                            constraint: missing (optional),
+                                            default: missing (optional),
+                                        },
+                                    ],
+                                    r_angle_token: R_ANGLE@24..25 ">" [] [],
+                                },
+                                L_PAREN@25..26 "(" [] [],
+                                R_PAREN@26..27 ")" [] [],
+                                TsReturnTypeAnnotation {
+                                    colon_token: COLON@27..29 ":" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@29..31 "A" [] [Whitespace(" ")],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                },
+                                JsFunctionBody {
+                                    l_curly_token: L_CURLY@31..32 "{" [] [],
+                                    directives: JsDirectiveList [],
+                                    statements: JsStatementList [],
+                                    r_curly_token: R_CURLY@32..34 "}" [] [Whitespace(" ")],
+                                },
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@34..35 "}" [] [],
+                },
+                r_paren_token: R_PAREN@35..36 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@36..37 ";" [] [],
+        },
+    ],
+    eof_token: EOF@37..38 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..38
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..37
+    0: JS_EXPRESSION_STATEMENT@0..37
+      0: JS_PARENTHESIZED_EXPRESSION@0..36
+        0: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] []
+        1: JS_OBJECT_EXPRESSION@15..35
+          0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
+          1: JS_OBJECT_MEMBER_LIST@17..34
+            0: JS_UNKNOWN_MEMBER@17..34
+              0: GET_KW@17..21 "get" [] [Whitespace(" ")]
+              1: JS_LITERAL_MEMBER_NAME@21..22
+                0: IDENT@21..22 "a" [] []
+              2: TS_TYPE_PARAMETERS@22..25
+                0: L_ANGLE@22..23 "<" [] []
+                1: TS_TYPE_PARAMETER_LIST@23..24
+                  0: TS_TYPE_PARAMETER@23..24
+                    0: TS_TYPE_PARAMETER_NAME@23..24
+                      0: IDENT@23..24 "A" [] []
+                    1: (empty)
+                    2: (empty)
+                2: R_ANGLE@24..25 ">" [] []
+              3: L_PAREN@25..26 "(" [] []
+              4: R_PAREN@26..27 ")" [] []
+              5: TS_RETURN_TYPE_ANNOTATION@27..31
+                0: COLON@27..29 ":" [] [Whitespace(" ")]
+                1: TS_REFERENCE_TYPE@29..31
+                  0: JS_REFERENCE_IDENTIFIER@29..31
+                    0: IDENT@29..31 "A" [] [Whitespace(" ")]
+                  1: (empty)
+              6: JS_FUNCTION_BODY@31..34
+                0: L_CURLY@31..32 "{" [] []
+                1: JS_DIRECTIVE_LIST@32..32
+                2: JS_STATEMENT_LIST@32..32
+                3: R_CURLY@32..34 "}" [] [Whitespace(" ")]
+          2: R_CURLY@34..35 "}" [] []
+        2: R_PAREN@35..36 ")" [] []
+      1: SEMICOLON@36..37 ";" [] []
+  3: EOF@37..38 "" [Newline("\n")] []
+--
+error[SyntaxError]: An accessor can not have type parameters
+  ┌─ ts_object_getter_type_parameters.js:2:9
+  │
+2 │ ({ get a<A>(): A {} });
+  │         ^^^
+
+--
+// TYPESCRIPT
+({ get a<A>(): A {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_setter_return_type.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_setter_return_type.js
@@ -1,0 +1,2 @@
+// TYPESCRIPT
+({ set a(value: string): void {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_setter_return_type.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_setter_return_type.rast
@@ -1,0 +1,104 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] [],
+                expression: JsObjectExpression {
+                    l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                    members: JsObjectMemberList [
+                        JsUnknownMember {
+                            items: [
+                                SET_KW@17..21 "set" [] [Whitespace(" ")],
+                                JsLiteralMemberName {
+                                    value: IDENT@21..22 "a" [] [],
+                                },
+                                L_PAREN@22..23 "(" [] [],
+                                JsFormalParameter {
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@23..28 "value" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                        ty: TsStringType {
+                                            string_token: STRING_KW@30..36 "string" [] [],
+                                        },
+                                    },
+                                    initializer: missing (optional),
+                                },
+                                R_PAREN@36..37 ")" [] [],
+                                TsReturnTypeAnnotation {
+                                    colon_token: COLON@37..39 ":" [] [Whitespace(" ")],
+                                    ty: TsVoidType {
+                                        void_token: VOID_KW@39..44 "void" [] [Whitespace(" ")],
+                                    },
+                                },
+                                JsFunctionBody {
+                                    l_curly_token: L_CURLY@44..45 "{" [] [],
+                                    directives: JsDirectiveList [],
+                                    statements: JsStatementList [],
+                                    r_curly_token: R_CURLY@45..47 "}" [] [Whitespace(" ")],
+                                },
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@47..48 "}" [] [],
+                },
+                r_paren_token: R_PAREN@48..49 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@49..50 ";" [] [],
+        },
+    ],
+    eof_token: EOF@50..51 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..51
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..50
+    0: JS_EXPRESSION_STATEMENT@0..50
+      0: JS_PARENTHESIZED_EXPRESSION@0..49
+        0: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] []
+        1: JS_OBJECT_EXPRESSION@15..48
+          0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
+          1: JS_OBJECT_MEMBER_LIST@17..47
+            0: JS_UNKNOWN_MEMBER@17..47
+              0: SET_KW@17..21 "set" [] [Whitespace(" ")]
+              1: JS_LITERAL_MEMBER_NAME@21..22
+                0: IDENT@21..22 "a" [] []
+              2: L_PAREN@22..23 "(" [] []
+              3: JS_FORMAL_PARAMETER@23..36
+                0: JS_IDENTIFIER_BINDING@23..28
+                  0: IDENT@23..28 "value" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@28..36
+                  0: COLON@28..30 ":" [] [Whitespace(" ")]
+                  1: TS_STRING_TYPE@30..36
+                    0: STRING_KW@30..36 "string" [] []
+                3: (empty)
+              4: R_PAREN@36..37 ")" [] []
+              5: TS_RETURN_TYPE_ANNOTATION@37..44
+                0: COLON@37..39 ":" [] [Whitespace(" ")]
+                1: TS_VOID_TYPE@39..44
+                  0: VOID_KW@39..44 "void" [] [Whitespace(" ")]
+              6: JS_FUNCTION_BODY@44..47
+                0: L_CURLY@44..45 "{" [] []
+                1: JS_DIRECTIVE_LIST@45..45
+                2: JS_STATEMENT_LIST@45..45
+                3: R_CURLY@45..47 "}" [] [Whitespace(" ")]
+          2: R_CURLY@47..48 "}" [] []
+        2: R_PAREN@48..49 ")" [] []
+      1: SEMICOLON@49..50 ";" [] []
+  3: EOF@50..51 "" [Newline("\n")] []
+--
+error[SyntaxError]: A 'set' accessor cannot have a return type annotation.
+  ┌─ ts_object_setter_return_type.js:2:24
+  │
+2 │ ({ set a(value: string): void {} });
+  │                        ^^^^^^
+
+--
+// TYPESCRIPT
+({ set a(value: string): void {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.js
@@ -1,0 +1,2 @@
+// TYPESCRIPT
+({ set a<A>(value: A) {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.rast
@@ -110,7 +110,7 @@ JsModule {
       1: SEMICOLON@41..42 ";" [] []
   3: EOF@42..43 "" [Newline("\n")] []
 --
-error[SyntaxError]: An accessor can not have type parameters
+error[SyntaxError]: An accessor cannot have type parameters
   ┌─ ts_object_setter_type_parameters.js:2:9
   │
 2 │ ({ set a<A>(value: A) {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_setter_type_parameters.rast
@@ -1,0 +1,121 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] [],
+                expression: JsObjectExpression {
+                    l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                    members: JsObjectMemberList [
+                        JsUnknownMember {
+                            items: [
+                                SET_KW@17..21 "set" [] [Whitespace(" ")],
+                                JsLiteralMemberName {
+                                    value: IDENT@21..22 "a" [] [],
+                                },
+                                TsTypeParameters {
+                                    l_angle_token: L_ANGLE@22..23 "<" [] [],
+                                    items: TsTypeParameterList [
+                                        TsTypeParameter {
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@23..24 "A" [] [],
+                                            },
+                                            constraint: missing (optional),
+                                            default: missing (optional),
+                                        },
+                                    ],
+                                    r_angle_token: R_ANGLE@24..25 ">" [] [],
+                                },
+                                L_PAREN@25..26 "(" [] [],
+                                JsFormalParameter {
+                                    binding: JsIdentifierBinding {
+                                        name_token: IDENT@26..31 "value" [] [],
+                                    },
+                                    question_mark_token: missing (optional),
+                                    type_annotation: TsTypeAnnotation {
+                                        colon_token: COLON@31..33 ":" [] [Whitespace(" ")],
+                                        ty: TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@33..34 "A" [] [],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                    },
+                                    initializer: missing (optional),
+                                },
+                                R_PAREN@34..36 ")" [] [Whitespace(" ")],
+                                JsFunctionBody {
+                                    l_curly_token: L_CURLY@36..37 "{" [] [],
+                                    directives: JsDirectiveList [],
+                                    statements: JsStatementList [],
+                                    r_curly_token: R_CURLY@37..39 "}" [] [Whitespace(" ")],
+                                },
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@39..40 "}" [] [],
+                },
+                r_paren_token: R_PAREN@40..41 ")" [] [],
+            },
+            semicolon_token: SEMICOLON@41..42 ";" [] [],
+        },
+    ],
+    eof_token: EOF@42..43 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..43
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..42
+    0: JS_EXPRESSION_STATEMENT@0..42
+      0: JS_PARENTHESIZED_EXPRESSION@0..41
+        0: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] []
+        1: JS_OBJECT_EXPRESSION@15..40
+          0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
+          1: JS_OBJECT_MEMBER_LIST@17..39
+            0: JS_UNKNOWN_MEMBER@17..39
+              0: SET_KW@17..21 "set" [] [Whitespace(" ")]
+              1: JS_LITERAL_MEMBER_NAME@21..22
+                0: IDENT@21..22 "a" [] []
+              2: TS_TYPE_PARAMETERS@22..25
+                0: L_ANGLE@22..23 "<" [] []
+                1: TS_TYPE_PARAMETER_LIST@23..24
+                  0: TS_TYPE_PARAMETER@23..24
+                    0: TS_TYPE_PARAMETER_NAME@23..24
+                      0: IDENT@23..24 "A" [] []
+                    1: (empty)
+                    2: (empty)
+                2: R_ANGLE@24..25 ">" [] []
+              3: L_PAREN@25..26 "(" [] []
+              4: JS_FORMAL_PARAMETER@26..34
+                0: JS_IDENTIFIER_BINDING@26..31
+                  0: IDENT@26..31 "value" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@31..34
+                  0: COLON@31..33 ":" [] [Whitespace(" ")]
+                  1: TS_REFERENCE_TYPE@33..34
+                    0: JS_REFERENCE_IDENTIFIER@33..34
+                      0: IDENT@33..34 "A" [] []
+                    1: (empty)
+                3: (empty)
+              5: R_PAREN@34..36 ")" [] [Whitespace(" ")]
+              6: JS_FUNCTION_BODY@36..39
+                0: L_CURLY@36..37 "{" [] []
+                1: JS_DIRECTIVE_LIST@37..37
+                2: JS_STATEMENT_LIST@37..37
+                3: R_CURLY@37..39 "}" [] [Whitespace(" ")]
+          2: R_CURLY@39..40 "}" [] []
+        2: R_PAREN@40..41 ")" [] []
+      1: SEMICOLON@41..42 ";" [] []
+  3: EOF@42..43 "" [Newline("\n")] []
+--
+error[SyntaxError]: An accessor can not have type parameters
+  ┌─ ts_object_setter_type_parameters.js:2:9
+  │
+2 │ ({ set a<A>(value: A) {} });
+  │         ^^^
+
+--
+// TYPESCRIPT
+({ set a<A>(value: A) {} });

--- a/crates/rslint_parser/test_data/inline/err/ts_property_parameter_pattern.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_property_parameter_pattern.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@24..35 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@35..36 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -102,8 +101,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@24..35
             0: IDENT@24..35 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@35..72
+          2: JS_CONSTRUCTOR_PARAMETERS@35..72
             0: L_PAREN@35..36 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@36..70
               0: TS_PROPERTY_PARAMETER@36..52
@@ -136,7 +134,7 @@ JsModule {
                         0: IDENT@68..69 "b" [] []
                     2: R_BRACK@69..70 "]" [] []
             2: R_PAREN@70..72 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@72..75
+          3: JS_FUNCTION_BODY@72..75
             0: L_CURLY@72..73 "{" [] []
             1: JS_DIRECTIVE_LIST@73..73
             2: JS_STATEMENT_LIST@73..73

--- a/crates/rslint_parser/test_data/inline/err/ts_setter_return_type_annotation.js
+++ b/crates/rslint_parser/test_data/inline/err/ts_setter_return_type_annotation.js
@@ -1,0 +1,4 @@
+// TYPESCRIPT
+class Test {
+    set a(value: string): void {}
+}

--- a/crates/rslint_parser/test_data/inline/err/ts_setter_return_type_annotation.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_setter_return_type_annotation.rast
@@ -1,0 +1,107 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..25 "Test" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@25..26 "{" [] [],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        SET_KW@26..35 "set" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                        JsLiteralMemberName {
+                            value: IDENT@35..36 "a" [] [],
+                        },
+                        L_PAREN@36..37 "(" [] [],
+                        JsFormalParameter {
+                            binding: JsIdentifierBinding {
+                                name_token: IDENT@37..42 "value" [] [],
+                            },
+                            question_mark_token: missing (optional),
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@42..44 ":" [] [Whitespace(" ")],
+                                ty: TsStringType {
+                                    string_token: STRING_KW@44..50 "string" [] [],
+                                },
+                            },
+                            initializer: missing (optional),
+                        },
+                        R_PAREN@50..51 ")" [] [],
+                        TsReturnTypeAnnotation {
+                            colon_token: COLON@51..53 ":" [] [Whitespace(" ")],
+                            ty: TsVoidType {
+                                void_token: VOID_KW@53..58 "void" [] [Whitespace(" ")],
+                            },
+                        },
+                        JsFunctionBody {
+                            l_curly_token: L_CURLY@58..59 "{" [] [],
+                            directives: JsDirectiveList [],
+                            statements: JsStatementList [],
+                            r_curly_token: R_CURLY@59..60 "}" [] [],
+                        },
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@60..62 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@62..63 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..63
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..62
+    0: JS_CLASS_STATEMENT@0..62
+      0: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@20..25
+        0: IDENT@20..25 "Test" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: (empty)
+      5: L_CURLY@25..26 "{" [] []
+      6: JS_CLASS_MEMBER_LIST@26..60
+        0: JS_UNKNOWN_MEMBER@26..60
+          0: SET_KW@26..35 "set" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+          1: JS_LITERAL_MEMBER_NAME@35..36
+            0: IDENT@35..36 "a" [] []
+          2: L_PAREN@36..37 "(" [] []
+          3: JS_FORMAL_PARAMETER@37..50
+            0: JS_IDENTIFIER_BINDING@37..42
+              0: IDENT@37..42 "value" [] []
+            1: (empty)
+            2: TS_TYPE_ANNOTATION@42..50
+              0: COLON@42..44 ":" [] [Whitespace(" ")]
+              1: TS_STRING_TYPE@44..50
+                0: STRING_KW@44..50 "string" [] []
+            3: (empty)
+          4: R_PAREN@50..51 ")" [] []
+          5: TS_RETURN_TYPE_ANNOTATION@51..58
+            0: COLON@51..53 ":" [] [Whitespace(" ")]
+            1: TS_VOID_TYPE@53..58
+              0: VOID_KW@53..58 "void" [] [Whitespace(" ")]
+          6: JS_FUNCTION_BODY@58..60
+            0: L_CURLY@58..59 "{" [] []
+            1: JS_DIRECTIVE_LIST@59..59
+            2: JS_STATEMENT_LIST@59..59
+            3: R_CURLY@59..60 "}" [] []
+      7: R_CURLY@60..62 "}" [Newline("\n")] []
+  3: EOF@62..63 "" [Newline("\n")] []
+--
+error[SyntaxError]: A 'set' accessor cannot have a return type annotation.
+  ┌─ ts_setter_return_type_annotation.js:3:25
+  │
+3 │     set a(value: string): void {}
+  │                         ^^^^^^
+
+--
+// TYPESCRIPT
+class Test {
+    set a(value: string): void {}
+}

--- a/crates/rslint_parser/test_data/inline/ok/arrow_in_constructor.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_in_constructor.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@9..23 "constructor" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@23..24 "(" [] [],
                         parameters: JsConstructorParameterList [],
@@ -117,12 +116,11 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@9..23
             0: IDENT@9..23 "constructor" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@23..26
+          2: JS_CONSTRUCTOR_PARAMETERS@23..26
             0: L_PAREN@23..24 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@24..24
             2: R_PAREN@24..26 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@26..72
+          3: JS_FUNCTION_BODY@26..72
             0: L_CURLY@26..27 "{" [] []
             1: JS_DIRECTIVE_LIST@27..27
             2: JS_STATEMENT_LIST@27..69

--- a/crates/rslint_parser/test_data/inline/ok/class_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_expr.rast
@@ -57,7 +57,6 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@37..50 "constructor" [Newline("\n"), Whitespace(" ")] [],
                                         },
-                                        type_parameters: missing (optional),
                                         parameters: JsConstructorParameters {
                                             l_paren_token: L_PAREN@50..51 "(" [] [],
                                             parameters: JsConstructorParameterList [],
@@ -155,12 +154,11 @@ JsModule {
                     0: (empty)
                     1: JS_LITERAL_MEMBER_NAME@37..50
                       0: IDENT@37..50 "constructor" [Newline("\n"), Whitespace(" ")] []
-                    2: (empty)
-                    3: JS_CONSTRUCTOR_PARAMETERS@50..53
+                    2: JS_CONSTRUCTOR_PARAMETERS@50..53
                       0: L_PAREN@50..51 "(" [] []
                       1: JS_CONSTRUCTOR_PARAMETER_LIST@51..51
                       2: R_PAREN@51..53 ")" [] [Whitespace(" ")]
-                    4: JS_FUNCTION_BODY@53..55
+                    3: JS_FUNCTION_BODY@53..55
                       0: L_CURLY@53..54 "{" [] []
                       1: JS_DIRECTIVE_LIST@54..54
                       2: JS_STATEMENT_LIST@54..54

--- a/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/constructor_class_member.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@11..25 "constructor" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@25..26 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -78,7 +77,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: JS_STRING_LITERAL@64..80 "\"constructor\"" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@80..81 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -145,8 +143,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@11..25
             0: IDENT@11..25 "constructor" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@25..29
+          2: JS_CONSTRUCTOR_PARAMETERS@25..29
             0: L_PAREN@25..26 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@26..27
               0: JS_FORMAL_PARAMETER@26..27
@@ -156,7 +153,7 @@ JsModule {
                 2: (empty)
                 3: (empty)
             2: R_PAREN@27..29 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@29..50
+          3: JS_FUNCTION_BODY@29..50
             0: L_CURLY@29..30 "{" [] []
             1: JS_DIRECTIVE_LIST@30..30
             2: JS_STATEMENT_LIST@30..46
@@ -188,8 +185,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@64..80
             0: JS_STRING_LITERAL@64..80 "\"constructor\"" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@80..84
+          2: JS_CONSTRUCTOR_PARAMETERS@80..84
             0: L_PAREN@80..81 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@81..82
               0: JS_FORMAL_PARAMETER@81..82
@@ -199,7 +195,7 @@ JsModule {
                 2: (empty)
                 3: (empty)
             2: R_PAREN@82..84 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@84..105
+          3: JS_FUNCTION_BODY@84..105
             0: L_CURLY@84..85 "{" [] []
             1: JS_DIRECTIVE_LIST@85..85
             2: JS_STATEMENT_LIST@85..101

--- a/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_object_member.rast
@@ -137,7 +137,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@162..168 "get" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@168..169 "(" [] [],
                                             items: JsParameterList [],

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_async_method.rast
@@ -23,7 +23,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@18..21 "foo" [] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@21..22 "(" [] [],
                                             items: JsParameterList [],
@@ -44,7 +44,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@37..40 "foo" [] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@40..41 "(" [] [],
                                             items: JsParameterList [],

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_generator_method.rast
@@ -23,7 +23,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@11..14 "foo" [] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@14..15 "(" [] [],
                                             items: JsParameterList [],

--- a/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_expr_method.rast
@@ -23,7 +23,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@9..15 "foo" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@15..16 "(" [] [],
                                             items: JsParameterList [],
@@ -44,7 +44,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: JS_STRING_LITERAL@21..29 "\"bar\"" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@29..30 "(" [] [],
                                             items: JsParameterList [
@@ -102,7 +102,7 @@ JsModule {
                                             },
                                             r_brack_token: R_BRACK@59..60 "]" [] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@60..61 "(" [] [],
                                             items: JsParameterList [
@@ -132,7 +132,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: JS_NUMBER_LITERAL@67..71 "5" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@71..72 "(" [] [],
                                             items: JsParameterList [

--- a/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
+++ b/crates/rslint_parser/test_data/inline/ok/scoped_declarations.rast
@@ -23,7 +23,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@9..16 "test" [Newline("\n"), Whitespace("  ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@16..17 "(" [] [],
                                             items: JsParameterList [],

--- a/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_object_member.rast
@@ -125,7 +125,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@105..110 "set" [Newline("\n"), Whitespace(" ")] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@110..111 "(" [] [],
                                             items: JsParameterList [],

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -24,7 +24,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@22..36 "constructor" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@36..37 "(" [] [],
                         parameters: JsConstructorParameterList [],
@@ -152,12 +151,11 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@22..36
             0: IDENT@22..36 "constructor" [Newline("\n"), Whitespace("  ")] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@36..39
+          2: JS_CONSTRUCTOR_PARAMETERS@36..39
             0: L_PAREN@36..37 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@37..37
             2: R_PAREN@37..39 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@39..57
+          3: JS_FUNCTION_BODY@39..57
             0: L_CURLY@39..40 "{" [] []
             1: JS_DIRECTIVE_LIST@40..40
             2: JS_STATEMENT_LIST@40..53

--- a/crates/rslint_parser/test_data/inline/ok/ts_arrow_function_type_parameters.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_arrow_function_type_parameters.js
@@ -1,0 +1,2 @@
+// TYPESCRIPT
+let a = <A, B extends A, C = string>(a: A, b: B, c: C) => "hello";

--- a/crates/rslint_parser/test_data/inline/ok/ts_arrow_function_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_arrow_function_type_parameters.rast
@@ -1,0 +1,223 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@0..18 "let" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@18..20 "a" [] [Whitespace(" ")],
+                        },
+                        excl_token: missing (optional),
+                        type_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@20..22 "=" [] [Whitespace(" ")],
+                            expression: JsArrowFunctionExpression {
+                                async_token: missing (optional),
+                                type_parameters: TsTypeParameters {
+                                    l_angle_token: L_ANGLE@22..23 "<" [] [],
+                                    items: TsTypeParameterList [
+                                        TsTypeParameter {
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@23..24 "A" [] [],
+                                            },
+                                            constraint: missing (optional),
+                                            default: missing (optional),
+                                        },
+                                        COMMA@24..26 "," [] [Whitespace(" ")],
+                                        TsTypeParameter {
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@26..28 "B" [] [Whitespace(" ")],
+                                            },
+                                            constraint: TsTypeConstraintClause {
+                                                extends_token: EXTENDS_KW@28..36 "extends" [] [Whitespace(" ")],
+                                                ty: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@36..37 "A" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            },
+                                            default: missing (optional),
+                                        },
+                                        COMMA@37..39 "," [] [Whitespace(" ")],
+                                        TsTypeParameter {
+                                            name: TsTypeParameterName {
+                                                ident_token: IDENT@39..41 "C" [] [Whitespace(" ")],
+                                            },
+                                            constraint: missing (optional),
+                                            default: TsDefaultTypeClause {
+                                                eq_token: EQ@41..43 "=" [] [Whitespace(" ")],
+                                                ty: TsStringType {
+                                                    string_token: STRING_KW@43..49 "string" [] [],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                    r_angle_token: R_ANGLE@49..50 ">" [] [],
+                                },
+                                parameters: JsParameters {
+                                    l_paren_token: L_PAREN@50..51 "(" [] [],
+                                    items: JsParameterList [
+                                        JsFormalParameter {
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@51..52 "a" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@52..54 ":" [] [Whitespace(" ")],
+                                                ty: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@54..55 "A" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                        COMMA@55..57 "," [] [Whitespace(" ")],
+                                        JsFormalParameter {
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@57..58 "b" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@58..60 ":" [] [Whitespace(" ")],
+                                                ty: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@60..61 "B" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                        COMMA@61..63 "," [] [Whitespace(" ")],
+                                        JsFormalParameter {
+                                            binding: JsIdentifierBinding {
+                                                name_token: IDENT@63..64 "c" [] [],
+                                            },
+                                            question_mark_token: missing (optional),
+                                            type_annotation: TsTypeAnnotation {
+                                                colon_token: COLON@64..66 ":" [] [Whitespace(" ")],
+                                                ty: TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@66..67 "C" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            },
+                                            initializer: missing (optional),
+                                        },
+                                    ],
+                                    r_paren_token: R_PAREN@67..69 ")" [] [Whitespace(" ")],
+                                },
+                                return_type_annotation: missing (optional),
+                                fat_arrow_token: FAT_ARROW@69..72 "=>" [] [Whitespace(" ")],
+                                body: JsStringLiteralExpression {
+                                    value_token: JS_STRING_LITERAL@72..79 "\"hello\"" [] [],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@79..80 ";" [] [],
+        },
+    ],
+    eof_token: EOF@80..81 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..81
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..80
+    0: JS_VARIABLE_STATEMENT@0..80
+      0: JS_VARIABLE_DECLARATIONS@0..79
+        0: LET_KW@0..18 "let" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@18..79
+          0: JS_VARIABLE_DECLARATION@18..79
+            0: JS_IDENTIFIER_BINDING@18..20
+              0: IDENT@18..20 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: (empty)
+            3: JS_INITIALIZER_CLAUSE@20..79
+              0: EQ@20..22 "=" [] [Whitespace(" ")]
+              1: JS_ARROW_FUNCTION_EXPRESSION@22..79
+                0: (empty)
+                1: TS_TYPE_PARAMETERS@22..50
+                  0: L_ANGLE@22..23 "<" [] []
+                  1: TS_TYPE_PARAMETER_LIST@23..49
+                    0: TS_TYPE_PARAMETER@23..24
+                      0: TS_TYPE_PARAMETER_NAME@23..24
+                        0: IDENT@23..24 "A" [] []
+                      1: (empty)
+                      2: (empty)
+                    1: COMMA@24..26 "," [] [Whitespace(" ")]
+                    2: TS_TYPE_PARAMETER@26..37
+                      0: TS_TYPE_PARAMETER_NAME@26..28
+                        0: IDENT@26..28 "B" [] [Whitespace(" ")]
+                      1: TS_TYPE_CONSTRAINT_CLAUSE@28..37
+                        0: EXTENDS_KW@28..36 "extends" [] [Whitespace(" ")]
+                        1: TS_REFERENCE_TYPE@36..37
+                          0: JS_REFERENCE_IDENTIFIER@36..37
+                            0: IDENT@36..37 "A" [] []
+                          1: (empty)
+                      2: (empty)
+                    3: COMMA@37..39 "," [] [Whitespace(" ")]
+                    4: TS_TYPE_PARAMETER@39..49
+                      0: TS_TYPE_PARAMETER_NAME@39..41
+                        0: IDENT@39..41 "C" [] [Whitespace(" ")]
+                      1: (empty)
+                      2: TS_DEFAULT_TYPE_CLAUSE@41..49
+                        0: EQ@41..43 "=" [] [Whitespace(" ")]
+                        1: TS_STRING_TYPE@43..49
+                          0: STRING_KW@43..49 "string" [] []
+                  2: R_ANGLE@49..50 ">" [] []
+                2: JS_PARAMETERS@50..69
+                  0: L_PAREN@50..51 "(" [] []
+                  1: JS_PARAMETER_LIST@51..67
+                    0: JS_FORMAL_PARAMETER@51..55
+                      0: JS_IDENTIFIER_BINDING@51..52
+                        0: IDENT@51..52 "a" [] []
+                      1: (empty)
+                      2: TS_TYPE_ANNOTATION@52..55
+                        0: COLON@52..54 ":" [] [Whitespace(" ")]
+                        1: TS_REFERENCE_TYPE@54..55
+                          0: JS_REFERENCE_IDENTIFIER@54..55
+                            0: IDENT@54..55 "A" [] []
+                          1: (empty)
+                      3: (empty)
+                    1: COMMA@55..57 "," [] [Whitespace(" ")]
+                    2: JS_FORMAL_PARAMETER@57..61
+                      0: JS_IDENTIFIER_BINDING@57..58
+                        0: IDENT@57..58 "b" [] []
+                      1: (empty)
+                      2: TS_TYPE_ANNOTATION@58..61
+                        0: COLON@58..60 ":" [] [Whitespace(" ")]
+                        1: TS_REFERENCE_TYPE@60..61
+                          0: JS_REFERENCE_IDENTIFIER@60..61
+                            0: IDENT@60..61 "B" [] []
+                          1: (empty)
+                      3: (empty)
+                    3: COMMA@61..63 "," [] [Whitespace(" ")]
+                    4: JS_FORMAL_PARAMETER@63..67
+                      0: JS_IDENTIFIER_BINDING@63..64
+                        0: IDENT@63..64 "c" [] []
+                      1: (empty)
+                      2: TS_TYPE_ANNOTATION@64..67
+                        0: COLON@64..66 ":" [] [Whitespace(" ")]
+                        1: TS_REFERENCE_TYPE@66..67
+                          0: JS_REFERENCE_IDENTIFIER@66..67
+                            0: IDENT@66..67 "C" [] []
+                          1: (empty)
+                      3: (empty)
+                  2: R_PAREN@67..69 ")" [] [Whitespace(" ")]
+                3: (empty)
+                4: FAT_ARROW@69..72 "=>" [] [Whitespace(" ")]
+                5: JS_STRING_LITERAL_EXPRESSION@72..79
+                  0: JS_STRING_LITERAL@72..79 "\"hello\"" [] []
+      1: SEMICOLON@79..80 ";" [] []
+  3: EOF@80..81 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_function_statement.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_function_statement.js
@@ -1,2 +1,3 @@
 // TYPESCRIPT
 function test(a: string, b?: number, c="default") {}
+function test2<A, B extends A, C = A>(a: A, b: B, c: C) {}

--- a/crates/rslint_parser/test_data/inline/ok/ts_function_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_function_statement.rast
@@ -65,14 +65,130 @@ JsModule {
                 r_curly_token: R_CURLY@65..66 "}" [] [],
             },
         },
+        JsFunctionStatement {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@66..76 "function" [Newline("\n")] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@76..81 "test2" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@81..82 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@82..83 "A" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                    COMMA@83..85 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@85..87 "B" [] [Whitespace(" ")],
+                        },
+                        constraint: TsTypeConstraintClause {
+                            extends_token: EXTENDS_KW@87..95 "extends" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@95..96 "A" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                        default: missing (optional),
+                    },
+                    COMMA@96..98 "," [] [Whitespace(" ")],
+                    TsTypeParameter {
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@98..100 "C" [] [Whitespace(" ")],
+                        },
+                        constraint: missing (optional),
+                        default: TsDefaultTypeClause {
+                            eq_token: EQ@100..102 "=" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@102..103 "A" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                    },
+                ],
+                r_angle_token: R_ANGLE@103..104 ">" [] [],
+            },
+            parameters: JsParameters {
+                l_paren_token: L_PAREN@104..105 "(" [] [],
+                items: JsParameterList [
+                    JsFormalParameter {
+                        binding: JsIdentifierBinding {
+                            name_token: IDENT@105..106 "a" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        type_annotation: TsTypeAnnotation {
+                            colon_token: COLON@106..108 ":" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@108..109 "A" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                    COMMA@109..111 "," [] [Whitespace(" ")],
+                    JsFormalParameter {
+                        binding: JsIdentifierBinding {
+                            name_token: IDENT@111..112 "b" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        type_annotation: TsTypeAnnotation {
+                            colon_token: COLON@112..114 ":" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@114..115 "B" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                    COMMA@115..117 "," [] [Whitespace(" ")],
+                    JsFormalParameter {
+                        binding: JsIdentifierBinding {
+                            name_token: IDENT@117..118 "c" [] [],
+                        },
+                        question_mark_token: missing (optional),
+                        type_annotation: TsTypeAnnotation {
+                            colon_token: COLON@118..120 ":" [] [Whitespace(" ")],
+                            ty: TsReferenceType {
+                                name: JsReferenceIdentifier {
+                                    value_token: IDENT@120..121 "C" [] [],
+                                },
+                                type_arguments: missing (optional),
+                            },
+                        },
+                        initializer: missing (optional),
+                    },
+                ],
+                r_paren_token: R_PAREN@121..123 ")" [] [Whitespace(" ")],
+            },
+            return_type_annotation: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@123..124 "{" [] [],
+                directives: JsDirectiveList [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@124..125 "}" [] [],
+            },
+        },
     ],
-    eof_token: EOF@66..67 "" [Newline("\n")] [],
+    eof_token: EOF@125..126 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..67
+0: JS_MODULE@0..126
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..66
+  2: JS_MODULE_ITEM_LIST@0..125
     0: JS_FUNCTION_STATEMENT@0..66
       0: (empty)
       1: FUNCTION_KW@0..23 "function" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
@@ -119,4 +235,86 @@ JsModule {
         1: JS_DIRECTIVE_LIST@65..65
         2: JS_STATEMENT_LIST@65..65
         3: R_CURLY@65..66 "}" [] []
-  3: EOF@66..67 "" [Newline("\n")] []
+    1: JS_FUNCTION_STATEMENT@66..125
+      0: (empty)
+      1: FUNCTION_KW@66..76 "function" [Newline("\n")] [Whitespace(" ")]
+      2: (empty)
+      3: JS_IDENTIFIER_BINDING@76..81
+        0: IDENT@76..81 "test2" [] []
+      4: TS_TYPE_PARAMETERS@81..104
+        0: L_ANGLE@81..82 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@82..103
+          0: TS_TYPE_PARAMETER@82..83
+            0: TS_TYPE_PARAMETER_NAME@82..83
+              0: IDENT@82..83 "A" [] []
+            1: (empty)
+            2: (empty)
+          1: COMMA@83..85 "," [] [Whitespace(" ")]
+          2: TS_TYPE_PARAMETER@85..96
+            0: TS_TYPE_PARAMETER_NAME@85..87
+              0: IDENT@85..87 "B" [] [Whitespace(" ")]
+            1: TS_TYPE_CONSTRAINT_CLAUSE@87..96
+              0: EXTENDS_KW@87..95 "extends" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@95..96
+                0: JS_REFERENCE_IDENTIFIER@95..96
+                  0: IDENT@95..96 "A" [] []
+                1: (empty)
+            2: (empty)
+          3: COMMA@96..98 "," [] [Whitespace(" ")]
+          4: TS_TYPE_PARAMETER@98..103
+            0: TS_TYPE_PARAMETER_NAME@98..100
+              0: IDENT@98..100 "C" [] [Whitespace(" ")]
+            1: (empty)
+            2: TS_DEFAULT_TYPE_CLAUSE@100..103
+              0: EQ@100..102 "=" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@102..103
+                0: JS_REFERENCE_IDENTIFIER@102..103
+                  0: IDENT@102..103 "A" [] []
+                1: (empty)
+        2: R_ANGLE@103..104 ">" [] []
+      5: JS_PARAMETERS@104..123
+        0: L_PAREN@104..105 "(" [] []
+        1: JS_PARAMETER_LIST@105..121
+          0: JS_FORMAL_PARAMETER@105..109
+            0: JS_IDENTIFIER_BINDING@105..106
+              0: IDENT@105..106 "a" [] []
+            1: (empty)
+            2: TS_TYPE_ANNOTATION@106..109
+              0: COLON@106..108 ":" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@108..109
+                0: JS_REFERENCE_IDENTIFIER@108..109
+                  0: IDENT@108..109 "A" [] []
+                1: (empty)
+            3: (empty)
+          1: COMMA@109..111 "," [] [Whitespace(" ")]
+          2: JS_FORMAL_PARAMETER@111..115
+            0: JS_IDENTIFIER_BINDING@111..112
+              0: IDENT@111..112 "b" [] []
+            1: (empty)
+            2: TS_TYPE_ANNOTATION@112..115
+              0: COLON@112..114 ":" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@114..115
+                0: JS_REFERENCE_IDENTIFIER@114..115
+                  0: IDENT@114..115 "B" [] []
+                1: (empty)
+            3: (empty)
+          3: COMMA@115..117 "," [] [Whitespace(" ")]
+          4: JS_FORMAL_PARAMETER@117..121
+            0: JS_IDENTIFIER_BINDING@117..118
+              0: IDENT@117..118 "c" [] []
+            1: (empty)
+            2: TS_TYPE_ANNOTATION@118..121
+              0: COLON@118..120 ":" [] [Whitespace(" ")]
+              1: TS_REFERENCE_TYPE@120..121
+                0: JS_REFERENCE_IDENTIFIER@120..121
+                  0: IDENT@120..121 "C" [] []
+                1: (empty)
+            3: (empty)
+        2: R_PAREN@121..123 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: JS_FUNCTION_BODY@123..125
+        0: L_CURLY@123..124 "{" [] []
+        1: JS_DIRECTIVE_LIST@124..124
+        2: JS_STATEMENT_LIST@124..124
+        3: R_CURLY@124..125 "}" [] []
+  3: EOF@125..126 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.js
@@ -1,0 +1,4 @@
+// TYPESCRIPT
+class Test {
+  test<A, B extends A, R>(a: A, b: B): R {}
+}

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.rast
@@ -1,0 +1,209 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassStatement {
+            class_token: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@20..25 "Test" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@25..26 "{" [] [],
+            members: JsClassMemberList [
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@26..33 "test" [Newline("\n"), Whitespace("  ")] [],
+                    },
+                    type_parameters: TsTypeParameters {
+                        l_angle_token: L_ANGLE@33..34 "<" [] [],
+                        items: TsTypeParameterList [
+                            TsTypeParameter {
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@34..35 "A" [] [],
+                                },
+                                constraint: missing (optional),
+                                default: missing (optional),
+                            },
+                            COMMA@35..37 "," [] [Whitespace(" ")],
+                            TsTypeParameter {
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@37..39 "B" [] [Whitespace(" ")],
+                                },
+                                constraint: TsTypeConstraintClause {
+                                    extends_token: EXTENDS_KW@39..47 "extends" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@47..48 "A" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                },
+                                default: missing (optional),
+                            },
+                            COMMA@48..50 "," [] [Whitespace(" ")],
+                            TsTypeParameter {
+                                name: TsTypeParameterName {
+                                    ident_token: IDENT@50..51 "R" [] [],
+                                },
+                                constraint: missing (optional),
+                                default: missing (optional),
+                            },
+                        ],
+                        r_angle_token: R_ANGLE@51..52 ">" [] [],
+                    },
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@52..53 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@53..54 "a" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@54..56 ":" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@56..57 "A" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                            COMMA@57..59 "," [] [Whitespace(" ")],
+                            JsFormalParameter {
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@59..60 "b" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@60..62 ":" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@62..63 "B" [] [],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@63..64 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@64..66 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@66..68 "R" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@68..69 "{" [] [],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [],
+                        r_curly_token: R_CURLY@69..70 "}" [] [],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@70..72 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@72..73 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..73
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..72
+    0: JS_CLASS_STATEMENT@0..72
+      0: CLASS_KW@0..20 "class" [Comments("// TYPESCRIPT"), Newline("\n")] [Whitespace(" ")]
+      1: JS_IDENTIFIER_BINDING@20..25
+        0: IDENT@20..25 "Test" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: (empty)
+      5: L_CURLY@25..26 "{" [] []
+      6: JS_CLASS_MEMBER_LIST@26..70
+        0: JS_METHOD_CLASS_MEMBER@26..70
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@26..33
+            0: IDENT@26..33 "test" [Newline("\n"), Whitespace("  ")] []
+          6: TS_TYPE_PARAMETERS@33..52
+            0: L_ANGLE@33..34 "<" [] []
+            1: TS_TYPE_PARAMETER_LIST@34..51
+              0: TS_TYPE_PARAMETER@34..35
+                0: TS_TYPE_PARAMETER_NAME@34..35
+                  0: IDENT@34..35 "A" [] []
+                1: (empty)
+                2: (empty)
+              1: COMMA@35..37 "," [] [Whitespace(" ")]
+              2: TS_TYPE_PARAMETER@37..48
+                0: TS_TYPE_PARAMETER_NAME@37..39
+                  0: IDENT@37..39 "B" [] [Whitespace(" ")]
+                1: TS_TYPE_CONSTRAINT_CLAUSE@39..48
+                  0: EXTENDS_KW@39..47 "extends" [] [Whitespace(" ")]
+                  1: TS_REFERENCE_TYPE@47..48
+                    0: JS_REFERENCE_IDENTIFIER@47..48
+                      0: IDENT@47..48 "A" [] []
+                    1: (empty)
+                2: (empty)
+              3: COMMA@48..50 "," [] [Whitespace(" ")]
+              4: TS_TYPE_PARAMETER@50..51
+                0: TS_TYPE_PARAMETER_NAME@50..51
+                  0: IDENT@50..51 "R" [] []
+                1: (empty)
+                2: (empty)
+            2: R_ANGLE@51..52 ">" [] []
+          7: JS_PARAMETERS@52..64
+            0: L_PAREN@52..53 "(" [] []
+            1: JS_PARAMETER_LIST@53..63
+              0: JS_FORMAL_PARAMETER@53..57
+                0: JS_IDENTIFIER_BINDING@53..54
+                  0: IDENT@53..54 "a" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@54..57
+                  0: COLON@54..56 ":" [] [Whitespace(" ")]
+                  1: TS_REFERENCE_TYPE@56..57
+                    0: JS_REFERENCE_IDENTIFIER@56..57
+                      0: IDENT@56..57 "A" [] []
+                    1: (empty)
+                3: (empty)
+              1: COMMA@57..59 "," [] [Whitespace(" ")]
+              2: JS_FORMAL_PARAMETER@59..63
+                0: JS_IDENTIFIER_BINDING@59..60
+                  0: IDENT@59..60 "b" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@60..63
+                  0: COLON@60..62 ":" [] [Whitespace(" ")]
+                  1: TS_REFERENCE_TYPE@62..63
+                    0: JS_REFERENCE_IDENTIFIER@62..63
+                      0: IDENT@62..63 "B" [] []
+                    1: (empty)
+                3: (empty)
+            2: R_PAREN@63..64 ")" [] []
+          8: TS_RETURN_TYPE_ANNOTATION@64..68
+            0: COLON@64..66 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@66..68
+              0: JS_REFERENCE_IDENTIFIER@66..68
+                0: IDENT@66..68 "R" [] [Whitespace(" ")]
+              1: (empty)
+          9: JS_FUNCTION_BODY@68..70
+            0: L_CURLY@68..69 "{" [] []
+            1: JS_DIRECTIVE_LIST@69..69
+            2: JS_STATEMENT_LIST@69..69
+            3: R_CURLY@69..70 "}" [] []
+      7: R_CURLY@70..72 "}" [Newline("\n")] []
+  3: EOF@72..73 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.js
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.js
@@ -1,0 +1,6 @@
+// TYPESCRIPT
+({
+    x<A>(maybeA: any): maybeA is A { return true },
+    y(a: string): string { return "string"; },
+    async *id<R>(param: Promise<R>): AsyncIterableIterator<R> { yield await param },
+})

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.rast
@@ -1,0 +1,400 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] [],
+                expression: JsObjectExpression {
+                    l_curly_token: L_CURLY@15..16 "{" [] [],
+                    members: JsObjectMemberList [
+                        JsMethodObjectMember {
+                            async_token: missing (optional),
+                            star_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@16..22 "x" [Newline("\n"), Whitespace("    ")] [],
+                            },
+                            type_params: TsTypeParameters {
+                                l_angle_token: L_ANGLE@22..23 "<" [] [],
+                                items: TsTypeParameterList [
+                                    TsTypeParameter {
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@23..24 "A" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                        default: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@24..25 ">" [] [],
+                            },
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@25..26 "(" [] [],
+                                items: JsParameterList [
+                                    JsFormalParameter {
+                                        binding: JsIdentifierBinding {
+                                            name_token: IDENT@26..32 "maybeA" [] [],
+                                        },
+                                        question_mark_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                                            ty: TsAnyType {
+                                                any_token: ANY_KW@34..37 "any" [] [],
+                                            },
+                                        },
+                                        initializer: missing (optional),
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@37..38 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@38..40 ":" [] [Whitespace(" ")],
+                                ty: TsTypePredicate {
+                                    asserts_token: missing (optional),
+                                    parameter_name: JsReferenceIdentifier {
+                                        value_token: IDENT@40..47 "maybeA" [] [Whitespace(" ")],
+                                    },
+                                    is_token: IS_KW@47..50 "is" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@50..52 "A" [] [Whitespace(" ")],
+                                        },
+                                        type_arguments: missing (optional),
+                                    },
+                                },
+                            },
+                            body: JsFunctionBody {
+                                l_curly_token: L_CURLY@52..54 "{" [] [Whitespace(" ")],
+                                directives: JsDirectiveList [],
+                                statements: JsStatementList [
+                                    JsReturnStatement {
+                                        return_token: RETURN_KW@54..61 "return" [] [Whitespace(" ")],
+                                        argument: JsBooleanLiteralExpression {
+                                            value_token: TRUE_KW@61..66 "true" [] [Whitespace(" ")],
+                                        },
+                                        semicolon_token: missing (optional),
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@66..67 "}" [] [],
+                            },
+                        },
+                        COMMA@67..68 "," [] [],
+                        JsMethodObjectMember {
+                            async_token: missing (optional),
+                            star_token: missing (optional),
+                            name: JsLiteralMemberName {
+                                value: IDENT@68..74 "y" [Newline("\n"), Whitespace("    ")] [],
+                            },
+                            type_params: missing (optional),
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@74..75 "(" [] [],
+                                items: JsParameterList [
+                                    JsFormalParameter {
+                                        binding: JsIdentifierBinding {
+                                            name_token: IDENT@75..76 "a" [] [],
+                                        },
+                                        question_mark_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@76..78 ":" [] [Whitespace(" ")],
+                                            ty: TsStringType {
+                                                string_token: STRING_KW@78..84 "string" [] [],
+                                            },
+                                        },
+                                        initializer: missing (optional),
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@84..85 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@85..87 ":" [] [Whitespace(" ")],
+                                ty: TsStringType {
+                                    string_token: STRING_KW@87..94 "string" [] [Whitespace(" ")],
+                                },
+                            },
+                            body: JsFunctionBody {
+                                l_curly_token: L_CURLY@94..96 "{" [] [Whitespace(" ")],
+                                directives: JsDirectiveList [],
+                                statements: JsStatementList [
+                                    JsReturnStatement {
+                                        return_token: RETURN_KW@96..103 "return" [] [Whitespace(" ")],
+                                        argument: JsStringLiteralExpression {
+                                            value_token: JS_STRING_LITERAL@103..111 "\"string\"" [] [],
+                                        },
+                                        semicolon_token: SEMICOLON@111..113 ";" [] [Whitespace(" ")],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@113..114 "}" [] [],
+                            },
+                        },
+                        COMMA@114..115 "," [] [],
+                        JsMethodObjectMember {
+                            async_token: ASYNC_KW@115..126 "async" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                            star_token: STAR@126..127 "*" [] [],
+                            name: JsLiteralMemberName {
+                                value: IDENT@127..129 "id" [] [],
+                            },
+                            type_params: TsTypeParameters {
+                                l_angle_token: L_ANGLE@129..130 "<" [] [],
+                                items: TsTypeParameterList [
+                                    TsTypeParameter {
+                                        name: TsTypeParameterName {
+                                            ident_token: IDENT@130..131 "R" [] [],
+                                        },
+                                        constraint: missing (optional),
+                                        default: missing (optional),
+                                    },
+                                ],
+                                r_angle_token: R_ANGLE@131..132 ">" [] [],
+                            },
+                            parameters: JsParameters {
+                                l_paren_token: L_PAREN@132..133 "(" [] [],
+                                items: JsParameterList [
+                                    JsFormalParameter {
+                                        binding: JsIdentifierBinding {
+                                            name_token: IDENT@133..138 "param" [] [],
+                                        },
+                                        question_mark_token: missing (optional),
+                                        type_annotation: TsTypeAnnotation {
+                                            colon_token: COLON@138..140 ":" [] [Whitespace(" ")],
+                                            ty: TsReferenceType {
+                                                name: JsReferenceIdentifier {
+                                                    value_token: IDENT@140..147 "Promise" [] [],
+                                                },
+                                                type_arguments: TsTypeArguments {
+                                                    l_angle_token: L_ANGLE@147..148 "<" [] [],
+                                                    ts_type_argument_list: TsTypeArgumentList [
+                                                        TsReferenceType {
+                                                            name: JsReferenceIdentifier {
+                                                                value_token: IDENT@148..149 "R" [] [],
+                                                            },
+                                                            type_arguments: missing (optional),
+                                                        },
+                                                    ],
+                                                    r_angle_token: R_ANGLE@149..150 ">" [] [],
+                                                },
+                                            },
+                                        },
+                                        initializer: missing (optional),
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@150..151 ")" [] [],
+                            },
+                            return_type_annotation: TsReturnTypeAnnotation {
+                                colon_token: COLON@151..153 ":" [] [Whitespace(" ")],
+                                ty: TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@153..174 "AsyncIterableIterator" [] [],
+                                    },
+                                    type_arguments: TsTypeArguments {
+                                        l_angle_token: L_ANGLE@174..175 "<" [] [],
+                                        ts_type_argument_list: TsTypeArgumentList [
+                                            TsReferenceType {
+                                                name: JsReferenceIdentifier {
+                                                    value_token: IDENT@175..176 "R" [] [],
+                                                },
+                                                type_arguments: missing (optional),
+                                            },
+                                        ],
+                                        r_angle_token: R_ANGLE@176..178 ">" [] [Whitespace(" ")],
+                                    },
+                                },
+                            },
+                            body: JsFunctionBody {
+                                l_curly_token: L_CURLY@178..180 "{" [] [Whitespace(" ")],
+                                directives: JsDirectiveList [],
+                                statements: JsStatementList [
+                                    JsExpressionStatement {
+                                        expression: JsYieldExpression {
+                                            yield_token: YIELD_KW@180..186 "yield" [] [Whitespace(" ")],
+                                            argument: JsYieldArgument {
+                                                star_token: missing (optional),
+                                                expression: JsAwaitExpression {
+                                                    await_token: AWAIT_KW@186..192 "await" [] [Whitespace(" ")],
+                                                    argument: JsIdentifierExpression {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@192..198 "param" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        semicolon_token: missing (optional),
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@198..199 "}" [] [],
+                            },
+                        },
+                        COMMA@199..200 "," [] [],
+                    ],
+                    r_curly_token: R_CURLY@200..202 "}" [Newline("\n")] [],
+                },
+                r_paren_token: R_PAREN@202..203 ")" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@203..204 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..204
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..203
+    0: JS_EXPRESSION_STATEMENT@0..203
+      0: JS_PARENTHESIZED_EXPRESSION@0..203
+        0: L_PAREN@0..15 "(" [Comments("// TYPESCRIPT"), Newline("\n")] []
+        1: JS_OBJECT_EXPRESSION@15..202
+          0: L_CURLY@15..16 "{" [] []
+          1: JS_OBJECT_MEMBER_LIST@16..200
+            0: JS_METHOD_OBJECT_MEMBER@16..67
+              0: (empty)
+              1: (empty)
+              2: JS_LITERAL_MEMBER_NAME@16..22
+                0: IDENT@16..22 "x" [Newline("\n"), Whitespace("    ")] []
+              3: TS_TYPE_PARAMETERS@22..25
+                0: L_ANGLE@22..23 "<" [] []
+                1: TS_TYPE_PARAMETER_LIST@23..24
+                  0: TS_TYPE_PARAMETER@23..24
+                    0: TS_TYPE_PARAMETER_NAME@23..24
+                      0: IDENT@23..24 "A" [] []
+                    1: (empty)
+                    2: (empty)
+                2: R_ANGLE@24..25 ">" [] []
+              4: JS_PARAMETERS@25..38
+                0: L_PAREN@25..26 "(" [] []
+                1: JS_PARAMETER_LIST@26..37
+                  0: JS_FORMAL_PARAMETER@26..37
+                    0: JS_IDENTIFIER_BINDING@26..32
+                      0: IDENT@26..32 "maybeA" [] []
+                    1: (empty)
+                    2: TS_TYPE_ANNOTATION@32..37
+                      0: COLON@32..34 ":" [] [Whitespace(" ")]
+                      1: TS_ANY_TYPE@34..37
+                        0: ANY_KW@34..37 "any" [] []
+                    3: (empty)
+                2: R_PAREN@37..38 ")" [] []
+              5: TS_RETURN_TYPE_ANNOTATION@38..52
+                0: COLON@38..40 ":" [] [Whitespace(" ")]
+                1: TS_TYPE_PREDICATE@40..52
+                  0: (empty)
+                  1: JS_REFERENCE_IDENTIFIER@40..47
+                    0: IDENT@40..47 "maybeA" [] [Whitespace(" ")]
+                  2: IS_KW@47..50 "is" [] [Whitespace(" ")]
+                  3: TS_REFERENCE_TYPE@50..52
+                    0: JS_REFERENCE_IDENTIFIER@50..52
+                      0: IDENT@50..52 "A" [] [Whitespace(" ")]
+                    1: (empty)
+              6: JS_FUNCTION_BODY@52..67
+                0: L_CURLY@52..54 "{" [] [Whitespace(" ")]
+                1: JS_DIRECTIVE_LIST@54..54
+                2: JS_STATEMENT_LIST@54..66
+                  0: JS_RETURN_STATEMENT@54..66
+                    0: RETURN_KW@54..61 "return" [] [Whitespace(" ")]
+                    1: JS_BOOLEAN_LITERAL_EXPRESSION@61..66
+                      0: TRUE_KW@61..66 "true" [] [Whitespace(" ")]
+                    2: (empty)
+                3: R_CURLY@66..67 "}" [] []
+            1: COMMA@67..68 "," [] []
+            2: JS_METHOD_OBJECT_MEMBER@68..114
+              0: (empty)
+              1: (empty)
+              2: JS_LITERAL_MEMBER_NAME@68..74
+                0: IDENT@68..74 "y" [Newline("\n"), Whitespace("    ")] []
+              3: (empty)
+              4: JS_PARAMETERS@74..85
+                0: L_PAREN@74..75 "(" [] []
+                1: JS_PARAMETER_LIST@75..84
+                  0: JS_FORMAL_PARAMETER@75..84
+                    0: JS_IDENTIFIER_BINDING@75..76
+                      0: IDENT@75..76 "a" [] []
+                    1: (empty)
+                    2: TS_TYPE_ANNOTATION@76..84
+                      0: COLON@76..78 ":" [] [Whitespace(" ")]
+                      1: TS_STRING_TYPE@78..84
+                        0: STRING_KW@78..84 "string" [] []
+                    3: (empty)
+                2: R_PAREN@84..85 ")" [] []
+              5: TS_RETURN_TYPE_ANNOTATION@85..94
+                0: COLON@85..87 ":" [] [Whitespace(" ")]
+                1: TS_STRING_TYPE@87..94
+                  0: STRING_KW@87..94 "string" [] [Whitespace(" ")]
+              6: JS_FUNCTION_BODY@94..114
+                0: L_CURLY@94..96 "{" [] [Whitespace(" ")]
+                1: JS_DIRECTIVE_LIST@96..96
+                2: JS_STATEMENT_LIST@96..113
+                  0: JS_RETURN_STATEMENT@96..113
+                    0: RETURN_KW@96..103 "return" [] [Whitespace(" ")]
+                    1: JS_STRING_LITERAL_EXPRESSION@103..111
+                      0: JS_STRING_LITERAL@103..111 "\"string\"" [] []
+                    2: SEMICOLON@111..113 ";" [] [Whitespace(" ")]
+                3: R_CURLY@113..114 "}" [] []
+            3: COMMA@114..115 "," [] []
+            4: JS_METHOD_OBJECT_MEMBER@115..199
+              0: ASYNC_KW@115..126 "async" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+              1: STAR@126..127 "*" [] []
+              2: JS_LITERAL_MEMBER_NAME@127..129
+                0: IDENT@127..129 "id" [] []
+              3: TS_TYPE_PARAMETERS@129..132
+                0: L_ANGLE@129..130 "<" [] []
+                1: TS_TYPE_PARAMETER_LIST@130..131
+                  0: TS_TYPE_PARAMETER@130..131
+                    0: TS_TYPE_PARAMETER_NAME@130..131
+                      0: IDENT@130..131 "R" [] []
+                    1: (empty)
+                    2: (empty)
+                2: R_ANGLE@131..132 ">" [] []
+              4: JS_PARAMETERS@132..151
+                0: L_PAREN@132..133 "(" [] []
+                1: JS_PARAMETER_LIST@133..150
+                  0: JS_FORMAL_PARAMETER@133..150
+                    0: JS_IDENTIFIER_BINDING@133..138
+                      0: IDENT@133..138 "param" [] []
+                    1: (empty)
+                    2: TS_TYPE_ANNOTATION@138..150
+                      0: COLON@138..140 ":" [] [Whitespace(" ")]
+                      1: TS_REFERENCE_TYPE@140..150
+                        0: JS_REFERENCE_IDENTIFIER@140..147
+                          0: IDENT@140..147 "Promise" [] []
+                        1: TS_TYPE_ARGUMENTS@147..150
+                          0: L_ANGLE@147..148 "<" [] []
+                          1: TS_TYPE_ARGUMENT_LIST@148..149
+                            0: TS_REFERENCE_TYPE@148..149
+                              0: JS_REFERENCE_IDENTIFIER@148..149
+                                0: IDENT@148..149 "R" [] []
+                              1: (empty)
+                          2: R_ANGLE@149..150 ">" [] []
+                    3: (empty)
+                2: R_PAREN@150..151 ")" [] []
+              5: TS_RETURN_TYPE_ANNOTATION@151..178
+                0: COLON@151..153 ":" [] [Whitespace(" ")]
+                1: TS_REFERENCE_TYPE@153..178
+                  0: JS_REFERENCE_IDENTIFIER@153..174
+                    0: IDENT@153..174 "AsyncIterableIterator" [] []
+                  1: TS_TYPE_ARGUMENTS@174..178
+                    0: L_ANGLE@174..175 "<" [] []
+                    1: TS_TYPE_ARGUMENT_LIST@175..176
+                      0: TS_REFERENCE_TYPE@175..176
+                        0: JS_REFERENCE_IDENTIFIER@175..176
+                          0: IDENT@175..176 "R" [] []
+                        1: (empty)
+                    2: R_ANGLE@176..178 ">" [] [Whitespace(" ")]
+              6: JS_FUNCTION_BODY@178..199
+                0: L_CURLY@178..180 "{" [] [Whitespace(" ")]
+                1: JS_DIRECTIVE_LIST@180..180
+                2: JS_STATEMENT_LIST@180..198
+                  0: JS_EXPRESSION_STATEMENT@180..198
+                    0: JS_YIELD_EXPRESSION@180..198
+                      0: YIELD_KW@180..186 "yield" [] [Whitespace(" ")]
+                      1: JS_YIELD_ARGUMENT@186..198
+                        0: (empty)
+                        1: JS_AWAIT_EXPRESSION@186..198
+                          0: AWAIT_KW@186..192 "await" [] [Whitespace(" ")]
+                          1: JS_IDENTIFIER_EXPRESSION@192..198
+                            0: JS_REFERENCE_IDENTIFIER@192..198
+                              0: IDENT@192..198 "param" [] [Whitespace(" ")]
+                    1: (empty)
+                3: R_CURLY@198..199 "}" [] []
+            5: COMMA@199..200 "," [] []
+          2: R_CURLY@200..202 "}" [Newline("\n")] []
+        2: R_PAREN@202..203 ")" [] []
+      1: (empty)
+  3: EOF@203..204 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_object_member_body.rast
@@ -14,7 +14,7 @@ JsModule {
                             name: JsLiteralMemberName {
                                 value: IDENT@16..22 "x" [Newline("\n"), Whitespace("    ")] [],
                             },
-                            type_params: TsTypeParameters {
+                            type_parameters: TsTypeParameters {
                                 l_angle_token: L_ANGLE@22..23 "<" [] [],
                                 items: TsTypeParameterList [
                                     TsTypeParameter {
@@ -84,7 +84,7 @@ JsModule {
                             name: JsLiteralMemberName {
                                 value: IDENT@68..74 "y" [Newline("\n"), Whitespace("    ")] [],
                             },
-                            type_params: missing (optional),
+                            type_parameters: missing (optional),
                             parameters: JsParameters {
                                 l_paren_token: L_PAREN@74..75 "(" [] [],
                                 items: JsParameterList [
@@ -132,7 +132,7 @@ JsModule {
                             name: JsLiteralMemberName {
                                 value: IDENT@127..129 "id" [] [],
                             },
-                            type_params: TsTypeParameters {
+                            type_parameters: TsTypeParameters {
                                 l_angle_token: L_ANGLE@129..130 "<" [] [],
                                 items: TsTypeParameterList [
                                     TsTypeParameter {

--- a/crates/rslint_parser/test_data/inline/ok/ts_property_parameter.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_property_parameter.rast
@@ -17,7 +17,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@24..35 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@35..36 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -84,7 +83,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@85..96 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@96..97 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -167,7 +165,6 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@185..196 "constructor" [] [],
                     },
-                    type_parameters: missing (optional),
                     parameters: JsConstructorParameters {
                         l_paren_token: L_PAREN@196..197 "(" [] [],
                         parameters: JsConstructorParameterList [
@@ -256,8 +253,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@24..35
             0: IDENT@24..35 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@35..70
+          2: JS_CONSTRUCTOR_PARAMETERS@35..70
             0: L_PAREN@35..36 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@36..68
               0: TS_PROPERTY_PARAMETER@36..45
@@ -287,7 +283,7 @@ JsModule {
                   2: (empty)
                   3: (empty)
             2: R_PAREN@68..70 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@70..73
+          3: JS_FUNCTION_BODY@70..73
             0: L_CURLY@70..71 "{" [] []
             1: JS_DIRECTIVE_LIST@71..71
             2: JS_STATEMENT_LIST@71..71
@@ -306,8 +302,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@85..96
             0: IDENT@85..96 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@96..170
+          2: JS_CONSTRUCTOR_PARAMETERS@96..170
             0: L_PAREN@96..97 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@97..168
               0: TS_READONLY_PROPERTY_PARAMETER@97..107
@@ -350,7 +345,7 @@ JsModule {
                   2: (empty)
                   3: (empty)
             2: R_PAREN@168..170 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@170..173
+          3: JS_FUNCTION_BODY@170..173
             0: L_CURLY@170..171 "{" [] []
             1: JS_DIRECTIVE_LIST@171..171
             2: JS_STATEMENT_LIST@171..171
@@ -369,8 +364,7 @@ JsModule {
           0: (empty)
           1: JS_LITERAL_MEMBER_NAME@185..196
             0: IDENT@185..196 "constructor" [] []
-          2: (empty)
-          3: JS_CONSTRUCTOR_PARAMETERS@196..253
+          2: JS_CONSTRUCTOR_PARAMETERS@196..253
             0: L_PAREN@196..197 "(" [] []
             1: JS_CONSTRUCTOR_PARAMETER_LIST@197..251
               0: TS_PROPERTY_PARAMETER@197..214
@@ -411,7 +405,7 @@ JsModule {
                   0: IDENT@247..251 "rest" [] []
                 2: (empty)
             2: R_PAREN@251..253 ")" [] [Whitespace(" ")]
-          4: JS_FUNCTION_BODY@253..256
+          3: JS_FUNCTION_BODY@253..256
             0: L_CURLY@253..254 "{" [] []
             1: JS_DIRECTIVE_LIST@254..254
             2: JS_STATEMENT_LIST@254..254

--- a/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
@@ -156,7 +156,7 @@ JsModule {
                                         name: JsLiteralMemberName {
                                             value: IDENT@119..123 "test" [] [],
                                         },
-                                        type_params: missing (optional),
+                                        type_parameters: missing (optional),
                                         parameters: JsParameters {
                                             l_paren_token: L_PAREN@123..124 "(" [] [],
                                             items: JsParameterList [

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -635,7 +635,6 @@ JsStaticInitializationBlockClassMember =
 JsConstructorClassMember =
 	access_modifier: ('private' | 'protected' | 'public')?
 	name: JsLiteralMemberName
-	type_parameters: TsTypeParameters?
 	parameters: JsConstructorParameters
 	body: JsFunctionBody
 

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -546,7 +546,7 @@ JsMethodObjectMember =
 	'async'?
 	'*'?
 	name: JsAnyObjectMemberName
-	type_params: TsTypeParameters?
+	type_parameters: TsTypeParameters?
 	parameters: JsParameters
 	return_type_annotation: TsReturnTypeAnnotation?
 	body: JsFunctionBody


### PR DESCRIPTION
## Summary

Adds type parameter parsing to function, arrow functions, and methods. Adds graceful recovery in case getters/setters have type parameters.

* Removes the `type_parameters` from the `ConstructorClassMember`. Constructors don't support type parameters
* Added improved diagnostics for getters, setters, or constructors with type parameters (this is a syntax error)
* Added improved diagnostics for setters with return type annotations
* Renamed `JsObjectMethodMember.type_params` to `type_parameters` to align with other nodes

## Test Plan

Added new tests for type parameters in methods, functions, arrow functions. 
