### PR TITLE
fix: correct line comments spacing

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -256,7 +256,10 @@ impl Formatter {
                 let comment = Token::from(comment);
 
                 let line_break = if is_single_line {
-                    hard_line_break()
+                    match line_count {
+                        0 | 1 => hard_line_break(),
+                        _ => empty_line(),
+                    }
                 } else {
                     match line_count {
                         0 => space_token(),

--- a/crates/rome_formatter/src/formatter_traits.rs
+++ b/crates/rome_formatter/src/formatter_traits.rs
@@ -1,3 +1,4 @@
+use crate::formatter::TriviaPrintMode;
 use crate::Token;
 use crate::{
     empty_element, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -260,7 +261,7 @@ impl FormatTokenAndNode for SyntaxToken {
         }
 
         with(format_elements![
-            formatter.print_leading_trivia(self),
+            formatter.print_leading_trivia(self, TriviaPrintMode::Full),
             Token::from(self),
             formatter.print_trailing_trivia(self),
         ])

--- a/crates/rome_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -72,12 +72,15 @@ it(
 
 expect(() => asyncRequest({ url: "/test-endpoint" }));
 // .toThrowError(/Required parameter/);
+
 expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }));
 // .toThrowError(/Required parameter/);
+
 expect(
 	() => asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
 );
 // .toThrowError(/Required parameter/);
+
 expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" })).not.toThrowError();
 
 expect(

--- a/crates/rome_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/comments.js.snap
@@ -62,6 +62,7 @@ Line width: 80
 // import {
 //     func, // trailing comma removal
 // } from 'module';
+
 expression( /* block comment */ );
 
 expression(

--- a/crates/rome_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 157
+assertion_line: 163
 expression: comments.js
 
 ---
@@ -65,9 +65,7 @@ Line width: 80
 
 expression( /* block comment */ );
 
-expression(
-	/* block comment */
-);
+expression( /* block comment */ );
 
 expression(
 	// line comment

--- a/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 157
+assertion_line: 163
 expression: if_else.js
 
 ---
@@ -114,7 +114,6 @@ if (true) {
 
 if (true) {
 	// trailing
-
 } else {
 	// trailing
 }

--- a/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -114,6 +114,7 @@ if (true) {
 
 if (true) {
 	// trailing
+
 } else {
 	// trailing
 }

--- a/crates/rome_formatter/tests/specs/prettier/assignment-comments/function.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/assignment-comments/function.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: function.js
 
 ---
@@ -92,10 +92,12 @@ f4 = () => {}; // Comment
 
 f5 =
   // Comment
+
   () => {};
 
 f6 = /* comment */
   // Comment
+
   () => {};
 
 let f1 = (
@@ -114,9 +116,11 @@ let f3 = (
 let f4 = () => {}; // Comment
 
 let f5 = // Comment
+
 () => {};
 
 let f6 = // Comment /* comment */
+
 () => {};
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/assignment-comments/number.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/assignment-comments/number.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: number.js
 
 ---
@@ -60,6 +60,7 @@ fnNumber =
 
 fnNumber =
   // Comment
+
   3;
 
 fnNumber =
@@ -78,6 +79,7 @@ fnNumber =
   3;
 
 var fnNumber = // Comment
+
 3;
 
 var fnNumber = // Comment0

--- a/crates/rome_formatter/tests/specs/prettier/assignment-comments/string.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/assignment-comments/string.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: string.js
 
 ---
@@ -86,10 +86,12 @@ fnString =
 
 fnString =
   // Comment
+
   "some" + "long" + "string";
 
 fnString =
   // Comment
+
   "some" + "long" + "string";
 
 fnString =
@@ -116,9 +118,11 @@ fnString =
   "some" + "long" + "string";
 
 var fnString = // Comment
+
 "some" + "long" + "string";
 
 var fnString = // Comment
+
 "some" + "long" + "string";
 
 var fnString = /* comment */

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/async-generators.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/async-generators.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: async-generators.js
 
 ---
@@ -18,6 +18,7 @@ async function* agf() {
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-async-generator-functions
+
 async function* agf() {
   await 1;
   yield 2;

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/bigint.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/bigint.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: bigint.js
 
 ---
@@ -140,42 +140,60 @@ const alsoGoodPrecision = 9007199254740993n;
 # Output
 ```js
 // https://github.com/tc39/proposal-bigint
+
 const previousMaxSafe = BigInt(Number.MAX_SAFE_INTEGER);
 // ↪ 9007199254740991
+
 const maxPlusOne = previousMaxSafe + 1n;
 // ↪ 9007199254740992n
+
 const theFuture = previousMaxSafe + 2n;
 // ↪ 9007199254740993n, this works now!
+
 const multi = previousMaxSafe * 2n;
 // ↪ 18014398509481982n
+
 // `–` is not minus sign,
 // SIC https://github.com/tc39/proposal-bigint#operators
 // const subtr = multi – 10n;
 // ↪ 18014398509481972n
+
 const mod = multi % 10n;
 // ↪ 2n
+
 const bigN = 2n ** 54n;
 // ↪ 18014398509481984n
+
 bigN * -1n;
 // ↪ –18014398509481984n
+
 0n === 0;
 // ↪ false
+
 0n == 0;
 // ↪ true
+
 1n < 2;
 // ↪ true
+
 2n > 1;
 // ↪ true
+
 2 > 2;
 // ↪ false
+
 2n > 2;
 // ↪ false
+
 2n >= 2;
 // ↪ true
+
 const mixed = [4n, 6, -12n, 10, 4, 0, 0n];
 // ↪  [4n, 6, -12n, 10, 4, 0, 0n]
+
 mixed.sort();
 // ↪ [-12n, 0, 0n, 10, 4n, 4, 6]
+
 if (0n) {
   console.log("Hello from the if!");
 } else {
@@ -183,18 +201,25 @@ if (0n) {
 }
 
 // ↪ "Hello from the else!"
+
 0n || 12n;
 // ↪ 12n
+
 0n && 12n;
 // ↪ 0n
+
 Boolean(0n);
 // ↪ false
+
 Boolean(12n);
 // ↪ true
+
 !12n;
 // ↪ false
+
 !0n;
 // ↪ true
+
 const view = new BigInt64Array(4);
 // ↪ [0n, 0n, 0n, 0n]
 view.length;
@@ -204,6 +229,7 @@ view[0];
 view[0] = 42n;
 view[0];
 // ↪ 42n
+
 // Highest possible BigInt value that can be represented as a
 // signed 64-bit integer.
 const max = 2n ** (64n - 1n) - 1n;
@@ -214,21 +240,30 @@ view[0] = max + 1n;
 view[0];
 // ↪ -9_223_372_036_854_775_808n
 //   ^ negative because of overflow
+
 1n + 2;
 // ↪ TypeError: Cannot mix BigInt and other types, use explicit conversions
+
 1n * 2 // ↪ TypeError: Cannot mix BigInt and other types, use explicit conversions
+
 + 1n;
 // ↪ TypeError: Cannot convert a BigInt value to a number
+
 Number(1n);
 // ↪ 1
+
 1n + "2";
 // ↪ "12"
+
 "2" + 1n;
 // ↪ "21"
+
 const badPrecision = BigInt(9007199254740993);
 // ↪9007199254740992n
+
 const goodPrecision = BigInt("9007199254740993");
 // ↪9007199254740993n
+
 const alsoGoodPrecision = 9007199254740993n;// ↪9007199254740993n
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/class-properties.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/class-properties.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: class-properties.js
 
 ---
@@ -38,6 +38,7 @@ class Bork {
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-class-properties
+
 class Bork {
   //Property initializer syntax
   instanceProperty = "bork";

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/dynamic-import.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/dynamic-import.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: dynamic-import.js
 
 ---
@@ -20,7 +20,9 @@ import(prettier).then(module => console.log(module));
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import
+
 // There is no example code on babel website
+
 import("./prettier.mjs");
 import(prettier);
 import("./prettier.mjs").then((module) => console.log(module));

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/export-namespace-from.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/export-namespace-from.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: export-namespace-from.js
 
 ---
@@ -15,6 +15,7 @@ export * as ns from 'mod';
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from
+
 export * as ns from 'mod';
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/function-sent.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/function-sent.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: function-sent.js
 
 ---
@@ -22,6 +22,7 @@ iterator.next(2); // Logs "Yield 2"
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-function-sent
+
 function* generator() {
   console.log("Sent", function.sent);
   console.log("Yield", yield);

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/import-meta.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/import-meta.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: import-meta.js
 
 ---
@@ -30,8 +30,11 @@ expression: import-meta.js
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-syntax-import-meta
+
 // Enabled by default https://github.com/babel/babel/pull/11406
+
 // from https://github.com/tc39/proposal-import-meta
+
 (async () => {
   const response = await fetch(new URL("../hamsters.jpg", import.meta.url));
   const blob = await response.blob();

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/logical-assignment-operators.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/logical-assignment-operators.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: logical-assignment-operators.js
 
 ---
@@ -19,6 +19,7 @@ obj.a.b &&= c;
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-logical-assignment-operators
+
 a ||= b;
 obj.a.b ||= c;
 

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/nullish-coalescing-operator.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/nullish-coalescing-operator.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: nullish-coalescing-operator.js
 
 ---
@@ -15,6 +15,7 @@ var foo = object.foo ?? "default";
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator
+
 var foo = object.foo ?? "default";
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/numeric-separator.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/numeric-separator.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: numeric-separator.js
 
 ---
@@ -48,6 +48,7 @@ console.log(c.toString(16), b); // c0, 192
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-numeric-separator
+
 let budget = 1_000_000_000_000;
 
 // What is the value of `budget`? It's 1 trillion!

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/object-rest-spread.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/object-rest-spread.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: object-rest-spread.js
 
 ---
@@ -21,6 +21,7 @@ console.log(n); // { x: 1, y: 2, a: 3, b: 4 }
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-transform-object-rest-spread
+
 let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
 console.log(x); // 1
 console.log(y); // 2

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/optional-catch-binding.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/optional-catch-binding.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: optional-catch-binding.js
 
 ---
@@ -27,6 +27,7 @@ try {
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-optional-catch-binding
+
 try {
   throw 0;
 } catch {

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/optional-chaining.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/optional-chaining.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: optional-chaining.js
 
 ---
@@ -74,6 +74,7 @@ const ret = delete obj?.foo?.bar?.baz; // true
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
+
 const obj = { foo: { bar: { baz: 42 } } };
 
 const baz = obj?.foo?.bar?.baz; // 42
@@ -83,6 +84,7 @@ const safe = obj?.qux?.baz; // undefined
 // Optional chaining and normal chaining can be intermixed
 obj?.foo.bar?.baz; // Only access `foo` if `obj` exists, and `baz` if
 // `bar` exists
+
 // Example usage with bracket notation:
 obj?.["foo"]?.bar?.baz; // 42
 

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/partial-application.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/partial-application.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: partial-application.js
 
 ---
@@ -33,6 +33,7 @@ super.f(?)        // partial application allowed for call on |SuperProperty|
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-partial-application
+
 function add(x, y) {
   return x + y;
 }

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/pipeline-operator-minimal.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/pipeline-operator-minimal.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: pipeline-operator-minimal.js
 
 ---
@@ -25,6 +25,7 @@ result //=> "Hello, hello!"
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-pipeline-operator
 // https://github.com/tc39/proposal-pipeline-operator/
+
 let result = exclaim(capitalize(doubleSay("hello")));
 result; //=> "Hello, hello!"
 

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/private-fields-in-in.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/private-fields-in-in.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: private-fields-in-in.js
 
 ---
@@ -67,6 +67,7 @@ class C3 {
 # Output
 ```js
 // https://github.com/tc39/proposal-private-fields-in-in
+
 class C {
   #brand;
 
@@ -113,6 +114,7 @@ class C3 {
 }// Invalid https://github.com/tc39/proposal-private-fields-in-in#try-statement
 // class C {
 //   #brand;
+
 //   static isC(obj) {
 //     return try obj.#brand;
 //   }

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/private-methods.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/private-methods.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: private-methods.js
 
 ---
@@ -31,7 +31,9 @@ class Counter extends HTMLElement {
 # Output
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-private-methods
+
 // Test for `classPrivateProperties` and `classPrivateMethods`
+
 class Counter extends HTMLElement {
   #xValue = 0;
   #render() {}

--- a/crates/rome_formatter/tests/specs/prettier/binary-expressions/test.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/binary-expressions/test.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: test.js
 
 ---
@@ -32,6 +32,7 @@ foo(obj.property * new Class() && obj instanceof Class && longVariable ? number 
 ```js
 // It should always break the highest precedence operators first, and
 // break them all at the same time.
+
 const x = longVariable + longVariable + longVariable;
 const x1 = longVariable + longVariable + longVariable + longVariable - longVariable + longVariable;
 const x2 = longVariable + longVariable * longVariable + longVariable - longVariable + longVariable;

--- a/crates/rome_formatter/tests/specs/prettier/classes-private-fields/optional-chaining.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/classes-private-fields/optional-chaining.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: optional-chaining.js
 
 ---
@@ -15,6 +15,7 @@ delete obj?.#x.a
 # Output
 ```js
 // https://github.com/babel/babel/pull/11669
+
 delete obj?.#x.a;
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/comments/blank.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/blank.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: blank.js
 
 ---
@@ -37,6 +37,7 @@ expression: blank.js
 // should still exist
 //
 // when printed.
+
 /**
  * @typedef {DataDrivenMapping|ConstantMapping} Mapping
  */
@@ -50,6 +51,7 @@ expression: blank.js
  * @property {Function} tickFormat
  */
 // comment
+
 // comment
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/comments/multi-comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/multi-comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: multi-comments.js
 
 ---
@@ -31,6 +31,7 @@ y;
 # Output
 ```js
 // #8323
+
 import { MapViewProps } from 'react-native-maps'; /*
 comment 14
 */ /* comment1

--- a/crates/rome_formatter/tests/specs/prettier/comments/return-statement.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/return-statement.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: return-statement.js
 
 ---
@@ -210,6 +210,7 @@ function excessiveEverything() {
 //     a
 //   ), b
 // }
+
 function sequenceExpressionInside() {
   return (a, b); // Reason for a
 }

--- a/crates/rome_formatter/tests/specs/prettier/comments/trailing_space.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/trailing_space.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: trailing_space.js
 
 ---
@@ -18,6 +18,7 @@ expression: trailing_space.js
 ```js
 #!/there/is-space-here->         
 // Do not trim trailing whitespace from this source file!
+
 // There is some space here ->
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/first-argument-expansion/test.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/first-argument-expansion/test.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: test.js
 
 ---
@@ -259,6 +259,7 @@ reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod(
 );
 
 // Don't do the rest of these
+
 func(
   function () {
     thing();

--- a/crates/rome_formatter/tests/specs/prettier/functional-composition/pipe-function-calls-with-comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/functional-composition/pipe-function-calls-with-comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: pipe-function-calls-with-comments.js
 
 ---
@@ -61,6 +61,7 @@ expression: pipe-function-calls-with-comments.js
 # Output
 ```js
 // input with some comments added to avoid reformatting
+
 (() => {
   pipe(
     // add a descriptive comment here

--- a/crates/rome_formatter/tests/specs/prettier/functional-composition/ramda_compose.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/functional-composition/ramda_compose.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: ramda_compose.js
 
 ---
@@ -87,6 +87,7 @@ followersForUser("JOE").then(
   (followers) => console.log("Followers:", followers),
 );
 // Followers: ["STEVE","SUZY"]
+
 const mapStateToProps = (state) =>
   ({
     users: R.compose(R.filter(R.propEq("status", "active")), R.values)(

--- a/crates/rome_formatter/tests/specs/prettier/functional-composition/ramda_pipe.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/functional-composition/ramda_pipe.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: ramda_pipe.js
 
 ---
@@ -40,6 +40,7 @@ f(3, 4); // -(3^4) + 1
 
 //  parseJson :: String -> Maybe *
 //  get :: String -> Object -> Maybe *
+
 //  getStateCode :: Maybe String -> Maybe String
 var getStateCode = R.pipeK(
   parseJson,
@@ -53,6 +54,7 @@ getStateCode("{"user":{"address":{"state":"ny"}}}");
 //=> Just('NY')
 getStateCode("[Invalid JSON]");
 //=> Nothing()
+
 //  followersForUser :: String -> Promise [User]
 var followersForUser = R.pipeP(db.getUserById, db.getFollowers);
 

--- a/crates/rome_formatter/tests/specs/prettier/generator/async.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/generator/async.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: async.js
 
 ---
@@ -27,6 +27,7 @@ const f = async function * (source, block, opts) {
 # Output
 ```js
 // https://github.com/meriyah/meriyah/commit/f21882c312284572ac6d7e7630c4a677d6caed92
+
 const f = async function* (source, block, opts) {
   for await (const entry of source) {
     yield async function () {

--- a/crates/rome_formatter/tests/specs/prettier/generator/function-name-starts-with-get.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/generator/function-name-starts-with-get.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: function-name-starts-with-get.js
 
 ---
@@ -19,6 +19,7 @@ function* getData() {
 # Output
 ```js
 // https://github.com/meriyah/meriyah/issues/164
+
 function get() {}
 
 function* getData() {

--- a/crates/rome_formatter/tests/specs/prettier/if/else.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/if/else.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: else.js
 
 ---
@@ -30,6 +30,7 @@ function f() {
 # Output
 ```js
 // Both functions below should be formatted exactly the same
+
 function f() {
   if (position) return { name: pair }; else return {
     name: pair.substring(0, position),

--- a/crates/rome_formatter/tests/specs/prettier/ignore/ignore-2.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/ignore/ignore-2.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: ignore-2.js
 
 ---
@@ -31,6 +31,7 @@ a = <div {...{}/* prettier-ignore */}/>
 # Output
 ```js
 // #8736
+
 function HelloWorld() {
   return (
     <div

--- a/crates/rome_formatter/tests/specs/prettier/ignore/ignore.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/ignore/ignore.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: ignore.js
 
 ---
@@ -80,6 +80,7 @@ function a() {
   const identity = Matrix.create(1, 0, 0, 0, 1, 0, 0, 0, 0);
 
   // Let's make sure that this comment doesn't interfere
+
   // prettier-ignore
   const commentsWithPrettierIgnore = { "ewww": "gross-formatting" };
 

--- a/crates/rome_formatter/tests/specs/prettier/method-chain/issue-4125.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/method-chain/issue-4125.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: issue-4125.js
 
 ---
@@ -161,6 +161,7 @@ var l = base
 # Output
 ```js
 // examples from https://github.com/prettier/prettier/issues/4125
+
 const sha256 = (data) => crypto.createHash("sha256").update(data).digest("hex");
 
 req.checkBody("id").isInt().optional();
@@ -182,6 +183,7 @@ const sha256_2 = (data) =>
   crypto.createHash("sha256").update(data).digest("hex"); // breakme
 
 // examples from https://github.com/prettier/prettier/pull/4765
+
 if ($(el).attr("href").includes("/wiki/")) {
 }
 
@@ -199,6 +201,7 @@ function palindrome(a, b) {
 }
 
 // examples from https://github.com/prettier/prettier/issues/1565
+
 d3.select("body").selectAll("p").data([1, 2, 3]).enter().style("color", "white");
 
 Object.keys(props).filter((key) => key in own === false).reduce(
@@ -235,6 +238,7 @@ fetchUser(
 ).then(fetchAccountForUser).catch(handleFetchError); //
 
 // examples from https://github.com/prettier/prettier/issues/3107
+
 function HelloWorld() {
   window.FooClient.setVars(
     { locale: getFooLocale({ page }), authorizationToken: data.token },

--- a/crates/rome_formatter/tests/specs/prettier/multiparser-graphql/graphql-tag.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/multiparser-graphql/graphql-tag.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: graphql-tag.js
 
 ---
@@ -182,6 +182,7 @@ const query = gql`
 `;
 
 // With interpolations:
+
 gql`
 query User {
   user(id:5){
@@ -194,6 +195,7 @@ ${USER_DETAILS_FRAGMENT}${FRIENDS_FRAGMENT}
 `;
 
 // Skip if non-toplevel interpolation:
+
 gql`
 query User {
   user(id:${id}){ name }
@@ -201,6 +203,7 @@ query User {
 `;
 
 // Skip if top-level interpolation within comment:
+
 gql`
 query User {
   user(id:5){ name }
@@ -209,14 +212,17 @@ query User {
 `;
 
 // Comment on last line:
+
 gql`
 query User {
   user(id:5){ name }
 }
 # comment`;
 // ` <-- editor syntax highlighting workaround
+
 // Preserve up to one blank line between things and enforce linebreak between
 // interpolations:
+
 gql`
 # comment
 ${one}${two}  ${three}
@@ -241,23 +247,30 @@ ${eight}
 `;
 
 // Interpolation directly before and after query:
+
 gql`${one} query Test { test }${two}`;
 
 // Only interpolation:
+
 gql`${test}`;
 
 // Only comment:
+
 gql`# comment`;
 // ` <-- editor syntax highlighting workaround
+
 // Only whitespace:
+
 gql`   `;
 
 // Empty:
+
 gql``;
 
 // Comments after other things:
 // Currently, comments after interpolations are moved to the next line.
 // We might want to keep them on the next line in the future.
+
 gql`
   ${test} # comment
 
@@ -274,6 +287,7 @@ gql`
 `;
 
 // Larger mixed test:
+
 gql`
 
 

--- a/crates/rome_formatter/tests/specs/prettier/multiparser-graphql/invalid.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/multiparser-graphql/invalid.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: invalid.js
 
 ---
@@ -35,6 +35,7 @@ gql`
 ```js
 // none of the embedded GraphQL should be formatted
 // for they have an invalid escape sequence
+
 gql`
   "\x"
   type   Foo    {

--- a/crates/rome_formatter/tests/specs/prettier/no-semi/class.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/no-semi/class.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: class.js
 
 ---
@@ -174,6 +174,7 @@ class A1 {
 
   // none of the semicolons above this comment can be omitted.
   // none of the semicolons below this comment are necessary.
+
   q() {}
   [h]() {}
 
@@ -211,6 +212,7 @@ class A2 {
 
   // none of the semicolons above this comment can be omitted.
   // none of the semicolons below this comment are necessary.
+
   q() {}
   [h]() {}
 

--- a/crates/rome_formatter/tests/specs/prettier/no-semi/no-semi.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/no-semi/no-semi.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: no-semi.js
 
 ---
@@ -92,6 +92,7 @@ aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
 # Output
 ```js
 // with preexisting semi
+
 x;
 [1, 2, 3].forEach(fn);
 x;
@@ -120,19 +121,23 @@ x;
 (x, y) => x;
 
 // doesn't have to be preceded by a semicolon
+
 class X {}
 [1, 2, 3].forEach(fn);
 
 // don't semicolon if it doesn't start statement
+
 if (true) (() => {})();
 
 // check indentation
+
 if (true) {
   x;
   (() => {})();
 }
 
 // check statement clauses
+
 do break; while (false);
 if (true) do break; while (false);
 
@@ -143,6 +148,7 @@ for (x of y)
 debugger;
 
 // check that it doesn't break non-ASI
+
 1 - 1;
 
 1 + 1;

--- a/crates/rome_formatter/tests/specs/prettier/numeric-separators/number.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/numeric-separators/number.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: number.js
 
 ---
@@ -16,6 +16,7 @@ a = 09.1_1;
 # Output
 ```js
 // https://github.com/babel/babel/pull/11854
+
 a = 09e1_1;
 a = 09.1_1;
 

--- a/crates/rome_formatter/tests/specs/prettier/optional-chaining/eval.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/optional-chaining/eval.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: eval.js
 
 ---
@@ -36,6 +36,7 @@ eval.foo?.(foo);
 # Output
 ```js
 // https://github.com/babel/babel/pull/11850
+
 let foo;
 
 /* indirect eval calls */

--- a/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
@@ -247,7 +247,6 @@ comments(
 
   short3,
   // More comments
-
 );
 
 differentArgTypes(
@@ -270,7 +269,6 @@ moreArgTypes(
     },
     oneThing + anotherThing,
     // Comment
-
   ),
 );
 

--- a/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: argument-list.js
 
 ---
@@ -219,8 +219,10 @@ function foo(
 ```js
 longArgNamesWithComments(
   // Hello World
+
   longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
   // Hello World
+
   longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
   /* Hello World */
   longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3,
@@ -230,6 +232,7 @@ shortArgNames(short, short2, short3);
 
 comments(
   // Comment
+
   /* Some comments */
   short,
   /* Another comment */
@@ -238,10 +241,13 @@ comments(
   /* Another comment */
 
   // Long Long Long Long Long Comment
+
   /* Long Long Long Long Long Comment */
   // Long Long Long Long Long Comment
+
   short3,
   // More comments
+
 );
 
 differentArgTypes(
@@ -256,6 +262,7 @@ moreArgTypes(
   { name: "Hello World", age: 29 },
   doSomething(
     // Hello world
+
     // Hello world again
     {
       name: "Hello World",
@@ -263,6 +270,7 @@ moreArgTypes(
     },
     oneThing + anotherThing,
     // Comment
+
   ),
 );
 
@@ -300,6 +308,7 @@ foo(
 doSomething.apply(
   null,
   // Comment
+
   [
     "Hello world 1",
     "Hello world 2",

--- a/crates/rome_formatter/tests/specs/prettier/quotes/strings.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/quotes/strings.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: strings.js
 
 ---
@@ -122,6 +122,7 @@ expression: strings.js
 // Note that even if a string already has the correct enclosing quotes, it is
 // still processed in order to remove unnecessarily escaped quotes within it,
 // for consistency.
+
 // Simple strings.
 "abc";
 "abc";

--- a/crates/rome_formatter/tests/specs/prettier/strings/non-octal-eight-and-nine.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/strings/non-octal-eight-and-nine.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: non-octal-eight-and-nine.js
 
 ---
@@ -19,6 +19,7 @@ expression: non-octal-eight-and-nine.js
 # Output
 ```js
 // https://github.com/babel/babel/pull/11852
+
 "\8", "\9";
 () => {
   "use strict";

--- a/crates/rome_formatter/tests/specs/prettier/switch/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/switch/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: comments.js
 
 ---
@@ -72,6 +72,7 @@ switch(x) {
 switch (true) {
   case true:
   // Good luck getting here
+
   case false:
 }
 
@@ -87,6 +88,7 @@ switch (x) {
     {}
 
   // other
+
   case y:
     {}
 }

--- a/crates/rome_formatter/tests/specs/prettier/test-declarations/test_declarations.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/test-declarations/test_declarations.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: test_declarations.js
 
 ---
@@ -138,6 +138,7 @@ it(
 # Output
 ```js
 // Shouldn't break
+
 it(
   "does something really long and complicated so I have to write a very long name for the test",
   () => {
@@ -308,6 +309,7 @@ skip(
 );
 
 // Should break
+
 it.only(
   "does something really long and complicated so I have to write a very long name for the test",
   10,
@@ -336,6 +338,7 @@ xskip(
 );
 
 // timeout
+
 it(
   `handles
   some

--- a/crates/rome_formatter/tests/specs/prettier/try/catch.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/try/catch.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: catch.js
 
 ---
@@ -49,10 +49,7 @@ try {} catch (/* comment */ foo) {}
 
 try {} catch (foo /* comment */ ) {}
 
-try {} catch (
-  foo
-  /* comment */
-) {}
+try {} catch (foo /* comment */ ) {}
 
 ```
 


### PR DESCRIPTION
## Summary

This corrects the printing of newlines between comments in leading trivias and the token they're attached to by inserting an empty line instead of a hard line break when 2 or more newlines are found between the comment and the token
