### PR TITLE
fix(rslint_parser): Remove `_token` postfix from non-uniono token fields

### DIFF
--- a/crates/rome_formatter/src/utils/call_expression.rs
+++ b/crates/rome_formatter/src/utils/call_expression.rs
@@ -43,9 +43,9 @@ use std::fmt::Debug;
 ///                 .execute() [
 ///                     something
 ///                 ]
-///             ]   
-///         ]   
-///     ]    
+///             ]
+///         ]
+///     ]
 /// ]
 /// ```
 /// So we need to navigate the AST and make sure that `something` is actually
@@ -57,7 +57,7 @@ use std::fmt::Debug;
 /// Our formatter makes sure that we don't format twice the same nodes. Let's say for example that
 /// we find a `something().execute()`, its AST is like this:
 ///
-/// ```block  
+/// ```block
 /// JsCallExpression {
 ///     callee: JsStaticMember {
 ///         object: JsCallExpression {
@@ -71,7 +71,7 @@ use std::fmt::Debug;
 ///
 /// When we track the first [rslint_parser::ast::JsCallExpression], we hold basically all the children,
 /// that applies for the rest of the nodes. If we decided to format all the children of each node,
-/// we will risk to format the last node, the `Reference`, four times.  
+/// we will risk to format the last node, the `Reference`, four times.
 ///
 /// To avoid this, when we encounter particular nodes, we don't format all of its children, but defer
 /// the formatting to the child itself.
@@ -99,7 +99,7 @@ use std::fmt::Debug;
 /// `something()()[1][3].then()`;
 /// 3. as many as consecutive [rslint_parser::ast::JsStaticMemberExpression] or [rslint_parser::ast::JsComputedExpression], this cover cases like
 /// `this.items[0].then()`
-///   
+///
 /// The rest of the groups are essentially a sequence of `[StaticMemberExpression , CallExpression]`.
 /// In order to achieve that, we simply start looping through the rest of the flatten items that we haven't seen.
 ///
