### PR TITLE
refactor(rome_formatter): format_delimited helpers

### DIFF
--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -120,7 +120,7 @@ impl Formatter {
     }
 
     /// Formats a group delimited by an opening and closing token, placing the
-    /// content in a block_indent group
+    /// content in a [block_indent] group
     pub(crate) fn format_delimited_block_indent(
         &self,
         open_token: &SyntaxToken,
@@ -137,7 +137,7 @@ impl Formatter {
     }
 
     /// Formats a group delimited by an opening and closing token, placing the
-    /// content in a soft_block_indent group
+    /// content in a [soft_block_indent] group
     pub(crate) fn format_delimited_soft_block_indent(
         &self,
         open_token: &SyntaxToken,
@@ -154,7 +154,7 @@ impl Formatter {
     }
 
     /// Formats a group delimited by an opening and closing token, placing the
-    /// content in an indent group with soft_line_break_or_space tokens at the
+    /// content in an [indent] group with [soft_line_break_or_space] tokens at the
     /// start and end
     pub(crate) fn format_delimited_soft_block_spaces(
         &self,

--- a/crates/rome_formatter/src/js/any/class.rs
+++ b/crates/rome_formatter/src/js/any/class.rs
@@ -1,8 +1,8 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    block_indent, format_elements, group_elements, join_elements_hard_line, space_token,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, join_elements_hard_line, space_token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 use rslint_parser::ast::JsAnyClass;
@@ -24,21 +24,15 @@ impl ToFormatElement for JsAnyClass {
             id,
             extends,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_block_indent(
                 &self.l_curly_token()?,
-                |open_token_trailing, close_token_leading| {
-                    Ok(block_indent(format_elements![
-                        open_token_trailing,
-                        join_elements_hard_line(
-                            self.members()
-                                .into_iter()
-                                .zip(formatter.format_nodes(self.members())?)
-                        ),
-                        close_token_leading,
-                    ]))
-                },
+                join_elements_hard_line(
+                    self.members()
+                        .into_iter()
+                        .zip(formatter.format_nodes(self.members())?)
+                ),
                 &self.r_curly_token()?
-            )?)
+            )?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -1,22 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsArrayAssignmentPattern;
 
 impl ToFormatElement for JsArrayAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_brack_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.elements().format(formatter)?,
-                    close_token_leading,
-                ]))
-            },
+            self.elements().format(formatter)?,
             &self.r_brack_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -1,26 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsObjectAssignmentPattern;
 
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(format_elements![
-                    space_token(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        self.properties().format(formatter)?,
-                        close_token_leading
-                    ]),
-                    space_token(),
-                ])
-            },
+            self.properties().format(formatter)?,
             &self.r_curly_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/js/auxiliary/function_body.rs
@@ -1,22 +1,18 @@
 use crate::{
-    block_indent, format_elements, formatter_traits::FormatTokenAndNode, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 use rslint_parser::ast::JsFunctionBody;
 
 impl ToFormatElement for JsFunctionBody {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_delimited(
+        formatter.format_delimited_block_indent(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(block_indent(format_elements![
-                    open_token_trailing,
-                    self.directives().format(formatter)?,
-                    formatter.format_list(self.statements()),
-                    close_token_leading,
-                ]))
-            },
+            format_elements![
+                self.directives().format(formatter)?,
+                formatter.format_list(self.statements()),
+            ],
             &self.r_curly_token()?,
         )
     }

--- a/crates/rome_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/js/bindings/array_binding_pattern.rs
@@ -1,22 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsArrayBindingPattern;
 
 impl ToFormatElement for JsArrayBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_brack_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.elements().format(formatter)?,
-                    close_token_leading
-                ]))
-            },
+            self.elements().format(formatter)?,
             &self.r_brack_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_formatter/src/js/bindings/constructor_parameters.rs
@@ -1,22 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsConstructorParameters;
 
 impl ToFormatElement for JsConstructorParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_paren_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.parameters().format(formatter)?,
-                    close_token_leading,
-                ]))
-            },
+            self.parameters().format(formatter)?,
             &self.r_paren_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/js/bindings/object_binding_pattern.rs
@@ -1,26 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsObjectBindingPattern;
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(format_elements![
-                    space_token(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        self.properties().format(formatter)?,
-                        close_token_leading,
-                    ]),
-                    space_token(),
-                ])
-            },
+            self.properties().format(formatter)?,
             &self.r_curly_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_formatter/src/js/bindings/parameters.rs
@@ -1,22 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsParameters;
 
 impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_paren_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.items().format(formatter)?,
-                    close_token_leading,
-                ]))
-            },
+            self.items().format(formatter)?,
             &self.r_paren_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    block_indent, format_elements, space_token, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsStaticInitializationBlockClassMember;
@@ -10,15 +9,9 @@ use rslint_parser::ast::JsStaticInitializationBlockClassMember;
 impl ToFormatElement for JsStaticInitializationBlockClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let static_token = self.static_token().format(formatter)?;
-        let separated = formatter.format_delimited(
+        let separated = formatter.format_delimited_block_indent(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(block_indent(format_elements![
-                    open_token_trailing,
-                    formatter.format_list(self.statements()),
-                    close_token_leading,
-                ]))
-            },
+            formatter.format_list(self.statements()),
             &self.r_curly_token()?,
         )?;
         Ok(format_elements![static_token, space_token(), separated])

