### PR TITLE
chore: hide generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto eol=lf
+crates/rslint_parser/src/ast/generated/* linguist-generated=true text=auto eol=lf
+crates/rslint_lexer/src/tables.rs linguist-generated=true text=auto eol=lf
+crates/rslint_syntax/src/generated.rs linguist-generated=true text=auto eol=lf


### PR DESCRIPTION
## Summary

Changes to the AST create changes in many generated files. These changes can be distracting from the real changes made by the author.

This PR sets the `linguist-generated=true` attribute for the files generated by the codegen so that they are hidden in diffs by default and no longer count to the repo's statistics.

[Source](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)

## Test Plan

You can see in #2072 that the generated files are hidden by default.
