### PR TITLE
fix(rslint_parser): error on static abstract members

### DIFF
--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1023,6 +1023,7 @@ fn parse_method_class_member_rest(
         .ok();
 
     let abstract_range = modifiers.get_range(ModifierKind::Abstract).cloned();
+    let static_range = modifiers.get_range(ModifierKind::Static).cloned();
     let is_async = flags.contains(SignatureFlags::ASYNC).then(|| true);
 
     parse_method_body(p, modifiers, flags);
@@ -1031,8 +1032,17 @@ fn parse_method_class_member_rest(
 
     // test_err ts typescript_abstract_classes_invalid_abstract_async_member
     // abstract class B { abstract async a(); }
-    if let Some((abstract_range, _)) = abstract_range.zip(is_async) {
-        let err = ts_parse_error::abstract_member_cannot_be_async(p, abstract_range);
+    if let Some((abstract_range, _)) = abstract_range.as_ref().zip(is_async) {
+        let err = ts_parse_error::abstract_member_cannot_be_async(p, abstract_range.clone());
+        p.error(err);
+        member.change_to_unknown(p);
+    }
+
+    // test_err ts typescript_abstract_classes_invalid_static_abstract_member
+    // abstract class A { abstract static fn1(); }
+    // abstract class B { static abstract fn1(); }
+    if let Some((abstract_range, _)) = abstract_range.zip(static_range) {
+        let err = ts_parse_error::abstract_member_cannot_be_static(p, abstract_range);
         p.error(err);
         member.change_to_unknown(p);
     }

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1374,6 +1374,19 @@ fn parse_class_member_modifiers(
                 continue;
             }
 
+            // We already give an error saying that these combinations are not valid
+            let previous_modifier_kind = previous_modifier.as_ref().map(|x| x.kind);
+            match (previous_modifier_kind, current_modifier.kind) {
+                (Some(ModifierKind::Static), ModifierKind::Abstract)
+                | (Some(ModifierKind::Abstract), ModifierKind::Static) => {
+                    valid = false;
+                    modifiers.set_range(current_modifier.clone());
+                    previous_modifier = Some(current_modifier);
+                    continue;
+                }
+                _ => {}
+            }
+
             // Checks the precedence of modifiers. The precedence is defined by the order of the
             // enum variants in [Modifier]
             if let Some(previous_modifier) = &previous_modifier {

--- a/crates/rslint_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/typescript/ts_parse_error.rs
@@ -18,3 +18,8 @@ pub(crate) fn abstract_member_cannot_be_async(p: &Parser, range: Range<usize>) -
     p.err_builder("async members cannot be abstract")
         .primary(range, "")
 }
+
+pub(crate) fn abstract_member_cannot_be_static(p: &Parser, range: Range<usize>) -> Diagnostic {
+    p.err_builder("static members cannot be abstract")
+        .primary(range, "")
+}

--- a/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.rast
@@ -118,13 +118,6 @@ JsModule {
       8: R_CURLY@86..87 "}" [] []
   3: EOF@87..88 "" [Newline("\n")] []
 --
-error[SyntaxError]: `static` modifier must precede `abstract`.
-  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:1:29
-  │
-1 │ abstract class A { abstract static fn1(); }
-  │                    -------- ^^^^^^
-
---
 error[SyntaxError]: static members cannot be abstract
   ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:1:20
   │

--- a/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.rast
+++ b/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.rast
@@ -1,0 +1,143 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassDeclaration {
+            abstract_token: ABSTRACT_KW@0..9 "abstract" [] [Whitespace(" ")],
+            class_token: CLASS_KW@9..15 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@15..17 "A" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@17..19 "{" [] [Whitespace(" ")],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        ABSTRACT_KW@19..28 "abstract" [] [Whitespace(" ")],
+                        STATIC_KW@28..35 "static" [] [Whitespace(" ")],
+                        JsLiteralMemberName {
+                            value: IDENT@35..38 "fn1" [] [],
+                        },
+                        JsParameters {
+                            l_paren_token: L_PAREN@38..39 "(" [] [],
+                            items: JsParameterList [],
+                            r_paren_token: R_PAREN@39..40 ")" [] [],
+                        },
+                    ],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@40..42 ";" [] [Whitespace(" ")],
+                },
+            ],
+            r_curly_token: R_CURLY@42..43 "}" [] [],
+        },
+        JsClassDeclaration {
+            abstract_token: ABSTRACT_KW@43..53 "abstract" [Newline("\n")] [Whitespace(" ")],
+            class_token: CLASS_KW@53..59 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@59..61 "B" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@61..63 "{" [] [Whitespace(" ")],
+            members: JsClassMemberList [
+                JsUnknownMember {
+                    items: [
+                        STATIC_KW@63..70 "static" [] [Whitespace(" ")],
+                        ABSTRACT_KW@70..79 "abstract" [] [Whitespace(" ")],
+                        JsLiteralMemberName {
+                            value: IDENT@79..82 "fn1" [] [],
+                        },
+                        JsParameters {
+                            l_paren_token: L_PAREN@82..83 "(" [] [],
+                            items: JsParameterList [],
+                            r_paren_token: R_PAREN@83..84 ")" [] [],
+                        },
+                    ],
+                },
+                JsEmptyClassMember {
+                    semicolon_token: SEMICOLON@84..86 ";" [] [Whitespace(" ")],
+                },
+            ],
+            r_curly_token: R_CURLY@86..87 "}" [] [],
+        },
+    ],
+    eof_token: EOF@87..88 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..88
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..87
+    0: JS_CLASS_DECLARATION@0..43
+      0: ABSTRACT_KW@0..9 "abstract" [] [Whitespace(" ")]
+      1: CLASS_KW@9..15 "class" [] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@15..17
+        0: IDENT@15..17 "A" [] [Whitespace(" ")]
+      3: (empty)
+      4: (empty)
+      5: (empty)
+      6: L_CURLY@17..19 "{" [] [Whitespace(" ")]
+      7: JS_CLASS_MEMBER_LIST@19..42
+        0: JS_UNKNOWN_MEMBER@19..40
+          0: ABSTRACT_KW@19..28 "abstract" [] [Whitespace(" ")]
+          1: STATIC_KW@28..35 "static" [] [Whitespace(" ")]
+          2: JS_LITERAL_MEMBER_NAME@35..38
+            0: IDENT@35..38 "fn1" [] []
+          3: JS_PARAMETERS@38..40
+            0: L_PAREN@38..39 "(" [] []
+            1: JS_PARAMETER_LIST@39..39
+            2: R_PAREN@39..40 ")" [] []
+        1: JS_EMPTY_CLASS_MEMBER@40..42
+          0: SEMICOLON@40..42 ";" [] [Whitespace(" ")]
+      8: R_CURLY@42..43 "}" [] []
+    1: JS_CLASS_DECLARATION@43..87
+      0: ABSTRACT_KW@43..53 "abstract" [Newline("\n")] [Whitespace(" ")]
+      1: CLASS_KW@53..59 "class" [] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@59..61
+        0: IDENT@59..61 "B" [] [Whitespace(" ")]
+      3: (empty)
+      4: (empty)
+      5: (empty)
+      6: L_CURLY@61..63 "{" [] [Whitespace(" ")]
+      7: JS_CLASS_MEMBER_LIST@63..86
+        0: JS_UNKNOWN_MEMBER@63..84
+          0: STATIC_KW@63..70 "static" [] [Whitespace(" ")]
+          1: ABSTRACT_KW@70..79 "abstract" [] [Whitespace(" ")]
+          2: JS_LITERAL_MEMBER_NAME@79..82
+            0: IDENT@79..82 "fn1" [] []
+          3: JS_PARAMETERS@82..84
+            0: L_PAREN@82..83 "(" [] []
+            1: JS_PARAMETER_LIST@83..83
+            2: R_PAREN@83..84 ")" [] []
+        1: JS_EMPTY_CLASS_MEMBER@84..86
+          0: SEMICOLON@84..86 ";" [] [Whitespace(" ")]
+      8: R_CURLY@86..87 "}" [] []
+  3: EOF@87..88 "" [Newline("\n")] []
+--
+error[SyntaxError]: `static` modifier must precede `abstract`.
+  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:1:29
+  │
+1 │ abstract class A { abstract static fn1(); }
+  │                    -------- ^^^^^^
+
+--
+error[SyntaxError]: static members cannot be abstract
+  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:1:20
+  │
+1 │ abstract class A { abstract static fn1(); }
+  │                    ^^^^^^^^
+
+--
+error[SyntaxError]: static members cannot be abstract
+  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:2:27
+  │
+2 │ abstract class B { static abstract fn1(); }
+  │                           ^^^^^^^^
+
+--
+abstract class A { abstract static fn1(); }
+abstract class B { static abstract fn1(); }

--- a/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.ts
+++ b/crates/rslint_parser/test_data/inline/err/typescript_abstract_classes_invalid_static_abstract_member.ts
@@ -1,0 +1,2 @@
+abstract class A { abstract static fn1(); }
+abstract class B { static abstract fn1(); }


### PR DESCRIPTION
Errors:

```
error[SyntaxError]: static members cannot be abstract
  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:1:20
  │
1 │ abstract class A { abstract static fn1(); }
  │                    ^^^^^^^^

--
error[SyntaxError]: static members cannot be abstract
  ┌─ typescript_abstract_classes_invalid_static_abstract_member.ts:2:27
  │
2 │ abstract class B { static abstract fn1(); }
  │                           ^^^^^^^^
```