--- a/crates/rome_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_formatter/src/js/declarations/catch_declaration.rs
@@ -1,24 +1,15 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
-use crate::{
-    format_elements, group_elements, soft_block_indent, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
-};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsCatchDeclaration;
 
 impl ToFormatElement for JsCatchDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_paren_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.binding().format(formatter)?,
-                    close_token_leading,
-                ]))
-            },
+            self.binding().format(formatter)?,
             &self.r_paren_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/array_expression.rs
@@ -1,24 +1,15 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
-use crate::{
-    format_elements, group_elements, soft_block_indent, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
-};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsArrayExpression;
 
 impl ToFormatElement for JsArrayExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_brack_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.elements().format(formatter)?,
-                    close_token_leading,
-                ]))
-            },
+            self.elements().format(formatter)?,
             &self.r_brack_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_formatter/src/js/expressions/call_arguments.rs
@@ -1,22 +1,15 @@
 use crate::{
-    format_elements, formatter_traits::FormatTokenAndNode, group_elements, soft_block_indent,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsCallArguments;
 
 impl ToFormatElement for JsCallArguments {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_paren_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.args().format(formatter)?,
-                    close_token_leading
-                ]))
-            },
+            self.args().format(formatter)?,
             &self.r_paren_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/object_expression.rs
@@ -1,8 +1,5 @@
 use crate::formatter_traits::FormatTokenAndNode;
-use crate::{
-    empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
-};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsObjectExpression;
 
@@ -10,26 +7,18 @@ impl ToFormatElement for JsObjectExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let members = self.members().format(formatter)?;
 
-        let space = if members.is_empty() {
-            empty_element()
+        if members.is_empty() {
+            formatter.format_delimited_soft_block_indent(
+                &self.l_curly_token()?,
+                members,
+                &self.r_curly_token()?,
+            )
         } else {
-            space_token()
-        };
-
-        Ok(group_elements(formatter.format_delimited(
-            &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(format_elements!(
-                    space.clone(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        members,
-                        close_token_leading
-                    ]),
-                    space,
-                ))
-            },
-            &self.r_curly_token()?,
-        )?))
+            formatter.format_delimited_soft_block_spaces(
+                &self.l_curly_token()?,
+                members,
+                &self.r_curly_token()?,
+            )
+        }
     }
 }

--- a/crates/rome_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_clause.rs
@@ -1,9 +1,6 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
-use crate::{
-    empty_element, format_elements, group_elements, if_group_fits_on_single_line,
-    soft_block_indent, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
-};
+use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsExportNamedClause;
 
@@ -11,23 +8,11 @@ impl ToFormatElement for JsExportNamedClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let specifiers = self.specifiers().format(formatter)?;
 
-        let list = group_elements(formatter.format_delimited(
+        let list = formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |leading, trailing| {
-                let space = if leading.is_empty() && specifiers.is_empty() && trailing.is_empty() {
-                    empty_element()
-                } else {
-                    if_group_fits_on_single_line(space_token())
-                };
-
-                Ok(format_elements!(
-                    space.clone(),
-                    soft_block_indent(format_elements![leading, specifiers, trailing]),
-                    space,
-                ))
-            },
+            specifiers,
             &self.r_curly_token()?,
-        )?);
+        )?;
 
         let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
 

--- a/crates/rome_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_from_clause.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    empty_element, format_elements, group_elements, if_group_fits_on_single_line,
-    soft_block_indent, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsExportNamedFromClause;
@@ -11,23 +10,11 @@ impl ToFormatElement for JsExportNamedFromClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let specifiers = self.specifiers().format(formatter)?;
 
-        let list = group_elements(formatter.format_delimited(
+        let list = formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |leading, trailing| {
-                let space = if leading.is_empty() && specifiers.is_empty() && trailing.is_empty() {
-                    empty_element()
-                } else {
-                    if_group_fits_on_single_line(space_token())
-                };
-
-                Ok(format_elements!(
-                    space.clone(),
-                    soft_block_indent(format_elements![leading, specifiers, trailing]),
-                    space,
-                ))
-            },
+            specifiers,
             &self.r_curly_token()?,
-        )?);
+        )?;
 
         let from = self.from_token().format(formatter)?;
         let source = self.source().format(formatter)?;

--- a/crates/rome_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_formatter/src/js/module/import_assertion.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsImportAssertion;
@@ -12,23 +11,11 @@ impl ToFormatElement for JsImportAssertion {
         let assert_token = self.assert_token().format(formatter)?;
         let assertions = self.assertions().format(formatter)?;
 
-        let result = group_elements(formatter.format_delimited(
+        let result = formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |leading, trailing| {
-                let space = if leading.is_empty() && assertions.is_empty() && trailing.is_empty() {
-                    empty_element()
-                } else {
-                    space_token()
-                };
-
-                Ok(format_elements!(
-                    space.clone(),
-                    soft_block_indent(format_elements![leading, assertions, trailing]),
-                    space,
-                ))
-            },
+            assertions,
             &self.r_curly_token()?,
-        )?);
+        )?;
 
         Ok(format_elements![assert_token, space_token(), result])
     }

