### PR TITLE
fix(rslint_parser): Type-arguments in `extends` heritage clause

### DIFF
--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -309,6 +309,11 @@ fn eat_class_heritage_clause(p: &mut Parser) {
     }
 }
 
+// test ts ts_extends_generic_type
+// type IHasVisualizationModel = string;
+// class D extends C<IHasVisualizationModel> {
+//     x = "string";
+// }
 fn parse_extends_clause(p: &mut Parser) -> ParsedSyntax {
     if !p.at(T![extends]) {
         return Absent;

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -1206,7 +1206,9 @@ pub fn parse_ts_type_arguments_in_expression(p: &mut Parser) -> ParsedSyntax {
     try_parse(p, |p| {
         let arguments = parse_ts_type_arguments_impl(p, false);
 
-        if p.tokens.last_tok().map(|t| t.kind) == Some(T![>]) {
+        if p.tokens.last_tok().map(|t| t.kind) == Some(T![>])
+            && matches!(p.cur(), T!['('] | BACKTICK)
+        {
             Present(arguments)
         } else {
             Absent

--- a/crates/rslint_parser/test_data/inline/ok/ts_extends_generic_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_extends_generic_type.rast
@@ -1,0 +1,122 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..28 "IHasVisualizationModel" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@28..30 "=" [] [Whitespace(" ")],
+            ty: TsStringType {
+                string_token: STRING_KW@30..36 "string" [] [],
+            },
+            semicolon_token: SEMICOLON@36..37 ";" [] [],
+        },
+        JsClassDeclaration {
+            abstract_token: missing (optional),
+            class_token: CLASS_KW@37..44 "class" [Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@44..46 "D" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: JsExtendsClause {
+                extends_token: EXTENDS_KW@46..54 "extends" [] [Whitespace(" ")],
+                super_class: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@54..55 "C" [] [],
+                    },
+                },
+                type_arguments: TsTypeArguments {
+                    l_angle_token: L_ANGLE@55..56 "<" [] [],
+                    ts_type_argument_list: TsTypeArgumentList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@56..78 "IHasVisualizationModel" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    ],
+                    r_angle_token: R_ANGLE@78..80 ">" [] [Whitespace(" ")],
+                },
+            },
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@80..81 "{" [] [],
+            members: JsClassMemberList [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@81..88 "x" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")],
+                    },
+                    property_annotation: missing (optional),
+                    value: JsInitializerClause {
+                        eq_token: EQ@88..90 "=" [] [Whitespace(" ")],
+                        expression: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@90..98 "\"string\"" [] [],
+                        },
+                    },
+                    semicolon_token: SEMICOLON@98..99 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@99..101 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@101..102 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..102
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..101
+    0: TS_TYPE_ALIAS_DECLARATION@0..37
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..28
+        0: IDENT@5..28 "IHasVisualizationModel" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@28..30 "=" [] [Whitespace(" ")]
+      4: TS_STRING_TYPE@30..36
+        0: STRING_KW@30..36 "string" [] []
+      5: SEMICOLON@36..37 ";" [] []
+    1: JS_CLASS_DECLARATION@37..101
+      0: (empty)
+      1: CLASS_KW@37..44 "class" [Newline("\n")] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@44..46
+        0: IDENT@44..46 "D" [] [Whitespace(" ")]
+      3: (empty)
+      4: JS_EXTENDS_CLAUSE@46..80
+        0: EXTENDS_KW@46..54 "extends" [] [Whitespace(" ")]
+        1: JS_IDENTIFIER_EXPRESSION@54..55
+          0: JS_REFERENCE_IDENTIFIER@54..55
+            0: IDENT@54..55 "C" [] []
+        2: TS_TYPE_ARGUMENTS@55..80
+          0: L_ANGLE@55..56 "<" [] []
+          1: TS_TYPE_ARGUMENT_LIST@56..78
+            0: TS_REFERENCE_TYPE@56..78
+              0: JS_REFERENCE_IDENTIFIER@56..78
+                0: IDENT@56..78 "IHasVisualizationModel" [] []
+              1: (empty)
+          2: R_ANGLE@78..80 ">" [] [Whitespace(" ")]
+      5: (empty)
+      6: L_CURLY@80..81 "{" [] []
+      7: JS_CLASS_MEMBER_LIST@81..99
+        0: JS_PROPERTY_CLASS_MEMBER@81..99
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@81..88
+            0: IDENT@81..88 "x" [Newline("\n"), Whitespace("    ")] [Whitespace(" ")]
+          6: (empty)
+          7: JS_INITIALIZER_CLAUSE@88..98
+            0: EQ@88..90 "=" [] [Whitespace(" ")]
+            1: JS_STRING_LITERAL_EXPRESSION@90..98
+              0: JS_STRING_LITERAL@90..98 "\"string\"" [] []
+          8: SEMICOLON@98..99 ";" [] []
+      8: R_CURLY@99..101 "}" [Newline("\n")] []
+  3: EOF@101..102 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_extends_generic_type.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_extends_generic_type.ts
@@ -1,0 +1,4 @@
+type IHasVisualizationModel = string;
+class D extends C<IHasVisualizationModel> {
+    x = "string";
+}


### PR DESCRIPTION
## Summary

The parser incorrectly parsed `B<A>` in `class T extends B<A>` as the start of a call expression with type arguments (assumed it would be `B<A>()`) instead of an identifier with type arguments.

This PR adds a check when speculatively parsing the type arguments of a call expression to only eat them if they're followed by a token that is valid coming after type arguments (either a template literal or `(`.

We may need to extend the list of valid tokens in the future to get better error recovery.

## Test Plan

* Added a new parser test 
* Verified that the regressions are tests that should fail with errors emitted by a type checker

closes #2122