@@ -274,7 +274,7 @@ fn flatten_call_expression(
             flatten_call_expression(queue, callee.syntax().to_owned(), formatter)?;
             let formatted = vec![
                 call_expression
-                    .optional_chain_token_token()
+                    .optional_chain_token()
                     .format_or_empty(formatter)?,
                 call_expression
                     .type_arguments()

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -385,7 +385,7 @@ impl JsCallExpression {
     pub fn callee(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn optional_chain_token_token(&self) -> Option<SyntaxToken> {
+    pub fn optional_chain_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 1usize)
     }
     pub fn type_arguments(&self) -> Option<TsTypeArguments> { support::node(&self.syntax, 2usize) }
@@ -3994,7 +3994,7 @@ impl TsIntersectionType {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
-    pub fn leading_separator_token_token(&self) -> Option<SyntaxToken> {
+    pub fn leading_separator_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 0usize)
     }
     pub fn types(&self) -> TsIntersectionTypeElementList { support::list(&self.syntax, 1usize) }
@@ -4981,7 +4981,7 @@ impl TsUnionType {
     #[doc = r" or a match on [SyntaxNode::kind]"]
     #[inline]
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
-    pub fn leading_separator_token_token(&self) -> Option<SyntaxToken> {
+    pub fn leading_separator_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, 0usize)
     }
     pub fn types(&self) -> TsUnionTypeVariantList { support::list(&self.syntax, 1usize) }
@@ -5997,8 +5997,8 @@ impl std::fmt::Debug for JsCallExpression {
         f.debug_struct("JsCallExpression")
             .field("callee", &support::DebugSyntaxResult(self.callee()))
             .field(
-                "optional_chain_token_token",
-                &support::DebugOptionalElement(self.optional_chain_token_token()),
+                "optional_chain_token",
+                &support::DebugOptionalElement(self.optional_chain_token()),
             )
             .field(
                 "type_arguments",
@@ -11387,8 +11387,8 @@ impl std::fmt::Debug for TsIntersectionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TsIntersectionType")
             .field(
-                "leading_separator_token_token",
-                &support::DebugOptionalElement(self.leading_separator_token_token()),
+                "leading_separator_token",
+                &support::DebugOptionalElement(self.leading_separator_token()),
             )
             .field("types", &self.types())
             .finish()
@@ -12948,8 +12948,8 @@ impl std::fmt::Debug for TsUnionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TsUnionType")
             .field(
-                "leading_separator_token_token",
-                &support::DebugOptionalElement(self.leading_separator_token_token()),
+                "leading_separator_token",
+                &support::DebugOptionalElement(self.leading_separator_token()),
             )
             .field("types", &self.types())
             .finish()

--- a/crates/rslint_parser/test_data/inline/err/await_in_parameter_initializer.rast
+++ b/crates/rslint_parser/test_data/inline/err/await_in_parameter_initializer.rast
@@ -30,7 +30,7 @@ JsModule {
                                                 value_token: IDENT@30..31 "b" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@31..32 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/binary_expressions_err.rast
@@ -9,7 +9,7 @@ JsModule {
                         value_token: IDENT@0..3 "foo" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@3..4 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
+++ b/crates/rslint_parser/test_data/inline/err/invalid_arg_list.rast
@@ -9,7 +9,7 @@ JsModule {
                         value_token: IDENT@0..3 "foo" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@3..4 "(" [] [],
@@ -38,7 +38,7 @@ JsModule {
                         value_token: IDENT@8..12 "foo" [Newline("\n")] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@12..13 "(" [] [],
@@ -74,7 +74,7 @@ JsModule {
                         value_token: IDENT@21..26 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@26..27 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/logical_expressions_err.rast
@@ -46,7 +46,7 @@ JsModule {
                         value_token: IDENT@24..28 "foo" [Newline("\n")] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@28..29 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/no_top_level_await_in_scripts.rast
+++ b/crates/rslint_parser/test_data/inline/err/no_top_level_await_in_scripts.rast
@@ -38,7 +38,7 @@ JsScript {
                         value_token: IDENT@41..45 "test" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@45..46 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/err/primary_expr_invalid_recovery.rast
@@ -40,7 +40,7 @@ JsModule {
                         value_token: IDENT@11..14 "foo" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@14..15 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -12,7 +12,7 @@ JsModule {
                                     value_token: IDENT@0..3 "foo" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@3..4 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
@@ -49,7 +49,7 @@ JsModule {
                                             SUPER_KW@33..43 "super" [Newline("\n"), Whitespace("    ")] [],
                                         ],
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@43..44 "(" [] [],
@@ -72,7 +72,7 @@ JsModule {
                                             value_token: IDENT@58..62 "test" [] [],
                                         },
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@62..63 "(" [] [],
@@ -96,7 +96,7 @@ JsModule {
                         SUPER_KW@71..77 "super" [Newline("\n")] [],
                     ],
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@77..78 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_after_optional_chain.rast
@@ -83,7 +83,7 @@ JsModule {
                                 value_token: IDENT@54..58 "func" [] [],
                             },
                         },
-                        optional_chain_token_token: QUESTIONDOT@58..60 "?." [] [],
+                        optional_chain_token: QUESTIONDOT@58..60 "?." [] [],
                         type_arguments: missing (optional),
                         arguments: JsCallArguments {
                             l_paren_token: L_PAREN@60..61 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/unary_delete.rast
+++ b/crates/rslint_parser/test_data/inline/err/unary_delete.rast
@@ -46,7 +46,7 @@ JsModule {
                                     value_token: IDENT@41..45 "func" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@45..46 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/unary_delete_parenthesized.rast
+++ b/crates/rslint_parser/test_data/inline/err/unary_delete_parenthesized.rast
@@ -108,7 +108,7 @@ JsModule {
                                         value_token: IDENT@89..93 "func" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@93..94 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/array_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_assignment_target.rast
@@ -93,7 +93,7 @@ JsModule {
                                         value_token: IDENT@54..58 "call" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@58..59 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/array_assignment_target_rest.rast
+++ b/crates/rslint_parser/test_data/inline/ok/array_assignment_target_rest.rast
@@ -117,7 +117,7 @@ JsModule {
                                                 value_token: IDENT@69..73 "call" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@73..74 "(" [] [],
@@ -164,7 +164,7 @@ JsModule {
                                                 value_token: IDENT@95..105 "expression" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@105..106 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/arrow_in_constructor.rast
+++ b/crates/rslint_parser/test_data/inline/ok/arrow_in_constructor.rast
@@ -47,7 +47,7 @@ JsModule {
                                                     callee: JsSuperExpression {
                                                         super_token: SUPER_KW@40..45 "super" [] [],
                                                     },
-                                                    optional_chain_token_token: missing (optional),
+                                                    optional_chain_token: missing (optional),
                                                     type_arguments: missing (optional),
                                                     arguments: JsCallArguments {
                                                         l_paren_token: L_PAREN@45..46 "(" [] [],
@@ -78,7 +78,7 @@ JsModule {
                                         callee: JsSuperExpression {
                                             super_token: SUPER_KW@61..66 "super" [] [],
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@66..67 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/assignment_target.rast
@@ -132,7 +132,7 @@ JsModule {
                                         value_token: IDENT@85..89 "call" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@89..90 "(" [] [],
@@ -145,7 +145,7 @@ JsModule {
                                 value_token: IDENT@92..97 "chain" [] [],
                             },
                         },
-                        optional_chain_token_token: missing (optional),
+                        optional_chain_token: missing (optional),
                         type_arguments: missing (optional),
                         arguments: JsCallArguments {
                             l_paren_token: L_PAREN@97..98 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/await_expression.rast
@@ -29,7 +29,7 @@ JsModule {
                                         value_token: IDENT@32..37 "inner" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@37..38 "(" [] [],
@@ -52,7 +52,7 @@ JsModule {
                                                 value_token: IDENT@50..55 "inner" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@55..56 "(" [] [],
@@ -72,7 +72,7 @@ JsModule {
                                             value_token: IDENT@67..72 "inner" [] [],
                                         },
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@72..73 "(" [] [],
@@ -126,7 +126,7 @@ JsModule {
                             value_token: IDENT@123..127 "test" [] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@127..128 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -48,7 +48,7 @@ JsModule {
                             callee: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@26..27 "3" [] [],
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@27..29 "(" [Newline("\n")] [],

--- a/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_statement.rast
@@ -17,7 +17,7 @@ JsModule {
                             value_token: IDENT@11..14 "log" [] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@14..15 "(" [] [],
@@ -57,7 +57,7 @@ JsModule {
                                     value_token: IDENT@51..54 "log" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@54..55 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/do_while_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/do_while_stmt.rast
@@ -30,7 +30,7 @@ JsModule {
                                     value_token: IDENT@31..36 "Error" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@36..37 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
+++ b/crates/rslint_parser/test_data/inline/ok/grouping_expr.rast
@@ -17,7 +17,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@6..7 ")" [] [],
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@7..9 "(" [Newline("\n")] [],

--- a/crates/rslint_parser/test_data/inline/ok/in_expr_in_arguments.rast
+++ b/crates/rslint_parser/test_data/inline/ok/in_expr_in_arguments.rast
@@ -32,7 +32,7 @@ JsModule {
                         value_token: IDENT@23..26 "foo" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@26..27 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/js_parenthesized_expression.rast
@@ -17,7 +17,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@6..7 ")" [] [],
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@7..9 "(" [Newline("\n")] [],

--- a/crates/rslint_parser/test_data/inline/ok/module.rast
+++ b/crates/rslint_parser/test_data/inline/ok/module.rast
@@ -41,7 +41,7 @@ JsModule {
                         value_token: IDENT@32..34 "c" [Newline("\n")] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@34..35 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/object_shorthand_property.rast
+++ b/crates/rslint_parser/test_data/inline/ok/object_shorthand_property.rast
@@ -72,7 +72,7 @@ JsModule {
                                                     value_token: IDENT@42..46 "call" [] [],
                                                 },
                                             },
-                                            optional_chain_token_token: missing (optional),
+                                            optional_chain_token: missing (optional),
                                             type_arguments: missing (optional),
                                             arguments: JsCallArguments {
                                                 l_paren_token: L_PAREN@46..47 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/parenthesized_sequence_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/parenthesized_sequence_expression.rast
@@ -153,7 +153,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@56..57 ")" [] [],
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@57..59 "(" [Newline("\n")] [],

--- a/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/property_assignment_target.rast
@@ -85,7 +85,7 @@ JsModule {
                                                 value_token: IDENT@32..36 "test" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@36..37 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
+++ b/crates/rslint_parser/test_data/inline/ok/rest_property_assignment_target.rast
@@ -117,7 +117,7 @@ JsModule {
                                                 value_token: IDENT@69..73 "call" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@73..74 "(" [] [],
@@ -164,7 +164,7 @@ JsModule {
                                                 value_token: IDENT@95..105 "expression" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@105..106 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/subscripts.rast
+++ b/crates/rslint_parser/test_data/inline/ok/subscripts.rast
@@ -30,7 +30,7 @@ JsModule {
                                     value_token: IDENT@8..12 "foo" [Newline("\n")] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@12..13 "(" [] [],
@@ -44,7 +44,7 @@ JsModule {
                                 r_paren_token: R_PAREN@16..17 ")" [] [],
                             },
                         },
-                        optional_chain_token_token: missing (optional),
+                        optional_chain_token: missing (optional),
                         type_arguments: missing (optional),
                         arguments: JsCallArguments {
                             l_paren_token: L_PAREN@17..18 "(" [] [],
@@ -58,7 +58,7 @@ JsModule {
                             r_paren_token: R_PAREN@21..22 ")" [] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@22..23 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -40,7 +40,7 @@ JsModule {
                                     callee: JsSuperExpression {
                                         super_token: SUPER_KW@40..50 "super" [Newline("\n"), Whitespace("    ")] [],
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@50..51 "(" [] [],
@@ -86,7 +86,7 @@ JsModule {
                                             value_token: IDENT@79..83 "test" [] [],
                                         },
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@83..84 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_call_expr_with_type_arguments.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_call_expr_with_type_arguments.rast
@@ -58,7 +58,7 @@ JsModule {
                         value_token: IDENT@24..26 "a" [Newline("\n")] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: TsTypeArguments {
                     l_angle_token: L_ANGLE@26..27 "<" [] [],
                     ts_type_argument_list: TsTypeArgumentList [
@@ -133,7 +133,7 @@ JsModule {
                                 value_token: IDENT@53..54 "a" [] [],
                             },
                         },
-                        optional_chain_token_token: missing (optional),
+                        optional_chain_token: missing (optional),
                         type_arguments: TsTypeArguments {
                             l_angle_token: L_ANGLE@54..55 "<" [] [],
                             ts_type_argument_list: TsTypeArgumentList [
@@ -166,7 +166,7 @@ JsModule {
                             r_paren_token: R_PAREN@64..65 ")" [] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@65..67 "(" [Newline("\n")] [],
@@ -191,7 +191,7 @@ JsModule {
                         r_paren_token: R_PAREN@74..75 ")" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: TsTypeArguments {
                     l_angle_token: L_ANGLE@75..76 "<" [] [],
                     ts_type_argument_list: TsTypeArgumentList [

--- a/crates/rslint_parser/test_data/inline/ok/ts_declare_type_alias.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_declare_type_alias.rast
@@ -27,14 +27,14 @@ JsModule {
                 type_parameters: missing (optional),
                 eq_token: EQ@40..42 "=" [] [Whitespace(" ")],
                 ty: TsUnionType {
-                    leading_separator_token_token: missing (optional),
+                    leading_separator_token: missing (optional),
                     types: TsUnionTypeVariantList [
                         TsStringType {
                             string_token: STRING_KW@42..49 "string" [] [Whitespace(" ")],
                         },
                         PIPE@49..51 "|" [] [Whitespace(" ")],
                         TsIntersectionType {
-                            leading_separator_token_token: missing (optional),
+                            leading_separator_token: missing (optional),
                             types: TsIntersectionTypeElementList [
                                 TsNumberType {
                                     number_token: NUMBER_KW@51..58 "number" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_default_type_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_default_type_clause.rast
@@ -49,7 +49,7 @@ JsModule {
                         constraint: TsTypeConstraintClause {
                             extends_token: EXTENDS_KW@31..39 "extends" [] [Whitespace(" ")],
                             ty: TsUnionType {
-                                leading_separator_token_token: missing (optional),
+                                leading_separator_token: missing (optional),
                                 types: TsUnionTypeVariantList [
                                     TsNumberType {
                                         number_token: NUMBER_KW@39..46 "number" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_function_overload.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_function_overload.rast
@@ -55,7 +55,7 @@ JsModule {
                         type_annotation: TsTypeAnnotation {
                             colon_token: COLON@47..49 ":" [] [Whitespace(" ")],
                             ty: TsUnionType {
-                                leading_separator_token_token: missing (optional),
+                                leading_separator_token: missing (optional),
                                 types: TsUnionTypeVariantList [
                                     TsStringType {
                                         string_token: STRING_KW@49..56 "string" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_global_variable.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_global_variable.rast
@@ -38,7 +38,7 @@ JsModule {
                         value_token: IDENT@55..58 "log" [] [],
                     },
                 },
-                optional_chain_token_token: missing (optional),
+                optional_chain_token: missing (optional),
                 type_arguments: missing (optional),
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@58..59 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_intersection_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_intersection_type.rast
@@ -10,7 +10,7 @@ JsModule {
             type_parameters: missing (optional),
             eq_token: EQ@7..9 "=" [] [Whitespace(" ")],
             ty: TsIntersectionType {
-                leading_separator_token_token: missing (optional),
+                leading_separator_token: missing (optional),
                 types: TsIntersectionTypeElementList [
                     TsStringType {
                         string_token: STRING_KW@9..16 "string" [] [Whitespace(" ")],
@@ -31,7 +31,7 @@ JsModule {
             type_parameters: missing (optional),
             eq_token: EQ@33..35 "=" [] [Whitespace(" ")],
             ty: TsIntersectionType {
-                leading_separator_token_token: AMP@35..37 "&" [] [Whitespace(" ")],
+                leading_separator_token: AMP@35..37 "&" [] [Whitespace(" ")],
                 types: TsIntersectionTypeElementList [
                     TsReferenceType {
                         name: JsReferenceIdentifier {

--- a/crates/rslint_parser/test_data/inline/ok/ts_mapped_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_mapped_type.rast
@@ -18,7 +18,7 @@ JsModule {
                 },
                 in_token: IN_KW@17..20 "in" [] [Whitespace(" ")],
                 keys_type: TsUnionType {
-                    leading_separator_token_token: missing (optional),
+                    leading_separator_token: missing (optional),
                     types: TsUnionTypeVariantList [
                         TsStringLiteralType {
                             literal_token: JS_STRING_LITERAL@20..24 "\"a\"" [] [Whitespace(" ")],
@@ -274,7 +274,7 @@ JsModule {
                                         l_angle_token: L_ANGLE@328..329 "<" [] [],
                                         ts_type_argument_list: TsTypeArgumentList [
                                             TsIntersectionType {
-                                                leading_separator_token_token: missing (optional),
+                                                leading_separator_token: missing (optional),
                                                 types: TsIntersectionTypeElementList [
                                                     TsStringType {
                                                         string_token: STRING_KW@329..336 "string" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_non_null_assertion_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_non_null_assertion_expression.rast
@@ -76,7 +76,7 @@ JsModule {
                             value_token: IDENT@41..46 "test" [Newline("\n")] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@46..47 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_optional_chain_call.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_optional_chain_call.rast
@@ -45,7 +45,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@15..16 ")" [] [],
                 },
-                optional_chain_token_token: QUESTIONDOT@16..18 "?." [] [],
+                optional_chain_token: QUESTIONDOT@16..18 "?." [] [],
                 type_arguments: TsTypeArguments {
                     l_angle_token: L_ANGLE@18..19 "<" [] [],
                     ts_type_argument_list: TsTypeArgumentList [

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_constraint_clause.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_constraint_clause.rast
@@ -49,7 +49,7 @@ JsModule {
                         constraint: TsTypeConstraintClause {
                             extends_token: EXTENDS_KW@39..47 "extends" [] [Whitespace(" ")],
                             ty: TsUnionType {
-                                leading_separator_token_token: missing (optional),
+                                leading_separator_token: missing (optional),
                                 types: TsUnionTypeVariantList [
                                     TsNumberType {
                                         number_token: NUMBER_KW@47..54 "number" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_operator.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_operator.rast
@@ -107,7 +107,7 @@ JsModule {
                                         value_token: IDENT@106..112 "Symbol" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@112..113 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_parameters.rast
@@ -43,7 +43,7 @@ JsModule {
                         constraint: TsTypeConstraintClause {
                             extends_token: EXTENDS_KW@39..47 "extends" [] [Whitespace(" ")],
                             ty: TsUnionType {
-                                leading_separator_token_token: missing (optional),
+                                leading_separator_token: missing (optional),
                                 types: TsUnionTypeVariantList [
                                     TsStringType {
                                         string_token: STRING_KW@47..54 "string" [] [Whitespace(" ")],

--- a/crates/rslint_parser/test_data/inline/ok/ts_type_variable.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_type_variable.rast
@@ -29,7 +29,7 @@ JsModule {
                             value_token: IDENT@17..41 "getFlowTypeInConstructor" [] [],
                         },
                     },
-                    optional_chain_token_token: missing (optional),
+                    optional_chain_token: missing (optional),
                     type_arguments: missing (optional),
                     arguments: JsCallArguments {
                         l_paren_token: L_PAREN@41..42 "(" [] [],
@@ -47,7 +47,7 @@ JsModule {
                                             value_token: IDENT@50..73 "getDeclaringConstructor" [] [],
                                         },
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@73..74 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_union_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_union_type.rast
@@ -10,7 +10,7 @@ JsModule {
             type_parameters: missing (optional),
             eq_token: EQ@7..9 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
-                leading_separator_token_token: missing (optional),
+                leading_separator_token: missing (optional),
                 types: TsUnionTypeVariantList [
                     TsStringType {
                         string_token: STRING_KW@9..16 "string" [] [Whitespace(" ")],
@@ -31,7 +31,7 @@ JsModule {
             type_parameters: missing (optional),
             eq_token: EQ@33..35 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
-                leading_separator_token_token: PIPE@35..37 "|" [] [Whitespace(" ")],
+                leading_separator_token: PIPE@35..37 "|" [] [Whitespace(" ")],
                 types: TsUnionTypeVariantList [
                     TsReferenceType {
                         name: JsReferenceIdentifier {
@@ -59,10 +59,10 @@ JsModule {
             type_parameters: missing (optional),
             eq_token: EQ@61..63 "=" [] [Whitespace(" ")],
             ty: TsUnionType {
-                leading_separator_token_token: missing (optional),
+                leading_separator_token: missing (optional),
                 types: TsUnionTypeVariantList [
                     TsIntersectionType {
-                        leading_separator_token_token: missing (optional),
+                        leading_separator_token: missing (optional),
                         types: TsIntersectionTypeElementList [
                             TsReferenceType {
                                 name: JsReferenceIdentifier {

--- a/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.rast
+++ b/crates/rslint_parser/test_data/inline/ok/type_arguments_no_recovery.rast
@@ -58,7 +58,7 @@ JsModule {
                                     value_token: IDENT@42..53 "completions" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@53..54 "(" [] [],
@@ -135,7 +135,7 @@ JsModule {
                                                                                     value_token: IDENT@150..156 "ranges" [] [],
                                                                                 },
                                                                             },
-                                                                            optional_chain_token_token: missing (optional),
+                                                                            optional_chain_token: missing (optional),
                                                                             type_arguments: missing (optional),
                                                                             arguments: JsCallArguments {
                                                                                 l_paren_token: L_PAREN@156..157 "(" [] [],
@@ -188,7 +188,7 @@ JsModule {
                                                                                     value_token: IDENT@214..220 "ranges" [] [],
                                                                                 },
                                                                             },
-                                                                            optional_chain_token_token: missing (optional),
+                                                                            optional_chain_token: missing (optional),
                                                                             type_arguments: missing (optional),
                                                                             arguments: JsCallArguments {
                                                                                 l_paren_token: L_PAREN@220..221 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/typescript_abstract_classes.rast
+++ b/crates/rslint_parser/test_data/inline/ok/typescript_abstract_classes.rast
@@ -135,7 +135,7 @@ JsModule {
                                             value_token: IDENT@153..156 "log" [] [],
                                         },
                                     },
-                                    optional_chain_token_token: missing (optional),
+                                    optional_chain_token: missing (optional),
                                     type_arguments: missing (optional),
                                     arguments: JsCallArguments {
                                         l_paren_token: L_PAREN@156..157 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/unary_delete.rast
+++ b/crates/rslint_parser/test_data/inline/ok/unary_delete.rast
@@ -103,7 +103,7 @@ JsModule {
                                     value_token: IDENT@91..95 "func" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@95..96 "(" [] [],
@@ -138,7 +138,7 @@ JsModule {
                                         value_token: IDENT@119..123 "func" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@123..124 "(" [] [],
@@ -395,7 +395,7 @@ JsModule {
                                     value_token: IDENT@351..355 "func" [] [],
                                 },
                             },
-                            optional_chain_token_token: missing (optional),
+                            optional_chain_token: missing (optional),
                             type_arguments: missing (optional),
                             arguments: JsCallArguments {
                                 l_paren_token: L_PAREN@355..356 "(" [] [],
@@ -434,7 +434,7 @@ JsModule {
                                         value_token: IDENT@380..384 "func" [] [],
                                     },
                                 },
-                                optional_chain_token_token: missing (optional),
+                                optional_chain_token: missing (optional),
                                 type_arguments: missing (optional),
                                 arguments: JsCallArguments {
                                     l_paren_token: L_PAREN@384..385 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/unary_delete_nested.rast
+++ b/crates/rslint_parser/test_data/inline/ok/unary_delete_nested.rast
@@ -62,7 +62,7 @@ JsModule {
                                                 value_token: IDENT@52..56 "func" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@56..57 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rslint_parser/test_data/inline/ok/with_statement.rast
@@ -63,7 +63,7 @@ JsScript {
                                                 value_token: IDENT@54..57 "log" [] [],
                                             },
                                         },
-                                        optional_chain_token_token: missing (optional),
+                                        optional_chain_token: missing (optional),
                                         type_arguments: missing (optional),
                                         arguments: JsCallArguments {
                                             l_paren_token: L_PAREN@57..58 "(" [] [],

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -348,7 +348,7 @@ JsNewExpression =
 // call expression
 JsCallExpression =
 	callee: JsAnyExpression
-	optional_chain_token: '?.'?
+	optional_chain: '?.'?
 	type_arguments: TsTypeArguments?
 	arguments: JsCallArguments
 
@@ -1652,14 +1652,14 @@ TsEmptyExternalModuleDeclarationBody = ';'
 
 // | a | b
 TsUnionType =
-	leading_separator_token: '|'?
+	leading_separator: '|'?
 	types: TsUnionTypeVariantList
 
 TsUnionTypeVariantList = (TsType ('|' TsType)*)
 
 // & a & b
 TsIntersectionType =
-	leading_separator_token: '&'?
+	leading_separator: '&'?
 	types: TsIntersectionTypeElementList
 
 TsIntersectionTypeElementList = (TsType ('&' TsType)*)


### PR DESCRIPTION
## Summary

Remove the `_token` prefix from non-union token fields because the codegen already appends the `_token` postfix (resulting in `.._token_token`).