--- a/crates/rome_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_formatter/src/js/module/named_import_specifiers.rs
@@ -1,8 +1,5 @@
 use crate::formatter_traits::FormatTokenAndNode;
-use crate::{
-    empty_element, format_elements, group_elements, soft_block_indent, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
-};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsNamedImportSpecifiers;
 
@@ -10,22 +7,10 @@ impl ToFormatElement for JsNamedImportSpecifiers {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let specifiers = self.specifiers().format(formatter)?;
 
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |leading, trailing| {
-                let space = if leading.is_empty() && specifiers.is_empty() && trailing.is_empty() {
-                    empty_element()
-                } else {
-                    space_token()
-                };
-
-                Ok(format_elements!(
-                    space.clone(),
-                    soft_block_indent(format_elements![leading, specifiers, trailing]),
-                    space,
-                ))
-            },
+            specifiers,
             &self.r_curly_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_formatter/src/js/statements/block_statement.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    block_indent, format_elements, hard_line_break, FormatElement, FormatResult, Formatter,
-    ToFormatElement,
+    format_elements, hard_line_break, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsBlockStatement;
@@ -20,15 +19,9 @@ impl ToFormatElement for JsBlockStatement {
                 self.r_curly_token().format(formatter)?
             ])
         } else {
-            formatter.format_delimited(
+            formatter.format_delimited_block_indent(
                 &self.l_curly_token()?,
-                |open_token_trailing, close_token_leading| {
-                    Ok(block_indent(format_elements![
-                        open_token_trailing,
-                        stmts,
-                        close_token_leading
-                    ]))
-                },
+                stmts,
                 &self.r_curly_token()?,
             )
         }

--- a/crates/rome_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/js/statements/do_while_statement.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, space_token, token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsDoWhileStatement;
@@ -16,15 +15,11 @@ impl ToFormatElement for JsDoWhileStatement {
             space_token(),
             self.while_token().format(formatter)?,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.test().format(formatter)?,
-                    close_token_leading,
-                ])),
+                self.test().format(formatter)?,
                 &self.r_paren_token()?,
-            )?),
+            )?,
             self.semicolon_token().format_or(formatter, || token(";"))?
         ])
     }

--- a/crates/rome_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_in_statement.rs
@@ -3,8 +3,8 @@ use rslint_parser::ast::JsForInStatement;
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 impl ToFormatElement for JsForInStatement {
@@ -18,19 +18,15 @@ impl ToFormatElement for JsForInStatement {
         Ok(format_elements![
             for_token,
             space_token(),
-            formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(group_elements(soft_block_indent(
-                    format_elements![
-                        open_token_trailing,
-                        initializer,
-                        soft_line_break_or_space(),
-                        in_token,
-                        soft_line_break_or_space(),
-                        expression,
-                        close_token_leading,
-                    ]
-                ))),
+                format_elements![
+                    initializer,
+                    soft_line_break_or_space(),
+                    in_token,
+                    soft_line_break_or_space(),
+                    expression,
+                ],
                 &self.r_paren_token()?
             )?,
             space_token(),

--- a/crates/rome_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_of_statement.rs
@@ -3,8 +3,8 @@ use rslint_parser::ast::JsForOfStatement;
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 impl ToFormatElement for JsForOfStatement {
@@ -22,19 +22,15 @@ impl ToFormatElement for JsForOfStatement {
             for_token,
             space_token(),
             await_token,
-            formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(group_elements(soft_block_indent(
-                    format_elements![
-                        open_token_trailing,
-                        initializer,
-                        soft_line_break_or_space(),
-                        of_token,
-                        soft_line_break_or_space(),
-                        expression,
-                        close_token_leading,
-                    ]
-                ))),
+                format_elements![
+                    initializer,
+                    soft_line_break_or_space(),
+                    of_token,
+                    soft_line_break_or_space(),
+                    expression,
+                ],
                 &self.r_paren_token()?
             )?,
             space_token(),

--- a/crates/rome_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_statement.rs
@@ -1,8 +1,8 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, soft_line_break_or_space, space_token,
-    FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, group_elements, soft_line_break_or_space, space_token, FormatElement,
+    FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsForStatement;
@@ -30,11 +30,9 @@ impl ToFormatElement for JsForStatement {
         Ok(group_elements(format_elements![
             self.for_token().format(formatter)?,
             space_token(),
-            formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(group_elements(soft_block_indent(
-                    format_elements![open_token_trailing, inner, close_token_leading]
-                ))),
+                inner,
                 &self.r_paren_token()?,
             )?,
             space_token(),

--- a/crates/rome_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_formatter/src/js/statements/if_statement.rs
@@ -1,8 +1,8 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
-    Formatter, ToFormatElement,
+    format_elements, group_elements, space_token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 use rslint_parser::ast::JsIfStatement;
@@ -19,17 +19,11 @@ impl ToFormatElement for JsIfStatement {
             group_elements(format_elements![
                 self.if_token().format(formatter)?,
                 space_token(),
-                group_elements(formatter.format_delimited(
+                formatter.format_delimited_soft_block_indent(
                     &self.l_paren_token()?,
-                    |open_token_trailing, close_token_leading| Ok(soft_block_indent(
-                        format_elements![
-                            open_token_trailing,
-                            self.test().format(formatter)?,
-                            close_token_leading
-                        ]
-                    )),
+                    self.test().format(formatter)?,
                     &self.r_paren_token()?,
-                )?),
+                )?,
                 space_token(),
             ]),
             self.consequent().format(formatter)?,

--- a/crates/rome_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/js/statements/switch_statement.rs
@@ -1,10 +1,10 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
-use crate::{block_indent, FormatResult};
+use crate::FormatResult;
 
 use crate::{
-    format_elements, group_elements, join_elements_hard_line, soft_block_indent, space_token,
-    FormatElement, Formatter, ToFormatElement,
+    format_elements, join_elements_hard_line, space_token, FormatElement, Formatter,
+    ToFormatElement,
 };
 
 use rslint_parser::ast::JsSwitchStatement;
@@ -14,31 +14,21 @@ impl ToFormatElement for JsSwitchStatement {
         Ok(format_elements![
             self.switch_token().format(formatter)?,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.discriminant().format(formatter)?,
-                    close_token_leading,
-                ])),
+                self.discriminant().format(formatter)?,
                 &self.r_paren_token()?,
-            )?),
+            )?,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_block_indent(
                 &self.l_curly_token()?,
-                |open_token_trailing, close_token_leading| {
-                    Ok(block_indent(format_elements![
-                        open_token_trailing,
-                        join_elements_hard_line(
-                            self.cases()
-                                .into_iter()
-                                .zip(formatter.format_nodes(self.cases())?)
-                        ),
-                        close_token_leading,
-                    ]))
-                },
+                join_elements_hard_line(
+                    self.cases()
+                        .into_iter()
+                        .zip(formatter.format_nodes(self.cases())?)
+                ),
                 &self.r_curly_token()?
-            )?)
+            )?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_formatter/src/js/statements/while_statement.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
-    Formatter, ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsWhileStatement;
@@ -12,15 +11,11 @@ impl ToFormatElement for JsWhileStatement {
         Ok(format_elements![
             self.while_token().format(formatter)?,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.test().format(formatter)?,
-                    close_token_leading,
-                ])),
+                self.test().format(formatter)?,
                 &self.r_paren_token()?,
-            )?),
+            )?,
             space_token(),
             self.body().format(formatter)?
         ])

