### PR TITLE
fix(rslint_parser): Stop statement and module recovery before `}`

### DIFF
--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/record-tuple-record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/record-tuple-record.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: record-tuple-record.js
 
 ---
@@ -20,12 +20,17 @@ const record2 = #{...record1, b: 5};
 ```js
 const record1 = #
 {
-    a: 1,
-    b: 2,
+  a: 1, b;
+  : 2,
     c: 3,
-};
+}
 
-const record2 = #{...record1, b: 5};
+
+
+const record2 = #
+{
+  ...record1, b: 5;
+}
 
 ```
 
@@ -57,12 +62,6 @@ error[SyntaxError]: expected an expression but instead found '...record1, b: 5'
   │
 7 │ const record2 = #{...record1, b: 5};
   │                   ^^^^^^^^^^^^^^^^ Expected an expression here
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-  ┌─ record-tuple-record.js:8:1
-  │
-8 │ 
-  │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/babel-plugins/v8intrinsic.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/babel-plugins/v8intrinsic.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: v8intrinsic.js
 
 ---
@@ -55,11 +55,12 @@ foo%bar()
 
 new %DebugPrint(null);
 
-function *foo() {
-  yield %StringParseInt("42", 10)
+function* foo() {
+  yield;
+  %StringParseInt("42", 10)
 }
 
-foo%bar()
+foo % bar();
 
 ```
 
@@ -85,12 +86,6 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
    │   │     │
    │   │     An explicit or implicit semicolon is expected here...
    │   ...Which is required to end this statement
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ v8intrinsic.js:26:1
-   │
-26 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/decorators/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/decorators/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: comments.js
 
 ---
@@ -48,16 +48,18 @@ var x = 100;
 
 @Hello(
 {
-  a: 'a', // Comment is in the wrong place
-  // test
-  b: '2'
-})
-class X {
-
+  a: "a", // test // Comment is in the wrong place
+  b;
+  : '2'
 }
+)
+class X {}
 
 
-@NgModule({
+
+
+@NgModule(
+{
   // Imports.
   imports: [
     // Angular modules.
@@ -67,15 +69,18 @@ class X {
     CoreModule,
     SharedModule,
   ],
-})
+}
+)
 export class AppModule {}
+
+
 
 // A
 @Foo()
 // B
 @Bar()
 // C
-export class Bar{}
+export class Bar {}
 
 ```
 
@@ -97,6 +102,12 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │ │    ^ An explicit or implicit semicolon is expected here...
   │ └────' ...Which is required to end this statement
 
+error[SyntaxError]: expected a statement but instead found ')'
+  ┌─ comments.js:7:2
+  │
+7 │ })
+  │  ^ Expected a statement here
+
 error[SyntaxError]: expected a statement but instead found '@NgModule('
    ┌─ comments.js:13:1
    │
@@ -115,12 +126,6 @@ error[SyntaxError]: expected a statement but instead found ')'
 23 │ })
    │  ^ Expected a statement here
 
-error[SyntaxError]: Illegal use of an import declaration not at the top level
-   ┌─ comments.js:24:1
-   │
-24 │ export class AppModule {}
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^ move this declaration to the top level
-
 error[SyntaxError]: expected a statement but instead found '@Foo()
 // B
 @Bar()'
@@ -130,18 +135,6 @@ error[SyntaxError]: expected a statement but instead found '@Foo()
 28 │ │ // B
 29 │ │ @Bar()
    │ └──────^ Expected a statement here
-
-error[SyntaxError]: Illegal use of an import declaration not at the top level
-   ┌─ comments.js:31:1
-   │
-31 │ export class Bar{}
-   │ ^^^^^^^^^^^^^^^^^^ move this declaration to the top level
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ comments.js:32:1
-   │
-32 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/record/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/record/destructuring.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: destructuring.js
 
 ---
@@ -21,11 +21,20 @@ assert(rest.c === 3);
 # Output
 ```js
 const { a, b } = #
-{ a: 1, b: 2 };
+{
+  a: 1, b;
+  : 2 
+}
 assert(a === 1);
 assert(b === 2);
 
-const { a, ...rest } = #{ a: 1, b: 2, c: 3 };
+
+
+const { a, ...rest } = #
+{
+  a: 1, b;
+  : 2, c: 3 
+}
 assert(a === 1);
 assert(typeof rest === "object");
 assert(rest.b === 2);
@@ -64,12 +73,6 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │                              │   │
   │                              │   An explicit or implicit semicolon is expected here...
   │                              ...Which is required to end this statement
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ destructuring.js:10:1
-   │
-10 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/record/record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/record/record.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: record.js
 
 ---
@@ -29,12 +29,17 @@ assert(record1.d?.a === undefined);
 ```js
 const record1 = #
 {
-    a: 1,
-    b: 2,
+  a: 1, b;
+  : 2,
     c: 3,
-};
+}
 
