### PR TITLE
fix(rome_formatter): various minor corrections to the formatter

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -349,9 +349,11 @@ where
     }
 
     concat_elements(IntersperseFn::new(
-        elements.into_iter().filter(|(_, e)| !e.is_empty()),
-        |prev_node, next_node| {
-            if get_lines_between_nodes(prev_node.syntax(), next_node.syntax()) > 1 {
+        elements.into_iter(),
+        |prev_node, next_node, next_elem| {
+            if next_elem.is_empty() {
+                empty_element()
+            } else if get_lines_between_nodes(prev_node.syntax(), next_node.syntax()) > 1 {
                 empty_line()
             } else {
                 separator()

--- a/crates/rome_formatter/src/intersperse.rs
+++ b/crates/rome_formatter/src/intersperse.rs
@@ -97,7 +97,7 @@ where
 impl<I, F, N> IntersperseFn<I, F, N>
 where
     I: Iterator<Item = (N, FormatElement)>,
-    F: FnMut(&N, &N) -> FormatElement,
+    F: FnMut(&N, &N, &FormatElement) -> FormatElement,
 {
     pub fn new(iter: I, separator_factory: F) -> Self {
         Self {
@@ -111,15 +111,15 @@ where
 impl<I, F, N> Iterator for IntersperseFn<I, F, N>
 where
     I: Iterator<Item = (N, FormatElement)>,
-    F: FnMut(&N, &N) -> FormatElement,
+    F: FnMut(&N, &N, &FormatElement) -> FormatElement,
 {
     type Item = FormatElement;
 
     #[inline]
     fn next(&mut self) -> Option<FormatElement> {
         if let Some(prev_node) = self.prev_item.take() {
-            if let Some((next_node, _)) = self.iter.peek() {
-                return Some((self.separator_factory)(&prev_node, next_node));
+            if let Some((next_node, next_elem)) = self.iter.peek() {
+                return Some((self.separator_factory)(&prev_node, next_node, next_elem));
             }
         }
 
@@ -147,6 +147,6 @@ where
 impl<I, F, N> ExactSizeIterator for IntersperseFn<I, F, N>
 where
     I: Iterator<Item = (N, FormatElement)>,
-    F: FnMut(&N, &N) -> FormatElement,
+    F: FnMut(&N, &N, &FormatElement) -> FormatElement,
 {
 }

--- a/crates/rome_formatter/src/ts/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/function_body.rs
@@ -10,6 +10,7 @@ impl ToFormatElement for JsFunctionBody {
             |open_token_trailing, close_token_leading| {
                 Ok(block_indent(format_elements![
                     open_token_trailing,
+                    self.directives().to_format_element(formatter)?,
                     formatter.format_list(self.statements()),
                     close_token_leading,
                 ]))

--- a/crates/rome_formatter/src/ts/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/ts/auxiliary/function_body.rs
@@ -1,5 +1,6 @@
 use crate::{
-    block_indent, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
+    block_indent, format_elements, formatter_traits::FormatTokenAndNode, FormatElement,
+    FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsFunctionBody;
 
@@ -10,7 +11,7 @@ impl ToFormatElement for JsFunctionBody {
             |open_token_trailing, close_token_leading| {
                 Ok(block_indent(format_elements![
                     open_token_trailing,
-                    self.directives().to_format_element(formatter)?,
+                    self.directives().format(formatter)?,
                     formatter.format_list(self.statements()),
                     close_token_leading,
                 ]))

--- a/crates/rome_formatter/src/ts/class/getter_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/getter_class_member.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
@@ -7,6 +7,8 @@ use rslint_parser::ast::JsGetterClassMember;
 impl ToFormatElement for JsGetterClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         Ok(format_elements![
+            self.static_token()
+                .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
             self.get_token().format(formatter)?,
             space_token(),
             self.name().format(formatter)?,

--- a/crates/rome_formatter/src/ts/class/method_class_member.rs
+++ b/crates/rome_formatter/src/ts/class/method_class_member.rs
@@ -6,6 +6,9 @@ use rslint_parser::ast::JsMethodClassMember;
 
 impl ToFormatElement for JsMethodClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let async_token = self
+            .async_token()
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
         let static_token = self
             .static_token()
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
@@ -15,6 +18,7 @@ impl ToFormatElement for JsMethodClassMember {
         let body = self.body().format(formatter)?;
         Ok(format_elements![
             static_token,
+            async_token,
             star_token,
             name,
             params,

--- a/crates/rome_formatter/src/ts/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/ts/statements/for_of_statement.rs
@@ -1,6 +1,7 @@
 use rslint_parser::ast::JsForOfStatement;
 
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
+
 use crate::{
     format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
     FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -9,6 +10,9 @@ use crate::{
 impl ToFormatElement for JsForOfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let for_token = self.for_token().format(formatter)?;
+        let await_token = self
+            .await_token()
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
         let initializer = self.initializer().format(formatter)?;
         let of_token = self.of_token().format(formatter)?;
         let expression = self.expression().format(formatter)?;
@@ -17,6 +21,7 @@ impl ToFormatElement for JsForOfStatement {
         Ok(format_elements![
             for_token,
             space_token(),
+            await_token,
             formatter.format_delimited(
                 &self.l_paren_token()?,
                 |open_token_trailing, close_token_leading| Ok(group_elements(soft_block_indent(

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js
@@ -6,6 +6,10 @@ class Foo extends Boar {
 		super();
 	}
 
+	static get sg() {
+
+	}
+
 	get g() {
 
 	}
@@ -18,6 +22,10 @@ class Foo extends Boar {
 
 	lorem() {
 		return "ipsum";
+	}
+
+	async ipsum() {
+
 	}
 
 	static foo;

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js
@@ -18,21 +18,27 @@ class Foo extends Boar {
 
 	}
 
-	* generator (){}
-
-	lorem() {
+	method() {
 		return "ipsum";
 	}
 
-	async ipsum() {
+	async asyncMethod() {}
 
-	}
+	* generatorMethod (){}
 
-	static foo;
-
-	static bar() {
+	static staticMethod() {
 		return "bar"
 	}
+
+	async * asyncGeneratorMethod (){}
+
+	static async staticAsyncMethod (){}
+
+	static * staticGeneratorMethod (){}
+
+	static async *staticAsyncGeneratorMethod() {}
+
+	static foo;
 
 	new_prop = 5
 

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
@@ -25,21 +25,27 @@ class Foo extends Boar {
 
 	}
 
-	* generator (){}
-
-	lorem() {
+	method() {
 		return "ipsum";
 	}
 
-	async ipsum() {
+	async asyncMethod() {}
 
-	}
+	* generatorMethod (){}
 
-	static foo;
-
-	static bar() {
+	static staticMethod() {
 		return "bar"
 	}
+
+	async * asyncGeneratorMethod (){}
+
+	static async staticAsyncMethod (){}
+
+	static * staticGeneratorMethod (){}
+
+	static async *staticAsyncGeneratorMethod() {}
+
+	static foo;
 
 	new_prop = 5
 
@@ -78,19 +84,27 @@ class Foo extends Boar {
 
 	set gg(a) {}
 
-	*generator() {}
-
-	lorem() {
+	method() {
 		return "ipsum";
 	}
 
-	async ipsum() {}
+	async asyncMethod() {}
 
-	static foo;
+	*generatorMethod() {}
 
-	static bar() {
+	static staticMethod() {
 		return "bar";
 	}
+
+	async *asyncGeneratorMethod() {}
+
+	static async staticAsyncMethod() {}
+
+	static *staticGeneratorMethod() {}
+
+	static async *staticAsyncGeneratorMethod() {}
+
+	static foo;
 
 	new_prop = 5;
 

--- a/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/class/class.js.snap
@@ -13,6 +13,10 @@ class Foo extends Boar {
 		super();
 	}
 
+	static get sg() {
+
+	}
+
 	get g() {
 
 	}
@@ -25,6 +29,10 @@ class Foo extends Boar {
 
 	lorem() {
 		return "ipsum";
+	}
+
+	async ipsum() {
+
 	}
 
 	static foo;
@@ -64,6 +72,8 @@ class Foo extends Boar {
 		super();
 	}
 
+	static get sg() {}
+
 	get g() {}
 
 	set gg(a) {}
@@ -73,6 +83,8 @@ class Foo extends Boar {
 	lorem() {
 		return "ipsum";
 	}
+
+	async ipsum() {}
 
 	static foo;
 

--- a/crates/rome_formatter/tests/specs/js/module/function/function.js
+++ b/crates/rome_formatter/tests/specs/js/module/function/function.js
@@ -26,3 +26,7 @@ function foo() {
 
 	return ref;
 }
+
+function directives() {
+  "use strict";
+}

--- a/crates/rome_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/function/function.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 43
+assertion_line: 57
 expression: function.js
 
 ---
@@ -34,6 +34,10 @@ function foo() {
 	return ref;
 }
 
+function directives() {
+  "use strict";
+}
+
 ---
 # Output
 function foo() {}
@@ -63,5 +67,9 @@ function foo() {
 	);
 
 	return ref;
+}
+
+function directives() {
+	"use strict";
 }
 

--- a/crates/rome_formatter/tests/specs/js/module/newlines.js
+++ b/crates/rome_formatter/tests/specs/js/module/newlines.js
@@ -18,6 +18,10 @@ statement();
 statement();
 
 
+;
+
+
+
 switch(a) {
     case 1:
         break;

--- a/crates/rome_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/newlines.js.snap
@@ -25,6 +25,10 @@ statement();
 statement();
 
 
+;
+
+
+
 switch(a) {
     case 1:
         break;

--- a/crates/rome_formatter/tests/specs/js/module/statement/for_of.js
+++ b/crates/rome_formatter/tests/specs/js/module/statement/for_of.js
@@ -4,3 +4,5 @@ for (let a of b) {}
 
 for (const aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks of aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 }
+
+for await ( const a of b ) {}

--- a/crates/rome_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 43
+assertion_line: 57
 expression: for_of.js
 
 ---
@@ -11,6 +11,8 @@ for (let a of b) {}
 
 for (const aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks of aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks) {
 }
+
+for await ( const a of b ) {}
 
 ---
 # Output
@@ -23,4 +25,6 @@ for (
 	of
 	aVeryLongVariableNameToEnforceLineBreaksaVeryLongVariableNameToEnforceLineBreaks
 ) {}
+
+for await (const a of b) {}
 


### PR DESCRIPTION
## Summary

This fixes a number of issues that were caught when running our formatter on the prettier test suite:

- Directive lists in function bodies were not printed
- The `static` token on class getters was not printed
- The `async` token on class methods was not printed
- The `static` token on class getters was not printed
- The `await` token on for-of statements was not printed
- The debug assertions in `get_lines_between_nodes` were raised when empty statements were being filtered

Most of these are fixed by formatting the missing tokens. For the last point, instead of filtering out empty statements from the iterator they are left in, but the `join_elements_with` function now skips emitting a line break before an empty element.