--- a/crates/rome_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_formatter/src/js/statements/with_statement.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{
-    format_elements, group_elements, soft_block_indent, space_token, FormatElement, FormatResult,
-    Formatter, ToFormatElement,
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
 use rslint_parser::ast::JsWithStatement;
@@ -12,15 +11,11 @@ impl ToFormatElement for JsWithStatement {
         Ok(format_elements![
             self.with_token().format(formatter)?,
             space_token(),
-            group_elements(formatter.format_delimited(
+            formatter.format_delimited_soft_block_indent(
                 &self.l_paren_token()?,
-                |open_token_trailing, close_token_leading| Ok(soft_block_indent(format_elements![
-                    open_token_trailing,
-                    self.object().format(formatter)?,
-                    close_token_leading,
-                ])),
+                self.object().format(formatter)?,
                 &self.r_paren_token()?,
-            )?),
+            )?,
             space_token(),
             self.body().format(formatter)?
         ])

--- a/crates/rome_formatter/src/ts/bindings/type_parameters.rs
+++ b/crates/rome_formatter/src/ts/bindings/type_parameters.rs
@@ -1,26 +1,16 @@
 use crate::{
-    format_elements, group_elements, join_elements, soft_block_indent, soft_line_break,
-    soft_line_break_or_space, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    join_elements, soft_line_break_or_space, token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 use rslint_parser::ast::TsTypeParameters;
 impl ToFormatElement for TsTypeParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let items = formatter.format_separated(self.items(), || token(","))?;
 
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_indent(
             &self.l_angle_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(format_elements![
-                    soft_line_break(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        join_elements(soft_line_break_or_space(), items),
-                        close_token_leading,
-                    ]),
-                    soft_line_break()
-                ])
-            },
+            join_elements(soft_line_break_or_space(), items),
             &self.r_angle_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_formatter/src/ts/declarations/enum_declaration.rs
@@ -1,7 +1,7 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    format_elements, group_elements, join_elements, soft_block_indent, soft_line_break_or_space,
-    space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+    format_elements, join_elements, soft_line_break_or_space, space_token, token, FormatElement,
+    FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::TsEnumDeclaration;
 
@@ -20,21 +20,11 @@ impl ToFormatElement for TsEnumDeclaration {
             .format_with(formatter, |id| format_elements![id, space_token()])?;
 
         let members = formatter.format_separated(self.members(), || token(","))?;
-        let list = group_elements(formatter.format_delimited(
+        let list = formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                Ok(format_elements![
-                    soft_line_break_or_space(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        join_elements(soft_line_break_or_space(), members),
-                        close_token_leading,
-                    ]),
-                    soft_line_break_or_space(),
-                ])
-            },
+            join_elements(soft_line_break_or_space(), members),
             &self.r_curly_token()?,
-        )?);
+        )?;
 
         Ok(format_elements![const_token, enum_token, id, list])
     }