-const record2 = #{...record1, b: 5};
+
+
+const record2 = #
+{
+  ...record1, b: 5;
+}
 
 assert(record1.a === 1);
 assert(record1["a"] === 1);
@@ -93,12 +98,6 @@ error[SyntaxError]: expected `,` but instead found `{`
    │
 12 │ assert(record2 === #{ a: 1, c: 3, b: 5 });
    │                     ^ unexpected
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ record.js:17:1
-   │
-17 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/record/spread.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/record/spread.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: spread.js
 
 ---
@@ -23,8 +23,15 @@ const formData = #
 }
 
 const taskNow = #
-{ id: 42, status: "WIP", ...formData }
-const taskLater = #{ ...taskNow, status: "DONE" }
+{
+  id: 42, status;
+  : "WIP", ...formData 
+}
+
+const taskLater = #
+{
+  ...taskNow, status: "DONE" ;
+}
 
 // A reminder: The ordering of keys in record literals does not affect equality (and is not retained)
 assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })
@@ -54,6 +61,12 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │                        │         An explicit or implicit semicolon is expected here...
   │                        ...Which is required to end this statement
 
+error[SyntaxError]: expected `IDENT` but instead found `{`
+  ┌─ spread.js:3:20
+  │
+3 │ const taskLater = #{ ...taskNow, status: "DONE" }
+  │                    ^ unexpected
+
 error[SyntaxError]: expected an expression but instead found '...taskNow, status: "DONE"'
   ┌─ spread.js:3:22
   │
@@ -77,12 +90,6 @@ error[SyntaxError]: expected `,` but instead found `{`
   │
 6 │ assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })
   │                       ^ unexpected
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-  ┌─ spread.js:7:1
-  │
-7 │ 
-  │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/record/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/record/syntax.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: syntax.js
 
 ---
@@ -18,8 +18,20 @@ expression: syntax.js
 {}
 
 #
