### PR TITLE
fix: correct JsExportNamedFromSpecifier printing order

### DIFF
--- a/crates/rome_formatter/src/js/lists/export_named_from_specifier_list.rs
+++ b/crates/rome_formatter/src/js/lists/export_named_from_specifier_list.rs
@@ -1,7 +1,14 @@
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::{ast::JsExportNamedFromSpecifierList, AstNode};
+use crate::{
+    join_elements, soft_line_break_or_space, token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
+};
+use rslint_parser::ast::JsExportNamedFromSpecifierList;
+
 impl ToFormatElement for JsExportNamedFromSpecifierList {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        Ok(join_elements(
+            soft_line_break_or_space(),
+            formatter.format_separated(self.clone(), || token(","))?,
+        ))
     }
 }

--- a/crates/rome_formatter/src/js/lists/export_named_specifier_list.rs
+++ b/crates/rome_formatter/src/js/lists/export_named_specifier_list.rs
@@ -1,7 +1,14 @@
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::{ast::JsExportNamedSpecifierList, AstNode};
+use crate::{
+    join_elements, soft_line_break_or_space, token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
+};
+use rslint_parser::ast::JsExportNamedSpecifierList;
+
 impl ToFormatElement for JsExportNamedSpecifierList {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        Ok(join_elements(
+            soft_line_break_or_space(),
+            formatter.format_separated(self.clone(), || token(","))?,
+        ))
     }
 }

--- a/crates/rome_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_formatter/src/js/module/export_named_from_specifier.rs
@@ -13,13 +13,15 @@ impl ToFormatElement for JsExportNamedFromSpecifier {
             .format_with_or_empty(formatter, |type_token| {
                 format_elements![type_token, space_token()]
             })?;
+
+        let source_name = self.source_name().format(formatter)?;
+
         let export_as = self
             .export_as()
             .format_with_or_empty(formatter, |export_as| {
-                format_elements![export_as, space_token()]
+                format_elements![space_token(), export_as]
             })?;
-        let source = self.source_name().format(formatter)?;
 
-        Ok(format_elements![type_token, export_as, source])
+        Ok(format_elements![type_token, source_name, export_as])
     }
 }

--- a/crates/rome_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 157
+assertion_line: 163
 expression: named_from_clause.js
 
 ---
@@ -21,11 +21,11 @@ export {
 Indent style: Tab
 Line width: 80
 -----
-export { a, as c b } from "fancy" assert { type: "json" };
+export { a, b as c } from "fancy" assert { type: "json" };
 
 export {
 	lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem_lorem,
-	as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_ lorem_lorem_lorem_lorem_lorem_,
+	lorem_lorem_lorem_lorem_lorem_ as ipsum_ipsum_ipsum_ipsum_ipsum_ipsum_,
 } from "fancy" assert {
 	type: "json",
 	"type2": "json",

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/module-string-names.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/module-string-names.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: module-string-names.js
 
 ---
@@ -14,7 +14,7 @@ export { smile as "😄" } from "./emojis.js";
 # Output
 ```js
 import { "😄" as smile } from "./emojis.js";
-export { as "😄" smile } from "./emojis.js" ;
+export { smile as "😄" } from "./emojis.js" ;
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/export/same-local-and-exported.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/export/same-local-and-exported.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: same-local-and-exported.js
 
 ---
@@ -15,8 +15,8 @@ export {c as /* comment */c} from 'c';
 # Output
 ```js
 export { a } from 'a' ;
-export { as b b } from 'b' ;
-export { as /* comment */ c c } from 'c' ;
+export { b as b } from 'b' ;
+export { c as /* comment */ c } from 'c' ;
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/exports/test.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/exports/test.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: test.js
 
 ---
@@ -22,9 +22,9 @@ export { undefinedExport };
 ```js
 export {
   value1,
-  as value2_renamed value2,
+  value2 as value2_renamed,
   value3,
-  as value4_renamed value4,
+  value4 as value4_renamed,
   value5,
 } from "exports" ;
 

--- a/crates/rome_formatter/tests/specs/prettier/module-string-names/module-string-names-export.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/module-string-names/module-string-names-export.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: module-string-names-export.js
 
 ---
@@ -17,11 +17,11 @@ export { "smile4" } from "./emojis.js";
 
 # Output
 ```js
-export { as "smile1" smile } from "./emojis.js" ;
-export { as smile2 "smile" } from "./emojis.js" ;
-export { as "smile3" "smile" } from "./emojis.js" ;
-export { foo1, as "foo2" bar } from "./emojis.js" ;
-export { "學而時習之，不亦說乎？", as "忠恕。" "吾道一以貫之。" } from "Confucius" ;
+export { smile as "smile1" } from "./emojis.js" ;
+export { "smile" as smile2 } from "./emojis.js" ;
+export { "smile" as "smile3" } from "./emojis.js" ;
+export { foo1, bar as "foo2" } from "./emojis.js" ;
+export { "學而時習之，不亦說乎？", "吾道一以貫之。" as "忠恕。" } from "Confucius" ;
 export { "smile4" } from "./emojis.js" ;
 
 ```


### PR DESCRIPTION
## Summary

This changes the printing order of named exports from `export { as bar foo } from "module"` to `export { foo as bar } from "module"`
