### PR TITLE
chor: Use `LF` endings for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-* text=auto
-crates/rslint_parser/test_data/**/* text eol=lf
-xtask/js.ungram text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
Our list of exceptions inside the `gitattributes` file when to use `LF` ending is ever-growing #2060, #2054.

Let's use the `LF` ending for all our files to solve this problem once and for all. This also aligns the configuration with our `.editorconfig`.

https://github.com/rome/tools/blob/a38b515dd1b3db064cf8778c004e18926d49a997/.editorconfig#L3-L4

## Test Plan

CI
