### PR TITLE
fix(rslint_parser): Template literal error recovery

### DIFF
--- a/crates/rslint_parser/src/parser/single_token_parse_recovery.rs
+++ b/crates/rslint_parser/src/parser/single_token_parse_recovery.rs
@@ -39,12 +39,8 @@ impl SingleTokenParseRecovery {
         let error = self.get_error();
         if let Some(error) = error {
             p.error(error);
-        } else {
-            // the check on state should be done only when there's no error
-            if p.state.no_recovery {
-                return;
-            }
         }
+
         if !self.parsing_is_recoverable(p) {
             let m = p.start();
             p.bump_any();

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -36,7 +36,6 @@ pub(crate) struct ParserState {
     /// node that disallows duplicate bindings, for example `let`, `const` or `import`.
     pub duplicate_binding_parent: Option<&'static str>,
     pub name_map: IndexMap<String, Range<usize>>,
-    pub(crate) no_recovery: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -65,7 +64,6 @@ impl ParserState {
             default_item: None,
             name_map: IndexMap::new(),
             duplicate_binding_parent: None,
-            no_recovery: false,
         };
 
         if syntax.top_level_await {

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -193,17 +193,11 @@ pub(crate) fn try_parse(
 ) -> ParsedSyntax {
     let checkpoint = p.checkpoint();
 
-    let res = if p.state.no_recovery {
-        func(p)
-    } else {
-        let last_no_recovery = std::mem::replace(&mut p.state.no_recovery, true);
-        let res = func(p);
-        p.state.no_recovery = last_no_recovery;
-        res
-    };
+    let res = func(p);
 
     if res.is_absent() {
         p.rewind(checkpoint);
     }
+
     res
 }

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -1266,6 +1266,17 @@ impl ParseSeparatedList for TypeArgumentsList {
 
     fn recover(&mut self, p: &mut Parser, parsed_element: ParsedSyntax) -> RecoveryResult {
         if parsed_element.is_absent() && !self.recover_on_errors {
+            // test ts type_arguments_no_recovery
+            // for (let i = 0 ; i < 3; ++i) {
+            //     verify.completions({
+            //         marker: `${i + 1}`,
+            //         exact: [
+            //             { name: "foo", replacementSpan: test.ranges()[i] },
+            //             { name: "bar", replacementSpan: test.ranges()[i] },
+            //         ]
+            //     });
+            // }
+
             // Parse conditional expression speculatively tries to parse a list of type arguments
             // The parser shouldn't perform error recovery in that case and simply bail out of parsing
             RecoveryResult::Err(RecoveryError::AlreadyRecovered)

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -12,7 +12,15 @@ use std::path::{Path, PathBuf};
 #[test]
 fn parser_smoke_test() {
     let src = r#"
-type A = string;
+for (let i = 0 ; i < 3; ++i) {
+    verify.completions({
+        marker: `${i + 1}`,
+        exact: [
+            { name: "foo", replacementSpan: test.ranges()[i] },
+            { name: "bar", replacementSpan: test.ranges()[i] },
+        ]
+    });
+}
     "#;
 
     let module = parse(src, 0, Syntax::default().typescript());

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -12,15 +12,7 @@ use std::path::{Path, PathBuf};
 #[test]
 fn parser_smoke_test() {
     let src = r#"
-for (let i = 0 ; i < 3; ++i) {
-    verify.completions({
-        marker: `${i + 1}`,
-        exact: [
-            { name: "foo", replacementSpan: test.ranges()[i] },
-            { name: "bar", replacementSpan: test.ranges()[i] },
-        ]
-    });
-}
+type A = string;
     "#;
 
     let module = parse(src, 0, Syntax::default().typescript());

--- a/crates/rslint_parser/test_data/inline/err/template_literal.js
+++ b/crates/rslint_parser/test_data/inline/err/template_literal.js
@@ -1,1 +1,2 @@
 let a = `foo ${}`
+let b = `${a a}`

--- a/crates/rslint_parser/test_data/inline/err/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal.rast
@@ -35,14 +35,57 @@ JsModule {
             },
             semicolon_token: missing (optional),
         },
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@17..22 "let" [Newline("\n")] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@22..24 "b" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@24..26 "=" [] [Whitespace(" ")],
+                            expression: JsUnknownExpression {
+                                items: [
+                                    BACKTICK@26..27 "`" [] [],
+                                    JsUnknown {
+                                        items: [
+                                            JsUnknown {
+                                                items: [
+                                                    DOLLAR_CURLY@27..29 "${" [] [],
+                                                    JsIdentifierExpression {
+                                                        name: JsReferenceIdentifier {
+                                                            value_token: IDENT@29..31 "a" [] [Whitespace(" ")],
+                                                        },
+                                                    },
+                                                    JsUnknown {
+                                                        items: [
+                                                            IDENT@31..32 "a" [] [],
+                                                        ],
+                                                    },
+                                                    R_CURLY@32..33 "}" [] [],
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                    BACKTICK@33..34 "`" [] [],
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
     ],
-    eof_token: EOF@17..18 "" [Newline("\n")] [],
+    eof_token: EOF@34..35 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..18
+0: JS_MODULE@0..35
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..17
+  2: JS_MODULE_ITEM_LIST@0..34
     0: JS_VARIABLE_STATEMENT@0..17
       0: JS_VARIABLE_DECLARATIONS@0..17
         0: LET_KW@0..4 "let" [] [Whitespace(" ")]
@@ -66,7 +109,30 @@ JsModule {
                     2: R_CURLY@15..16 "}" [] []
                 4: BACKTICK@16..17 "`" [] []
       1: (empty)
-  3: EOF@17..18 "" [Newline("\n")] []
+    1: JS_VARIABLE_STATEMENT@17..34
+      0: JS_VARIABLE_DECLARATIONS@17..34
+        0: LET_KW@17..22 "let" [Newline("\n")] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@22..34
+          0: JS_VARIABLE_DECLARATION@22..34
+            0: JS_IDENTIFIER_BINDING@22..24
+              0: IDENT@22..24 "b" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@24..34
+              0: EQ@24..26 "=" [] [Whitespace(" ")]
+              1: JS_UNKNOWN_EXPRESSION@26..34
+                0: BACKTICK@26..27 "`" [] []
+                1: JS_UNKNOWN@27..33
+                  0: JS_UNKNOWN@27..33
+                    0: DOLLAR_CURLY@27..29 "${" [] []
+                    1: JS_IDENTIFIER_EXPRESSION@29..31
+                      0: JS_REFERENCE_IDENTIFIER@29..31
+                        0: IDENT@29..31 "a" [] [Whitespace(" ")]
+                    2: JS_UNKNOWN@31..32
+                      0: IDENT@31..32 "a" [] []
+                    3: R_CURLY@32..33 "}" [] []
+                2: BACKTICK@33..34 "`" [] []
+      1: (empty)
+  3: EOF@34..35 "" [Newline("\n")] []
 --
 error[SyntaxError]: expected an expression but instead found '}'
   ┌─ template_literal.js:1:16
@@ -75,4 +141,12 @@ error[SyntaxError]: expected an expression but instead found '}'
   │                ^ Expected an expression here
 
 --
+error[SyntaxError]: expected `'}'` but instead found `a`
+  ┌─ template_literal.js:2:14
+  │
+2 │ let b = `${a a}`
+  │              ^ unexpected
+
+--
 let a = `foo ${}`
+let b = `${a a}`

--- a/crates/rslint_parser/test_data/inline/err/ts_template_literal_error.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_template_literal_error.rast
@@ -1,0 +1,209 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasStatement {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..7 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@7..9 "=" [] [Whitespace(" ")],
+            ty: TsStringLiteralType {
+                literal_token: JS_STRING_LITERAL@9..12 "\"a\"" [] [],
+            },
+            semicolon_token: SEMICOLON@12..13 ";" [] [],
+        },
+        TsTypeAliasStatement {
+            type_token: TYPE_KW@13..19 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@19..21 "B" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@21..23 "=" [] [Whitespace(" ")],
+            ty: TsStringLiteralType {
+                literal_token: JS_STRING_LITERAL@23..26 "\"b\"" [] [],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsUnknownStatement {
+            items: [
+                TYPE_KW@26..32 "type" [Newline("\n")] [Whitespace(" ")],
+                TsIdentifierBinding {
+                    name_token: IDENT@32..34 "C" [] [Whitespace(" ")],
+                },
+                EQ@34..36 "=" [] [Whitespace(" ")],
+                JsUnknown {
+                    items: [
+                        BACKTICK@36..37 "`" [] [],
+                        JsUnknown {
+                            items: [
+                                JsUnknown {
+                                    items: [
+                                        DOLLAR_CURLY@37..39 "${" [] [],
+                                        TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@39..41 "A" [] [Whitespace(" ")],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        JsUnknown {
+                                            items: [
+                                                IDENT@41..42 "B" [] [],
+                                            ],
+                                        },
+                                        R_CURLY@42..43 "}" [] [],
+                                    ],
+                                },
+                                TsTemplateChunkElement {
+                                    template_chunk_token: TEMPLATE_CHUNK@43..46 "bcd" [] [],
+                                },
+                            ],
+                        },
+                        BACKTICK@46..47 "`" [] [],
+                    ],
+                },
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                TYPE_KW@47..53 "type" [Newline("\n")] [Whitespace(" ")],
+                TsIdentifierBinding {
+                    name_token: IDENT@53..55 "D" [] [Whitespace(" ")],
+                },
+                EQ@55..57 "=" [] [Whitespace(" ")],
+                JsUnknown {
+                    items: [
+                        BACKTICK@57..58 "`" [] [],
+                        JsUnknown {
+                            items: [
+                                JsUnknown {
+                                    items: [
+                                        DOLLAR_CURLY@58..60 "${" [] [],
+                                        TsReferenceType {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@60..62 "A" [] [Whitespace(" ")],
+                                            },
+                                            type_arguments: missing (optional),
+                                        },
+                                        JsUnknown {
+                                            items: [
+                                                IDENT@62..63 "B" [] [],
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        BACKTICK@63..64 "`" [] [],
+                    ],
+                },
+            ],
+        },
+        JsUnknownStatement {
+            items: [
+                ERROR_TOKEN@64..65 "\n" [] [],
+            ],
+        },
+    ],
+    eof_token: EOF@65..65 "" [] [],
+}
+
+0: JS_MODULE@0..65
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..65
+    0: TS_TYPE_ALIAS_STATEMENT@0..13
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..7
+        0: IDENT@5..7 "A" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@7..9 "=" [] [Whitespace(" ")]
+      4: TS_STRING_LITERAL_TYPE@9..12
+        0: JS_STRING_LITERAL@9..12 "\"a\"" [] []
+      5: SEMICOLON@12..13 ";" [] []
+    1: TS_TYPE_ALIAS_STATEMENT@13..26
+      0: TYPE_KW@13..19 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@19..21
+        0: IDENT@19..21 "B" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@21..23 "=" [] [Whitespace(" ")]
+      4: TS_STRING_LITERAL_TYPE@23..26
+        0: JS_STRING_LITERAL@23..26 "\"b\"" [] []
+      5: (empty)
+    2: JS_UNKNOWN_STATEMENT@26..47
+      0: TYPE_KW@26..32 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@32..34
+        0: IDENT@32..34 "C" [] [Whitespace(" ")]
+      2: EQ@34..36 "=" [] [Whitespace(" ")]
+      3: JS_UNKNOWN@36..47
+        0: BACKTICK@36..37 "`" [] []
+        1: JS_UNKNOWN@37..46
+          0: JS_UNKNOWN@37..43
+            0: DOLLAR_CURLY@37..39 "${" [] []
+            1: TS_REFERENCE_TYPE@39..41
+              0: JS_REFERENCE_IDENTIFIER@39..41
+                0: IDENT@39..41 "A" [] [Whitespace(" ")]
+              1: (empty)
+            2: JS_UNKNOWN@41..42
+              0: IDENT@41..42 "B" [] []
+            3: R_CURLY@42..43 "}" [] []
+          1: TS_TEMPLATE_CHUNK_ELEMENT@43..46
+            0: TEMPLATE_CHUNK@43..46 "bcd" [] []
+        2: BACKTICK@46..47 "`" [] []
+    3: JS_UNKNOWN_STATEMENT@47..64
+      0: TYPE_KW@47..53 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@53..55
+        0: IDENT@53..55 "D" [] [Whitespace(" ")]
+      2: EQ@55..57 "=" [] [Whitespace(" ")]
+      3: JS_UNKNOWN@57..64
+        0: BACKTICK@57..58 "`" [] []
+        1: JS_UNKNOWN@58..63
+          0: JS_UNKNOWN@58..63
+            0: DOLLAR_CURLY@58..60 "${" [] []
+            1: TS_REFERENCE_TYPE@60..62
+              0: JS_REFERENCE_IDENTIFIER@60..62
+                0: IDENT@60..62 "A" [] [Whitespace(" ")]
+              1: (empty)
+            2: JS_UNKNOWN@62..63
+              0: IDENT@62..63 "B" [] []
+        2: BACKTICK@63..64 "`" [] []
+    4: JS_UNKNOWN_STATEMENT@64..65
+      0: ERROR_TOKEN@64..65 "\n" [] []
+  3: EOF@65..65 "" [] []
+--
+error: unterminated template literal
+  ┌─ ts_template_literal_error.ts:5:1
+  │
+5 │ 
+  │ ^
+
+--
+error[SyntaxError]: expected `'}'` but instead found `B`
+  ┌─ ts_template_literal_error.ts:3:15
+  │
+3 │ type C = `${A B}bcd`
+  │               ^ unexpected
+
+--
+error[SyntaxError]: expected `'}'` but instead found `B`
+  ┌─ ts_template_literal_error.ts:4:15
+  │
+4 │ type D = `${A B`
+  │               ^ unexpected
+
+--
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ ts_template_literal_error.ts:4:17
+  │    
+4 │ ┌   type D = `${A B`
+  │ │ ┌────────────────^
+5 │ │ │ 
+  │ └─│' ...Which is required to end this statement
+  │   └^ An explicit or implicit semicolon is expected here...
+
+--
+type A = "a";
+type B = "b"
+type C = `${A B}bcd`
+type D = `${A B`

--- a/crates/rslint_parser/test_data/inline/err/ts_template_literal_error.ts
+++ b/crates/rslint_parser/test_data/inline/err/ts_template_literal_error.ts
@@ -1,0 +1,4 @@
+type A = "a";
+type B = "b"
+type C = `${A B}bcd`
+type D = `${A B`

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.js
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.js
@@ -2,3 +2,4 @@ let a = `foo ${bar}`;
 let b = ``;
 let c = `${foo}`;
 let d = `foo`;
+let e = `${{ a: "string" }}`;

--- a/crates/rslint_parser/test_data/inline/ok/template_literal.rast
+++ b/crates/rslint_parser/test_data/inline/ok/template_literal.rast
@@ -125,14 +125,58 @@ JsModule {
             },
             semicolon_token: SEMICOLON@65..66 ";" [] [],
         },
+        JsVariableStatement {
+            declarations: JsVariableDeclarations {
+                kind: LET_KW@66..71 "let" [Newline("\n")] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@71..73 "e" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@73..75 "=" [] [Whitespace(" ")],
+                            expression: JsTemplate {
+                                tag: missing (optional),
+                                type_arguments: missing (optional),
+                                l_tick_token: BACKTICK@75..76 "`" [] [],
+                                elements: JsTemplateElementList [
+                                    JsTemplateElement {
+                                        dollar_curly_token: DOLLAR_CURLY@76..78 "${" [] [],
+                                        expression: JsObjectExpression {
+                                            l_curly_token: L_CURLY@78..80 "{" [] [Whitespace(" ")],
+                                            members: JsObjectMemberList [
+                                                JsPropertyObjectMember {
+                                                    name: JsLiteralMemberName {
+                                                        value: IDENT@80..81 "a" [] [],
+                                                    },
+                                                    colon_token: COLON@81..83 ":" [] [Whitespace(" ")],
+                                                    value: JsStringLiteralExpression {
+                                                        value_token: JS_STRING_LITERAL@83..92 "\"string\"" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            ],
+                                            r_curly_token: R_CURLY@92..93 "}" [] [],
+                                        },
+                                        r_curly_token: R_CURLY@93..94 "}" [] [],
+                                    },
+                                ],
+                                r_tick_token: BACKTICK@94..95 "`" [] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@95..96 ";" [] [],
+        },
     ],
-    eof_token: EOF@66..67 "" [Newline("\n")] [],
+    eof_token: EOF@96..97 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..67
+0: JS_MODULE@0..97
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..66
+  2: JS_MODULE_ITEM_LIST@0..96
     0: JS_VARIABLE_STATEMENT@0..21
       0: JS_VARIABLE_DECLARATIONS@0..20
         0: LET_KW@0..4 "let" [] [Whitespace(" ")]
@@ -217,4 +261,34 @@ JsModule {
                     0: TEMPLATE_CHUNK@61..64 "foo" [] []
                 4: BACKTICK@64..65 "`" [] []
       1: SEMICOLON@65..66 ";" [] []
-  3: EOF@66..67 "" [Newline("\n")] []
+    4: JS_VARIABLE_STATEMENT@66..96
+      0: JS_VARIABLE_DECLARATIONS@66..95
+        0: LET_KW@66..71 "let" [Newline("\n")] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@71..95
+          0: JS_VARIABLE_DECLARATION@71..95
+            0: JS_IDENTIFIER_BINDING@71..73
+              0: IDENT@71..73 "e" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@73..95
+              0: EQ@73..75 "=" [] [Whitespace(" ")]
+              1: JS_TEMPLATE@75..95
+                0: (empty)
+                1: (empty)
+                2: BACKTICK@75..76 "`" [] []
+                3: JS_TEMPLATE_ELEMENT_LIST@76..94
+                  0: JS_TEMPLATE_ELEMENT@76..94
+                    0: DOLLAR_CURLY@76..78 "${" [] []
+                    1: JS_OBJECT_EXPRESSION@78..93
+                      0: L_CURLY@78..80 "{" [] [Whitespace(" ")]
+                      1: JS_OBJECT_MEMBER_LIST@80..92
+                        0: JS_PROPERTY_OBJECT_MEMBER@80..92
+                          0: JS_LITERAL_MEMBER_NAME@80..81
+                            0: IDENT@80..81 "a" [] []
+                          1: COLON@81..83 ":" [] [Whitespace(" ")]
+                          2: JS_STRING_LITERAL_EXPRESSION@83..92
+                            0: JS_STRING_LITERAL@83..92 "\"string\"" [] [Whitespace(" ")]
+                      2: R_CURLY@92..93 "}" [] []
+                    2: R_CURLY@93..94 "}" [] []
+                4: BACKTICK@94..95 "`" [] []
+      1: SEMICOLON@95..96 ";" [] []
+  3: EOF@96..97 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.rast
@@ -1,0 +1,393 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsForStatement {
+            for_token: FOR_KW@0..4 "for" [] [Whitespace(" ")],
+            l_paren_token: L_PAREN@4..5 "(" [] [],
+            initializer: JsVariableDeclarations {
+                kind: LET_KW@5..9 "let" [] [Whitespace(" ")],
+                items: JsVariableDeclarationList [
+                    JsVariableDeclaration {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@9..11 "i" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@11..13 "=" [] [Whitespace(" ")],
+                            expression: JsNumberLiteralExpression {
+                                value_token: JS_NUMBER_LITERAL@13..15 "0" [] [Whitespace(" ")],
+                            },
+                        },
+                    },
+                ],
+            },
+            first_semi_token: SEMICOLON@15..17 ";" [] [Whitespace(" ")],
+            test: JsBinaryExpression {
+                left: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@17..19 "i" [] [Whitespace(" ")],
+                    },
+                },
+                operator: L_ANGLE@19..21 "<" [] [Whitespace(" ")],
+                right: JsNumberLiteralExpression {
+                    value_token: JS_NUMBER_LITERAL@21..22 "3" [] [],
+                },
+            },
+            second_semi_token: SEMICOLON@22..24 ";" [] [Whitespace(" ")],
+            update: JsPreUpdateExpression {
+                operator: PLUS2@24..26 "++" [] [],
+                operand: JsIdentifierAssignment {
+                    name_token: IDENT@26..27 "i" [] [],
+                },
+            },
+            r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@29..30 "{" [] [],
+                statements: JsStatementList [
+                    JsExpressionStatement {
+                        expression: JsCallExpression {
+                            callee: JsStaticMemberExpression {
+                                object: JsIdentifierExpression {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@30..41 "verify" [Newline("\n"), Whitespace("    ")] [],
+                                    },
+                                },
+                                operator: DOT@41..42 "." [] [],
+                                member: JsName {
+                                    value_token: IDENT@42..53 "completions" [] [],
+                                },
+                            },
+                            optional_chain_token_token: missing (optional),
+                            type_arguments: missing (optional),
+                            arguments: JsCallArguments {
+                                l_paren_token: L_PAREN@53..54 "(" [] [],
+                                args: JsCallArgumentList [
+                                    JsObjectExpression {
+                                        l_curly_token: L_CURLY@54..55 "{" [] [],
+                                        members: JsObjectMemberList [
+                                            JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@55..70 "marker" [Newline("\n"), Whitespace("        ")] [],
+                                                },
+                                                colon_token: COLON@70..72 ":" [] [Whitespace(" ")],
+                                                value: JsTemplate {
+                                                    tag: missing (optional),
+                                                    type_arguments: missing (optional),
+                                                    l_tick_token: BACKTICK@72..73 "`" [] [],
+                                                    elements: JsTemplateElementList [
+                                                        JsTemplateElement {
+                                                            dollar_curly_token: DOLLAR_CURLY@73..75 "${" [] [],
+                                                            expression: JsBinaryExpression {
+                                                                left: JsIdentifierExpression {
+                                                                    name: JsReferenceIdentifier {
+                                                                        value_token: IDENT@75..77 "i" [] [Whitespace(" ")],
+                                                                    },
+                                                                },
+                                                                operator: PLUS@77..79 "+" [] [Whitespace(" ")],
+                                                                right: JsNumberLiteralExpression {
+                                                                    value_token: JS_NUMBER_LITERAL@79..80 "1" [] [],
+                                                                },
+                                                            },
+                                                            r_curly_token: R_CURLY@80..81 "}" [] [],
+                                                        },
+                                                    ],
+                                                    r_tick_token: BACKTICK@81..82 "`" [] [],
+                                                },
+                                            },
+                                            COMMA@82..83 "," [] [],
+                                            JsPropertyObjectMember {
+                                                name: JsLiteralMemberName {
+                                                    value: IDENT@83..97 "exact" [Newline("\n"), Whitespace("        ")] [],
+                                                },
+                                                colon_token: COLON@97..99 ":" [] [Whitespace(" ")],
+                                                value: JsArrayExpression {
+                                                    l_brack_token: L_BRACK@99..100 "[" [] [],
+                                                    elements: JsArrayElementList [
+                                                        JsObjectExpression {
+                                                            l_curly_token: L_CURLY@100..115 "{" [Newline("\n"), Whitespace("            ")] [Whitespace(" ")],
+                                                            members: JsObjectMemberList [
+                                                                JsPropertyObjectMember {
+                                                                    name: JsLiteralMemberName {
+                                                                        value: IDENT@115..119 "name" [] [],
+                                                                    },
+                                                                    colon_token: COLON@119..121 ":" [] [Whitespace(" ")],
+                                                                    value: JsStringLiteralExpression {
+                                                                        value_token: JS_STRING_LITERAL@121..126 "\"foo\"" [] [],
+                                                                    },
+                                                                },
+                                                                COMMA@126..128 "," [] [Whitespace(" ")],
+                                                                JsPropertyObjectMember {
+                                                                    name: JsLiteralMemberName {
+                                                                        value: IDENT@128..143 "replacementSpan" [] [],
+                                                                    },
+                                                                    colon_token: COLON@143..145 ":" [] [Whitespace(" ")],
+                                                                    value: JsComputedMemberExpression {
+                                                                        object: JsCallExpression {
+                                                                            callee: JsStaticMemberExpression {
+                                                                                object: JsIdentifierExpression {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@145..149 "test" [] [],
+                                                                                    },
+                                                                                },
+                                                                                operator: DOT@149..150 "." [] [],
+                                                                                member: JsName {
+                                                                                    value_token: IDENT@150..156 "ranges" [] [],
+                                                                                },
+                                                                            },
+                                                                            optional_chain_token_token: missing (optional),
+                                                                            type_arguments: missing (optional),
+                                                                            arguments: JsCallArguments {
+                                                                                l_paren_token: L_PAREN@156..157 "(" [] [],
+                                                                                args: JsCallArgumentList [],
+                                                                                r_paren_token: R_PAREN@157..158 ")" [] [],
+                                                                            },
+                                                                        },
+                                                                        optional_chain_token: missing (optional),
+                                                                        l_brack_token: L_BRACK@158..159 "[" [] [],
+                                                                        member: JsIdentifierExpression {
+                                                                            name: JsReferenceIdentifier {
+                                                                                value_token: IDENT@159..160 "i" [] [],
+                                                                            },
+                                                                        },
+                                                                        r_brack_token: R_BRACK@160..162 "]" [] [Whitespace(" ")],
+                                                                    },
+                                                                },
+                                                            ],
+                                                            r_curly_token: R_CURLY@162..163 "}" [] [],
+                                                        },
+                                                        COMMA@163..164 "," [] [],
+                                                        JsObjectExpression {
+                                                            l_curly_token: L_CURLY@164..179 "{" [Newline("\n"), Whitespace("            ")] [Whitespace(" ")],
+                                                            members: JsObjectMemberList [
+                                                                JsPropertyObjectMember {
+                                                                    name: JsLiteralMemberName {
+                                                                        value: IDENT@179..183 "name" [] [],
+                                                                    },
+                                                                    colon_token: COLON@183..185 ":" [] [Whitespace(" ")],
+                                                                    value: JsStringLiteralExpression {
+                                                                        value_token: JS_STRING_LITERAL@185..190 "\"bar\"" [] [],
+                                                                    },
+                                                                },
+                                                                COMMA@190..192 "," [] [Whitespace(" ")],
+                                                                JsPropertyObjectMember {
+                                                                    name: JsLiteralMemberName {
+                                                                        value: IDENT@192..207 "replacementSpan" [] [],
+                                                                    },
+                                                                    colon_token: COLON@207..209 ":" [] [Whitespace(" ")],
+                                                                    value: JsComputedMemberExpression {
+                                                                        object: JsCallExpression {
+                                                                            callee: JsStaticMemberExpression {
+                                                                                object: JsIdentifierExpression {
+                                                                                    name: JsReferenceIdentifier {
+                                                                                        value_token: IDENT@209..213 "test" [] [],
+                                                                                    },
+                                                                                },
+                                                                                operator: DOT@213..214 "." [] [],
+                                                                                member: JsName {
+                                                                                    value_token: IDENT@214..220 "ranges" [] [],
+                                                                                },
+                                                                            },
+                                                                            optional_chain_token_token: missing (optional),
+                                                                            type_arguments: missing (optional),
+                                                                            arguments: JsCallArguments {
+                                                                                l_paren_token: L_PAREN@220..221 "(" [] [],
+                                                                                args: JsCallArgumentList [],
+                                                                                r_paren_token: R_PAREN@221..222 ")" [] [],
+                                                                            },
+                                                                        },
+                                                                        optional_chain_token: missing (optional),
+                                                                        l_brack_token: L_BRACK@222..223 "[" [] [],
+                                                                        member: JsIdentifierExpression {
+                                                                            name: JsReferenceIdentifier {
+                                                                                value_token: IDENT@223..224 "i" [] [],
+                                                                            },
+                                                                        },
+                                                                        r_brack_token: R_BRACK@224..226 "]" [] [Whitespace(" ")],
+                                                                    },
+                                                                },
+                                                            ],
+                                                            r_curly_token: R_CURLY@226..227 "}" [] [],
+                                                        },
+                                                        COMMA@227..228 "," [] [],
+                                                    ],
+                                                    r_brack_token: R_BRACK@228..238 "]" [Newline("\n"), Whitespace("        ")] [],
+                                                },
+                                            },
+                                        ],
+                                        r_curly_token: R_CURLY@238..244 "}" [Newline("\n"), Whitespace("    ")] [],
+                                    },
+                                ],
+                                r_paren_token: R_PAREN@244..245 ")" [] [],
+                            },
+                        },
+                        semicolon_token: SEMICOLON@245..246 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@246..248 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@248..249 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..249
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..248
+    0: JS_FOR_STATEMENT@0..248
+      0: FOR_KW@0..4 "for" [] [Whitespace(" ")]
+      1: L_PAREN@4..5 "(" [] []
+      2: JS_VARIABLE_DECLARATIONS@5..15
+        0: LET_KW@5..9 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATION_LIST@9..15
+          0: JS_VARIABLE_DECLARATION@9..15
+            0: JS_IDENTIFIER_BINDING@9..11
+              0: IDENT@9..11 "i" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@11..15
+              0: EQ@11..13 "=" [] [Whitespace(" ")]
+              1: JS_NUMBER_LITERAL_EXPRESSION@13..15
+                0: JS_NUMBER_LITERAL@13..15 "0" [] [Whitespace(" ")]
+      3: SEMICOLON@15..17 ";" [] [Whitespace(" ")]
+      4: JS_BINARY_EXPRESSION@17..22
+        0: JS_IDENTIFIER_EXPRESSION@17..19
+          0: JS_REFERENCE_IDENTIFIER@17..19
+            0: IDENT@17..19 "i" [] [Whitespace(" ")]
+        1: L_ANGLE@19..21 "<" [] [Whitespace(" ")]
+        2: JS_NUMBER_LITERAL_EXPRESSION@21..22
+          0: JS_NUMBER_LITERAL@21..22 "3" [] []
+      5: SEMICOLON@22..24 ";" [] [Whitespace(" ")]
+      6: JS_PRE_UPDATE_EXPRESSION@24..27
+        0: PLUS2@24..26 "++" [] []
+        1: JS_IDENTIFIER_ASSIGNMENT@26..27
+          0: IDENT@26..27 "i" [] []
+      7: R_PAREN@27..29 ")" [] [Whitespace(" ")]
+      8: JS_BLOCK_STATEMENT@29..248
+        0: L_CURLY@29..30 "{" [] []
+        1: JS_STATEMENT_LIST@30..246
+          0: JS_EXPRESSION_STATEMENT@30..246
+            0: JS_CALL_EXPRESSION@30..245
+              0: JS_STATIC_MEMBER_EXPRESSION@30..53
+                0: JS_IDENTIFIER_EXPRESSION@30..41
+                  0: JS_REFERENCE_IDENTIFIER@30..41
+                    0: IDENT@30..41 "verify" [Newline("\n"), Whitespace("    ")] []
+                1: DOT@41..42 "." [] []
+                2: JS_NAME@42..53
+                  0: IDENT@42..53 "completions" [] []
+              1: (empty)
+              2: (empty)
+              3: JS_CALL_ARGUMENTS@53..245
+                0: L_PAREN@53..54 "(" [] []
+                1: JS_CALL_ARGUMENT_LIST@54..244
+                  0: JS_OBJECT_EXPRESSION@54..244
+                    0: L_CURLY@54..55 "{" [] []
+                    1: JS_OBJECT_MEMBER_LIST@55..238
+                      0: JS_PROPERTY_OBJECT_MEMBER@55..82
+                        0: JS_LITERAL_MEMBER_NAME@55..70
+                          0: IDENT@55..70 "marker" [Newline("\n"), Whitespace("        ")] []
+                        1: COLON@70..72 ":" [] [Whitespace(" ")]
+                        2: JS_TEMPLATE@72..82
+                          0: (empty)
+                          1: (empty)
+                          2: BACKTICK@72..73 "`" [] []
+                          3: JS_TEMPLATE_ELEMENT_LIST@73..81
+                            0: JS_TEMPLATE_ELEMENT@73..81
+                              0: DOLLAR_CURLY@73..75 "${" [] []
+                              1: JS_BINARY_EXPRESSION@75..80
+                                0: JS_IDENTIFIER_EXPRESSION@75..77
+                                  0: JS_REFERENCE_IDENTIFIER@75..77
+                                    0: IDENT@75..77 "i" [] [Whitespace(" ")]
+                                1: PLUS@77..79 "+" [] [Whitespace(" ")]
+                                2: JS_NUMBER_LITERAL_EXPRESSION@79..80
+                                  0: JS_NUMBER_LITERAL@79..80 "1" [] []
+                              2: R_CURLY@80..81 "}" [] []
+                          4: BACKTICK@81..82 "`" [] []
+                      1: COMMA@82..83 "," [] []
+                      2: JS_PROPERTY_OBJECT_MEMBER@83..238
+                        0: JS_LITERAL_MEMBER_NAME@83..97
+                          0: IDENT@83..97 "exact" [Newline("\n"), Whitespace("        ")] []
+                        1: COLON@97..99 ":" [] [Whitespace(" ")]
+                        2: JS_ARRAY_EXPRESSION@99..238
+                          0: L_BRACK@99..100 "[" [] []
+                          1: JS_ARRAY_ELEMENT_LIST@100..228
+                            0: JS_OBJECT_EXPRESSION@100..163
+                              0: L_CURLY@100..115 "{" [Newline("\n"), Whitespace("            ")] [Whitespace(" ")]
+                              1: JS_OBJECT_MEMBER_LIST@115..162
+                                0: JS_PROPERTY_OBJECT_MEMBER@115..126
+                                  0: JS_LITERAL_MEMBER_NAME@115..119
+                                    0: IDENT@115..119 "name" [] []
+                                  1: COLON@119..121 ":" [] [Whitespace(" ")]
+                                  2: JS_STRING_LITERAL_EXPRESSION@121..126
+                                    0: JS_STRING_LITERAL@121..126 "\"foo\"" [] []
+                                1: COMMA@126..128 "," [] [Whitespace(" ")]
+                                2: JS_PROPERTY_OBJECT_MEMBER@128..162
+                                  0: JS_LITERAL_MEMBER_NAME@128..143
+                                    0: IDENT@128..143 "replacementSpan" [] []
+                                  1: COLON@143..145 ":" [] [Whitespace(" ")]
+                                  2: JS_COMPUTED_MEMBER_EXPRESSION@145..162
+                                    0: JS_CALL_EXPRESSION@145..158
+                                      0: JS_STATIC_MEMBER_EXPRESSION@145..156
+                                        0: JS_IDENTIFIER_EXPRESSION@145..149
+                                          0: JS_REFERENCE_IDENTIFIER@145..149
+                                            0: IDENT@145..149 "test" [] []
+                                        1: DOT@149..150 "." [] []
+                                        2: JS_NAME@150..156
+                                          0: IDENT@150..156 "ranges" [] []
+                                      1: (empty)
+                                      2: (empty)
+                                      3: JS_CALL_ARGUMENTS@156..158
+                                        0: L_PAREN@156..157 "(" [] []
+                                        1: JS_CALL_ARGUMENT_LIST@157..157
+                                        2: R_PAREN@157..158 ")" [] []
+                                    1: (empty)
+                                    2: L_BRACK@158..159 "[" [] []
+                                    3: JS_IDENTIFIER_EXPRESSION@159..160
+                                      0: JS_REFERENCE_IDENTIFIER@159..160
+                                        0: IDENT@159..160 "i" [] []
+                                    4: R_BRACK@160..162 "]" [] [Whitespace(" ")]
+                              2: R_CURLY@162..163 "}" [] []
+                            1: COMMA@163..164 "," [] []
+                            2: JS_OBJECT_EXPRESSION@164..227
+                              0: L_CURLY@164..179 "{" [Newline("\n"), Whitespace("            ")] [Whitespace(" ")]
+                              1: JS_OBJECT_MEMBER_LIST@179..226
+                                0: JS_PROPERTY_OBJECT_MEMBER@179..190
+                                  0: JS_LITERAL_MEMBER_NAME@179..183
+                                    0: IDENT@179..183 "name" [] []
+                                  1: COLON@183..185 ":" [] [Whitespace(" ")]
+                                  2: JS_STRING_LITERAL_EXPRESSION@185..190
+                                    0: JS_STRING_LITERAL@185..190 "\"bar\"" [] []
+                                1: COMMA@190..192 "," [] [Whitespace(" ")]
+                                2: JS_PROPERTY_OBJECT_MEMBER@192..226
+                                  0: JS_LITERAL_MEMBER_NAME@192..207
+                                    0: IDENT@192..207 "replacementSpan" [] []
+                                  1: COLON@207..209 ":" [] [Whitespace(" ")]
+                                  2: JS_COMPUTED_MEMBER_EXPRESSION@209..226
+                                    0: JS_CALL_EXPRESSION@209..222
+                                      0: JS_STATIC_MEMBER_EXPRESSION@209..220
+                                        0: JS_IDENTIFIER_EXPRESSION@209..213
+                                          0: JS_REFERENCE_IDENTIFIER@209..213
+                                            0: IDENT@209..213 "test" [] []
+                                        1: DOT@213..214 "." [] []
+                                        2: JS_NAME@214..220
+                                          0: IDENT@214..220 "ranges" [] []
+                                      1: (empty)
+                                      2: (empty)
+                                      3: JS_CALL_ARGUMENTS@220..222
+                                        0: L_PAREN@220..221 "(" [] []
+                                        1: JS_CALL_ARGUMENT_LIST@221..221
+                                        2: R_PAREN@221..222 ")" [] []
+                                    1: (empty)
+                                    2: L_BRACK@222..223 "[" [] []
+                                    3: JS_IDENTIFIER_EXPRESSION@223..224
+                                      0: JS_REFERENCE_IDENTIFIER@223..224
+                                        0: IDENT@223..224 "i" [] []
+                                    4: R_BRACK@224..226 "]" [] [Whitespace(" ")]
+                              2: R_CURLY@226..227 "}" [] []
+                            3: COMMA@227..228 "," [] []
+                          2: R_BRACK@228..238 "]" [Newline("\n"), Whitespace("        ")] []
+                    2: R_CURLY@238..244 "}" [Newline("\n"), Whitespace("    ")] []
+                2: R_PAREN@244..245 ")" [] []
+            1: SEMICOLON@245..246 ";" [] []
+        2: R_CURLY@246..248 "}" [Newline("\n")] []
+  3: EOF@248..249 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.ts
+++ b/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.ts
@@ -1,0 +1,9 @@
+for (let i = 0 ; i < 3; ++i) {
+    verify.completions({
+        marker: `${i + 1}`,
+        exact: [
+            { name: "foo", replacementSpan: test.ranges()[i] },
+            { name: "bar", replacementSpan: test.ranges()[i] },
+        ]
+    });
+}


### PR DESCRIPTION
## Summary

The following typescript test panicked.

```ts
for (let i = 0 ; i < 3; ++i) {
    verify.completions({
        marker: `${i + 1}`,
        exact: [
            { name: "foo", replacementSpan: test.ranges()[i] },
            { name: "bar", replacementSpan: test.ranges()[i] },
        ]
    });
}
```

It revealed two problems:

1. The `parse_conditional_expr` tried to parse the `<` as a call expression with type arguments. The problem was that `parse_type_arguments` performed error recovery when it wasn't able to parse a valid type name. Thus, `parse_ts_type_parameters` ended up parsing the `${i + 1}` as a typescript template literal type
2. `${i + 1}` isn't a valid TypeScript template literal. The parser recognised the template element and then tried to parse `i + 1` as a type. This consumed the `i` but left the `+ 1` tokens. Now, the parser panicked because the parse loop assumes that only specific tokens ever come after a `BACKTICK`.

This PR fixes both issues by:
* Not performing error recovery in the branch where the parser speculatively parses type arguments.
* Skip over any invalid tokens inside `TemplateElement`s to ensure the parser doesn't hit the unreachable branch.

This PR further removes the `no_recovery` flag. This is only needed in this specific case. Therefore, passing it down is easier to maintain.

## Test Plan

Added new parser tests covering the error recovery branch.
