### PR TITLE
Windows: inline test file ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto
-crates/rslint_parser/test_data/**/*.js text eol=lf
+crates/rslint_parser/test_data/**/*.{js,ts} text eol=lf
 xtask/js.ungram text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * text=auto
-crates/rslint_parser/test_data/**/*.{js,ts} text eol=lf
+crates/rslint_parser/test_data/**/* text eol=lf
 xtask/js.ungram text eol=lf


### PR DESCRIPTION
## Summary

Our windows build is failing because `ts` line endings are converted to windows line endings by git on check out. 

This PR changes the line ending to LF for all files in the test data directory


https://github.com/rome/tools/actions/runs/1807656578

## Test Plan

Test in prod? 