### PR TITLE
docs: move extension development instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,3 +226,27 @@ cargo watch -i '*.new' -x 'test -p rome_formatter formatter'
 After test execution, you will get a new `arrow.js.snap.new` file.
 
 To actually update the snapshot, run `cargo insta review` to interactively review and accept the pending snapshot. `arrow.js.snap.new` will be replaced with `arrow.js.snap`
+
+## VS Code Extension Development
+
+To build the VS Code extension from source, navigate to the `editors/vscode` directory and run:
+
+```bash
+npm install
+npm run build
+```
+
+This will create a `rome_lsp.vsix` which you can install into VS Code by running:
+
+```bash
+npm run install-extension
+```
+
+The Rome language server is the binary crate `rome_lsp` which can be built using `cargo build`.
+
+Use the `"rome.lspBin"` VS Code setting to set the path to the executable:
+```json
+	"rome.lspBin": "/path/to/rome/target/debug/rome_lsp"
+```
+
+When performing any benchmarks for the language server, be sure to use a release build.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,19 +1,9 @@
-# Minimal LSP client for development
+# Rome VS Code Extension
 
-## Preparing the LSP server executable
+Adds support for the Rome language server to provide formatting, diagnostics, and code actions.
 
-From the root of the repository:
+## Usage
 
-```
-cargo install --path crates/rome_lsp
-```
+This extension may be bundled with a prebuilt binary for `rome_lsp`, the Rome language server.
 
-Alternately, you can set `"rome.lspBin"` in your vscode config to point to the `rome_lsp` binary of your choice (e.g. a debug build).
-
-## Installing the LSP client extension into VS Code
-
-```
-npm install
-npm run build
-npm run install-extension
-```
+You can set the path to a `rome_lsp` executable using the `"rome.lspBin"` setting in your VS Code Settings.


### PR DESCRIPTION
## Summary

The `README.md` for the VS Code extension will appear in the Marketplace and when viewing installed extensions, so it shouldn't include development instructions. This PR moves those instructions to the `CONTRIBUTING.md` file.

The `cargo install --path crates/rome_lsp` option was removed because the current extension no longer supports it.