--- a/crates/rome_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_formatter/src/ts/types/object_type.rs
@@ -1,26 +1,12 @@
-use crate::{
-    format_elements, group_elements, soft_block_indent, soft_line_break_or_space, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
-};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::TsObjectType;
 
 impl ToFormatElement for TsObjectType {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        Ok(group_elements(formatter.format_delimited(
+        formatter.format_delimited_soft_block_spaces(
             &self.l_curly_token()?,
-            |open_token_trailing, close_token_leading| {
-                let list = self.members().to_format_element(formatter)?;
-                Ok(format_elements![
-                    soft_line_break_or_space(),
-                    soft_block_indent(format_elements![
-                        open_token_trailing,
-                        list,
-                        close_token_leading
-                    ]),
-                    soft_line_break_or_space()
-                ])
-            },
+            self.members().to_format_element(formatter)?,
             &self.r_curly_token()?,
-        )?))
+        )
     }
 }

--- a/crates/rome_formatter/tests/specs/js/module/comments.js
+++ b/crates/rome_formatter/tests/specs/js/module/comments.js
@@ -45,3 +45,12 @@ statement(); /* block comment */
 statement();
 
 statement(); // inline
+
+// leading
+[1, 2, 3];
+  
+[1, 2, 3] // trailing
+
+function name() /* comment */ {}
+
+function name(very, long, list, of_parameters, to, insert, a_break, in_the, parameters, group) /* comment */ {}

--- a/crates/rome_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/comments.js.snap
@@ -52,6 +52,16 @@ statement(); /* block comment */
 statement();
 
 statement(); // inline
+
+// leading
+[1, 2, 3];
+  
+[1, 2, 3] // trailing
+
+function name() /* comment */ {}
+
+function name(very, long, list, of_parameters, to, insert, a_break, in_the, parameters, group) /* comment */ {}
+
 =============================
 # Outputs
 ## Output 1
@@ -101,4 +111,24 @@ statement(); /* block comment */
 statement();
 
 statement(); // inline
+
+// leading
+[1, 2, 3];
+
+[1, 2, 3]; // trailing
+
+function name() {} /* comment */
+
+function name(
+	very,
+	long,
+	list,
+	of_parameters,
+	to,
+	insert,
+	a_break,
+	in_the,
+	parameters,
+	group,
+) {} /* comment */
 

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/partial-application.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/partial-application.js.snap
@@ -48,29 +48,13 @@ let newScore = player.score
   |> add(7, ?)
   |> clamp(0, 100, ?); // shallow stack, the pipe to `clamp` is the same frame as the pipe to `add`.
 
-f(
-  x,
-  ?,
-); // partial application from left
-f(
-  ?, x,
-); // partial application from right
-f(
-  ?, x, ?,
-); // partial application for any arg
-o.f(
-  x,
-  ?,
-); // partial application from left
-o.f(
-  ?, x,
-); // partial application from right
-o.f(
-  ?, x, ?,
-); // partial application for any arg
-super.f(
-  ?,
-); // partial application allowed for call on |SuperProperty|
+f(x, ?); // partial application from left
+f(?, x); // partial application from right
+f(?, x, ?); // partial application for any arg
+o.f(x, ?); // partial application from left
+o.f(?, x); // partial application from right
+o.f(?, x, ?); // partial application for any arg
+super.f(?); // partial application allowed for call on |SuperProperty|
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/comments-closure-typecast/iife.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments-closure-typecast/iife.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: iife.js
 
 ---