-{ a: 1, b: 2 }
-#{ a: 1, b: #[2, 3, #{ c: 4 }] }
+{
+  a: 1, b;
+  : 2 
+}
+
+#
+{
+  a: 1, b;
+  : #[2, 3, #
+  {
+    c: 4;
+  }
+  ] 
+}
 
 ```
 
@@ -52,6 +64,12 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │       │   An explicit or implicit semicolon is expected here...
   │       ...Which is required to end this statement
 
+error[SyntaxError]: expected `IDENT` but instead found `{`
+  ┌─ syntax.js:3:2
+  │
+3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
+  │  ^ unexpected
+
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ syntax.js:3:11
   │
@@ -61,17 +79,11 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
   │       │   An explicit or implicit semicolon is expected here...
   │       ...Which is required to end this statement
 
-error[SyntaxError]: expected a statement but instead found '] }'
+error[SyntaxError]: expected a statement but instead found ']'
   ┌─ syntax.js:3:30
   │
 3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
-  │                              ^^^ Expected a statement here
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-  ┌─ syntax.js:4:1
-  │
-4 │ 
-  │ ^ the file ends here
+  │                              ^ Expected a statement here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/template-literals/css-prop.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/template-literals/css-prop.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: css-prop.js
 
 ---
@@ -37,7 +37,7 @@ const TestComponent = ({ children, ...props }) => (
 
 # Output
 ```js
-function SomeComponent (props) {
+function SomeComponent(props) {
   // Create styles as if you're calling css and the class will be applied to the component
   return (<div css={`
     color: blue;
@@ -51,9 +51,19 @@ function SomeComponent (props) {
       font-size: 20px;
     }
   `}>
-    This will be blue until hovered.
-    <div className="some-class">
-      This font size will be 20px
+    This
+  will;
+  be;
+  blue;
+  until;
+  hovered.
+    <div
+  className = "some-class" > This;
+  font;
+  size;
+  will;
+  be;
+  20px
     </div>
   </div>)
 }
@@ -206,44 +216,31 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
    │                           │  An explicit or implicit semicolon is expected here...
    │                           ...Which is required to end this statement
 
-error[SyntaxError]: expected an expression but instead found '...'
-   ┌─ css-prop.js:22:36
-   │
-22 │ const TestComponent = ({ children, ...props }) => (
-   │                                    ^^^ Expected an expression here
-
-error[SyntaxError]: expected a statement but instead found ') => (
-  <div css='
-   ┌─ css-prop.js:22:46
-   │  
-22 │   const TestComponent = ({ children, ...props }) => (
-   │ ┌──────────────────────────────────────────────^
-23 │ │   <div css={`color: white; background: black`}>
-   │ └───────────^ Expected a statement here
-
-error[SyntaxError]: expected a statement but instead found '>'
-   ┌─ css-prop.js:23:47
+error[SyntaxError]: Invalid assignment to `<div css`
+   ┌─ css-prop.js:23:3
    │
 23 │   <div css={`color: white; background: black`}>
-   │                                               ^ Expected a statement here
+   │   ^^^^^^^^ This expression cannot be assigned to
 
-error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
-   ┌─ css-prop.js:25:3
+error[SyntaxError]: expected a property, a shorthand property, a getter, a setter, or a method but instead found '`color: white; background: black`'
+   ┌─ css-prop.js:23:13
+   │
+23 │   <div css={`color: white; background: black`}>
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected a property, a shorthand property, a getter, a setter, or a method here
+
+error[SyntaxError]: Expected an expression for the right hand side of a `<`, but found an operator instead
+   ┌─ css-prop.js:25:4
    │
 25 │   </div>
-   │   ^ TypeScript only syntax
+   │   -^ But this operator was encountered instead
+   │   │ 
+   │   This operator requires a right hand side value
 
 error[SyntaxError]: expected an expression but instead found ')'
    ┌─ css-prop.js:26:1
    │
 26 │ );
    │ ^ Expected an expression here
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ css-prop.js:27:1
-   │
-27 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/test-declarations/angular_async.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/test-declarations/angular_async.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: angular_async.js
 
 ---
@@ -84,7 +84,10 @@ it(
 * and parent.type is CallExpression. This test makes sure that
 * no errors are thrown when calling isTestCall(parent)
 */
-function x() { async(() => {}) }
+function x() {
+  async (() => {};
+  ) 
+}
 
 ```
 
@@ -164,12 +167,6 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
    │                │             │
    │                │             An explicit or implicit semicolon is expected here...
    │                ...Which is required to end this statement
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ angular_async.js:35:1
-   │
-35 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/v8_intrinsic/intrinsic_call.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/v8_intrinsic/intrinsic_call.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 121
 expression: intrinsic_call.js
 
 ---
@@ -35,18 +35,17 @@ function doSmth()     {
 
 # Output
 ```js
-function doSmth()     {
+function doSmth() {
+  
             %DebugPrint
         (
                 foo )
-  }
+}
 
-    function printFunc  (
-        f
-) {
-    if(%
+function printFunc(f) {
+  if(%
     IsAsmWasmCode(f))              console.log("asm.js");
-        if(
+  if(
 
         % IsWasmCode(
         f))
@@ -54,7 +53,7 @@ function doSmth()     {
                 "wasm"
             );
 
-    console.log
+  console.log
     (%
         GetFunctioName(f)
         );
@@ -66,21 +65,13 @@ function doSmth()     {
 ```
 error[SyntaxError]: expected a statement but instead found '%DebugPrint
         (
-                foo )
-  }'
+                foo )'
   ┌─ intrinsic_call.js:2:13
   │  
 2 │ ┌             %DebugPrint
 3 │ │         (
 4 │ │                 foo )
-5 │ │   }
-  │ └───^ Expected a statement here
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ intrinsic_call.js:25:1
-   │
-25 │ 
-   │ ^ the file ends here
+  │ └─────────────────────^ Expected a statement here
 
 
 ```

--- a/crates/rslint_parser/test_data/inline/err/module_closing_curly.rast
+++ b/crates/rslint_parser/test_data/inline/err/module_closing_curly.rast
@@ -1,0 +1,89 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsDeclareStatement {
+            declare_token: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")],
+            declaration: TsModuleDeclaration {
+                module_or_namespace: MODULE_KW@8..15 "module" [] [Whitespace(" ")],
+                name: TsIdentifierBinding {
+                    name_token: IDENT@15..17 "A" [] [Whitespace(" ")],
+                },
+                body: TsModuleBlock {
+                    l_curly_token: L_CURLY@17..18 "{" [] [],
+                    items: JsModuleItemList [
+                        JsExpressionStatement {
+                            expression: JsStringLiteralExpression {
+                                value_token: JS_STRING_LITERAL@18..26 "\"name\"" [Newline("\n"), Whitespace(" ")] [],
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                        JsUnknownStatement {
+                            items: [
+                                COLON@26..28 ":" [] [Whitespace(" ")],
+                                JS_STRING_LITERAL@28..45 "\"troublesome-lib\"" [] [],
+                                COMMA@45..46 "," [] [],
+                                JS_STRING_LITERAL@46..57 "\"typings\"" [Newline("\n"), Whitespace(" ")] [],
+                                COLON@57..59 ":" [] [Whitespace(" ")],
+                                JS_STRING_LITERAL@59..75 "\"lib/index.d.ts\"" [] [],
+                                COMMA@75..76 "," [] [],
+                                JS_STRING_LITERAL@76..87 "\"version\"" [Newline("\n"), Whitespace(" ")] [],
+                                COLON@87..89 ":" [] [Whitespace(" ")],
+                                JS_STRING_LITERAL@89..96 "\"0.0.1\"" [] [],
+                            ],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@96..98 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@98..99 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..99
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..98
+    0: TS_DECLARE_STATEMENT@0..98
+      0: DECLARE_KW@0..8 "declare" [] [Whitespace(" ")]
+      1: TS_MODULE_DECLARATION@8..98
+        0: MODULE_KW@8..15 "module" [] [Whitespace(" ")]
+        1: TS_IDENTIFIER_BINDING@15..17
+          0: IDENT@15..17 "A" [] [Whitespace(" ")]
+        2: TS_MODULE_BLOCK@17..98
+          0: L_CURLY@17..18 "{" [] []
+          1: JS_MODULE_ITEM_LIST@18..96
+            0: JS_EXPRESSION_STATEMENT@18..26
+              0: JS_STRING_LITERAL_EXPRESSION@18..26
+                0: JS_STRING_LITERAL@18..26 "\"name\"" [Newline("\n"), Whitespace(" ")] []
+              1: (empty)
+            1: JS_UNKNOWN_STATEMENT@26..96
+              0: COLON@26..28 ":" [] [Whitespace(" ")]
+              1: JS_STRING_LITERAL@28..45 "\"troublesome-lib\"" [] []
+              2: COMMA@45..46 "," [] []
+              3: JS_STRING_LITERAL@46..57 "\"typings\"" [Newline("\n"), Whitespace(" ")] []
+              4: COLON@57..59 ":" [] [Whitespace(" ")]
+              5: JS_STRING_LITERAL@59..75 "\"lib/index.d.ts\"" [] []
+              6: COMMA@75..76 "," [] []
+              7: JS_STRING_LITERAL@76..87 "\"version\"" [Newline("\n"), Whitespace(" ")] []
+              8: COLON@87..89 ":" [] [Whitespace(" ")]
+              9: JS_STRING_LITERAL@89..96 "\"0.0.1\"" [] []
+          2: R_CURLY@96..98 "}" [Newline("\n")] []
+  3: EOF@98..99 "" [Newline("\n")] []
+--
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ module_closing_curly.ts:2:8
+  │
+2 │  "name": "troublesome-lib",
+  │  ------^
+  │  │     │
+  │  │     An explicit or implicit semicolon is expected here...
+  │  ...Which is required to end this statement
+
+--
+declare module A {
+ "name": "troublesome-lib",
+ "typings": "lib/index.d.ts",
+ "version": "0.0.1"
+}

--- a/crates/rslint_parser/test_data/inline/err/module_closing_curly.ts
+++ b/crates/rslint_parser/test_data/inline/err/module_closing_curly.ts
@@ -1,0 +1,5 @@
+declare module A {
+ "name": "troublesome-lib",
+ "typings": "lib/index.d.ts",
+ "version": "0.0.1"
+}

--- a/crates/rslint_parser/test_data/inline/err/statements_closing_curly.js
+++ b/crates/rslint_parser/test_data/inline/err/statements_closing_curly.js
@@ -1,0 +1,5 @@
+{
+"name": "troublesome-lib",
+"typings": "lib/index.d.ts",
+"version": "0.0.1"
+}

--- a/crates/rslint_parser/test_data/inline/err/statements_closing_curly.rast
+++ b/crates/rslint_parser/test_data/inline/err/statements_closing_curly.rast
@@ -1,0 +1,74 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBlockStatement {
+            l_curly_token: L_CURLY@0..1 "{" [] [],
+            statements: JsStatementList [
+                JsExpressionStatement {
+                    expression: JsStringLiteralExpression {
+                        value_token: JS_STRING_LITERAL@1..8 "\"name\"" [Newline("\n")] [],
+                    },
+                    semicolon_token: missing (optional),
+                },
+                JsUnknownStatement {
+                    items: [
+                        COLON@8..10 ":" [] [Whitespace(" ")],
+                        JS_STRING_LITERAL@10..27 "\"troublesome-lib\"" [] [],
+                        COMMA@27..28 "," [] [],
+                        JS_STRING_LITERAL@28..38 "\"typings\"" [Newline("\n")] [],
+                        COLON@38..40 ":" [] [Whitespace(" ")],
+                        JS_STRING_LITERAL@40..56 "\"lib/index.d.ts\"" [] [],
+                        COMMA@56..57 "," [] [],
+                        JS_STRING_LITERAL@57..67 "\"version\"" [Newline("\n")] [],
+                        COLON@67..69 ":" [] [Whitespace(" ")],
+                        JS_STRING_LITERAL@69..76 "\"0.0.1\"" [] [],
+                    ],
+                },
+            ],
+            r_curly_token: R_CURLY@76..78 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@78..79 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..79
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..78
+    0: JS_BLOCK_STATEMENT@0..78
+      0: L_CURLY@0..1 "{" [] []
+      1: JS_STATEMENT_LIST@1..76
+        0: JS_EXPRESSION_STATEMENT@1..8
+          0: JS_STRING_LITERAL_EXPRESSION@1..8
+            0: JS_STRING_LITERAL@1..8 "\"name\"" [Newline("\n")] []
+          1: (empty)
+        1: JS_UNKNOWN_STATEMENT@8..76
+          0: COLON@8..10 ":" [] [Whitespace(" ")]
+          1: JS_STRING_LITERAL@10..27 "\"troublesome-lib\"" [] []
+          2: COMMA@27..28 "," [] []
+          3: JS_STRING_LITERAL@28..38 "\"typings\"" [Newline("\n")] []
+          4: COLON@38..40 ":" [] [Whitespace(" ")]
+          5: JS_STRING_LITERAL@40..56 "\"lib/index.d.ts\"" [] []
+          6: COMMA@56..57 "," [] []
+          7: JS_STRING_LITERAL@57..67 "\"version\"" [Newline("\n")] []
+          8: COLON@67..69 ":" [] [Whitespace(" ")]
+          9: JS_STRING_LITERAL@69..76 "\"0.0.1\"" [] []
+      2: R_CURLY@76..78 "}" [Newline("\n")] []
+  3: EOF@78..79 "" [Newline("\n")] []
+--
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ statements_closing_curly.js:2:7
+  │
+2 │ "name": "troublesome-lib",
+  │ ------^
+  │ │     │
+  │ │     An explicit or implicit semicolon is expected here...
+  │ ...Which is required to end this statement
+
+--
+{
+"name": "troublesome-lib",
+"typings": "lib/index.d.ts",
+"version": "0.0.1"
+}


### PR DESCRIPTION
## Summary

Example:
```
{
"name": "troublesome-lib",
"typings": "lib/index.d.ts",
"version": "0.0.1"
}
```

The parser tries to parse this as a block statement but then fails because of the `"name":`. The existing error recovery incorrectly eats away all tokens including `}` which then results in a parse error that the closing `}` is missing.

Before:

```
error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
  ┌─ statements_closing_curly.js:3:7
  │
3 │ "name": "troublesome-lib",
  │ ------^
  │ │     │
  │ │     An explicit or implicit semicolon is expected here...
  │ ...Which is required to end this statement

--
error[SyntaxError]: expected `'}'` but instead the file ends
  ┌─ statements_closing_curly.js:7:1
  │
7 │
  │ ^ the file ends here
```

After:

```
error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
  ┌─ statements_closing_curly.js:2:7
  │
2 │ "name": "troublesome-lib",
  │ ------^
  │ │     │
  │ │     An explicit or implicit semicolon is expected here...
  │ ...Which is required to end this statement

```

## Test Plan

Added new parser tests
