### PR TITLE
fix(rslint_parser): function types in conditional type lhs

### DIFF
--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -178,6 +178,21 @@ fn is_nth_at_ts_type_parameters(p: &Parser, n: usize) -> bool {
 }
 
 pub(crate) fn parse_ts_type(p: &mut Parser) -> ParsedSyntax {
+    parse_ts_type_impl(p, ConditionalType::Allowed)
+}
+
+enum ConditionalType {
+    Allowed,
+    Disallowed,
+}
+
+impl ConditionalType {
+    fn is_allowed(&self) -> bool {
+        matches!(self, ConditionalType::Allowed)
+    }
+}
+
+fn parse_ts_type_impl(p: &mut Parser, conditional_type: ConditionalType) -> ParsedSyntax {
     p.with_state(EnterType, |p| {
         if is_at_constructor_type(p) {
             return parse_ts_constructor_type(p);
@@ -187,24 +202,33 @@ pub(crate) fn parse_ts_type(p: &mut Parser) -> ParsedSyntax {
             return parse_ts_function_type(p);
         }
 
-        parse_ts_union_type_or_higher(p).map(|left| {
-            // test ts ts_conditional_type
-            // type A = number;
-            // type B = string extends number ? string : number;
-            // type C = A extends (B extends A ? number : string) ? void : number;
-            if !p.has_linebreak_before_n(0) && p.at(T![extends]) {
-                let m = left.precede(p);
-                p.bump(T![extends]);
-                parse_ts_union_type_or_higher(p).or_add_diagnostic(p, expected_ts_type);
-                p.expect(T![?]);
-                parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
-                p.expect(T![:]);
-                parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
-                m.complete(p, TS_CONDITIONAL_TYPE)
-            } else {
-                left
-            }
-        })
+        let left = parse_ts_union_type_or_higher(p);
+
+        // test ts ts_conditional_type_call_signature_lhs
+        // type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;
+        if conditional_type.is_allowed() {
+            left.map(|left| {
+                // test ts ts_conditional_type
+                // type A = number;
+                // type B = string extends number ? string : number;
+                // type C = A extends (B extends A ? number : string) ? void : number;
+                if !p.has_linebreak_before_n(0) && p.at(T![extends]) {
+                    let m = left.precede(p);
+                    p.bump(T![extends]);
+                    parse_ts_type_impl(p, ConditionalType::Disallowed)
+                        .or_add_diagnostic(p, expected_ts_type);
+                    p.expect(T![?]);
+                    parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+                    p.expect(T![:]);
+                    parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
+                    m.complete(p, TS_CONDITIONAL_TYPE)
+                } else {
+                    left
+                }
+            })
+        } else {
+            left
+        }
     })
 }
 

--- a/crates/rslint_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.rast
@@ -1,0 +1,192 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..6 "X" [] [],
+            },
+            type_parameters: TsTypeParameters {
+                l_angle_token: L_ANGLE@6..7 "<" [] [],
+                items: TsTypeParameterList [
+                    TsTypeParameter {
+                        name: TsTypeParameterName {
+                            ident_token: IDENT@7..8 "V" [] [],
+                        },
+                        constraint: missing (optional),
+                        default: missing (optional),
+                    },
+                ],
+                r_angle_token: R_ANGLE@8..10 ">" [] [Whitespace(" ")],
+            },
+            eq_token: EQ@10..12 "=" [] [Whitespace(" ")],
+            ty: TsConditionalType {
+                check_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@12..14 "V" [] [Whitespace(" ")],
+                    },
+                    type_arguments: missing (optional),
+                },
+                extends_token: EXTENDS_KW@14..22 "extends" [] [Whitespace(" ")],
+                extends_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@22..23 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                dotdotdot_token: DOT2@23..26 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@26..30 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@30..32 ":" [] [Whitespace(" ")],
+                                    ty: TsArrayType {
+                                        element_type: TsAnyType {
+                                            any_token: ANY_KW@32..35 "any" [] [],
+                                        },
+                                        l_brack_token: L_BRACK@35..36 "[" [] [],
+                                        r_brack_token: R_BRACK@36..37 "]" [] [],
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@37..39 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@39..42 "=>" [] [Whitespace(" ")],
+                    return_type: TsAnyType {
+                        any_token: ANY_KW@42..46 "any" [] [Whitespace(" ")],
+                    },
+                },
+                question_mark_token: QUESTION@46..48 "?" [] [Whitespace(" ")],
+                true_type: TsFunctionType {
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@48..49 "(" [] [],
+                        items: JsParameterList [
+                            JsRestParameter {
+                                dotdotdot_token: DOT2@49..52 "..." [] [],
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@52..56 "args" [] [],
+                                },
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@56..58 ":" [] [Whitespace(" ")],
+                                    ty: TsReferenceType {
+                                        name: JsReferenceIdentifier {
+                                            value_token: IDENT@58..68 "Parameters" [] [],
+                                        },
+                                        type_arguments: TsTypeArguments {
+                                            l_angle_token: L_ANGLE@68..69 "<" [] [],
+                                            ts_type_argument_list: TsTypeArgumentList [
+                                                TsReferenceType {
+                                                    name: JsReferenceIdentifier {
+                                                        value_token: IDENT@69..70 "V" [] [],
+                                                    },
+                                                    type_arguments: missing (optional),
+                                                },
+                                            ],
+                                            r_angle_token: R_ANGLE@70..71 ">" [] [],
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                        r_paren_token: R_PAREN@71..73 ")" [] [Whitespace(" ")],
+                    },
+                    fat_arrow_token: FAT_ARROW@73..76 "=>" [] [Whitespace(" ")],
+                    return_type: TsVoidType {
+                        void_token: VOID_KW@76..81 "void" [] [Whitespace(" ")],
+                    },
+                },
+                colon_token: COLON@81..83 ":" [] [Whitespace(" ")],
+                false_type: TsReferenceType {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@83..91 "Function" [] [],
+                    },
+                    type_arguments: missing (optional),
+                },
+            },
+            semicolon_token: SEMICOLON@91..92 ";" [] [],
+        },
+    ],
+    eof_token: EOF@92..93 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..93
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..92
+    0: TS_TYPE_ALIAS_DECLARATION@0..92
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..6
+        0: IDENT@5..6 "X" [] []
+      2: TS_TYPE_PARAMETERS@6..10
+        0: L_ANGLE@6..7 "<" [] []
+        1: TS_TYPE_PARAMETER_LIST@7..8
+          0: TS_TYPE_PARAMETER@7..8
+            0: TS_TYPE_PARAMETER_NAME@7..8
+              0: IDENT@7..8 "V" [] []
+            1: (empty)
+            2: (empty)
+        2: R_ANGLE@8..10 ">" [] [Whitespace(" ")]
+      3: EQ@10..12 "=" [] [Whitespace(" ")]
+      4: TS_CONDITIONAL_TYPE@12..91
+        0: TS_REFERENCE_TYPE@12..14
+          0: JS_REFERENCE_IDENTIFIER@12..14
+            0: IDENT@12..14 "V" [] [Whitespace(" ")]
+          1: (empty)
+        1: EXTENDS_KW@14..22 "extends" [] [Whitespace(" ")]
+        2: TS_FUNCTION_TYPE@22..46
+          0: (empty)
+          1: JS_PARAMETERS@22..39
+            0: L_PAREN@22..23 "(" [] []
+            1: JS_PARAMETER_LIST@23..37
+              0: JS_REST_PARAMETER@23..37
+                0: DOT2@23..26 "..." [] []
+                1: JS_IDENTIFIER_BINDING@26..30
+                  0: IDENT@26..30 "args" [] []
+                2: TS_TYPE_ANNOTATION@30..37
+                  0: COLON@30..32 ":" [] [Whitespace(" ")]
+                  1: TS_ARRAY_TYPE@32..37
+                    0: TS_ANY_TYPE@32..35
+                      0: ANY_KW@32..35 "any" [] []
+                    1: L_BRACK@35..36 "[" [] []
+                    2: R_BRACK@36..37 "]" [] []
+            2: R_PAREN@37..39 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@39..42 "=>" [] [Whitespace(" ")]
+          3: TS_ANY_TYPE@42..46
+            0: ANY_KW@42..46 "any" [] [Whitespace(" ")]
+        3: QUESTION@46..48 "?" [] [Whitespace(" ")]
+        4: TS_FUNCTION_TYPE@48..81
+          0: (empty)
+          1: JS_PARAMETERS@48..73
+            0: L_PAREN@48..49 "(" [] []
+            1: JS_PARAMETER_LIST@49..71
+              0: JS_REST_PARAMETER@49..71
+                0: DOT2@49..52 "..." [] []
+                1: JS_IDENTIFIER_BINDING@52..56
+                  0: IDENT@52..56 "args" [] []
+                2: TS_TYPE_ANNOTATION@56..71
+                  0: COLON@56..58 ":" [] [Whitespace(" ")]
+                  1: TS_REFERENCE_TYPE@58..71
+                    0: JS_REFERENCE_IDENTIFIER@58..68
+                      0: IDENT@58..68 "Parameters" [] []
+                    1: TS_TYPE_ARGUMENTS@68..71
+                      0: L_ANGLE@68..69 "<" [] []
+                      1: TS_TYPE_ARGUMENT_LIST@69..70
+                        0: TS_REFERENCE_TYPE@69..70
+                          0: JS_REFERENCE_IDENTIFIER@69..70
+                            0: IDENT@69..70 "V" [] []
+                          1: (empty)
+                      2: R_ANGLE@70..71 ">" [] []
+            2: R_PAREN@71..73 ")" [] [Whitespace(" ")]
+          2: FAT_ARROW@73..76 "=>" [] [Whitespace(" ")]
+          3: TS_VOID_TYPE@76..81
+            0: VOID_KW@76..81 "void" [] [Whitespace(" ")]
+        5: COLON@81..83 ":" [] [Whitespace(" ")]
+        6: TS_REFERENCE_TYPE@83..91
+          0: JS_REFERENCE_IDENTIFIER@83..91
+            0: IDENT@83..91 "Function" [] []
+          1: (empty)
+      5: SEMICOLON@91..92 ";" [] []
+  3: EOF@92..93 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_conditional_type_call_signature_lhs.ts
@@ -1,0 +1,1 @@
+type X<V> = V extends (...args: any[]) => any ? (...args: Parameters<V>) => void : Function;


### PR DESCRIPTION
## Summary
TypeScript allows call signatures as the left-hand side of conditional types:

```ts
type X<V> = V extends (...args: any[]) => any ? true : false;
```

The parser used to call into `parse_ts_union_type_or_higher` to avoid parsing out another conditional type as the left-hand sie. However, this means the parser doesn't try to parse out function or constructor types.

This PR correctly parses function and constructor types as the left-hand side of conditional types.

part of #2113

## Test Plan

Added new parser tests. Verified that the regressions are tests that test for the presence of type checker errors. 
