### PR TITLE
feat(rslint_parser): TypeScript `import` extensions

### DIFF
--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -1656,16 +1656,17 @@ impl JsImportDefaultClause {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
-        support::required_node(&self.syntax, 0usize)
+        support::required_node(&self.syntax, 1usize)
     }
     pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 1usize)
+        support::required_token(&self.syntax, 2usize)
     }
     pub fn source(&self) -> SyntaxResult<JsModuleSource> {
-        support::required_node(&self.syntax, 2usize)
+        support::required_node(&self.syntax, 3usize)
     }
-    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 3usize) }
+    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 4usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportNamedClause {
@@ -1679,19 +1680,20 @@ impl JsImportNamedClause {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn default_specifier(&self) -> Option<JsDefaultImportSpecifier> {
-        support::node(&self.syntax, 0usize)
+        support::node(&self.syntax, 1usize)
     }
     pub fn named_import(&self) -> SyntaxResult<JsAnyNamedImport> {
-        support::required_node(&self.syntax, 1usize)
+        support::required_node(&self.syntax, 2usize)
     }
     pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 2usize)
+        support::required_token(&self.syntax, 3usize)
     }
     pub fn source(&self) -> SyntaxResult<JsModuleSource> {
-        support::required_node(&self.syntax, 3usize)
+        support::required_node(&self.syntax, 4usize)
     }
-    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 4usize) }
+    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 5usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsImportNamespaceClause {
@@ -1705,22 +1707,23 @@ impl JsImportNamespaceClause {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 0usize)
-    }
-    pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
+    pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
+        support::required_token(&self.syntax, 2usize)
+    }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
-        support::required_node(&self.syntax, 2usize)
+        support::required_node(&self.syntax, 3usize)
     }
     pub fn from_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 3usize)
+        support::required_token(&self.syntax, 4usize)
     }
     pub fn source(&self) -> SyntaxResult<JsModuleSource> {
-        support::required_node(&self.syntax, 4usize)
+        support::required_node(&self.syntax, 5usize)
     }
-    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 5usize) }
+    pub fn assertion(&self) -> Option<JsImportAssertion> { support::node(&self.syntax, 6usize) }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsInExpression {
@@ -1990,14 +1993,15 @@ impl JsNamedImportSpecifier {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn name(&self) -> SyntaxResult<JsLiteralExportName> {
-        support::required_node(&self.syntax, 0usize)
+        support::required_node(&self.syntax, 1usize)
     }
     pub fn as_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 1usize)
+        support::required_token(&self.syntax, 2usize)
     }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
