### PR TITLE
fix: implement ToFormatElement for JsExpressionSnipped

### DIFF
--- a/crates/rome_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_formatter/src/js/auxiliary/expression_snipped.rs
@@ -1,7 +1,14 @@
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::{ast::JsExpressionSnipped, AstNode};
+use crate::{
+    format_elements, formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
+};
+use rslint_parser::ast::JsExpressionSnipped;
+
 impl ToFormatElement for JsExpressionSnipped {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(formatter.format_verbatim(self.syntax()))
+        Ok(format_elements![
+            self.expression().format(formatter)?,
+            self.eof_token().format(formatter)?,
+        ])
     }
 }


### PR DESCRIPTION
## Summary

Besides lists (being handled in #2096) this is the last JavaScript node not having a proper implementation of `ToFormatElement`