@@ -32,9 +32,7 @@ const helpers2 = ((function () { /** @type {Helpers} */
 
 // TODO: @param is misplaced https://github.com/prettier/prettier/issues/5850
 const helpers = ((/** @param {Partial<Helpers>} helpers */ /** @type {Helpers} */
-(
-  helpers = {},
-) => helpers)());
+(helpers = {}) => helpers)());
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/comments-closure-typecast/object-with-comment.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments-closure-typecast/object-with-comment.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: object-with-comment.js
 
 ---
@@ -23,9 +23,7 @@ const objectWithComment2 = /** @type MyType */ (  /* comment */  {
 # Output
 ```js
 const objectWithComment = (/* comment */ /** @type MyType */
-{
-  foo: bar,
-});
+{ foo: bar });
 
 const objectWithComment2 = /** @type MyType */ ( /* comment */ { foo: bar });
 

--- a/crates/rome_formatter/tests/specs/prettier/comments/function-declaration.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/function-declaration.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: function-declaration.js
 
 ---
@@ -82,24 +82,24 @@ KEYPAD_NUMBERS.map(num => ( // Buttons 0-9
 
 function f1() {} /* f */
 function f2( /* args */ ) {}
-function f3() /* returns */ {}
-function f4( /* args */ ) /* returns */ {} /* f */
+function f3() {} /* returns */
+function f4( /* args */ ) {} /* f */ /* returns */
 
 function f5( /* a */ a) {} /* f */
 function f6(a /* a */ ) {} /* f */
-function f7( /* a */ a) /* returns */ {} /* f */
+function f7( /* a */ a) {} /* f */ /* returns */
 
 const obj = {
   f1() {}, /* f */
   f2( /* args */ ) {},
-  f3() /* returns */ {},
-  f4( /* args */ ) /* returns */ {}, /* f */
+  f3() {}, /* returns */
+  f4( /* args */ ) {}, /* f */ /* returns */
 };
 
 (function f() {})(); /* f */
 (function f( /* args */ ) {})();
-(function f() /* returns */ {})();
-(function f( /* args */ ) /* returns */ {})(); /* f */
+(function f() {})(); /* returns */
+(function f( /* args */ ) {})(); /* f */ /* returns */
 
 class C1 {
   f() {} /* f */
@@ -108,10 +108,10 @@ class C2 {
   f( /* args */ ) {}
 }
 class C3 {
-  f() /* returns */ {}
+  f() {} /* returns */
 }
 class C4 {
-  f( /* args */ ) /* returns */ {} /* f */
+  f( /* args */ ) {} /* f */ /* returns */
 }
 
 function foo1() // this is a function

--- a/crates/rome_formatter/tests/specs/prettier/comments/if.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/if.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: if.js
 
 ---
@@ -87,54 +87,34 @@ else if (4) {
 else {
 }
 
-if (
-  5
-) true; // comment
+if (5) true; // comment
 
-if (
-  6
-) { // comment
+if (6) { // comment
   true;
-} else if (
-  7
-) true; else { // comment // comment
+} else if (7) true; else { // comment // comment
   true;
 }
 
-if (
-  8
-) // comment // comment
+if (8) // comment // comment
 {
   true;
-} else if (
-  9
-) // comment // comment
+} else if (9) // comment // comment
 true; else // comment // comment
 {
   true;
 }
 
-if (
-  10
-) { /* comment */ // comment
+if (10) { /* comment */ // comment
   true;
-} else if (11) /* comment */ true; else if (
-  12
-) true; else if ( // comment /* comment */ // comment
-  13
-) true; else { /* comment */ /* comment */ // comment /* comment */
+} else if (11) /* comment */ true; else if (12) true; else if (13) true; else { // comment /* comment */ // comment /* comment */ /* comment */ // comment /* comment */
   true;
 }
 
-if (
-  14
-) /* comment */ // comment
+if (14) /* comment */ // comment
 // comment
 {
   true;
-} else if (
-  15
-) /* comment */ // comment
+} else if (15) /* comment */ // comment
 /* comment */ // comment
 true;
 

--- a/crates/rome_formatter/tests/specs/prettier/comments/last-arg.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/last-arg.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: last-arg.js
 
 ---
@@ -59,12 +59,7 @@ class Foo {
 
   d(lol /*string*/ , lol2 /*string*/ , lol3 /*string*/ , lol4 /*string*/ ) {}
 
-  d(
-    lol, /*string*/
-    lol2, /*string*/
-    lol3, /*string*/
-    lol4, /*string*/
-  ) {} /*string*/
+  d(lol /*string*/ , lol2 /*string*/ , lol3 /*string*/ , lol4 /*string*/ ) {} /*string*/
 
   // prettier-ignore
   c(lol /*string*/ ) {}

--- a/crates/rome_formatter/tests/specs/prettier/comments/while.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/comments/while.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: while.js
 
 ---
@@ -39,13 +39,11 @@ while (
   // Comment
 ) {}
 
-while (
-  true
-) {} // Comment
+while (true) {} // Comment
 
 while (true) {} // Comment
 
-while (true) /*Comment*/ {}
+while (true) {} /*Comment*/
 
 while (
   true && true // Comment // Comment
@@ -53,11 +51,9 @@ while (
 
 while (true) {} // comment
 
-while (true) /* comment */ ++x;
+while (true) ++x; /* comment */
 
-while (
-  1
-) foo(); // Comment
+while (1) foo(); // Comment
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/empty-paren-comment/class-property.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/empty-paren-comment/class-property.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: class-property.js
 
 ---
@@ -22,7 +22,7 @@ class Foo {
 ```js
 class Foo {
   f( /* ... */ ) {}
-  f() /* ... */ {}
+  f() {} /* ... */
   f = ( /* ... */ ) => {};
   static f( /* ... */ ) {}
   static f = ( /* ... */ ) => {};

--- a/crates/rome_formatter/tests/specs/prettier/if/if_comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/if/if_comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: if_comments.js
 
 ---
@@ -78,20 +78,14 @@ async function f1() {
 }
 
 async function f2() {
-  if (untrackedChoice === 0) /* Cancel */ null; else if (
-    untrackedChoice === 1
-  ) shouldAmend = true; else if (untrackedChoice === 2) /* Allow Untracked */ allowUntracked = /* Add */
+  if (untrackedChoice === 0) /* Cancel */ null; else if (untrackedChoice === 1) shouldAmend = /* Add */
+    true; else if (untrackedChoice === 2) /* Allow Untracked */ allowUntracked =
     true;
 }
 
 async function f3() {
-  if (
-    untrackedChoice === 0
-  ) null; else if ( /* Cancel */ // Cancel
-    untrackedChoice === 1
-  ) shouldAmend = true; else if ( /* Add */ // Add
-    untrackedChoice === 2
-  ) allowUntracked = true; /* Allow Untracked */ // Allow Untracked
+  if (untrackedChoice === 0) null; else if (untrackedChoice === 1) shouldAmend = /* Cancel */ // Cancel /* Add */ // Add
+    true; else if (untrackedChoice === 2) allowUntracked = true; /* Allow Untracked */ // Allow Untracked
 }
 
 async function f4() {

--- a/crates/rome_formatter/tests/specs/prettier/last-argument-expansion/arrow.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/last-argument-expansion/arrow.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: arrow.js
 
 ---
@@ -31,9 +31,9 @@ export default function searchUsers(action$) {
     (action) => action.payload.query,
   ).filter((q) => !!q).switchMap(
     (q) =>
-      Observable.timer(
-        800,
-      ).takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS)).mergeMap( // debounce
+      Observable.timer(800).takeUntil( // debounce
+        action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS),
+      ).mergeMap(
         () =>
           Observable.merge(
             Observable.of(replace(`?q=${q}`)),

--- a/crates/rome_formatter/tests/specs/prettier/method-chain/comment.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/method-chain/comment.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: comment.js
 
 ---
@@ -73,13 +73,9 @@ function f() {
 _.a(a)/* very very very very very very very long such that it is longer than 80 columns */
 .a();
 
-_.a(
-  a,
-).a(); /* very very very very very very very long such that it is longer than 80 columns */
+_.a(a).a(); /* very very very very very very very long such that it is longer than 80 columns */
 
-_.a(
-  a,
-).a(); /* very very very very very very very long such that it is longer than 80 columns */
+_.a(a).a(); /* very very very very very very very long such that it is longer than 80 columns */
 
 Something// $FlowFixMe(>=0.41.0)
 .getInstance(this.props.dao).getters();
@@ -101,11 +97,7 @@ const configModel = this.baseConfigurationService.getCache().consolidated.merge(
   this.cachedWorkspaceConfig,
 );
 
-this.doWriteConfiguration(
-  target,
-  value,
-  options,
-).then( // queue up writes to prevent race conditions
+this.doWriteConfiguration(target, value, options).then( // queue up writes to prevent race conditions
   () => null,
   (error) => {
     return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(

--- a/crates/rome_formatter/tests/specs/prettier/method-chain/issue-4125.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/method-chain/issue-4125.js.snap
@@ -233,9 +233,7 @@ const date = moment.utc(userInput).hour(0).minute(0).second(0);
 
 fetchUser(id).then(fetchAccountForUser).catch(handleFetchError);
 
-fetchUser(
-  id,
-).then(fetchAccountForUser).catch(handleFetchError); //
+fetchUser(id).then(fetchAccountForUser).catch(handleFetchError); //
 
 // examples from https://github.com/prettier/prettier/issues/3107
 
@@ -260,9 +258,9 @@ action$.ofType(ActionTypes.SEARCHED_USERS).map((action) => action.payload.query)
   (q) => !!q,
 ).switchMap(
   (q) =>
-    Observable.timer(
-      800,
-    ).takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS)).mergeMap( // debounce
+    Observable.timer(800).takeUntil( // debounce
+      action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS),
+    ).mergeMap(
       () =>
         Observable.merge(
           Observable.of(replace(`?q=${q}`)),

--- a/crates/rome_formatter/tests/specs/prettier/objects/expression.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/objects/expression.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: expression.js
 
 ---
@@ -43,8 +43,8 @@ a = () => ({}).x;
 ({}::b()``[''].c++ && 0 ? 0 : 0, 0
 )
 ({}(), 0);
-({ } = 0);
-(({ } = 0), 1);
+({} = 0);
+(({} = 0), 1);
 
 const a1 = { someKey: (shortName, shortName) };
 

--- a/crates/rome_formatter/tests/specs/prettier/optional-chaining/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/optional-chaining/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: comments.js
 
 ---
@@ -75,10 +75,9 @@ foo.bar.baz?.doSomething("Hello World")// Hello world
 );
 
 (somethingGood ? thisIsIt : maybeNot)// Hello world
-.doSomething("Hello World")?.doAnotherThing(
-  "Foo",
-  { foo: bar },
-).run(() => console.log("Bar")); // Run this // Do this
+.doSomething("Hello World")?.doAnotherThing("Foo", { foo: bar }).run( // Run this
+  () => console.log("Bar"),
+); // Do this
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/preserve-line/argument-list.js.snap
@@ -263,10 +263,7 @@ moreArgTypes(
     // Hello world
 
     // Hello world again
-    {
-      name: "Hello World",
-      age: 34,
-    },
+    { name: "Hello World", age: 34 },
     oneThing + anotherThing,
     // Comment
   ),
@@ -282,10 +279,7 @@ evenMoreArgTypes(
 foo.apply(
   null,
   // Array here
-  [
-    1,
-    2,
-  ],
+  [1, 2],
 );
 
 bar.on(
@@ -307,11 +301,7 @@ doSomething.apply(
   null,
   // Comment
 
-  [
-    "Hello world 1",
-    "Hello world 2",
-    "Hello world 3",
-  ],
+  ["Hello world 1", "Hello world 2", "Hello world 3"],
 );
 
 doAnotherThing("node", { solution_type, time_frame });
@@ -338,10 +328,7 @@ doSomething(
   /* Comment */
 
   // This is important
-  {
-    helloWorld,
-    someImportantStuff,
-  },
+  { helloWorld, someImportantStuff },
 );
 
 function foo(one, two, three, four, five, six, seven, eight, nine, ten, eleven) {}

--- a/crates/rome_formatter/tests/specs/prettier/preserve-line/member-chain.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/preserve-line/member-chain.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: member-chain.js
 
 ---
@@ -83,10 +83,9 @@ foo.bar.baz.doSomething("Hello World")// Hello world
 );
 
 (somethingGood ? thisIsIt : maybeNot)// Hello world
-.doSomething("Hello World").doAnotherThing(
-  "Foo",
-  { foo: bar },
-).run(() => console.log("Bar")); // Run this // Do this
+.doSomething("Hello World").doAnotherThing("Foo", { foo: bar }).run( // Run this
+  () => console.log("Bar"),
+); // Do this
 
 helloWorld.text().then((t) => t);
 

--- a/crates/rome_formatter/tests/specs/prettier/record/shorthand.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/record/shorthand.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: shorthand.js
 
 ---
@@ -20,9 +20,7 @@ const record = #
 {
   url;
 }
-console.log(
-  record.url,
-); // https://github.com/tc39/proposal-record-tuple
+console.log(record.url); // https://github.com/tc39/proposal-record-tuple
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/trailing-comma/trailing_whitespace.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/trailing-comma/trailing_whitespace.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: trailing_whitespace.js
 
 ---
@@ -98,7 +98,7 @@ this.getAttribute(
   },
 );
 this.getAttribute(
-  function (s) /*string*/ {
+  function (s) { /*string*/
     console.log();
   },
 );

--- a/crates/rome_formatter/tests/specs/prettier/unary-expression/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/unary-expression/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 121
 expression: comments.js
 
 ---
@@ -324,36 +324,22 @@ x || y);
 !(x || y); // foo
 
 ![1, 2, 3];
-!([1, 2, 3] /* foo */ );
+!([1, 2, 3]); /* foo */
 !([1, 2, 3]); /* foo */
 !(/* foo */
-[
-  1,
-  2,
-  3,
-]);
+[1, 2, 3]);
 !([1, 2, 3]/* foo */
 );
-!([
-  1,
-  2,
-  3,
-]); // foo
+!([1, 2, 3]); // foo
 
 !{ a: 1, b: 2 };
-!({ a: 1, b: 2 } /* foo */ );
+!({ a: 1, b: 2 }); /* foo */
 !({ a: 1, b: 2 }); /* foo */
 !(/* foo */
-{
-  a: 1,
-  b: 2,
-});
+{ a: 1, b: 2 });
 !({ a: 1, b: 2 }/* foo */
 );
-!({
-  a: 1,
-  b: 2,
-}); // foo
+!({ a: 1, b: 2 }); // foo
 
 !function () {
   return x;
@@ -426,7 +412,7 @@ x ? y : z);
 !(x ? y : z); // foo
 
 !x();
-!(x() /* foo */ );
+!(x()); /* foo */
 !(x()); /* foo */
 !(/* foo */
 x());
@@ -435,7 +421,7 @@ x());
 !(x()); // foo
 
 !new x();
-!(new x() /* foo */ );
+!(new x()); /* foo */
 !(new x()); /* foo */
 !(/* foo */
 new x());

--- a/crates/rome_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -25,7 +25,7 @@ const enum C {
 Indent style: Tab
 Line width: 80
 -----
-enum A { }
+enum A {}
 enum B {
 	a = "something",
 	b = "something",


### PR DESCRIPTION
## Summary

This PR adjusts the grouping semantics of the `format_delimited` function, as well as introduce new helper methods to make using it less verbose.

### Group elements

The first change is mostly significant for the formatter output and changes how the `FormatElements` returned by `format_delimited` are placed into groups. Previously most call sites of this method were invoked as `group_elements(format_delimited(open_token, |trailing, leading| *_indent([trailing, content, leading]), close_token))`, which yields the following IR:

```
Group [
    open_token_leading_trivia,
    open_token,
    Indent [
        open_token_trailing_trivia,
        content,
        close_token_leading_trivia,
    ],
    close_token,
    close_token_trailing_trivia,
]
```

With this change the method is now used as just `format_delimited_*_indent(open_token, content, close_token)` and results in the following IR:

```
open_token_leading_trivia,
Group [
    open_token,
    Indent [
        open_token_trailing_trivia,
        content,
        close_token_leading_trivia
    ],
    close_token,
],
close_token_trailing_trivia
```

The leading and trailing trivias are now pushed out of the group, which is important as these can be empty lines or single-line comments that would force the group to break when its actual content could have fit on a single line:

```
// This comment is a leading trivia on the [ token
[1, 2, 3]
```

Previously the comment would have been included in the group and the array expression would have thus been unnecessarily broken on multiple lines.

### Shorthand helpers

The different call sites of `format_delimited` vary slightly in how they handle their inner indentation but can be broadly categorized into 3 cases:
- `block_indent([trailing, content, leading])`
- `soft_block_indent([trailing, content, leading])`
- `[space, soft_block_indent([trailing, content, leading]), space]`

These 3 case are now implemented in `format_delimited_block_indent`, `format_delimited_soft_block_indent` and `format_delimited_soft_block_spaces` respectively, and the `format_delimited` method has been made private.