-        support::required_node(&self.syntax, 2usize)
+        support::required_node(&self.syntax, 3usize)
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2655,8 +2659,9 @@ impl JsShorthandNamedImportSpecifier {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, 0usize) }
     pub fn local_name(&self) -> SyntaxResult<JsAnyBinding> {
-        support::required_node(&self.syntax, 0usize)
+        support::required_node(&self.syntax, 1usize)
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -7899,6 +7904,10 @@ impl AstNode for JsImportDefaultClause {
 impl std::fmt::Debug for JsImportDefaultClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsImportDefaultClause")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field("local_name", &support::DebugSyntaxResult(self.local_name()))
             .field("from_token", &support::DebugSyntaxResult(self.from_token()))
             .field("source", &support::DebugSyntaxResult(self.source()))
@@ -7929,6 +7938,10 @@ impl AstNode for JsImportNamedClause {
 impl std::fmt::Debug for JsImportNamedClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsImportNamedClause")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field(
                 "default_specifier",
                 &support::DebugOptionalElement(self.default_specifier()),
@@ -7966,6 +7979,10 @@ impl AstNode for JsImportNamespaceClause {
 impl std::fmt::Debug for JsImportNamespaceClause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsImportNamespaceClause")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field("star_token", &support::DebugSyntaxResult(self.star_token()))
             .field("as_token", &support::DebugSyntaxResult(self.as_token()))
             .field("local_name", &support::DebugSyntaxResult(self.local_name()))
@@ -8368,6 +8385,10 @@ impl AstNode for JsNamedImportSpecifier {
 impl std::fmt::Debug for JsNamedImportSpecifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsNamedImportSpecifier")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field("name", &support::DebugSyntaxResult(self.name()))
             .field("as_token", &support::DebugSyntaxResult(self.as_token()))
             .field("local_name", &support::DebugSyntaxResult(self.local_name()))
@@ -9343,6 +9364,10 @@ impl AstNode for JsShorthandNamedImportSpecifier {
 impl std::fmt::Debug for JsShorthandNamedImportSpecifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsShorthandNamedImportSpecifier")
+            .field(
+                "type_token",
+                &support::DebugOptionalElement(self.type_token()),
+            )
             .field("local_name", &support::DebugSyntaxResult(self.local_name()))
             .finish()
     }

--- a/crates/rslint_parser/src/ast/generated/syntax_factory.rs
+++ b/crates/rslint_parser/src/ast/generated/syntax_factory.rs
@@ -2871,8 +2871,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_IMPORT_DEFAULT_CLAUSE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<5usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsAnyBinding::can_cast(element.kind()) {
                         slots.mark_present();
@@ -2911,8 +2918,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_IMPORT_NAMED_CLAUSE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<5usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<6usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsDefaultImportSpecifier::can_cast(element.kind()) {
                         slots.mark_present();
@@ -2958,8 +2972,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_IMPORT_NAMESPACE_CLAUSE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<6usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<7usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if element.kind() == T ! [*] {
                         slots.mark_present();
@@ -3439,8 +3460,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_NAMED_IMPORT_SPECIFIER => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsLiteralExportName::can_cast(element.kind()) {
                         slots.mark_present();
@@ -4516,8 +4544,15 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_SHORTHAND_NAMED_IMPORT_SPECIFIER => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T![type] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsAnyBinding::can_cast(element.kind()) {
                         slots.mark_present();

--- a/crates/rslint_parser/src/syntax/js_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/js_parse_error.rs
@@ -141,18 +141,6 @@ pub(crate) fn expected_named_import_specifier(p: &Parser, range: Range<usize>) -
     expected_node("identifier", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_local_name_for_default_import(
-    p: &Parser,
-    range: Range<usize>,
-) -> Diagnostic {
-    p.err_builder("`default` imports must be aliased")
-        .primary(p.cur_tok().range(), "`default` used here")
-        .secondary(
-            range.end..range.end,
-            "add the `as` keyword followed by an identifier name here",
-        )
-}
-
 pub(crate) fn duplicate_assertion_keys_error(
     p: &Parser,
     key: &str,

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -163,15 +163,8 @@ fn parse_import_clause(p: &mut Parser) -> ParsedSyntax {
     // import type * as foo2 from "./mod";
     // import type { foo3 } from "mod";
     let is_typed = is_at_contextual_keyword(p, "type")
-        && match p.nth(1) {
-            T![*] | T!['{'] => true,
-            _ if is_nth_at_identifier_binding(p, 1)
-                && !is_nth_at_contextual_keyword(p, 1, "from") =>
-            {
-                true
-            }
-            _ => false,
-        };
+        && (matches!(p.nth(1), T![*] | T!['{'])
+            || (is_nth_at_identifier_binding(p, 1) && !is_nth_at_contextual_keyword(p, 1, "from")));
 
     if is_typed {
         expect_contextual_keyword(p, "type", T![type]);

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -1,10 +1,13 @@
 use crate::parser::{expected_any, expected_node, ParserProgress, RecoveryResult, ToDiagnostic};
 use crate::state::EnterAmbientContext;
-use crate::syntax::binding::{is_at_identifier_binding, parse_binding};
+use crate::syntax::binding::{
+    is_at_identifier_binding, is_nth_at_identifier_binding, parse_binding, parse_identifier_binding,
+};
 use crate::syntax::class::parse_export_default_class_case;
 use crate::syntax::expr::{
-    is_nth_at_expression, is_nth_at_reference_identifier, parse_assignment_expression_or_higher,
-    parse_name, parse_reference_identifier, ExpressionContext,
+    is_nth_at_expression, is_nth_at_identifier, is_nth_at_reference_identifier,
+    parse_assignment_expression_or_higher, parse_name, parse_reference_identifier,
+    ExpressionContext,
 };
 use crate::syntax::function::parse_export_default_function_case;
 use crate::syntax::js_parse_error::{
@@ -149,36 +152,88 @@ pub(crate) fn parse_import_or_import_equals_declaration(p: &mut Parser) -> Parse
 // test import_default_clause
 // import foo from "test";
 fn parse_import_clause(p: &mut Parser) -> ParsedSyntax {
-    match p.cur() {
-        JS_STRING_LITERAL => parse_import_bare_clause(p),
-        T![*] => parse_import_namespace_clause(p),
-        T!['{'] => parse_import_named_clause(p),
-        _ => match parse_binding(p) {
-            Absent => Absent,
-            Present(binding) => {
-                let m = binding.precede(p);
+    if p.at(JS_STRING_LITERAL) {
+        return parse_import_bare_clause(p);
+    }
 
-                if matches!(p.cur(), T![,] | T!['{']) {
-                    p.expect(T![,]);
+    let pos = p.token_pos();
+    let m = p.start();
 
-                    let default_specifier = m.complete(p, JS_DEFAULT_IMPORT_SPECIFIER);
-                    let named_clause = default_specifier.precede(p);
-
-                    parse_named_import(p).or_add_diagnostic(p, expected_named_import);
-                    expect_contextual_keyword(p, "from", T![from]);
-                    parse_module_source(p).or_add_diagnostic(p, expected_module_source);
-                    parse_import_assertion(p).ok();
-
-                    Present(named_clause.complete(p, JS_IMPORT_NAMED_CLAUSE))
-                } else {
-                    expect_contextual_keyword(p, "from", T![from]);
-                    parse_module_source(p).or_add_diagnostic(p, expected_module_source);
-                    parse_import_assertion(p).ok();
-
-                    Present(m.complete(p, JS_IMPORT_DEFAULT_CLAUSE))
-                }
+    // test ts ts_import_clause_types
+    // import type from "./mod"; // not a type
+    // import type foo from "./mod";
+    // import type * as foo2 from "./mod";
+    // import type { foo3 } from "mod";
+    let is_typed = if is_at_contextual_keyword(p, "type") {
+        let is_type_import = match p.nth(1) {
+            T![*] | T!['{'] => true,
+            _ if is_nth_at_identifier_binding(p, 1)
+                && !is_nth_at_contextual_keyword(p, 1, "from") =>
+            {
+                true
             }
-        },
+            _ => false,
+        };
+
+        if is_type_import {
+            expect_contextual_keyword(p, "type", T![type]);
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    let clause = match p.cur() {
+        T![*] => parse_import_namespace_clause_rest(p, m),
+        T!['{'] => parse_import_named_clause_rest(p, m),
+        _ if is_at_identifier_binding(p) => {
+            parse_identifier_binding(p).unwrap();
+            parse_import_default_or_named_clause_rest(p, m)
+        }
+        _ => {
+            // SAFETY: Safe because the parser only eats the "type" keyword if it's followed by
+            // either a *, {, or binding
+            debug_assert_eq!(pos, p.token_pos());
+            m.abandon(p);
+            return Absent;
+        }
+    };
+
+    if is_typed {
+        TypeScript.exclusive_syntax(p, clause, |p, clause| {
+            ts_only_syntax_error(p, "'import type'", clause.range(p))
+        })
+    } else {
+        Present(clause)
+    }
+}
+
+/// Parses the rest of an import named or default clause.
+/// Rest meaning, everything after `type binding`
+fn parse_import_default_or_named_clause_rest(p: &mut Parser, m: Marker) -> CompletedMarker {
+    match p.cur() {
+        T![,] | T!['{'] => {
+            p.expect(T![,]);
+
+            let default_specifier = m.complete(p, JS_DEFAULT_IMPORT_SPECIFIER);
+            let named_clause = default_specifier.precede(p);
+
+            parse_named_import(p).or_add_diagnostic(p, expected_named_import);
+            expect_contextual_keyword(p, "from", T![from]);
+            parse_module_source(p).or_add_diagnostic(p, expected_module_source);
+            parse_import_assertion(p).ok();
+
+            named_clause.complete(p, JS_IMPORT_NAMED_CLAUSE)
+        }
+        _ => {
+            expect_contextual_keyword(p, "from", T![from]);
+            parse_module_source(p).or_add_diagnostic(p, expected_module_source);
+            parse_import_assertion(p).ok();
+
+            m.complete(p, JS_IMPORT_DEFAULT_CLAUSE)
+        }
     }
 }
 
@@ -195,21 +250,16 @@ fn parse_import_bare_clause(p: &mut Parser) -> ParsedSyntax {
 
 // test import_decl
 // import * as foo from "bla";
-fn parse_import_namespace_clause(p: &mut Parser) -> ParsedSyntax {
-    if !p.at(T![*]) {
-        return Absent;
-    }
+fn parse_import_namespace_clause_rest(p: &mut Parser, m: Marker) -> CompletedMarker {
+    p.expect(T![*]);
 
-    let m = p.start();
-
-    p.bump_any();
     expect_contextual_keyword(p, "as", T![as]);
     parse_binding(p).or_add_diagnostic(p, expected_binding);
     expect_contextual_keyword(p, "from", T![from]);
     parse_module_source(p).or_add_diagnostic(p, expected_module_source);
     parse_import_assertion(p).ok();
 
-    Present(m.complete(p, JS_IMPORT_NAMESPACE_CLAUSE))
+    m.complete(p, JS_IMPORT_NAMESPACE_CLAUSE)
 }
 
 // test import_named_clause
@@ -218,20 +268,14 @@ fn parse_import_namespace_clause(p: &mut Parser) -> ParsedSyntax {
 // import e, { f } from "b";
 // import g, * as lorem from "c";
 // import { f as x, default as w, "a-b-c" as y } from "b";
-fn parse_import_named_clause(p: &mut Parser) -> ParsedSyntax {
-    if !p.at(T!['{']) {
-        return Absent;
-    }
-
-    let m = p.start();
-
+fn parse_import_named_clause_rest(p: &mut Parser, m: Marker) -> CompletedMarker {
     parse_default_import_specifier(p).ok();
     parse_named_import(p).or_add_diagnostic(p, expected_named_import);
     expect_contextual_keyword(p, "from", T![from]);
     parse_module_source(p).or_add_diagnostic(p, expected_module_source);
     parse_import_assertion(p).ok();
 
-    Present(m.complete(p, JS_IMPORT_NAMED_CLAUSE))
+    m.complete(p, JS_IMPORT_NAMED_CLAUSE)
 }
 
 fn parse_default_import_specifier(p: &mut Parser) -> ParsedSyntax {
@@ -268,7 +312,7 @@ fn parse_named_import_specifier_list(p: &mut Parser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    p.bump_any();
+    p.bump(T!['{']);
     NamedImportSpecifierList.parse_list(p);
     p.expect(T!['}']);
 
@@ -279,7 +323,7 @@ struct NamedImportSpecifierList;
 
 impl ParseSeparatedList for NamedImportSpecifierList {
     fn parse_element(&mut self, p: &mut Parser) -> ParsedSyntax {
-        parse_named_import_specifier(p).or_else(|| parse_shorthand_named_import_specifier(p))
+        parse_any_named_import_specifier(p)
     }
 
     fn is_at_list_end(&mut self, p: &mut Parser) -> bool {
@@ -311,51 +355,83 @@ impl ParseSeparatedList for NamedImportSpecifierList {
     }
 }
 
-fn parse_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
-    let m = p.start();
-
-    // test import_as_identifier
-    // import { as } from "test";
-    //
-    // test import_as_as_as_identifier
-    // import { as as as } from "test";
-    //
-    // test_err import_as_identifier_err
-    // import { as c } from "test";
-    if is_nth_at_literal_export_name(p, 0) && p.nth_src(1) == "as" {
-        parse_literal_export_name(p).ok();
-    } else if p.cur_src() == "as" && is_nth_at_literal_export_name(p, 1) {
-        p.error(expected_literal_export_name(p, p.cur_tok().range()));
-    } else {
-        m.abandon(p);
+// test ts ts_named_import_specifier_with_type
+// import { type, type as } from "./mod";
+// import { type as other } from "./mod"
+// import { type as as } from "./mod";
+// import { type as as as } from "./mod"
+// import { type "test-abcd" as test } from "./mod";
+fn parse_any_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
+    if !is_nth_at_literal_export_name(p, 0) {
+        // covers `type` and `as` too
         return Absent;
     }
 
-    expect_contextual_keyword(p, "as", T![as]);
-    parse_binding(p).or_add_diagnostic(p, expected_binding);
+    let m = p.start();
 
-    Present(m.complete(p, JS_NAMED_IMPORT_SPECIFIER))
-}
+    if p.at(JS_STRING_LITERAL) {
+        // import { "name" ... } must be a named export because of the string literal
+        parse_literal_export_name(p).unwrap();
+        expect_contextual_keyword(p, "as", T![as]);
+        parse_binding(p).or_add_diagnostic(p, expected_binding);
+        return Present(m.complete(p, JS_NAMED_IMPORT_SPECIFIER));
+    }
 
-fn parse_shorthand_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
-    if p.at(T![default]) {
+    // It can either be a shorthand specifier or a named specifier from here onwards.
+    // Use the specifier metadata helper to determine if it is a `type` (`import { type a }`) import
+    // and if it is a named import (`import { a as b }`).
+    let metadata = specifier_metadata(
+        p,
+        is_nth_at_literal_export_name,
+        is_nth_at_identifier_binding,
+    );
+
+    if metadata.is_type {
+        expect_contextual_keyword(p, "type", T![type]);
+    }
+
+    let specifier = if metadata.has_alias {
+        if metadata.is_local_name_missing {
+            // test_err import_as_identifier_err
+            // import { as c } from "test";
+            p.error(expected_literal_export_name(
+                p,
+                p.cur_tok().start()..p.cur_tok().start(),
+            ));
+        } else {
+            // test import_as_as_as_identifier
+            // import { as as as } from "test";
+            parse_literal_export_name(p).or_add_diagnostic(p, expected_literal_export_name);
+        }
+
+        expect_contextual_keyword(p, "as", T![as]);
+        parse_binding(p).or_add_diagnostic(p, expected_binding);
+        m.complete(p, JS_NAMED_IMPORT_SPECIFIER)
+    } else if p.at(T![default]) {
+        // import { default } from "test"
         p.error(expected_local_name_for_default_import(
             p,
             p.cur_tok().range(),
         ));
 
-        let shorthand = p.start();
         let binding = p.start();
         p.bump_any();
         binding.complete(p, JS_UNKNOWN_BINDING);
-        return Present(shorthand.complete(p, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER));
-    }
+        m.complete(p, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER)
+    } else {
+        // test import_as_identifier
+        // import { as } from "test";
+        parse_binding(p).or_add_diagnostic(p, expected_identifier);
+        m.complete(p, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER)
+    };
 
-    parse_binding(p).map(|binding| {
-        binding
-            .precede(p)
-            .complete(p, JS_SHORTHAND_NAMED_IMPORT_SPECIFIER)
-    })
+    if metadata.is_type {
+        TypeScript.exclusive_syntax(p, specifier, |p, specifier| {
+            ts_only_syntax_error(p, "'import { type x ident }'", specifier.range(p))
+        })
+    } else {
+        Present(specifier)
+    }
 }
 
 // test import_assertion
@@ -664,13 +740,18 @@ impl ParseSeparatedList for ExportNamedSpecifierList {
 }
 
 fn parse_any_export_named_specifier(p: &mut Parser) -> ParsedSyntax {
+    // covers `type` and `as` too
     if !is_nth_at_reference_identifier(p, 0) {
         return Absent;
     }
 
     let m = p.start();
 
-    let metadata = specifier_metadata(p);
+    let metadata = specifier_metadata(
+        p,
+        is_nth_at_reference_identifier,
+        is_nth_at_literal_export_name,
+    );
 
     // test ts ts_export_named_type_specifier
     // export { type }
@@ -707,7 +788,7 @@ fn parse_any_export_named_specifier(p: &mut Parser) -> ParsedSyntax {
 
     if metadata.is_type {
         TypeScript.exclusive_syntax(p, specifier, |p, specifier| {
-            ts_only_syntax_error(p, "export { type }'", specifier.range(p))
+            ts_only_syntax_error(p, "export { type ident }'", specifier.range(p))
         })
     } else {
         Present(specifier)
@@ -735,10 +816,18 @@ struct SpecifierMetadata {
 // export { type type };
 // export { type as };
 // export { type a as aa };
-fn specifier_metadata(p: &Parser) -> SpecifierMetadata {
+fn specifier_metadata<LocalNamePred, AliasPred>(
+    p: &Parser,
+    is_nth_name: LocalNamePred,
+    is_nth_alias: AliasPred,
+) -> SpecifierMetadata
+where
+    LocalNamePred: Fn(&Parser, usize) -> bool,
+    AliasPred: Fn(&Parser, usize) -> bool,
+{
     let mut metadata = SpecifierMetadata::default();
 
-    // This may be a typed export, but it could also be the name of the export:
+    // This may be a typed import/export, but it could also be the name of the import/export:
     // ```ts
     // { type}              // name: `type`
     // { type type }        // name: `type`    type-export: `true`
@@ -746,7 +835,7 @@ fn specifier_metadata(p: &Parser) -> SpecifierMetadata {
     // { type as as }       // name: `type`    type-export: `false` (aliased to `as`)
     // { type as as as }    // name: `as`      type-export: `true`, aliased to `as`
     // ```
-    if is_at_contextual_keyword(p, "type") && is_nth_at_reference_identifier(p, 1) {
+    if is_at_contextual_keyword(p, "type") {
         // `{ type identifier }`
 
         if is_nth_at_contextual_keyword(p, 1, "as") {
@@ -756,11 +845,11 @@ fn specifier_metadata(p: &Parser) -> SpecifierMetadata {
                 metadata.has_alias = true;
                 // `{ type as as }`: Type can either be an identifier or the type keyword
 
-                if is_nth_at_literal_export_name(p, 3) {
+                if is_nth_alias(p, 3) {
                     // `{ type as as x }` or `{ type as as "x"}`
                     metadata.is_type = true;
                 }
-            } else if is_nth_at_literal_export_name(p, 2) {
+            } else if is_nth_alias(p, 2) {
                 // `{ type as x }` or `{ type as "x" }`
                 metadata.has_alias = true;
             } else {
@@ -769,10 +858,10 @@ fn specifier_metadata(p: &Parser) -> SpecifierMetadata {
             }
         } else {
             // `{ type x }` or `{ type "x" }` or `{ type x as }`
-            metadata.is_type = true;
+            metadata.is_type = is_nth_name(p, 1);
             metadata.has_alias = is_nth_at_contextual_keyword(p, 2, "as");
         }
-    } else if is_at_contextual_keyword(p, "as") && is_nth_at_literal_export_name(p, 1) {
+    } else if is_at_contextual_keyword(p, "as") && is_nth_alias(p, 1) {
         metadata.has_alias = true;
 
         // error recovery case in case someone typed "as x" but forgot the local name.
@@ -906,15 +995,17 @@ impl ParseSeparatedList for ExportNamedFromSpecifierList {
 // export { type A } from "a"
 // export { type } from "./type";
 fn parse_export_named_from_specifier(p: &mut Parser) -> ParsedSyntax {
-    if !is_nth_at_literal_export_name(p, 0)
-        && !is_at_contextual_keyword(p, "type")
-        && !is_at_contextual_keyword(p, "as")
-    {
+    // also covers the contextual keywords `type` and `as`
+    if !is_nth_at_literal_export_name(p, 0) {
         return Absent;
     }
 
     let m = p.start();
-    let metadata = specifier_metadata(p);
+    let metadata = specifier_metadata(
+        p,
+        is_nth_at_reference_identifier,
+        is_nth_at_literal_export_name,
+    );
 
     if metadata.is_type {
         expect_contextual_keyword(p, "type", T![type]);
@@ -937,7 +1028,7 @@ fn parse_export_named_from_specifier(p: &mut Parser) -> ParsedSyntax {
 
     if metadata.is_type {
         TypeScript.exclusive_syntax(p, specifier, |p, specifier| {
-            ts_only_syntax_error(p, "export { type }'", specifier.range(p))
+            ts_only_syntax_error(p, "export { type ident }''", specifier.range(p))
         })
     } else {
         specifier

--- a/crates/rslint_parser/test_data/inline/err/import_as_identifier_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_as_identifier_err.rast
@@ -5,11 +5,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: missing (required),
                             as_token: AS_KW@9..12 "as" [] [Whitespace(" ")],
                             local_name: JsIdentifierBinding {
@@ -39,27 +41,29 @@ JsModule {
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@7..27
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@7..16
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..16
           0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@9..14
             0: JS_NAMED_IMPORT_SPECIFIER@9..14
               0: (empty)
-              1: AS_KW@9..12 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@12..14
+              1: (empty)
+              2: AS_KW@9..12 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@12..14
                 0: IDENT@12..14 "c" [] [Whitespace(" ")]
           2: R_CURLY@14..16 "}" [] [Whitespace(" ")]
-        2: FROM_KW@16..21 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@21..27
+        3: FROM_KW@16..21 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@21..27
           0: JS_STRING_LITERAL@21..27 "\"test\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@27..28 ";" [] []
   3: EOF@28..29 "" [Newline("\n")] []
 --
-error[SyntaxError]: expected a string literal, or an identifier but instead found 'as'
+error[SyntaxError]: expected a string literal, or an identifier but instead found ''
   ┌─ import_as_identifier_err.js:1:10
   │
 1 │ import { as c } from "test";
-  │          ^^ Expected a string literal, or an identifier here
+  │          ^ Expected a string literal, or an identifier here
 
 --
 import { as c } from "test";

--- a/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_assertion_err.rast
@@ -69,11 +69,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@80..88 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@88..90 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@90..94 "foo" [] [Whitespace(" ")],
                             },
@@ -135,6 +137,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@159..167 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@167..172 "foo2" [] [Whitespace(" ")],
                 },
@@ -191,6 +194,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@261..269 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@269..275 "ipsum" [] [Whitespace(" ")],
                 },
@@ -240,11 +244,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@345..353 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@353..355 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@355..357 "a" [] [Whitespace(" ")],
                             },
@@ -322,16 +328,18 @@ JsModule {
       0: IMPORT_KW@80..88 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@88..119
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@88..96
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@88..96
           0: L_CURLY@88..90 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@90..94
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@90..94
-              0: JS_IDENTIFIER_BINDING@90..94
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@90..94
                 0: IDENT@90..94 "foo" [] [Whitespace(" ")]
           2: R_CURLY@94..96 "}" [] [Whitespace(" ")]
-        2: (empty)
         3: (empty)
-        4: JS_IMPORT_ASSERTION@96..119
+        4: (empty)
+        5: JS_IMPORT_ASSERTION@96..119
           0: ASSERT_KW@96..103 "assert" [] [Whitespace(" ")]
           1: L_CURLY@103..105 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@105..118
@@ -367,12 +375,13 @@ JsModule {
     9: JS_IMPORT@159..242
       0: IMPORT_KW@159..167 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@167..241
-        0: JS_IDENTIFIER_BINDING@167..172
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@167..172
           0: IDENT@167..172 "foo2" [] [Whitespace(" ")]
-        1: FROM_KW@172..177 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@177..188
+        2: FROM_KW@172..177 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@177..188
           0: JS_STRING_LITERAL@177..188 "\"foo.json\"" [] [Whitespace(" ")]
-        3: JS_IMPORT_ASSERTION@188..241
+        4: JS_IMPORT_ASSERTION@188..241
           0: ASSERT_KW@188..195 "assert" [] [Whitespace(" ")]
           1: L_CURLY@195..197 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@197..240
@@ -406,12 +415,13 @@ JsModule {
     11: JS_IMPORT@261..345
       0: IMPORT_KW@261..269 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@269..344
-        0: JS_IDENTIFIER_BINDING@269..275
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@269..275
           0: IDENT@269..275 "ipsum" [] [Whitespace(" ")]
-        1: FROM_KW@275..280 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@280..293
+        2: FROM_KW@275..280 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@280..293
           0: JS_STRING_LITERAL@280..293 "\"ipsum.json\"" [] [Whitespace(" ")]
-        3: JS_IMPORT_ASSERTION@293..344
+        4: JS_IMPORT_ASSERTION@293..344
           0: ASSERT_KW@293..300 "assert" [] [Whitespace(" ")]
           1: L_CURLY@300..302 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@302..343
@@ -443,17 +453,19 @@ JsModule {
       0: IMPORT_KW@345..353 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@353..379
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@353..359
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@353..359
           0: L_CURLY@353..355 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@355..357
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@355..357
-              0: JS_IDENTIFIER_BINDING@355..357
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@355..357
                 0: IDENT@355..357 "a" [] [Whitespace(" ")]
           2: R_CURLY@357..359 "}" [] [Whitespace(" ")]
-        2: FROM_KW@359..364 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@364..373
+        3: FROM_KW@359..364 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@364..373
           0: JS_STRING_LITERAL@364..373 "\"a.json\"" [] [Whitespace(" ")]
-        4: JS_IMPORT_ASSERTION@373..379
+        5: JS_IMPORT_ASSERTION@373..379
           0: ASSERT_KW@373..379 "assert" [] []
           1: (empty)
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@379..379

--- a/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_decl_not_top_level.rast
@@ -9,6 +9,7 @@ JsModule {
                     items: [
                         IMPORT_KW@1..10 "import" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")],
                         JsImportDefaultClause {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@10..14 "foo" [] [Whitespace(" ")],
                             },
@@ -38,12 +39,13 @@ JsModule {
         0: JS_UNKNOWN_STATEMENT@1..25
           0: IMPORT_KW@1..10 "import" [Newline("\n"), Whitespace(" ")] [Whitespace(" ")]
           1: JS_IMPORT_DEFAULT_CLAUSE@10..24
-            0: JS_IDENTIFIER_BINDING@10..14
+            0: (empty)
+            1: JS_IDENTIFIER_BINDING@10..14
               0: IDENT@10..14 "foo" [] [Whitespace(" ")]
-            1: FROM_KW@14..19 "from" [] [Whitespace(" ")]
-            2: JS_MODULE_SOURCE@19..24
+            2: FROM_KW@14..19 "from" [] [Whitespace(" ")]
+            3: JS_MODULE_SOURCE@19..24
               0: JS_STRING_LITERAL@19..24 "\"bar\"" [] []
-            3: (empty)
+            4: (empty)
           2: SEMICOLON@24..25 ";" [] []
       2: R_CURLY@25..27 "}" [Newline("\n")] []
   3: EOF@27..28 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/err/import_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_err.rast
@@ -155,13 +155,13 @@ JsModule {
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@120..122 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
-                        JsShorthandNamedImportSpecifier {
+                        JsNamedImportSpecifier {
                             type_token: missing (optional),
-                            local_name: JsUnknownBinding {
-                                items: [
-                                    DEFAULT_KW@122..130 "default" [] [Whitespace(" ")],
-                                ],
+                            name: JsLiteralExportName {
+                                value: IDENT@122..130 "default" [] [Whitespace(" ")],
                             },
+                            as_token: missing (required),
+                            local_name: missing (required),
                         },
                     ],
                     r_curly_token: R_CURLY@130..132 "}" [] [Whitespace(" ")],
@@ -390,10 +390,12 @@ JsModule {
         2: JS_NAMED_IMPORT_SPECIFIERS@120..132
           0: L_CURLY@120..122 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@122..130
-            0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@122..130
+            0: JS_NAMED_IMPORT_SPECIFIER@122..130
               0: (empty)
-              1: JS_UNKNOWN_BINDING@122..130
-                0: DEFAULT_KW@122..130 "default" [] [Whitespace(" ")]
+              1: JS_LITERAL_EXPORT_NAME@122..130
+                0: IDENT@122..130 "default" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
           2: R_CURLY@130..132 "}" [] [Whitespace(" ")]
         3: FROM_KW@132..137 "from" [] [Whitespace(" ")]
         4: JS_MODULE_SOURCE@137..140
@@ -511,13 +513,11 @@ error[SyntaxError]: expected `,` but instead found `+`
   │             ^ unexpected
 
 --
-error[SyntaxError]: `default` imports must be aliased
-  ┌─ import_err.js:6:10
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ import_err.js:6:18
   │
 6 │ import { default } from "c";
-  │          ^^^^^^^- add the `as` keyword followed by an identifier name here
-  │          │       
-  │          `default` used here
+  │                  ^ unexpected
 
 --
 error[SyntaxError]: expected `as` but instead found `}`

--- a/crates/rslint_parser/test_data/inline/err/import_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_err.rast
@@ -10,6 +10,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@7..15 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamespaceClause {
+                type_token: missing (optional),
                 star_token: STAR@15..16 "*" [] [],
                 as_token: missing (required),
                 local_name: missing (required),
@@ -22,6 +23,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@17..25 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamespaceClause {
+                type_token: missing (optional),
                 star_token: STAR@25..27 "*" [] [Whitespace(" ")],
                 as_token: AS_KW@27..30 "as" [] [Whitespace(" ")],
                 local_name: JsIdentifierBinding {
@@ -77,11 +79,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@51..59 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@59..61 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@61..64 "aa" [] [Whitespace(" ")],
                             },
@@ -95,6 +99,7 @@ JsModule {
                         },
                         COMMA@68..70 "," [] [Whitespace(" ")],
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@70..73 "dd" [] [Whitespace(" ")],
                             },
@@ -113,17 +118,20 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@84..92 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@92..94 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@94..96 "ab" [] [],
                             },
                         },
                         COMMA@96..98 "," [] [Whitespace(" ")],
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@98..101 "ac" [] [Whitespace(" ")],
                             },
@@ -142,11 +150,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@112..120 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@120..122 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsUnknownBinding {
                                 items: [
                                     DEFAULT_KW@122..130 "default" [] [Whitespace(" ")],
@@ -167,14 +177,18 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@141..149 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@149..151 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
-                        JsUnknownNamedImportSpecifier {
-                            items: [
-                                JS_STRING_LITERAL@151..155 "\"a\"" [] [Whitespace(" ")],
-                            ],
+                        JsNamedImportSpecifier {
+                            type_token: missing (optional),
+                            name: JsLiteralExportName {
+                                value: JS_STRING_LITERAL@151..155 "\"a\"" [] [Whitespace(" ")],
+                            },
+                            as_token: missing (required),
+                            local_name: missing (required),
                         },
                     ],
                     r_curly_token: R_CURLY@155..157 "}" [] [Whitespace(" ")],
@@ -190,11 +204,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@166..174 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@174..176 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: missing (required),
                             as_token: AS_KW@176..179 "as" [] [Whitespace(" ")],
                             local_name: JsIdentifierBinding {
@@ -240,6 +256,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@211..219 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@219..221 "y" [] [Whitespace(" ")],
                 },
@@ -270,23 +287,25 @@ JsModule {
     1: JS_IMPORT@7..17
       0: IMPORT_KW@7..15 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMESPACE_CLAUSE@15..16
-        0: STAR@15..16 "*" [] []
-        1: (empty)
+        0: (empty)
+        1: STAR@15..16 "*" [] []
         2: (empty)
         3: (empty)
         4: (empty)
         5: (empty)
+        6: (empty)
       2: SEMICOLON@16..17 ";" [] []
     2: JS_IMPORT@17..31
       0: IMPORT_KW@17..25 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMESPACE_CLAUSE@25..31
-        0: STAR@25..27 "*" [] [Whitespace(" ")]
-        1: AS_KW@27..30 "as" [] [Whitespace(" ")]
-        2: JS_IDENTIFIER_BINDING@30..31
+        0: (empty)
+        1: STAR@25..27 "*" [] [Whitespace(" ")]
+        2: AS_KW@27..30 "as" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@30..31
           0: IDENT@30..31 "c" [] []
-        3: (empty)
         4: (empty)
         5: (empty)
+        6: (empty)
       2: (empty)
     3: JS_UNKNOWN_STATEMENT@31..33
       0: COMMA@31..33 "," [] [Whitespace(" ")]
@@ -317,11 +336,13 @@ JsModule {
       0: IMPORT_KW@51..59 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@59..83
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@59..75
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@59..75
           0: L_CURLY@59..61 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@61..73
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@61..64
-              0: JS_IDENTIFIER_BINDING@61..64
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@61..64
                 0: IDENT@61..64 "aa" [] [Whitespace(" ")]
             1: (empty)
             2: JS_UNKNOWN_NAMED_IMPORT_SPECIFIER@64..68
@@ -329,82 +350,95 @@ JsModule {
               1: IDENT@66..68 "bb" [] []
             3: COMMA@68..70 "," [] [Whitespace(" ")]
             4: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@70..73
-              0: JS_IDENTIFIER_BINDING@70..73
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@70..73
                 0: IDENT@70..73 "dd" [] [Whitespace(" ")]
           2: R_CURLY@73..75 "}" [] [Whitespace(" ")]
-        2: FROM_KW@75..80 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@80..83
+        3: FROM_KW@75..80 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@80..83
           0: JS_STRING_LITERAL@80..83 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@83..84 ";" [] []
     8: JS_IMPORT@84..112
       0: IMPORT_KW@84..92 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@92..111
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@92..103
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@92..103
           0: L_CURLY@92..94 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@94..101
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@94..96
-              0: JS_IDENTIFIER_BINDING@94..96
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@94..96
                 0: IDENT@94..96 "ab" [] []
             1: COMMA@96..98 "," [] [Whitespace(" ")]
             2: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@98..101
-              0: JS_IDENTIFIER_BINDING@98..101
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@98..101
                 0: IDENT@98..101 "ac" [] [Whitespace(" ")]
           2: R_CURLY@101..103 "}" [] [Whitespace(" ")]
-        2: FROM_KW@103..108 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@108..111
+        3: FROM_KW@103..108 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@108..111
           0: JS_STRING_LITERAL@108..111 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@111..112 ";" [] []
     9: JS_IMPORT@112..141
       0: IMPORT_KW@112..120 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@120..140
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@120..132
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@120..132
           0: L_CURLY@120..122 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@122..130
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@122..130
-              0: JS_UNKNOWN_BINDING@122..130
+              0: (empty)
+              1: JS_UNKNOWN_BINDING@122..130
                 0: DEFAULT_KW@122..130 "default" [] [Whitespace(" ")]
           2: R_CURLY@130..132 "}" [] [Whitespace(" ")]
-        2: FROM_KW@132..137 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@137..140
+        3: FROM_KW@132..137 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@137..140
           0: JS_STRING_LITERAL@137..140 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@140..141 ";" [] []
     10: JS_IMPORT@141..166
       0: IMPORT_KW@141..149 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@149..165
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@149..157
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@149..157
           0: L_CURLY@149..151 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@151..155
-            0: JS_UNKNOWN_NAMED_IMPORT_SPECIFIER@151..155
-              0: JS_STRING_LITERAL@151..155 "\"a\"" [] [Whitespace(" ")]
+            0: JS_NAMED_IMPORT_SPECIFIER@151..155
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@151..155
+                0: JS_STRING_LITERAL@151..155 "\"a\"" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
           2: R_CURLY@155..157 "}" [] [Whitespace(" ")]
-        2: FROM_KW@157..162 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@162..165
+        3: FROM_KW@157..162 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@162..165
           0: JS_STRING_LITERAL@162..165 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@165..166 ";" [] []
     11: JS_IMPORT@166..192
       0: IMPORT_KW@166..174 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@174..191
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@174..183
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@174..183
           0: L_CURLY@174..176 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@176..181
             0: JS_NAMED_IMPORT_SPECIFIER@176..181
               0: (empty)
-              1: AS_KW@176..179 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@179..181
+              1: (empty)
+              2: AS_KW@176..179 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@179..181
                 0: IDENT@179..181 "x" [] [Whitespace(" ")]
           2: R_CURLY@181..183 "}" [] [Whitespace(" ")]
-        2: FROM_KW@183..188 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@188..191
+        3: FROM_KW@183..188 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@188..191
           0: JS_STRING_LITERAL@188..191 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@191..192 ";" [] []
     12: JS_IMPORT@192..200
       0: IMPORT_KW@192..200 "import" [Newline("\n")] [Whitespace(" ")]
@@ -426,11 +460,12 @@ JsModule {
     16: JS_IMPORT@211..226
       0: IMPORT_KW@211..219 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@219..226
-        0: JS_IDENTIFIER_BINDING@219..221
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@219..221
           0: IDENT@219..221 "y" [] [Whitespace(" ")]
-        1: FROM_KW@221..226 "from" [] [Whitespace(" ")]
-        2: (empty)
+        2: FROM_KW@221..226 "from" [] [Whitespace(" ")]
         3: (empty)
+        4: (empty)
       2: (empty)
     17: JS_EXPRESSION_STATEMENT@226..228
       0: JS_NUMBER_LITERAL_EXPRESSION@226..227
@@ -485,18 +520,18 @@ error[SyntaxError]: `default` imports must be aliased
   │          `default` used here
 
 --
-error[SyntaxError]: expected an identifier but instead found '"a"'
-  ┌─ import_err.js:7:10
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ import_err.js:7:14
   │
 7 │ import { "a" } from "c";
-  │          ^^^ Expected an identifier here
+  │              ^ unexpected
 
 --
-error[SyntaxError]: expected a string literal, or an identifier but instead found 'as'
+error[SyntaxError]: expected a string literal, or an identifier but instead found ''
   ┌─ import_err.js:8:10
   │
 8 │ import { as x } from "c";
-  │          ^^ Expected a string literal, or an identifier here
+  │          ^ Expected a string literal, or an identifier here
 
 --
 error[SyntaxError]: expected a default import, a namespace import, or a named import but instead found '4'

--- a/crates/rslint_parser/test_data/inline/err/ts_export_syntax_in_js.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_export_syntax_in_js.rast
@@ -318,14 +318,14 @@ error[SyntaxError]: 'export type' declarations are a TypeScript only feature. Co
   │        ^^^^^^^^^^^ TypeScript only syntax
 
 --
-error[SyntaxError]: export { type }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: export { type ident }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ ts_export_syntax_in_js.js:3:10
   │
 3 │ export { type b };
   │          ^^^^^^ TypeScript only syntax
 
 --
-error[SyntaxError]: export { type }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: export { type ident }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ ts_export_syntax_in_js.js:4:10
   │
 4 │ export { type c as cc };
@@ -339,14 +339,14 @@ error[SyntaxError]: 'export type' declarations are a TypeScript only feature. Co
   │        ^^^^^^^^^^^^^^^^^^^^^^ TypeScript only syntax
 
 --
-error[SyntaxError]: export { type }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: export { type ident }'' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ ts_export_syntax_in_js.js:6:10
   │
 6 │ export { type e } from "./e";
   │          ^^^^^^ TypeScript only syntax
 
 --
-error[SyntaxError]: export { type }' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+error[SyntaxError]: export { type ident }'' are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
   ┌─ ts_export_syntax_in_js.js:7:10
   │
 7 │ export { type e as ee } from "./e";

--- a/crates/rslint_parser/test_data/inline/err/ts_named_import_specifier_error.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_named_import_specifier_error.rast
@@ -1,0 +1,234 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsImport {
+            import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: missing (optional),
+                            name: JsLiteralExportName {
+                                value: IDENT@9..17 "default" [] [Whitespace(" ")],
+                            },
+                            as_token: missing (required),
+                            local_name: missing (required),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@17..19 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@19..24 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@24..31 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@31..32 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@32..40 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@40..42 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: TYPE_KW@42..47 "type" [] [Whitespace(" ")],
+                            name: JsLiteralExportName {
+                                value: IDENT@47..55 "default" [] [Whitespace(" ")],
+                            },
+                            as_token: missing (required),
+                            local_name: missing (required),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@55..57 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@57..62 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@62..69 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@69..70 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@70..78 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@78..80 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: missing (optional),
+                            name: JsLiteralExportName {
+                                value: JS_STRING_LITERAL@80..95 "\"literal-name\"" [] [Whitespace(" ")],
+                            },
+                            as_token: missing (required),
+                            local_name: missing (required),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@95..97 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@97..102 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@102..109 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@109..110 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@110..118 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@118..120 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: TYPE_KW@120..125 "type" [] [Whitespace(" ")],
+                            name: JsLiteralExportName {
+                                value: JS_STRING_LITERAL@125..140 "\"literal-name\"" [] [Whitespace(" ")],
+                            },
+                            as_token: missing (required),
+                            local_name: missing (required),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@140..142 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@142..147 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@147..154 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@154..155 ";" [] [],
+        },
+    ],
+    eof_token: EOF@155..156 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..156
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..155
+    0: JS_IMPORT@0..32
+      0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@7..31
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..19
+          0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@9..17
+            0: JS_NAMED_IMPORT_SPECIFIER@9..17
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@9..17
+                0: IDENT@9..17 "default" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
+          2: R_CURLY@17..19 "}" [] [Whitespace(" ")]
+        3: FROM_KW@19..24 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@24..31
+          0: JS_STRING_LITERAL@24..31 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@31..32 ";" [] []
+    1: JS_IMPORT@32..70
+      0: IMPORT_KW@32..40 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@40..69
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@40..57
+          0: L_CURLY@40..42 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@42..55
+            0: JS_NAMED_IMPORT_SPECIFIER@42..55
+              0: TYPE_KW@42..47 "type" [] [Whitespace(" ")]
+              1: JS_LITERAL_EXPORT_NAME@47..55
+                0: IDENT@47..55 "default" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
+          2: R_CURLY@55..57 "}" [] [Whitespace(" ")]
+        3: FROM_KW@57..62 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@62..69
+          0: JS_STRING_LITERAL@62..69 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@69..70 ";" [] []
+    2: JS_IMPORT@70..110
+      0: IMPORT_KW@70..78 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@78..109
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@78..97
+          0: L_CURLY@78..80 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@80..95
+            0: JS_NAMED_IMPORT_SPECIFIER@80..95
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@80..95
+                0: JS_STRING_LITERAL@80..95 "\"literal-name\"" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
+          2: R_CURLY@95..97 "}" [] [Whitespace(" ")]
+        3: FROM_KW@97..102 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@102..109
+          0: JS_STRING_LITERAL@102..109 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@109..110 ";" [] []
+    3: JS_IMPORT@110..155
+      0: IMPORT_KW@110..118 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@118..154
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@118..142
+          0: L_CURLY@118..120 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@120..140
+            0: JS_NAMED_IMPORT_SPECIFIER@120..140
+              0: TYPE_KW@120..125 "type" [] [Whitespace(" ")]
+              1: JS_LITERAL_EXPORT_NAME@125..140
+                0: JS_STRING_LITERAL@125..140 "\"literal-name\"" [] [Whitespace(" ")]
+              2: (empty)
+              3: (empty)
+          2: R_CURLY@140..142 "}" [] [Whitespace(" ")]
+        3: FROM_KW@142..147 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@147..154
+          0: JS_STRING_LITERAL@147..154 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@154..155 ";" [] []
+  3: EOF@155..156 "" [Newline("\n")] []
+--
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ ts_named_import_specifier_error.ts:1:18
+  │
+1 │ import { default } from "./mod";
+  │                  ^ unexpected
+
+--
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ ts_named_import_specifier_error.ts:2:23
+  │
+2 │ import { type default } from "./mod";
+  │                       ^ unexpected
+
+--
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ ts_named_import_specifier_error.ts:3:25
+  │
+3 │ import { "literal-name" } from "./mod";
+  │                         ^ unexpected
+
+--
+error[SyntaxError]: expected `as` but instead found `}`
+  ┌─ ts_named_import_specifier_error.ts:4:30
+  │
+4 │ import { type "literal-name" } from "./mod";
+  │                              ^ unexpected
+
+--
+import { default } from "./mod";
+import { type default } from "./mod";
+import { "literal-name" } from "./mod";
+import { type "literal-name" } from "./mod";

--- a/crates/rslint_parser/test_data/inline/err/ts_named_import_specifier_error.ts
+++ b/crates/rslint_parser/test_data/inline/err/ts_named_import_specifier_error.ts
@@ -1,0 +1,4 @@
+import { default } from "./mod";
+import { type default } from "./mod";
+import { "literal-name" } from "./mod";
+import { type "literal-name" } from "./mod";

--- a/crates/rslint_parser/test_data/inline/ok/import_as_as_as_identifier.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_as_as_as_identifier.rast
@@ -5,11 +5,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: JsLiteralExportName {
                                 value: IDENT@9..12 "as" [] [Whitespace(" ")],
                             },
@@ -41,19 +43,21 @@ JsModule {
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@7..31
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@7..20
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..20
           0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@9..18
             0: JS_NAMED_IMPORT_SPECIFIER@9..18
-              0: JS_LITERAL_EXPORT_NAME@9..12
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@9..12
                 0: IDENT@9..12 "as" [] [Whitespace(" ")]
-              1: AS_KW@12..15 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@15..18
+              2: AS_KW@12..15 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@15..18
                 0: IDENT@15..18 "as" [] [Whitespace(" ")]
           2: R_CURLY@18..20 "}" [] [Whitespace(" ")]
-        2: FROM_KW@20..25 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@25..31
+        3: FROM_KW@20..25 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@25..31
           0: JS_STRING_LITERAL@25..31 "\"test\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@31..32 ";" [] []
   3: EOF@32..33 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_as_identifier.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_as_identifier.rast
@@ -5,11 +5,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@9..12 "as" [] [Whitespace(" ")],
                             },
@@ -37,16 +39,18 @@ JsModule {
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@7..25
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@7..14
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..14
           0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@9..12
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@9..12
-              0: JS_IDENTIFIER_BINDING@9..12
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@9..12
                 0: IDENT@9..12 "as" [] [Whitespace(" ")]
           2: R_CURLY@12..14 "}" [] [Whitespace(" ")]
-        2: FROM_KW@14..19 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@19..25
+        3: FROM_KW@14..19 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@19..25
           0: JS_STRING_LITERAL@19..25 "\"test\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@25..26 ";" [] []
   3: EOF@26..27 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_assertion.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_assertion.rast
@@ -47,6 +47,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@74..82 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@82..86 "foo" [] [Whitespace(" ")],
                 },
@@ -72,11 +73,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@126..134 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@134..135 "{" [] [],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@135..139 "test" [] [],
                             },
@@ -106,6 +109,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@178..186 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@186..195 "foo_json" [] [Whitespace(" ")],
                 },
@@ -196,12 +200,13 @@ JsModule {
     2: JS_IMPORT@74..126
       0: IMPORT_KW@74..82 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@82..125
-        0: JS_IDENTIFIER_BINDING@82..86
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@82..86
           0: IDENT@82..86 "foo" [] [Whitespace(" ")]
-        1: FROM_KW@86..91 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@91..102
+        2: FROM_KW@86..91 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@91..102
           0: JS_STRING_LITERAL@91..102 "\"foo.json\"" [] [Whitespace(" ")]
-        3: JS_IMPORT_ASSERTION@102..125
+        4: JS_IMPORT_ASSERTION@102..125
           0: ASSERT_KW@102..109 "assert" [] [Whitespace(" ")]
           1: L_CURLY@109..111 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@111..124
@@ -215,17 +220,19 @@ JsModule {
       0: IMPORT_KW@126..134 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@134..178
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@134..141
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@134..141
           0: L_CURLY@134..135 "{" [] []
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@135..139
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@135..139
-              0: JS_IDENTIFIER_BINDING@135..139
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@135..139
                 0: IDENT@135..139 "test" [] []
           2: R_CURLY@139..141 "}" [] [Whitespace(" ")]
-        2: FROM_KW@141..146 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@146..157
+        3: FROM_KW@141..146 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@146..157
           0: JS_STRING_LITERAL@146..157 "\"foo.json\"" [] [Whitespace(" ")]
-        4: JS_IMPORT_ASSERTION@157..178
+        5: JS_IMPORT_ASSERTION@157..178
           0: ASSERT_KW@157..164 "assert" [] [Whitespace(" ")]
           1: L_CURLY@164..166 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@166..177
@@ -238,12 +245,13 @@ JsModule {
     4: JS_IMPORT@178..259
       0: IMPORT_KW@178..186 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@186..258
-        0: JS_IDENTIFIER_BINDING@186..195
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@186..195
           0: IDENT@186..195 "foo_json" [] [Whitespace(" ")]
-        1: FROM_KW@195..200 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@200..211
+        2: FROM_KW@195..200 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@200..211
           0: JS_STRING_LITERAL@200..211 "\"foo.json\"" [] [Whitespace(" ")]
-        3: JS_IMPORT_ASSERTION@211..258
+        4: JS_IMPORT_ASSERTION@211..258
           0: ASSERT_KW@211..218 "assert" [] [Whitespace(" ")]
           1: L_CURLY@218..220 "{" [] [Whitespace(" ")]
           2: JS_IMPORT_ASSERTION_ENTRY_LIST@220..257

--- a/crates/rslint_parser/test_data/inline/ok/import_decl.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_decl.rast
@@ -5,6 +5,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportNamespaceClause {
+                type_token: missing (optional),
                 star_token: STAR@7..9 "*" [] [Whitespace(" ")],
                 as_token: AS_KW@9..12 "as" [] [Whitespace(" ")],
                 local_name: JsIdentifierBinding {
@@ -29,13 +30,14 @@ JsModule {
     0: JS_IMPORT@0..27
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_NAMESPACE_CLAUSE@7..26
-        0: STAR@7..9 "*" [] [Whitespace(" ")]
-        1: AS_KW@9..12 "as" [] [Whitespace(" ")]
-        2: JS_IDENTIFIER_BINDING@12..16
+        0: (empty)
+        1: STAR@7..9 "*" [] [Whitespace(" ")]
+        2: AS_KW@9..12 "as" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@12..16
           0: IDENT@12..16 "foo" [] [Whitespace(" ")]
-        3: FROM_KW@16..21 "from" [] [Whitespace(" ")]
-        4: JS_MODULE_SOURCE@21..26
+        4: FROM_KW@16..21 "from" [] [Whitespace(" ")]
+        5: JS_MODULE_SOURCE@21..26
           0: JS_STRING_LITERAL@21..26 "\"bla\"" [] []
-        5: (empty)
+        6: (empty)
       2: SEMICOLON@26..27 ";" [] []
   3: EOF@27..28 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_default_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_default_clause.rast
@@ -5,6 +5,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@7..11 "foo" [] [Whitespace(" ")],
                 },
@@ -27,11 +28,12 @@ JsModule {
     0: JS_IMPORT@0..23
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@7..22
-        0: JS_IDENTIFIER_BINDING@7..11
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@7..11
           0: IDENT@7..11 "foo" [] [Whitespace(" ")]
-        1: FROM_KW@11..16 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@16..22
+        2: FROM_KW@11..16 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@16..22
           0: JS_STRING_LITERAL@16..22 "\"test\"" [] []
-        3: (empty)
+        4: (empty)
       2: SEMICOLON@22..23 ";" [] []
   3: EOF@23..24 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/import_named_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/import_named_clause.rast
@@ -5,6 +5,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@7..8 "{" [] [],
@@ -22,23 +23,27 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@19..27 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@27..29 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@29..30 "a" [] [],
                             },
                         },
                         COMMA@30..32 "," [] [Whitespace(" ")],
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@32..33 "b" [] [],
                             },
                         },
                         COMMA@33..35 "," [] [Whitespace(" ")],
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@35..36 "c" [] [],
                             },
@@ -58,6 +63,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@49..57 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: JsDefaultImportSpecifier {
                     local_name: JsIdentifierBinding {
                         name_token: IDENT@57..58 "e" [] [],
@@ -68,6 +74,7 @@ JsModule {
                     l_curly_token: L_CURLY@60..62 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@62..64 "f" [] [Whitespace(" ")],
                             },
@@ -86,6 +93,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@75..83 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: JsDefaultImportSpecifier {
                     local_name: JsIdentifierBinding {
                         name_token: IDENT@83..84 "g" [] [],
@@ -110,11 +118,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@106..114 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@114..116 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: JsLiteralExportName {
                                 value: IDENT@116..118 "f" [] [Whitespace(" ")],
                             },
@@ -125,6 +135,7 @@ JsModule {
                         },
                         COMMA@122..124 "," [] [Whitespace(" ")],
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: JsLiteralExportName {
                                 value: IDENT@124..132 "default" [] [Whitespace(" ")],
                             },
@@ -135,6 +146,7 @@ JsModule {
                         },
                         COMMA@136..138 "," [] [Whitespace(" ")],
                         JsNamedImportSpecifier {
+                            type_token: missing (optional),
                             name: JsLiteralExportName {
                                 value: JS_STRING_LITERAL@138..146 "\"a-b-c\"" [] [Whitespace(" ")],
                             },
@@ -166,107 +178,119 @@ JsModule {
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@7..18
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@7..10
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..10
           0: L_CURLY@7..8 "{" [] []
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@8..8
           2: R_CURLY@8..10 "}" [] [Whitespace(" ")]
-        2: FROM_KW@10..15 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@15..18
+        3: FROM_KW@10..15 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@15..18
           0: JS_STRING_LITERAL@15..18 "\"a\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@18..19 ";" [] []
     1: JS_IMPORT@19..49
       0: IMPORT_KW@19..27 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@27..48
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@27..40
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@27..40
           0: L_CURLY@27..29 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@29..38
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@29..30
-              0: JS_IDENTIFIER_BINDING@29..30
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@29..30
                 0: IDENT@29..30 "a" [] []
             1: COMMA@30..32 "," [] [Whitespace(" ")]
             2: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@32..33
-              0: JS_IDENTIFIER_BINDING@32..33
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@32..33
                 0: IDENT@32..33 "b" [] []
             3: COMMA@33..35 "," [] [Whitespace(" ")]
             4: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@35..36
-              0: JS_IDENTIFIER_BINDING@35..36
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@35..36
                 0: IDENT@35..36 "c" [] []
             5: COMMA@36..38 "," [] [Whitespace(" ")]
           2: R_CURLY@38..40 "}" [] [Whitespace(" ")]
-        2: FROM_KW@40..45 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@45..48
+        3: FROM_KW@40..45 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@45..48
           0: JS_STRING_LITERAL@45..48 "\"b\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@48..49 ";" [] []
     2: JS_IMPORT@49..75
       0: IMPORT_KW@49..57 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@57..74
-        0: JS_DEFAULT_IMPORT_SPECIFIER@57..60
+        0: (empty)
+        1: JS_DEFAULT_IMPORT_SPECIFIER@57..60
           0: JS_IDENTIFIER_BINDING@57..58
             0: IDENT@57..58 "e" [] []
           1: COMMA@58..60 "," [] [Whitespace(" ")]
-        1: JS_NAMED_IMPORT_SPECIFIERS@60..66
+        2: JS_NAMED_IMPORT_SPECIFIERS@60..66
           0: L_CURLY@60..62 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@62..64
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@62..64
-              0: JS_IDENTIFIER_BINDING@62..64
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@62..64
                 0: IDENT@62..64 "f" [] [Whitespace(" ")]
           2: R_CURLY@64..66 "}" [] [Whitespace(" ")]
-        2: FROM_KW@66..71 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@71..74
+        3: FROM_KW@66..71 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@71..74
           0: JS_STRING_LITERAL@71..74 "\"b\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@74..75 ";" [] []
     3: JS_IMPORT@75..106
       0: IMPORT_KW@75..83 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@83..105
-        0: JS_DEFAULT_IMPORT_SPECIFIER@83..86
+        0: (empty)
+        1: JS_DEFAULT_IMPORT_SPECIFIER@83..86
           0: JS_IDENTIFIER_BINDING@83..84
             0: IDENT@83..84 "g" [] []
           1: COMMA@84..86 "," [] [Whitespace(" ")]
-        1: JS_NAMESPACE_IMPORT_SPECIFIER@86..97
+        2: JS_NAMESPACE_IMPORT_SPECIFIER@86..97
           0: STAR@86..88 "*" [] [Whitespace(" ")]
           1: AS_KW@88..91 "as" [] [Whitespace(" ")]
           2: JS_IDENTIFIER_BINDING@91..97
             0: IDENT@91..97 "lorem" [] [Whitespace(" ")]
-        2: FROM_KW@97..102 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@102..105
+        3: FROM_KW@97..102 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@102..105
           0: JS_STRING_LITERAL@102..105 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@105..106 ";" [] []
     4: JS_IMPORT@106..162
       0: IMPORT_KW@106..114 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@114..161
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@114..153
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@114..153
           0: L_CURLY@114..116 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@116..151
             0: JS_NAMED_IMPORT_SPECIFIER@116..122
-              0: JS_LITERAL_EXPORT_NAME@116..118
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@116..118
                 0: IDENT@116..118 "f" [] [Whitespace(" ")]
-              1: AS_KW@118..121 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@121..122
+              2: AS_KW@118..121 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@121..122
                 0: IDENT@121..122 "x" [] []
             1: COMMA@122..124 "," [] [Whitespace(" ")]
             2: JS_NAMED_IMPORT_SPECIFIER@124..136
-              0: JS_LITERAL_EXPORT_NAME@124..132
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@124..132
                 0: IDENT@124..132 "default" [] [Whitespace(" ")]
-              1: AS_KW@132..135 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@135..136
+              2: AS_KW@132..135 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@135..136
                 0: IDENT@135..136 "w" [] []
             3: COMMA@136..138 "," [] [Whitespace(" ")]
             4: JS_NAMED_IMPORT_SPECIFIER@138..151
-              0: JS_LITERAL_EXPORT_NAME@138..146
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@138..146
                 0: JS_STRING_LITERAL@138..146 "\"a-b-c\"" [] [Whitespace(" ")]
-              1: AS_KW@146..149 "as" [] [Whitespace(" ")]
-              2: JS_IDENTIFIER_BINDING@149..151
+              2: AS_KW@146..149 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@149..151
                 0: IDENT@149..151 "y" [] [Whitespace(" ")]
           2: R_CURLY@151..153 "}" [] [Whitespace(" ")]
-        2: FROM_KW@153..158 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@158..161
+        3: FROM_KW@153..158 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@158..161
           0: JS_STRING_LITERAL@158..161 "\"b\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@161..162 ";" [] []
   3: EOF@162..163 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/module.rast
+++ b/crates/rslint_parser/test_data/inline/ok/module.rast
@@ -5,6 +5,7 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
             import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
                 local_name: JsIdentifierBinding {
                     name_token: IDENT@7..9 "a" [] [Whitespace(" ")],
                 },
@@ -53,11 +54,13 @@ JsModule {
         JsImport {
             import_token: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")],
             import_clause: JsImportNamedClause {
+                type_token: missing (optional),
                 default_specifier: missing (optional),
                 named_import: JsNamedImportSpecifiers {
                     l_curly_token: L_CURLY@45..47 "{" [] [Whitespace(" ")],
                     specifiers: JsNamedImportSpecifierList [
                         JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
                             local_name: JsIdentifierBinding {
                                 name_token: IDENT@47..49 "c" [] [Whitespace(" ")],
                             },
@@ -84,12 +87,13 @@ JsModule {
     0: JS_IMPORT@0..18
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_DEFAULT_CLAUSE@7..17
-        0: JS_IDENTIFIER_BINDING@7..9
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@7..9
           0: IDENT@7..9 "a" [] [Whitespace(" ")]
-        1: FROM_KW@9..14 "from" [] [Whitespace(" ")]
-        2: JS_MODULE_SOURCE@14..17
+        2: FROM_KW@9..14 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@14..17
           0: JS_STRING_LITERAL@14..17 "\"b\"" [] []
-        3: (empty)
+        4: (empty)
       2: SEMICOLON@17..18 ";" [] []
     1: JS_EXPORT@18..32
       0: EXPORT_KW@18..26 "export" [Newline("\n")] [Whitespace(" ")]
@@ -119,16 +123,18 @@ JsModule {
       0: IMPORT_KW@37..45 "import" [Newline("\n")] [Whitespace(" ")]
       1: JS_IMPORT_NAMED_CLAUSE@45..59
         0: (empty)
-        1: JS_NAMED_IMPORT_SPECIFIERS@45..51
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@45..51
           0: L_CURLY@45..47 "{" [] [Whitespace(" ")]
           1: JS_NAMED_IMPORT_SPECIFIER_LIST@47..49
             0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@47..49
-              0: JS_IDENTIFIER_BINDING@47..49
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@47..49
                 0: IDENT@47..49 "c" [] [Whitespace(" ")]
           2: R_CURLY@49..51 "}" [] [Whitespace(" ")]
-        2: FROM_KW@51..56 "from" [] [Whitespace(" ")]
-        3: JS_MODULE_SOURCE@56..59
+        3: FROM_KW@51..56 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@56..59
           0: JS_STRING_LITERAL@56..59 "\"c\"" [] []
-        4: (empty)
+        5: (empty)
       2: SEMICOLON@59..60 ";" [] []
   3: EOF@60..61 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_import_clause_types.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_import_clause_types.rast
@@ -1,0 +1,138 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsImport {
+            import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+            import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
+                local_name: JsIdentifierBinding {
+                    name_token: IDENT@7..12 "type" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@12..17 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@17..24 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@24..39 ";" [] [Whitespace(" "), Comments("// not a type")],
+        },
+        JsImport {
+            import_token: IMPORT_KW@39..47 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportDefaultClause {
+                type_token: TYPE_KW@47..52 "type" [] [Whitespace(" ")],
+                local_name: JsIdentifierBinding {
+                    name_token: IDENT@52..56 "foo" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@56..61 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@61..68 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@68..69 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@69..77 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamespaceClause {
+                type_token: TYPE_KW@77..82 "type" [] [Whitespace(" ")],
+                star_token: STAR@82..84 "*" [] [Whitespace(" ")],
+                as_token: AS_KW@84..87 "as" [] [Whitespace(" ")],
+                local_name: JsIdentifierBinding {
+                    name_token: IDENT@87..92 "foo2" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@92..97 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@97..104 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@104..105 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@105..113 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: TYPE_KW@113..118 "type" [] [Whitespace(" ")],
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@118..120 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@120..125 "foo3" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@125..127 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@127..132 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@132..137 "\"mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@137..138 ";" [] [],
+        },
+    ],
+    eof_token: EOF@138..139 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..139
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..138
+    0: JS_IMPORT@0..39
+      0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
+      1: JS_IMPORT_DEFAULT_CLAUSE@7..24
+        0: (empty)
+        1: JS_IDENTIFIER_BINDING@7..12
+          0: IDENT@7..12 "type" [] [Whitespace(" ")]
+        2: FROM_KW@12..17 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@17..24
+          0: JS_STRING_LITERAL@17..24 "\"./mod\"" [] []
+        4: (empty)
+      2: SEMICOLON@24..39 ";" [] [Whitespace(" "), Comments("// not a type")]
+    1: JS_IMPORT@39..69
+      0: IMPORT_KW@39..47 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_DEFAULT_CLAUSE@47..68
+        0: TYPE_KW@47..52 "type" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_BINDING@52..56
+          0: IDENT@52..56 "foo" [] [Whitespace(" ")]
+        2: FROM_KW@56..61 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@61..68
+          0: JS_STRING_LITERAL@61..68 "\"./mod\"" [] []
+        4: (empty)
+      2: SEMICOLON@68..69 ";" [] []
+    2: JS_IMPORT@69..105
+      0: IMPORT_KW@69..77 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMESPACE_CLAUSE@77..104
+        0: TYPE_KW@77..82 "type" [] [Whitespace(" ")]
+        1: STAR@82..84 "*" [] [Whitespace(" ")]
+        2: AS_KW@84..87 "as" [] [Whitespace(" ")]
+        3: JS_IDENTIFIER_BINDING@87..92
+          0: IDENT@87..92 "foo2" [] [Whitespace(" ")]
+        4: FROM_KW@92..97 "from" [] [Whitespace(" ")]
+        5: JS_MODULE_SOURCE@97..104
+          0: JS_STRING_LITERAL@97..104 "\"./mod\"" [] []
+        6: (empty)
+      2: SEMICOLON@104..105 ";" [] []
+    3: JS_IMPORT@105..138
+      0: IMPORT_KW@105..113 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@113..137
+        0: TYPE_KW@113..118 "type" [] [Whitespace(" ")]
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@118..127
+          0: L_CURLY@118..120 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@120..125
+            0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@120..125
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@120..125
+                0: IDENT@120..125 "foo3" [] [Whitespace(" ")]
+          2: R_CURLY@125..127 "}" [] [Whitespace(" ")]
+        3: FROM_KW@127..132 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@132..137
+          0: JS_STRING_LITERAL@132..137 "\"mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@137..138 ";" [] []
+  3: EOF@138..139 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_import_clause_types.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_import_clause_types.ts
@@ -1,0 +1,4 @@
+import type from "./mod"; // not a type
+import type foo from "./mod";
+import type * as foo2 from "./mod";
+import type { foo3 } from "mod";

--- a/crates/rslint_parser/test_data/inline/ok/ts_named_import_specifier_with_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_named_import_specifier_with_type.rast
@@ -1,0 +1,268 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsImport {
+            import_token: IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@7..9 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsShorthandNamedImportSpecifier {
+                            type_token: missing (optional),
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@9..13 "type" [] [],
+                            },
+                        },
+                        COMMA@13..15 "," [] [Whitespace(" ")],
+                        JsShorthandNamedImportSpecifier {
+                            type_token: TYPE_KW@15..20 "type" [] [Whitespace(" ")],
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@20..23 "as" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@23..25 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@25..30 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@30..37 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@37..38 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@38..46 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@46..48 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: missing (optional),
+                            name: JsLiteralExportName {
+                                value: IDENT@48..53 "type" [] [Whitespace(" ")],
+                            },
+                            as_token: AS_KW@53..56 "as" [] [Whitespace(" ")],
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@56..62 "other" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@62..64 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@64..69 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@69..76 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsImport {
+            import_token: IMPORT_KW@76..84 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@84..86 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: missing (optional),
+                            name: JsLiteralExportName {
+                                value: IDENT@86..91 "type" [] [Whitespace(" ")],
+                            },
+                            as_token: AS_KW@91..94 "as" [] [Whitespace(" ")],
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@94..97 "as" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@97..99 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@99..104 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@104..111 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@111..112 ";" [] [],
+        },
+        JsImport {
+            import_token: IMPORT_KW@112..120 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@120..122 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: TYPE_KW@122..127 "type" [] [Whitespace(" ")],
+                            name: JsLiteralExportName {
+                                value: IDENT@127..130 "as" [] [Whitespace(" ")],
+                            },
+                            as_token: AS_KW@130..133 "as" [] [Whitespace(" ")],
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@133..136 "as" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@136..138 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@138..143 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@143..150 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: missing (optional),
+        },
+        JsImport {
+            import_token: IMPORT_KW@150..158 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportNamedClause {
+                type_token: missing (optional),
+                default_specifier: missing (optional),
+                named_import: JsNamedImportSpecifiers {
+                    l_curly_token: L_CURLY@158..160 "{" [] [Whitespace(" ")],
+                    specifiers: JsNamedImportSpecifierList [
+                        JsNamedImportSpecifier {
+                            type_token: TYPE_KW@160..165 "type" [] [Whitespace(" ")],
+                            name: JsLiteralExportName {
+                                value: JS_STRING_LITERAL@165..177 "\"test-abcd\"" [] [Whitespace(" ")],
+                            },
+                            as_token: AS_KW@177..180 "as" [] [Whitespace(" ")],
+                            local_name: JsIdentifierBinding {
+                                name_token: IDENT@180..185 "test" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@185..187 "}" [] [Whitespace(" ")],
+                },
+                from_token: FROM_KW@187..192 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@192..199 "\"./mod\"" [] [],
+                },
+                assertion: missing (optional),
+            },
+            semicolon_token: SEMICOLON@199..200 ";" [] [],
+        },
+    ],
+    eof_token: EOF@200..201 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..201
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..200
+    0: JS_IMPORT@0..38
+      0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@7..37
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@7..25
+          0: L_CURLY@7..9 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@9..23
+            0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@9..13
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@9..13
+                0: IDENT@9..13 "type" [] []
+            1: COMMA@13..15 "," [] [Whitespace(" ")]
+            2: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@15..23
+              0: TYPE_KW@15..20 "type" [] [Whitespace(" ")]
+              1: JS_IDENTIFIER_BINDING@20..23
+                0: IDENT@20..23 "as" [] [Whitespace(" ")]
+          2: R_CURLY@23..25 "}" [] [Whitespace(" ")]
+        3: FROM_KW@25..30 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@30..37
+          0: JS_STRING_LITERAL@30..37 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@37..38 ";" [] []
+    1: JS_IMPORT@38..76
+      0: IMPORT_KW@38..46 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@46..76
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@46..64
+          0: L_CURLY@46..48 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@48..62
+            0: JS_NAMED_IMPORT_SPECIFIER@48..62
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@48..53
+                0: IDENT@48..53 "type" [] [Whitespace(" ")]
+              2: AS_KW@53..56 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@56..62
+                0: IDENT@56..62 "other" [] [Whitespace(" ")]
+          2: R_CURLY@62..64 "}" [] [Whitespace(" ")]
+        3: FROM_KW@64..69 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@69..76
+          0: JS_STRING_LITERAL@69..76 "\"./mod\"" [] []
+        5: (empty)
+      2: (empty)
+    2: JS_IMPORT@76..112
+      0: IMPORT_KW@76..84 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@84..111
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@84..99
+          0: L_CURLY@84..86 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@86..97
+            0: JS_NAMED_IMPORT_SPECIFIER@86..97
+              0: (empty)
+              1: JS_LITERAL_EXPORT_NAME@86..91
+                0: IDENT@86..91 "type" [] [Whitespace(" ")]
+              2: AS_KW@91..94 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@94..97
+                0: IDENT@94..97 "as" [] [Whitespace(" ")]
+          2: R_CURLY@97..99 "}" [] [Whitespace(" ")]
+        3: FROM_KW@99..104 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@104..111
+          0: JS_STRING_LITERAL@104..111 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@111..112 ";" [] []
+    3: JS_IMPORT@112..150
+      0: IMPORT_KW@112..120 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@120..150
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@120..138
+          0: L_CURLY@120..122 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@122..136
+            0: JS_NAMED_IMPORT_SPECIFIER@122..136
+              0: TYPE_KW@122..127 "type" [] [Whitespace(" ")]
+              1: JS_LITERAL_EXPORT_NAME@127..130
+                0: IDENT@127..130 "as" [] [Whitespace(" ")]
+              2: AS_KW@130..133 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@133..136
+                0: IDENT@133..136 "as" [] [Whitespace(" ")]
+          2: R_CURLY@136..138 "}" [] [Whitespace(" ")]
+        3: FROM_KW@138..143 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@143..150
+          0: JS_STRING_LITERAL@143..150 "\"./mod\"" [] []
+        5: (empty)
+      2: (empty)
+    4: JS_IMPORT@150..200
+      0: IMPORT_KW@150..158 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_NAMED_CLAUSE@158..199
+        0: (empty)
+        1: (empty)
+        2: JS_NAMED_IMPORT_SPECIFIERS@158..187
+          0: L_CURLY@158..160 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@160..185
+            0: JS_NAMED_IMPORT_SPECIFIER@160..185
+              0: TYPE_KW@160..165 "type" [] [Whitespace(" ")]
+              1: JS_LITERAL_EXPORT_NAME@165..177
+                0: JS_STRING_LITERAL@165..177 "\"test-abcd\"" [] [Whitespace(" ")]
+              2: AS_KW@177..180 "as" [] [Whitespace(" ")]
+              3: JS_IDENTIFIER_BINDING@180..185
+                0: IDENT@180..185 "test" [] [Whitespace(" ")]
+          2: R_CURLY@185..187 "}" [] [Whitespace(" ")]
+        3: FROM_KW@187..192 "from" [] [Whitespace(" ")]
+        4: JS_MODULE_SOURCE@192..199
+          0: JS_STRING_LITERAL@192..199 "\"./mod\"" [] []
+        5: (empty)
+      2: SEMICOLON@199..200 ";" [] []
+  3: EOF@200..201 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_named_import_specifier_with_type.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_named_import_specifier_with_type.ts
@@ -1,0 +1,5 @@
+import { type, type as } from "./mod";
+import { type as other } from "./mod"
+import { type as as } from "./mod";
+import { type as as as } from "./mod"
+import { type "test-abcd" as test } from "./mod";

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -1090,7 +1090,7 @@ JsImportBareClause =
 // import foo from "mod"
 // import type foo from "mod"
 JsImportDefaultClause =
-		// 'type'?
+		'type'?
 		local_name: JsAnyBinding
 		'from'
 		source: JsModuleSource
@@ -1099,7 +1099,7 @@ JsImportDefaultClause =
 // import * as foo from "mod";
 // import type * as foo from "mod";
 JsImportNamespaceClause =
-  // 'type'
+  'type'?
 	'*'
 	'as'
 	local_name: JsAnyBinding
@@ -1119,7 +1119,7 @@ JsImportNamespaceClause =
 //        ^^^^^^^^^^^^^^^^^^^^^^^
 // import foo, { type bar } from "mod";
 JsImportNamedClause =
-    // 'type'?
+    'type'?
     default_specifier: JsDefaultImportSpecifier?
     named_import: JsAnyNamedImport
     'from'
@@ -1162,7 +1162,7 @@ JsAnyNamedImportSpecifier =
 // import { type foo as test } from "mod";
 //          ^^^^^^^^^^^^^^^^^
 JsNamedImportSpecifier =
-    // 'type'?
+    'type'?
     name: JsLiteralExportName
     'as'
     local_name: JsAnyBinding
@@ -1170,7 +1170,7 @@ JsNamedImportSpecifier =
 // import { type foo } from "mod";
 //          ^^^^^^^^
 JsShorthandNamedImportSpecifier =
-    // 'type'?
+    'type'?
     local_name: JsAnyBinding
 
 // import a from "mod" assert { type: "json" }


### PR DESCRIPTION
## Summary

Adds support for TypeScript's `import` extensions:

```ts 
import { type A, type b as C } from "./mod";
import type foo from "./mod";
import type * as foo2 from "./mod";
import type { foo3 } from "mod";
```

## Test Plan

Added new parser tests
