### PR TITLE
feat(rome_formatter): add function for converting file to format_element

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -254,6 +254,16 @@ pub fn format(options: FormatOptions, syntax: &SyntaxNode) -> FormatResult<Forma
     Ok(Printer::new(options).print(&element))
 }
 
+/// Outputs formatter IR for a JavaScript (and its super languages) file
+///
+/// It returns a [FormatElement] result. Mostly for debugging purposes.
+pub fn to_format_element(
+    options: FormatOptions,
+    syntax: &SyntaxNode,
+) -> FormatResult<FormatElement> {
+    Formatter::new(options).format_root(syntax)
+}
+
 /// Formats a range within a file, supported by Rome
 ///
 /// This runs a simple heuristic to determine the initial indentation
@@ -495,7 +505,7 @@ while(
     function func() {
     func(     /* comment */
     );
-    
+
     let array =
         [ 1
     , 2];


### PR DESCRIPTION
Not sure what to name this tbh. `to_format_element` seems logical but it's specifically the root, so we could call it `root_to_format_element`. Thoughts?
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
