### PR TITLE
refactor(rome_formatter): use node destructuring in JS

### DIFF
--- a/crates/rome_formatter/src/js/assignments/array_assignment_pattern.rs
+++ b/crates/rome_formatter/src/js/assignments/array_assignment_pattern.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsArrayAssignmentPattern;
+use rslint_parser::ast::JsArrayAssignmentPatternFields;
 
 impl ToFormatElement for JsArrayAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsArrayAssignmentPatternFields {
+            l_brack_token,
+            elements,
+            r_brack_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_brack_token()?,
-            self.elements().format(formatter)?,
-            &self.r_brack_token()?,
+            &l_brack_token?,
+            elements.format(formatter)?,
+            &r_brack_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
+++ b/crates/rome_formatter/src/js/assignments/array_assignment_pattern_rest_element.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsArrayAssignmentPatternRestElement;
+use rslint_parser::ast::JsArrayAssignmentPatternRestElementFields;
 
 impl ToFormatElement for JsArrayAssignmentPatternRestElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsArrayAssignmentPatternRestElementFields {
+            dotdotdot_token,
+            pattern,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.pattern().format(formatter)?
+            dotdotdot_token.format(formatter)?,
+            pattern.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/assignment_with_default.rs
+++ b/crates/rome_formatter/src/js/assignments/assignment_with_default.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsAssignmentWithDefault;
+use rslint_parser::ast::JsAssignmentWithDefaultFields;
 
 impl ToFormatElement for JsAssignmentWithDefault {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsAssignmentWithDefaultFields {
+            pattern,
+            eq_token,
+            default,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.pattern().format(formatter)?,
+            pattern.format(formatter)?,
             space_token(),
-            self.eq_token().format(formatter)?,
+            eq_token.format(formatter)?,
             space_token(),
-            self.default().format(formatter)?,
+            default.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/computed_member_assignment.rs
+++ b/crates/rome_formatter/src/js/assignments/computed_member_assignment.rs
@@ -3,14 +3,22 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsComputedMemberAssignment;
+use rslint_parser::ast::JsComputedMemberAssignmentFields;
 
 impl ToFormatElement for JsComputedMemberAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsComputedMemberAssignmentFields {
+            object,
+            l_brack_token,
+            member,
+            r_brack_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.object().format(formatter)?,
-            self.l_brack_token().format(formatter)?,
-            self.member().format(formatter)?,
-            self.r_brack_token().format(formatter)?,
+            object.format(formatter)?,
+            l_brack_token.format(formatter)?,
+            member.format(formatter)?,
+            r_brack_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/identifier_assignment.rs
+++ b/crates/rome_formatter/src/js/assignments/identifier_assignment.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsIdentifierAssignment;
+use rslint_parser::ast::JsIdentifierAssignmentFields;
 
 impl ToFormatElement for JsIdentifierAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.name_token().format(formatter)
+        let JsIdentifierAssignmentFields { name_token } = self.as_fields();
+
+        name_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/assignments/object_assignment_pattern.rs
+++ b/crates/rome_formatter/src/js/assignments/object_assignment_pattern.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectAssignmentPattern;
+use rslint_parser::ast::JsObjectAssignmentPatternFields;
 
 impl ToFormatElement for JsObjectAssignmentPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsObjectAssignmentPatternFields {
+            l_curly_token,
+            properties,
+            r_curly_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
-            self.properties().format(formatter)?,
-            &self.r_curly_token()?,
+            &l_curly_token?,
+            properties.format(formatter)?,
+            &r_curly_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/assignments/object_assignment_pattern_property.rs
+++ b/crates/rome_formatter/src/js/assignments/object_assignment_pattern_property.rs
@@ -5,17 +5,24 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectAssignmentPatternProperty;
+use rslint_parser::ast::JsObjectAssignmentPatternPropertyFields;
 
 impl ToFormatElement for JsObjectAssignmentPatternProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let init_node = self
-            .init()
-            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
+        let JsObjectAssignmentPatternPropertyFields {
+            member,
+            colon_token,
+            pattern,
+            init,
+        } = self.as_fields();
+
+        let init_node =
+            init.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
         Ok(format_elements![
-            self.member().format(formatter)?,
-            self.colon_token().format(formatter)?,
+            member.format(formatter)?,
+            colon_token.format(formatter)?,
             space_token(),
-            self.pattern().format(formatter)?,
+            pattern.format(formatter)?,
             init_node,
         ])
     }

--- a/crates/rome_formatter/src/js/assignments/object_assignment_pattern_rest.rs
+++ b/crates/rome_formatter/src/js/assignments/object_assignment_pattern_rest.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsObjectAssignmentPatternRest;
+use rslint_parser::ast::JsObjectAssignmentPatternRestFields;
 
 impl ToFormatElement for JsObjectAssignmentPatternRest {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsObjectAssignmentPatternRestFields {
+            dotdotdot_token,
+            target,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.target().format(formatter)?,
+            dotdotdot_token.format(formatter)?,
+            target.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
+++ b/crates/rome_formatter/src/js/assignments/object_assignment_pattern_shorthand_property.rs
@@ -5,15 +5,15 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectAssignmentPatternShorthandProperty;
+use rslint_parser::ast::JsObjectAssignmentPatternShorthandPropertyFields;
 
 impl ToFormatElement for JsObjectAssignmentPatternShorthandProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let init_node = self
-            .init()
-            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
-        Ok(format_elements![
-            self.identifier().format(formatter)?,
-            init_node
-        ])
+        let JsObjectAssignmentPatternShorthandPropertyFields { identifier, init } =
+            self.as_fields();
+
+        let init_node =
+            init.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
+        Ok(format_elements![identifier.format(formatter)?, init_node])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/parenthesized_assignment.rs
+++ b/crates/rome_formatter/src/js/assignments/parenthesized_assignment.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsParenthesizedAssignment;
+use rslint_parser::ast::JsParenthesizedAssignmentFields;
 
 impl ToFormatElement for JsParenthesizedAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsParenthesizedAssignmentFields {
+            l_paren_token,
+            assignment,
+            r_paren_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.l_paren_token().format(formatter)?,
-            self.assignment().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            l_paren_token.format(formatter)?,
+            assignment.format(formatter)?,
+            r_paren_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/assignments/static_member_assignment.rs
+++ b/crates/rome_formatter/src/js/assignments/static_member_assignment.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsStaticMemberAssignment;
+use rslint_parser::ast::JsStaticMemberAssignmentFields;
 
 impl ToFormatElement for JsStaticMemberAssignment {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsStaticMemberAssignmentFields {
+            object,
+            dot_token,
+            member,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.object().format(formatter)?,
-            self.dot_token().format(formatter)?,
-            self.member().format(formatter)?,
+            object.format(formatter)?,
+            dot_token.format(formatter)?,
+            member.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/case_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/case_clause.rs
@@ -8,13 +8,21 @@ use crate::{
 };
 
 use rslint_parser::ast::JsCaseClause;
+use rslint_parser::ast::JsCaseClauseFields;
 
 impl ToFormatElement for JsCaseClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let case_word = self.case_token().format(formatter)?;
-        let colon = self.colon_token().format(formatter)?;
-        let test = self.test().format(formatter)?;
-        let cons = formatter.format_list(self.consequent());
+        let JsCaseClauseFields {
+            case_token,
+            test,
+            colon_token,
+            consequent,
+        } = self.as_fields();
+
+        let case_word = case_token.format(formatter)?;
+        let colon = colon_token.format(formatter)?;
+        let test = test.format(formatter)?;
+        let cons = formatter.format_list(consequent);
 
         Ok(format_elements![
             case_word,

--- a/crates/rome_formatter/src/js/auxiliary/catch_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/catch_clause.rs
@@ -5,25 +5,32 @@ use crate::{
 };
 
 use rslint_parser::ast::JsCatchClause;
+use rslint_parser::ast::JsCatchClauseFields;
 
 impl ToFormatElement for JsCatchClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.declaration().format_with_or(
+        let JsCatchClauseFields {
+            catch_token,
+            declaration,
+            body,
+        } = self.as_fields();
+
+        declaration.format_with_or(
             formatter,
             |declaration| {
                 Ok(format_elements![
-                    self.catch_token().format(formatter)?,
+                    catch_token.format(formatter)?,
                     space_token(),
                     declaration,
                     space_token(),
-                    self.body().format(formatter)?
+                    body.format(formatter)?
                 ])
             },
             || {
                 Ok(format_elements![
-                    self.catch_token().format(formatter)?,
+                    catch_token.format(formatter)?,
                     space_token(),
-                    self.body().format(formatter)?
+                    body.format(formatter)?
                 ])
             },
         )

--- a/crates/rome_formatter/src/js/auxiliary/default_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/default_clause.rs
@@ -8,12 +8,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsDefaultClause;
+use rslint_parser::ast::JsDefaultClauseFields;
 
 impl ToFormatElement for JsDefaultClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default = self.default_token().format(formatter)?;
-        let colon = self.colon_token().format(formatter)?;
-        let statements = formatter.format_list(self.consequent());
+        let JsDefaultClauseFields {
+            default_token,
+            colon_token,
+            consequent,
+        } = self.as_fields();
+
+        let default = default_token.format(formatter)?;
+        let colon = colon_token.format(formatter)?;
+        let statements = formatter.format_list(consequent);
 
         Ok(format_elements![
             default,

--- a/crates/rome_formatter/src/js/auxiliary/directive.rs
+++ b/crates/rome_formatter/src/js/auxiliary/directive.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsDirective;
+use rslint_parser::ast::JsDirectiveFields;
 
 impl ToFormatElement for JsDirective {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsDirectiveFields {
+            value_token,
+            semicolon_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.value_token().format(formatter)?,
-            self.semicolon_token().format_or(formatter, || token(";"))?,
+            value_token.format(formatter)?,
+            semicolon_token.format_or(formatter, || token(";"))?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/else_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/else_clause.rs
@@ -5,13 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsElseClause;
+use rslint_parser::ast::JsElseClauseFields;
 
 impl ToFormatElement for JsElseClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsElseClauseFields {
+            else_token,
+            alternate,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.else_token().format(formatter)?,
+            else_token.format(formatter)?,
             space_token(),
-            self.alternate().format(formatter)?,
+            alternate.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/expression_snipped.rs
+++ b/crates/rome_formatter/src/js/auxiliary/expression_snipped.rs
@@ -3,12 +3,18 @@ use crate::{
     ToFormatElement,
 };
 use rslint_parser::ast::JsExpressionSnipped;
+use rslint_parser::ast::JsExpressionSnippedFields;
 
 impl ToFormatElement for JsExpressionSnipped {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsExpressionSnippedFields {
+            expression,
+            eof_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.expression().format(formatter)?,
-            self.eof_token().format(formatter)?,
+            expression.format(formatter)?,
+            eof_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/finally_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/finally_clause.rs
@@ -5,13 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsFinallyClause;
+use rslint_parser::ast::JsFinallyClauseFields;
 
 impl ToFormatElement for JsFinallyClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsFinallyClauseFields {
+            finally_token,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.finally_token().format(formatter)?,
+            finally_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/function_body.rs
+++ b/crates/rome_formatter/src/js/auxiliary/function_body.rs
@@ -4,16 +4,24 @@ use crate::{
 };
 
 use rslint_parser::ast::JsFunctionBody;
+use rslint_parser::ast::JsFunctionBodyFields;
 
 impl ToFormatElement for JsFunctionBody {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsFunctionBodyFields {
+            l_curly_token,
+            directives,
+            statements,
+            r_curly_token,
+        } = self.as_fields();
+
         formatter.format_delimited_block_indent(
-            &self.l_curly_token()?,
+            &l_curly_token?,
             format_elements![
-                self.directives().format(formatter)?,
-                formatter.format_list(self.statements()),
+                directives.format(formatter)?,
+                formatter.format_list(statements),
             ],
-            &self.r_curly_token()?,
+            &r_curly_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/initializer_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/initializer_clause.rs
@@ -5,13 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsInitializerClause;
+use rslint_parser::ast::JsInitializerClauseFields;
 
 impl ToFormatElement for JsInitializerClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsInitializerClauseFields {
+            eq_token,
+            expression,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.eq_token().format(formatter)?,
+            eq_token.format(formatter)?,
             space_token(),
-            self.expression().format(formatter)?
+            expression.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/module.rs
+++ b/crates/rome_formatter/src/js/auxiliary/module.rs
@@ -4,14 +4,22 @@ use crate::{
     FormatResult, Formatter, ToFormatElement,
 };
 use rslint_parser::ast::JsModule;
+use rslint_parser::ast::JsModuleFields;
 
 impl ToFormatElement for JsModule {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsModuleFields {
+            interpreter_token,
+            directives,
+            items,
+            eof_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            format_interpreter(self.interpreter_token(), formatter)?,
-            self.directives().format(formatter)?,
-            formatter.format_list(self.items()),
-            self.eof_token().format(formatter)?,
+            format_interpreter(interpreter_token, formatter)?,
+            directives.format(formatter)?,
+            formatter.format_list(items),
+            eof_token.format(formatter)?,
             hard_line_break()
         ])
     }

--- a/crates/rome_formatter/src/js/auxiliary/name.rs
+++ b/crates/rome_formatter/src/js/auxiliary/name.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsName;
+use rslint_parser::ast::JsNameFields;
 
 impl ToFormatElement for JsName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsNameFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/new_target.rs
+++ b/crates/rome_formatter/src/js/auxiliary/new_target.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::NewTarget;
+use rslint_parser::ast::NewTargetFields;
 
 impl ToFormatElement for NewTarget {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let NewTargetFields {
+            new_token,
+            dot_token,
+            target_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.new_token().format(formatter)?,
-            self.dot_token().format(formatter)?,
-            self.target_token().format(formatter)?,
+            new_token.format(formatter)?,
+            dot_token.format(formatter)?,
+            target_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/private_name.rs
+++ b/crates/rome_formatter/src/js/auxiliary/private_name.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsPrivateName;
+use rslint_parser::ast::JsPrivateNameFields;
 
 impl ToFormatElement for JsPrivateName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsPrivateNameFields {
+            hash_token,
+            value_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.hash_token().format(formatter)?,
-            self.value_token().format(formatter)?
+            hash_token.format(formatter)?,
+            value_token.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/reference_identifier.rs
+++ b/crates/rome_formatter/src/js/auxiliary/reference_identifier.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsReferenceIdentifier;
+use rslint_parser::ast::JsReferenceIdentifierFields;
 
 impl ToFormatElement for JsReferenceIdentifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsReferenceIdentifierFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/script.rs
+++ b/crates/rome_formatter/src/js/auxiliary/script.rs
@@ -5,14 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsScript;
+use rslint_parser::ast::JsScriptFields;
 
 impl ToFormatElement for JsScript {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsScriptFields {
+            interpreter_token,
+            directives,
+            statements,
+            eof_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            format_interpreter(self.interpreter_token(), formatter)?,
-            self.directives().format(formatter)?,
-            formatter.format_list(self.statements()),
-            self.eof_token().format(formatter)?,
+            format_interpreter(interpreter_token, formatter)?,
+            directives.format(formatter)?,
+            formatter.format_list(statements),
+            eof_token.format(formatter)?,
             hard_line_break()
         ])
     }

--- a/crates/rome_formatter/src/js/auxiliary/spread.rs
+++ b/crates/rome_formatter/src/js/auxiliary/spread.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsSpread;
+use rslint_parser::ast::JsSpreadFields;
 
 impl ToFormatElement for JsSpread {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsSpreadFields {
+            dotdotdot_token,
+            argument,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.argument().format(formatter)?
+            dotdotdot_token.format(formatter)?,
+            argument.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/variable_declaration_clause.rs
+++ b/crates/rome_formatter/src/js/auxiliary/variable_declaration_clause.rs
@@ -3,11 +3,17 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsVariableDeclarationClause;
+use rslint_parser::ast::JsVariableDeclarationClauseFields;
 
 impl ToFormatElement for JsVariableDeclarationClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let declarations = self.declaration().format(formatter)?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let JsVariableDeclarationClauseFields {
+            declaration,
+            semicolon_token,
+        } = self.as_fields();
+
+        let declarations = declaration.format(formatter)?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![declarations, semicolon])
     }

--- a/crates/rome_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_formatter/src/js/auxiliary/variable_declarator.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::utils::format_initializer_clause;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsVariableDeclarator;
@@ -14,6 +14,10 @@ impl ToFormatElement for JsVariableDeclarator {
 
         let initializer = format_initializer_clause(formatter, initializer)?;
 
-        Ok(format_elements![id.format(formatter)?, initializer])
+        Ok(format_elements![
+            id.format(formatter)?,
+            variable_annotation.format_or_empty(formatter)?,
+            initializer
+        ])
     }
 }

--- a/crates/rome_formatter/src/js/auxiliary/variable_declarator.rs
+++ b/crates/rome_formatter/src/js/auxiliary/variable_declarator.rs
@@ -2,11 +2,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::utils::format_initializer_clause;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsVariableDeclarator;
+use rslint_parser::ast::JsVariableDeclaratorFields;
 
 impl ToFormatElement for JsVariableDeclarator {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let initializer = format_initializer_clause(formatter, self.initializer())?;
+        let JsVariableDeclaratorFields {
+            id,
+            variable_annotation,
+            initializer,
+        } = self.as_fields();
 
-        Ok(format_elements![self.id().format(formatter)?, initializer])
+        let initializer = format_initializer_clause(formatter, initializer)?;
+
+        Ok(format_elements![id.format(formatter)?, initializer])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/array_binding_pattern.rs
+++ b/crates/rome_formatter/src/js/bindings/array_binding_pattern.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsArrayBindingPattern;
+use rslint_parser::ast::JsArrayBindingPatternFields;
 
 impl ToFormatElement for JsArrayBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsArrayBindingPatternFields {
+            l_brack_token,
+            elements,
+            r_brack_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_brack_token()?,
-            self.elements().format(formatter)?,
-            &self.r_brack_token()?,
+            &l_brack_token?,
+            elements.format(formatter)?,
+            &r_brack_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
+++ b/crates/rome_formatter/src/js/bindings/array_binding_pattern_rest_element.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsArrayBindingPatternRestElement;
+use rslint_parser::ast::JsArrayBindingPatternRestElementFields;
 
 impl ToFormatElement for JsArrayBindingPatternRestElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsArrayBindingPatternRestElementFields {
+            dotdotdot_token,
+            pattern,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.pattern().format(formatter)?,
+            dotdotdot_token.format(formatter)?,
+            pattern.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/binding_pattern_with_default.rs
+++ b/crates/rome_formatter/src/js/bindings/binding_pattern_with_default.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsBindingPatternWithDefault;
+use rslint_parser::ast::JsBindingPatternWithDefaultFields;
 
 impl ToFormatElement for JsBindingPatternWithDefault {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsBindingPatternWithDefaultFields {
+            pattern,
+            eq_token,
+            default,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.pattern().format(formatter)?,
+            pattern.format(formatter)?,
             space_token(),
-            self.eq_token().format(formatter)?,
+            eq_token.format(formatter)?,
             space_token(),
-            self.default().format(formatter)?
+            default.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/constructor_parameters.rs
+++ b/crates/rome_formatter/src/js/bindings/constructor_parameters.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsConstructorParameters;
+use rslint_parser::ast::JsConstructorParametersFields;
 
 impl ToFormatElement for JsConstructorParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsConstructorParametersFields {
+            l_paren_token,
+            parameters,
+            r_paren_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_paren_token()?,
-            self.parameters().format(formatter)?,
-            &self.r_paren_token()?,
+            &l_paren_token?,
+            parameters.format(formatter)?,
+            &r_paren_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_formatter/src/js/bindings/formal_parameter.rs
@@ -18,6 +18,7 @@ impl ToFormatElement for JsFormalParameter {
 
         Ok(format_elements![
             binding.format(formatter)?,
+            question_mark_token.format_or_empty(formatter)?,
             type_annotation,
             initializer
         ])

--- a/crates/rome_formatter/src/js/bindings/formal_parameter.rs
+++ b/crates/rome_formatter/src/js/bindings/formal_parameter.rs
@@ -2,14 +2,22 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::utils::format_initializer_clause;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsFormalParameter;
+use rslint_parser::ast::JsFormalParameterFields;
 
 impl ToFormatElement for JsFormalParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_annotation = self.type_annotation().format_or_empty(formatter)?;
-        let initializer = format_initializer_clause(formatter, self.initializer())?;
+        let JsFormalParameterFields {
+            binding,
+            question_mark_token,
+            type_annotation,
+            initializer,
+        } = self.as_fields();
+
+        let type_annotation = type_annotation.format_or_empty(formatter)?;
+        let initializer = format_initializer_clause(formatter, initializer)?;
 
         Ok(format_elements![
-            self.binding().format(formatter)?,
+            binding.format(formatter)?,
             type_annotation,
             initializer
         ])

--- a/crates/rome_formatter/src/js/bindings/identifier_binding.rs
+++ b/crates/rome_formatter/src/js/bindings/identifier_binding.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsIdentifierBinding;
+use rslint_parser::ast::JsIdentifierBindingFields;
 
 impl ToFormatElement for JsIdentifierBinding {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.name_token().format(formatter)
+        let JsIdentifierBindingFields { name_token } = self.as_fields();
+
+        name_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_formatter/src/js/bindings/object_binding_pattern.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectBindingPattern;
+use rslint_parser::ast::JsObjectBindingPatternFields;
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsObjectBindingPatternFields {
+            l_curly_token,
+            properties,
+            r_curly_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
-            self.properties().format(formatter)?,
-            &self.r_curly_token()?,
+            &l_curly_token?,
+            properties.format(formatter)?,
+            &r_curly_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/object_binding_pattern_property.rs
+++ b/crates/rome_formatter/src/js/bindings/object_binding_pattern_property.rs
@@ -5,17 +5,24 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectBindingPatternProperty;
+use rslint_parser::ast::JsObjectBindingPatternPropertyFields;
 
 impl ToFormatElement for JsObjectBindingPatternProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let init_node = self
-            .init()
-            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
+        let JsObjectBindingPatternPropertyFields {
+            member,
+            colon_token,
+            pattern,
+            init,
+        } = self.as_fields();
+
+        let init_node =
+            init.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
         Ok(format_elements![
-            self.member().format(formatter)?,
-            self.colon_token().format(formatter)?,
+            member.format(formatter)?,
+            colon_token.format(formatter)?,
             space_token(),
-            self.pattern().format(formatter)?,
+            pattern.format(formatter)?,
             init_node,
         ])
     }

--- a/crates/rome_formatter/src/js/bindings/object_binding_pattern_rest.rs
+++ b/crates/rome_formatter/src/js/bindings/object_binding_pattern_rest.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsObjectBindingPatternRest;
+use rslint_parser::ast::JsObjectBindingPatternRestFields;
 
 impl ToFormatElement for JsObjectBindingPatternRest {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsObjectBindingPatternRestFields {
+            dotdotdot_token,
+            binding,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.binding().format(formatter)?,
+            dotdotdot_token.format(formatter)?,
+            binding.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
+++ b/crates/rome_formatter/src/js/bindings/object_binding_pattern_shorthand_property.rs
@@ -5,15 +5,14 @@ use crate::{
 };
 
 use rslint_parser::ast::JsObjectBindingPatternShorthandProperty;
+use rslint_parser::ast::JsObjectBindingPatternShorthandPropertyFields;
 
 impl ToFormatElement for JsObjectBindingPatternShorthandProperty {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let init_node = self
-            .init()
-            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
-        Ok(format_elements![
-            self.identifier().format(formatter)?,
-            init_node
-        ])
+        let JsObjectBindingPatternShorthandPropertyFields { identifier, init } = self.as_fields();
+
+        let init_node =
+            init.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
+        Ok(format_elements![identifier.format(formatter)?, init_node])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/parameters.rs
+++ b/crates/rome_formatter/src/js/bindings/parameters.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsParameters;
+use rslint_parser::ast::JsParametersFields;
 
 impl ToFormatElement for JsParameters {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsParametersFields {
+            l_paren_token,
+            items,
+            r_paren_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_paren_token()?,
-            self.items().format(formatter)?,
-            &self.r_paren_token()?,
+            &l_paren_token?,
+            items.format(formatter)?,
+            &r_paren_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_formatter/src/js/bindings/rest_parameter.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
@@ -16,6 +16,7 @@ impl ToFormatElement for JsRestParameter {
         Ok(format_elements![
             dotdotdot_token.format(formatter)?,
             binding.format(formatter)?,
+            type_annotation.format_or_empty(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/bindings/rest_parameter.rs
+++ b/crates/rome_formatter/src/js/bindings/rest_parameter.rs
@@ -3,12 +3,19 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsRestParameter;
+use rslint_parser::ast::JsRestParameterFields;
 
 impl ToFormatElement for JsRestParameter {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsRestParameterFields {
+            dotdotdot_token,
+            binding,
+            type_annotation,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.dotdotdot_token().format(formatter)?,
-            self.binding().format(formatter)?,
+            dotdotdot_token.format(formatter)?,
+            binding.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/constructor_class_member.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -17,6 +17,8 @@ impl ToFormatElement for JsConstructorClassMember {
         } = self.as_fields();
 
         Ok(format_elements![
+            access_modifier
+                .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
             name.format(formatter)?,
             parameters.format(formatter)?,
             space_token(),

--- a/crates/rome_formatter/src/js/classes/constructor_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/constructor_class_member.rs
@@ -5,14 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsConstructorClassMember;
+use rslint_parser::ast::JsConstructorClassMemberFields;
 
 impl ToFormatElement for JsConstructorClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsConstructorClassMemberFields {
+            access_modifier,
+            name,
+            parameters,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.name().format(formatter)?,
-            self.parameters().format(formatter)?,
+            name.format(formatter)?,
+            parameters.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/empty_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/empty_class_member.rs
@@ -1,9 +1,12 @@
 use crate::{empty_element, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsEmptyClassMember;
+use rslint_parser::ast::JsEmptyClassMemberFields;
 
 impl ToFormatElement for JsEmptyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_replaced(&self.semicolon_token()?, empty_element())
+        let JsEmptyClassMemberFields { semicolon_token } = self.as_fields();
+
+        formatter.format_replaced(&semicolon_token?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_formatter/src/js/classes/extends_clause.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -18,7 +18,8 @@ impl ToFormatElement for JsExtendsClause {
         Ok(format_elements![
             extends_token.format(formatter)?,
             space_token(),
-            super_class.format(formatter)?
+            super_class.format(formatter)?,
+            type_arguments.format_or_empty(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/extends_clause.rs
+++ b/crates/rome_formatter/src/js/classes/extends_clause.rs
@@ -5,13 +5,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExtendsClause;
+use rslint_parser::ast::JsExtendsClauseFields;
 
 impl ToFormatElement for JsExtendsClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsExtendsClauseFields {
+            extends_token,
+            super_class,
+            type_arguments,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.extends_token().format(formatter)?,
+            extends_token.format(formatter)?,
             space_token(),
-            self.super_class().format(formatter)?
+            super_class.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/getter_class_member.rs
@@ -5,19 +5,32 @@ use crate::{
 };
 
 use rslint_parser::ast::JsGetterClassMember;
+use rslint_parser::ast::JsGetterClassMemberFields;
 
 impl ToFormatElement for JsGetterClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsGetterClassMemberFields {
+            access_modifier,
+            static_token,
+            abstract_token,
+            get_token,
+            name,
+            l_paren_token,
+            r_paren_token,
+            return_type,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.static_token()
+            static_token
                 .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
-            self.get_token().format(formatter)?,
+            get_token.format(formatter)?,
             space_token(),
-            self.name().format(formatter)?,
-            self.l_paren_token().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            name.format(formatter)?,
+            l_paren_token.format(formatter)?,
+            r_paren_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/getter_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/getter_class_member.rs
@@ -22,13 +22,18 @@ impl ToFormatElement for JsGetterClassMember {
         } = self.as_fields();
 
         Ok(format_elements![
+            access_modifier
+                .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
             static_token
+                .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
+            abstract_token
                 .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?,
             get_token.format(formatter)?,
             space_token(),
             name.format(formatter)?,
             l_paren_token.format(formatter)?,
             r_paren_token.format(formatter)?,
+            return_type.format_or_empty(formatter)?,
             space_token(),
             body.format(formatter)?
         ])

--- a/crates/rome_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/method_class_member.rs
@@ -5,19 +5,32 @@ use crate::{
 };
 
 use rslint_parser::ast::JsMethodClassMember;
+use rslint_parser::ast::JsMethodClassMemberFields;
 
 impl ToFormatElement for JsMethodClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let async_token = self
-            .async_token()
+        let JsMethodClassMemberFields {
+            access_modifier,
+            static_token,
+            abstract_token,
+            async_token,
+            star_token,
+            name,
+            question_mark_token,
+            type_parameters,
+            parameters,
+            return_type_annotation,
+            body,
+        } = self.as_fields();
+
+        let async_token = async_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
-        let static_token = self
-            .static_token()
+        let static_token = static_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
-        let star_token = self.star_token().format_or_empty(formatter)?;
-        let name = self.name().format(formatter)?;
-        let params = self.parameters().format(formatter)?;
-        let body = self.body().format(formatter)?;
+        let star_token = star_token.format_or_empty(formatter)?;
+        let name = name.format(formatter)?;
+        let params = parameters.format(formatter)?;
+        let body = body.format(formatter)?;
         Ok(format_elements![
             static_token,
             async_token,

--- a/crates/rome_formatter/src/js/classes/method_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/method_class_member.rs
@@ -23,20 +23,34 @@ impl ToFormatElement for JsMethodClassMember {
             body,
         } = self.as_fields();
 
-        let async_token = async_token
+        let access_modifier = access_modifier
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
         let static_token = static_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let abstract_token = abstract_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let async_token = async_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let star_token = star_token.format_or_empty(formatter)?;
         let name = name.format(formatter)?;
+        let question_mark_token = question_mark_token.format_or_empty(formatter)?;
+        let type_parameters = type_parameters.format_or_empty(formatter)?;
         let params = parameters.format(formatter)?;
+        let return_type_annotation = return_type_annotation.format_or_empty(formatter)?;
         let body = body.format(formatter)?;
+
         Ok(format_elements![
+            access_modifier,
             static_token,
+            abstract_token,
             async_token,
             star_token,
             name,
+            question_mark_token,
+            type_parameters,
             params,
+            return_type_annotation,
             space_token(),
             body
         ])

--- a/crates/rome_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/property_class_member.rs
@@ -5,22 +5,33 @@ use crate::{
 };
 
 use rslint_parser::ast::JsPropertyClassMember;
+use rslint_parser::ast::JsPropertyClassMemberFields;
 
 impl ToFormatElement for JsPropertyClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let static_token = self
-            .static_token()
+        let JsPropertyClassMemberFields {
+            declare_token,
+            access_modifier,
+            static_token,
+            readonly_token,
+            abstract_token,
+            name,
+            property_annotation,
+            value,
+            semicolon_token,
+        } = self.as_fields();
+
+        let static_token = static_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
 
-        let init = self
-            .value()
-            .format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
+        let init =
+            value.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
 
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             static_token,
-            self.name().format(formatter)?,
+            name.format(formatter)?,
             init,
             semicolon
         ])

--- a/crates/rome_formatter/src/js/classes/property_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/property_class_member.rs
@@ -21,8 +21,18 @@ impl ToFormatElement for JsPropertyClassMember {
             semicolon_token,
         } = self.as_fields();
 
+        let declare_token = declare_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let access_modifier = access_modifier
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
         let static_token = static_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let readonly_token = readonly_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+        let abstract_token = abstract_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
+        let property_annotation = property_annotation.format_or_empty(formatter)?;
 
         let init =
             value.format_with_or_empty(formatter, |node| format_elements![space_token(), node])?;
@@ -30,8 +40,13 @@ impl ToFormatElement for JsPropertyClassMember {
         let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
+            declare_token,
+            access_modifier,
             static_token,
+            readonly_token,
+            abstract_token,
             name.format(formatter)?,
+            property_annotation,
             init,
             semicolon
         ])

--- a/crates/rome_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/setter_class_member.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -22,6 +22,9 @@ impl ToFormatElement for JsSetterClassMember {
         } = self.as_fields();
 
         Ok(format_elements![
+            access_modifier.format_or_empty(formatter)?,
+            static_token.format_or_empty(formatter)?,
+            abstract_token.format_or_empty(formatter)?,
             set_token.format(formatter)?,
             space_token(),
             name.format(formatter)?,

--- a/crates/rome_formatter/src/js/classes/setter_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/setter_class_member.rs
@@ -5,18 +5,31 @@ use crate::{
 };
 
 use rslint_parser::ast::JsSetterClassMember;
+use rslint_parser::ast::JsSetterClassMemberFields;
 
 impl ToFormatElement for JsSetterClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsSetterClassMemberFields {
+            access_modifier,
+            static_token,
+            abstract_token,
+            set_token,
+            name,
+            l_paren_token,
+            parameter,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.set_token().format(formatter)?,
+            set_token.format(formatter)?,
             space_token(),
-            self.name().format(formatter)?,
-            self.l_paren_token().format(formatter)?,
-            self.parameter().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            name.format(formatter)?,
+            l_paren_token.format(formatter)?,
+            parameter.format(formatter)?,
+            r_paren_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/classes/static_initialization_block_class_member.rs
+++ b/crates/rome_formatter/src/js/classes/static_initialization_block_class_member.rs
@@ -5,14 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsStaticInitializationBlockClassMember;
+use rslint_parser::ast::JsStaticInitializationBlockClassMemberFields;
 
 impl ToFormatElement for JsStaticInitializationBlockClassMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let static_token = self.static_token().format(formatter)?;
+        let JsStaticInitializationBlockClassMemberFields {
+            static_token,
+            l_curly_token,
+            statements,
+            r_curly_token,
+        } = self.as_fields();
+
+        let static_token = static_token.format(formatter)?;
         let separated = formatter.format_delimited_block_indent(
-            &self.l_curly_token()?,
-            formatter.format_list(self.statements()),
-            &self.r_curly_token()?,
+            &l_curly_token?,
+            formatter.format_list(statements),
+            &r_curly_token?,
         )?;
         Ok(format_elements![static_token, space_token(), separated])
     }

--- a/crates/rome_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_formatter/src/js/declarations/catch_declaration.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsCatchDeclaration;
+use rslint_parser::ast::JsCatchDeclarationFields;
 
 impl ToFormatElement for JsCatchDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsCatchDeclarationFields {
+            l_paren_token,
+            binding,
+            r_paren_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_paren_token()?,
-            self.binding().format(formatter)?,
-            &self.r_paren_token()?,
+            &l_paren_token?,
+            binding.format(formatter)?,
+            &r_paren_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/declarations/for_variable_declaration.rs
+++ b/crates/rome_formatter/src/js/declarations/for_variable_declaration.rs
@@ -5,13 +5,19 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
+use rslint_parser::ast::JsForVariableDeclarationFields;
 
 impl ToFormatElement for JsForVariableDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsForVariableDeclarationFields {
+            kind_token,
+            declarator,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.kind_token().format(formatter)?,
+            kind_token.format(formatter)?,
             space_token(),
-            self.declarator().format(formatter)?,
+            declarator.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/declarations/variable_declaration.rs
+++ b/crates/rome_formatter/src/js/declarations/variable_declaration.rs
@@ -5,13 +5,16 @@ use crate::{
 };
 
 use rslint_parser::ast::JsVariableDeclaration;
+use rslint_parser::ast::JsVariableDeclarationFields;
 
 impl ToFormatElement for JsVariableDeclaration {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsVariableDeclarationFields { kind, declarators } = self.as_fields();
+
         Ok(format_elements![
-            self.kind().format(formatter)?,
+            kind.format(formatter)?,
             space_token(),
-            self.declarators().format(formatter)?,
+            declarators.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/array_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/array_expression.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsArrayExpression;
+use rslint_parser::ast::JsArrayExpressionFields;
 
 impl ToFormatElement for JsArrayExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsArrayExpressionFields {
+            l_brack_token,
+            elements,
+            r_brack_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_brack_token()?,
-            self.elements().format(formatter)?,
-            &self.r_brack_token()?,
+            &l_brack_token?,
+            elements.format(formatter)?,
+            &r_brack_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/assignment_expression.rs
@@ -6,14 +6,21 @@ use crate::{
 };
 
 use rslint_parser::ast::JsAssignmentExpression;
+use rslint_parser::ast::JsAssignmentExpressionFields;
 
 impl ToFormatElement for JsAssignmentExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsAssignmentExpressionFields {
+            left,
+            operator_token,
+            right,
+        } = self.as_fields();
+
         Ok(group_elements(format_elements![
-            self.left().format(formatter)?,
+            left.format(formatter)?,
             space_token(),
-            self.operator_token().format(formatter)?,
-            group_elements(soft_line_indent_or_space(self.right().format(formatter)?)),
+            operator_token.format(formatter)?,
+            group_elements(soft_line_indent_or_space(right.format(formatter)?)),
         ]))
     }
 }

--- a/crates/rome_formatter/src/js/expressions/await_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/await_expression.rs
@@ -5,13 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsAwaitExpression;
+use rslint_parser::ast::JsAwaitExpressionFields;
 
 impl ToFormatElement for JsAwaitExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsAwaitExpressionFields {
+            await_token,
+            argument,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.await_token().format(formatter)?,
+            await_token.format(formatter)?,
             space_token(),
-            self.argument().format(formatter)?,
+            argument.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/big_int_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/big_int_literal_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsBigIntLiteralExpression;
+use rslint_parser::ast::JsBigIntLiteralExpressionFields;
 
 impl ToFormatElement for JsBigIntLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsBigIntLiteralExpressionFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/binary_expression.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsBinaryExpression;
+use rslint_parser::ast::JsBinaryExpressionFields;
 
 impl ToFormatElement for JsBinaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsBinaryExpressionFields {
+            left,
+            operator,
+            right,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.left().format(formatter)?,
+            left.format(formatter)?,
             space_token(),
-            self.operator().format(formatter)?,
+            operator.format(formatter)?,
             space_token(),
-            self.right().format(formatter)?,
+            right.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/boolean_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/boolean_literal_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsBooleanLiteralExpression;
+use rslint_parser::ast::JsBooleanLiteralExpressionFields;
 
 impl ToFormatElement for JsBooleanLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsBooleanLiteralExpressionFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/rome_formatter/src/js/expressions/call_arguments.rs
@@ -3,13 +3,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsCallArguments;
+use rslint_parser::ast::JsCallArgumentsFields;
 
 impl ToFormatElement for JsCallArguments {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsCallArgumentsFields {
+            l_paren_token,
+            args,
+            r_paren_token,
+        } = self.as_fields();
+
         formatter.format_delimited_soft_block_indent(
-            &self.l_paren_token()?,
-            self.args().format(formatter)?,
-            &self.r_paren_token()?,
+            &l_paren_token?,
+            args.format(formatter)?,
+            &r_paren_token?,
         )
     }
 }

--- a/crates/rome_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/call_expression.rs
@@ -1,18 +1,10 @@
 use crate::utils::format_call_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsCallExpression;
-use rslint_parser::ast::JsCallExpressionFields;
 use rslint_parser::AstNode;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsCallExpressionFields {
-            callee,
-            optional_chain_token,
-            type_arguments,
-            arguments,
-        } = self.as_fields();
-
         format_call_expression(self.syntax(), formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/call_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/call_expression.rs
@@ -1,10 +1,18 @@
 use crate::utils::format_call_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsCallExpression;
+use rslint_parser::ast::JsCallExpressionFields;
 use rslint_parser::AstNode;
 
 impl ToFormatElement for JsCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsCallExpressionFields {
+            callee,
+            optional_chain_token,
+            type_arguments,
+            arguments,
+        } = self.as_fields();
+
         format_call_expression(self.syntax(), formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/computed_member_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/computed_member_expression.rs
@@ -3,17 +3,26 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsComputedMemberExpression;
+use rslint_parser::ast::JsComputedMemberExpressionFields;
 
 impl ToFormatElement for JsComputedMemberExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let optional_chain_token = self.optional_chain_token().format_or_empty(formatter)?;
+        let JsComputedMemberExpressionFields {
+            object,
+            optional_chain_token,
+            l_brack_token,
+            member,
+            r_brack_token,
+        } = self.as_fields();
+
+        let optional_chain_token = optional_chain_token.format_or_empty(formatter)?;
 
         Ok(format_elements![
-            self.object().format(formatter)?,
+            object.format(formatter)?,
             optional_chain_token,
-            self.l_brack_token().format(formatter)?,
-            self.member().format(formatter)?,
-            self.r_brack_token().format(formatter)?,
+            l_brack_token.format(formatter)?,
+            member.format(formatter)?,
+            r_brack_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/conditional_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/conditional_expression.rs
@@ -5,19 +5,28 @@ use crate::{
 };
 
 use rslint_parser::ast::JsConditionalExpression;
+use rslint_parser::ast::JsConditionalExpressionFields;
 
 impl ToFormatElement for JsConditionalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsConditionalExpressionFields {
+            test,
+            question_mark_token,
+            consequent,
+            colon_token,
+            alternate,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.test().format(formatter)?,
+            test.format(formatter)?,
             space_token(),
-            self.question_mark_token().format(formatter)?,
+            question_mark_token.format(formatter)?,
             space_token(),
-            self.consequent().format(formatter)?,
+            consequent.format(formatter)?,
             space_token(),
-            self.colon_token().format(formatter)?,
+            colon_token.format(formatter)?,
             space_token(),
-            self.alternate().format(formatter)?,
+            alternate.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/identifier_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/identifier_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsIdentifierExpression;
+use rslint_parser::ast::JsIdentifierExpressionFields;
 
 impl ToFormatElement for JsIdentifierExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.name().format(formatter)
+        let JsIdentifierExpressionFields { name } = self.as_fields();
+
+        name.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/import_call_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/import_call_expression.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsImportCallExpression;
+use rslint_parser::ast::JsImportCallExpressionFields;
 
 impl ToFormatElement for JsImportCallExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsImportCallExpressionFields {
+            import_token,
+            arguments,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.import_token().format(formatter)?,
-            self.arguments().format(formatter)?,
+            import_token.format(formatter)?,
+            arguments.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/in_expression.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsInExpression;
+use rslint_parser::ast::JsInExpressionFields;
 
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsInExpressionFields {
+            property,
+            in_token,
+            object,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.property().format(formatter)?,
+            property.format(formatter)?,
             space_token(),
-            self.in_token().format(formatter)?,
+            in_token.format(formatter)?,
             space_token(),
-            self.object().format(formatter)?,
+            object.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/instanceof_expression.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsInstanceofExpression;
+use rslint_parser::ast::JsInstanceofExpressionFields;
 
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsInstanceofExpressionFields {
+            left,
+            instanceof_token,
+            right,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.left().format(formatter)?,
+            left.format(formatter)?,
             space_token(),
-            self.instanceof_token().format(formatter)?,
+            instanceof_token.format(formatter)?,
             space_token(),
-            self.right().format(formatter)?,
+            right.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/logical_expression.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsLogicalExpression;
+use rslint_parser::ast::JsLogicalExpressionFields;
 
 impl ToFormatElement for JsLogicalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsLogicalExpressionFields {
+            left,
+            operator,
+            right,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.left().format(formatter)?,
+            left.format(formatter)?,
             space_token(),
-            self.operator().format(formatter)?,
+            operator.format(formatter)?,
             space_token(),
-            self.right().format(formatter)?,
+            right.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/new_expression.rs
@@ -21,9 +21,9 @@ impl ToFormatElement for JsNewExpression {
 
         Ok(format_elements![
             new_token.format(formatter)?,
-            // TODO handle TsTypeArgs
             space_token(),
             callee.format(formatter)?,
+            type_arguments.format_or_empty(formatter)?,
             arguments,
         ])
     }

--- a/crates/rome_formatter/src/js/expressions/new_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/new_expression.rs
@@ -5,18 +5,25 @@ use crate::{
 };
 
 use rslint_parser::ast::JsNewExpression;
+use rslint_parser::ast::JsNewExpressionFields;
 
 impl ToFormatElement for JsNewExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let arguments = self
-            .arguments()
-            .format_or(formatter, || format_elements![token("("), token(")")])?;
+        let JsNewExpressionFields {
+            new_token,
+            callee,
+            type_arguments,
+            arguments,
+        } = self.as_fields();
+
+        let arguments =
+            arguments.format_or(formatter, || format_elements![token("("), token(")")])?;
 
         Ok(format_elements![
-            self.new_token().format(formatter)?,
+            new_token.format(formatter)?,
             // TODO handle TsTypeArgs
             space_token(),
-            self.callee().format(formatter)?,
+            callee.format(formatter)?,
             arguments,
         ])
     }

--- a/crates/rome_formatter/src/js/expressions/null_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/null_literal_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsNullLiteralExpression;
+use rslint_parser::ast::JsNullLiteralExpressionFields;
 
 impl ToFormatElement for JsNullLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsNullLiteralExpressionFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/number_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/number_literal_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsNumberLiteralExpression;
+use rslint_parser::ast::JsNumberLiteralExpressionFields;
 
 impl ToFormatElement for JsNumberLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsNumberLiteralExpressionFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/object_expression.rs
@@ -2,23 +2,22 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsObjectExpression;
+use rslint_parser::ast::JsObjectExpressionFields;
 
 impl ToFormatElement for JsObjectExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let members = self.members().format(formatter)?;
+        let JsObjectExpressionFields {
+            l_curly_token,
+            members,
+            r_curly_token,
+        } = self.as_fields();
+
+        let members = members.format(formatter)?;
 
         if members.is_empty() {
-            formatter.format_delimited_soft_block_indent(
-                &self.l_curly_token()?,
-                members,
-                &self.r_curly_token()?,
-            )
+            formatter.format_delimited_soft_block_indent(&l_curly_token?, members, &r_curly_token?)
         } else {
-            formatter.format_delimited_soft_block_spaces(
-                &self.l_curly_token()?,
-                members,
-                &self.r_curly_token()?,
-            )
+            formatter.format_delimited_soft_block_spaces(&l_curly_token?, members, &r_curly_token?)
         }
     }
 }

--- a/crates/rome_formatter/src/js/expressions/parenthesized_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/parenthesized_expression.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsParenthesizedExpression;
+use rslint_parser::ast::JsParenthesizedExpressionFields;
 
 impl ToFormatElement for JsParenthesizedExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsParenthesizedExpressionFields {
+            l_paren_token,
+            expression,
+            r_paren_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.l_paren_token().format(formatter)?,
-            self.expression().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            l_paren_token.format(formatter)?,
+            expression.format(formatter)?,
+            r_paren_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/post_update_expression.rs
@@ -3,12 +3,15 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsPostUpdateExpression;
+use rslint_parser::ast::JsPostUpdateExpressionFields;
 
 impl ToFormatElement for JsPostUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsPostUpdateExpressionFields { operand, operator } = self.as_fields();
+
         Ok(format_elements![
-            self.operand().format(formatter)?,
-            self.operator().format(formatter)?,
+            operand.format(formatter)?,
+            operator.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/pre_update_expression.rs
@@ -3,12 +3,15 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsPreUpdateExpression;
+use rslint_parser::ast::JsPreUpdateExpressionFields;
 
 impl ToFormatElement for JsPreUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsPreUpdateExpressionFields { operator, operand } = self.as_fields();
+
         Ok(format_elements![
-            self.operator().format(formatter)?,
-            self.operand().format(formatter)?,
+            operator.format(formatter)?,
+            operand.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/regex_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/regex_literal_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsRegexLiteralExpression;
+use rslint_parser::ast::JsRegexLiteralExpressionFields;
 
 impl ToFormatElement for JsRegexLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsRegexLiteralExpressionFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/sequence_expression.rs
@@ -5,14 +5,21 @@ use crate::{
 };
 
 use rslint_parser::ast::JsSequenceExpression;
+use rslint_parser::ast::JsSequenceExpressionFields;
 
 impl ToFormatElement for JsSequenceExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsSequenceExpressionFields {
+            left,
+            comma_token,
+            right,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.left().format(formatter)?,
-            self.comma_token().format(formatter)?,
+            left.format(formatter)?,
+            comma_token.format(formatter)?,
             space_token(),
-            self.right().format(formatter)?,
+            right.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/static_member_expression.rs
@@ -5,13 +5,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsStaticMemberExpression;
+use rslint_parser::ast::JsStaticMemberExpressionFields;
 
 impl ToFormatElement for JsStaticMemberExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsStaticMemberExpressionFields {
+            object,
+            operator,
+            member,
+        } = self.as_fields();
+
         Ok(group_elements(format_elements![
-            self.object().format(formatter)?,
-            self.operator().format(formatter)?,
-            self.member().format(formatter)?,
+            object.format(formatter)?,
+            operator.format(formatter)?,
+            member.format(formatter)?,
         ]))
     }
 }

--- a/crates/rome_formatter/src/js/expressions/string_literal_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/string_literal_expression.rs
@@ -5,10 +5,13 @@ use crate::format_element::normalize_newlines;
 use crate::{format_element::Token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsStringLiteralExpression;
+use rslint_parser::ast::JsStringLiteralExpressionFields;
 
 impl ToFormatElement for JsStringLiteralExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let value_token = self.value_token()?;
+        let JsStringLiteralExpressionFields { value_token } = self.as_fields();
+
+        let value_token = value_token?;
         let quoted = value_token.text_trimmed();
 
         // uses single quotes

--- a/crates/rome_formatter/src/js/expressions/super_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/super_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsSuperExpression;
+use rslint_parser::ast::JsSuperExpressionFields;
 
 impl ToFormatElement for JsSuperExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.super_token().format(formatter)
+        let JsSuperExpressionFields { super_token } = self.as_fields();
+
+        super_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/template.rs
+++ b/crates/rome_formatter/src/js/expressions/template.rs
@@ -16,11 +16,13 @@ impl ToFormatElement for JsTemplate {
         } = self.as_fields();
 
         let tag = tag.format_or_empty(formatter)?;
+        let type_arguments = type_arguments.format_or_empty(formatter)?;
         let l_tick = l_tick_token.format(formatter)?;
         let r_tick = r_tick_token.format(formatter)?;
 
         Ok(format_elements![
             tag,
+            type_arguments,
             l_tick,
             concat_elements(formatter.format_nodes(elements)?),
             r_tick

--- a/crates/rome_formatter/src/js/expressions/template.rs
+++ b/crates/rome_formatter/src/js/expressions/template.rs
@@ -3,17 +3,26 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsTemplate;
+use rslint_parser::ast::JsTemplateFields;
 
 impl ToFormatElement for JsTemplate {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let tag = self.tag().format_or_empty(formatter)?;
-        let l_tick = self.l_tick_token().format(formatter)?;
-        let r_tick = self.r_tick_token().format(formatter)?;
+        let JsTemplateFields {
+            tag,
+            type_arguments,
+            l_tick_token,
+            elements,
+            r_tick_token,
+        } = self.as_fields();
+
+        let tag = tag.format_or_empty(formatter)?;
+        let l_tick = l_tick_token.format(formatter)?;
+        let r_tick = r_tick_token.format(formatter)?;
 
         Ok(format_elements![
             tag,
             l_tick,
-            concat_elements(formatter.format_nodes(self.elements())?),
+            concat_elements(formatter.format_nodes(elements)?),
             r_tick
         ])
     }

--- a/crates/rome_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_formatter/src/js/expressions/template_chunk_element.rs
@@ -4,12 +4,17 @@ use crate::{
 };
 
 use rslint_parser::ast::JsTemplateChunkElement;
+use rslint_parser::ast::JsTemplateChunkElementFields;
 
 impl ToFormatElement for JsTemplateChunkElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsTemplateChunkElementFields {
+            template_chunk_token,
+        } = self.as_fields();
+
         // Per https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-static-semantics-trv:
         // In template literals, the '\r' and '\r\n' line terminators are normalized to '\n'
-        let chunk = self.template_chunk_token()?;
+        let chunk = template_chunk_token?;
         formatter.format_replaced(
             &chunk,
             FormatElement::from(Token::new_dynamic(

--- a/crates/rome_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_formatter/src/js/expressions/template_element.rs
@@ -3,12 +3,19 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsTemplateElement;
+use rslint_parser::ast::JsTemplateElementFields;
 
 impl ToFormatElement for JsTemplateElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let dollar_curly = self.dollar_curly_token().format(formatter)?;
-        let expression = self.expression().format(formatter)?;
-        let r_curly = self.r_curly_token().format(formatter)?;
+        let JsTemplateElementFields {
+            dollar_curly_token,
+            expression,
+            r_curly_token,
+        } = self.as_fields();
+
+        let dollar_curly = dollar_curly_token.format(formatter)?;
+        let expression = expression.format(formatter)?;
+        let r_curly = r_curly_token.format(formatter)?;
         Ok(format_elements![dollar_curly, expression, r_curly])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/this_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/this_expression.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsThisExpression;
+use rslint_parser::ast::JsThisExpressionFields;
 
 impl ToFormatElement for JsThisExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.this_token().format(formatter)
+        let JsThisExpressionFields { this_token } = self.as_fields();
+
+        this_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/unary_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/unary_expression.rs
@@ -7,11 +7,14 @@ use crate::{
 
 use rslint_parser::ast::JsUnaryExpression;
 
+use rslint_parser::ast::JsUnaryExpressionFields;
 use rslint_parser::{token_set, T};
 
 impl ToFormatElement for JsUnaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let operator = self.operator()?;
+        let JsUnaryExpressionFields { operator, argument } = self.as_fields();
+
+        let operator = operator?;
         let space_or_empty =
             if token_set![T![delete], T![void], T![typeof]].contains(operator.kind()) {
                 space_token()
@@ -19,9 +22,9 @@ impl ToFormatElement for JsUnaryExpression {
                 empty_element()
             };
         Ok(format_elements![
-            self.operator().format(formatter)?,
+            operator.format(formatter)?,
             space_or_empty,
-            self.argument().format(formatter)?,
+            argument.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/yield_argument.rs
+++ b/crates/rome_formatter/src/js/expressions/yield_argument.rs
@@ -5,15 +5,21 @@ use crate::{
 };
 
 use rslint_parser::ast::JsYieldArgument;
+use rslint_parser::ast::JsYieldArgumentFields;
 
 impl ToFormatElement for JsYieldArgument {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star_token = self.star_token().format_or_empty(formatter)?;
+        let JsYieldArgumentFields {
+            star_token,
+            expression,
+        } = self.as_fields();
+
+        let star_token = star_token.format_or_empty(formatter)?;
 
         Ok(format_elements![
             star_token,
             space_token(),
-            self.expression().format(formatter)?
+            expression.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/expressions/yield_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/yield_expression.rs
@@ -3,14 +3,17 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsYieldExpression;
+use rslint_parser::ast::JsYieldExpressionFields;
 
 impl ToFormatElement for JsYieldExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let argument = self.argument().format_or_empty(formatter)?;
+        let JsYieldExpressionFields {
+            yield_token,
+            argument,
+        } = self.as_fields();
 
-        Ok(format_elements![
-            self.yield_token().format(formatter)?,
-            argument
-        ])
+        let argument = argument.format_or_empty(formatter)?;
+
+        Ok(format_elements![yield_token.format(formatter)?, argument])
     }
 }

--- a/crates/rome_formatter/src/js/module/default_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/default_import_specifier.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsDefaultImportSpecifier;
+use rslint_parser::ast::JsDefaultImportSpecifierFields;
 
 impl ToFormatElement for JsDefaultImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsDefaultImportSpecifierFields {
+            local_name,
+            trailing_comma_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.local_name().format(formatter)?,
-            self.trailing_comma_token().format(formatter)?
+            local_name.format(formatter)?,
+            trailing_comma_token.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/module/export.rs
+++ b/crates/rome_formatter/src/js/module/export.rs
@@ -5,11 +5,17 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExport;
+use rslint_parser::ast::JsExportFields;
 
 impl ToFormatElement for JsExport {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let export_token = self.export_token().format(formatter)?;
-        let export_clause = self.export_clause().format(formatter)?;
+        let JsExportFields {
+            export_token,
+            export_clause,
+        } = self.as_fields();
+
+        let export_token = export_token.format(formatter)?;
+        let export_clause = export_clause.format(formatter)?;
         Ok(format_elements![export_token, space_token(), export_clause])
     }
 }

--- a/crates/rome_formatter/src/js/module/export_as_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_as_clause.rs
@@ -5,11 +5,17 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportAsClause;
+use rslint_parser::ast::JsExportAsClauseFields;
 
 impl ToFormatElement for JsExportAsClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let as_token = self.as_token().format(formatter)?;
-        let exported_name = self.exported_name().format(formatter)?;
+        let JsExportAsClauseFields {
+            as_token,
+            exported_name,
+        } = self.as_fields();
+
+        let as_token = as_token.format(formatter)?;
+        let exported_name = exported_name.format(formatter)?;
 
         Ok(format_elements![as_token, space_token(), exported_name])
     }

--- a/crates/rome_formatter/src/js/module/export_default_expression_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_default_expression_clause.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportDefaultExpressionClause;
+use rslint_parser::ast::JsExportDefaultExpressionClauseFields;
 
 impl ToFormatElement for JsExportDefaultExpressionClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let default_token = self.default_token().format(formatter)?;
-        let class = self.expression().format(formatter)?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let JsExportDefaultExpressionClauseFields {
+            default_token,
+            expression,
+            semicolon_token,
+        } = self.as_fields();
+
+        let default_token = default_token.format(formatter)?;
+        let class = expression.format(formatter)?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
         Ok(format_elements![
             default_token,
             space_token(),

--- a/crates/rome_formatter/src/js/module/export_from_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_from_clause.rs
@@ -5,24 +5,30 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportFromClause;
+use rslint_parser::ast::JsExportFromClauseFields;
 
 impl ToFormatElement for JsExportFromClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = self.star_token().format(formatter)?;
+        let JsExportFromClauseFields {
+            star_token,
+            export_as,
+            from_token,
+            source,
+            assertion,
+            semicolon_token,
+        } = self.as_fields();
 
-        let export_as = self
-            .export_as()
-            .format_with_or_empty(formatter, |as_token| {
-                format_elements![as_token, space_token()]
-            })?;
-        let from = self.from_token().format(formatter)?;
-        let source = self.source().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let star = star_token.format(formatter)?;
+
+        let export_as = export_as.format_with_or_empty(formatter, |as_token| {
+            format_elements![as_token, space_token()]
+        })?;
+        let from = from_token.format(formatter)?;
+        let source = source.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             star,

--- a/crates/rome_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_clause.rs
@@ -1,6 +1,8 @@
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
-use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{
+    format_elements, space_token, token, FormatElement, FormatResult, Formatter, ToFormatElement,
+};
 
 use rslint_parser::ast::JsExportNamedClause;
 use rslint_parser::ast::JsExportNamedClauseFields;
@@ -15,6 +17,9 @@ impl ToFormatElement for JsExportNamedClause {
             semicolon_token,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let specifiers = specifiers.format(formatter)?;
 
         let list = formatter.format_delimited_soft_block_spaces(
@@ -25,6 +30,6 @@ impl ToFormatElement for JsExportNamedClause {
 
         let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
-        Ok(format_elements![list, semicolon])
+        Ok(format_elements![type_token, list, semicolon])
     }
 }

--- a/crates/rome_formatter/src/js/module/export_named_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_clause.rs
@@ -3,18 +3,27 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsExportNamedClause;
+use rslint_parser::ast::JsExportNamedClauseFields;
 
 impl ToFormatElement for JsExportNamedClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let specifiers = self.specifiers().format(formatter)?;
+        let JsExportNamedClauseFields {
+            type_token,
+            l_curly_token,
+            specifiers,
+            r_curly_token,
+            semicolon_token,
+        } = self.as_fields();
+
+        let specifiers = specifiers.format(formatter)?;
 
         let list = formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
+            &l_curly_token?,
             specifiers,
-            &self.r_curly_token()?,
+            &r_curly_token?,
         )?;
 
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![list, semicolon])
     }

--- a/crates/rome_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_from_clause.rs
@@ -5,25 +5,35 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportNamedFromClause;
+use rslint_parser::ast::JsExportNamedFromClauseFields;
 
 impl ToFormatElement for JsExportNamedFromClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let specifiers = self.specifiers().format(formatter)?;
+        let JsExportNamedFromClauseFields {
+            type_token,
+            l_curly_token,
+            specifiers,
+            r_curly_token,
+            from_token,
+            source,
+            assertion,
+            semicolon_token,
+        } = self.as_fields();
+
+        let specifiers = specifiers.format(formatter)?;
 
         let list = formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
+            &l_curly_token?,
             specifiers,
-            &self.r_curly_token()?,
+            &r_curly_token?,
         )?;
 
-        let from = self.from_token().format(formatter)?;
-        let source = self.source().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let from = from_token.format(formatter)?;
+        let source = source.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             list,

--- a/crates/rome_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_formatter/src/js/module/export_named_from_clause.rs
@@ -20,6 +20,9 @@ impl ToFormatElement for JsExportNamedFromClause {
             semicolon_token,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let specifiers = specifiers.format(formatter)?;
 
         let list = formatter.format_delimited_soft_block_spaces(
@@ -36,6 +39,7 @@ impl ToFormatElement for JsExportNamedFromClause {
         let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
+            type_token,
             list,
             space_token(),
             from,

--- a/crates/rome_formatter/src/js/module/export_named_from_specifier.rs
+++ b/crates/rome_formatter/src/js/module/export_named_from_specifier.rs
@@ -5,22 +5,25 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportNamedFromSpecifier;
+use rslint_parser::ast::JsExportNamedFromSpecifierFields;
 
 impl ToFormatElement for JsExportNamedFromSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = self
-            .type_token()
-            .format_with_or_empty(formatter, |type_token| {
-                format_elements![type_token, space_token()]
-            })?;
+        let JsExportNamedFromSpecifierFields {
+            type_token,
+            source_name,
+            export_as,
+        } = self.as_fields();
 
-        let source_name = self.source_name().format(formatter)?;
+        let type_token = type_token.format_with_or_empty(formatter, |type_token| {
+            format_elements![type_token, space_token()]
+        })?;
 
-        let export_as = self
-            .export_as()
-            .format_with_or_empty(formatter, |export_as| {
-                format_elements![space_token(), export_as]
-            })?;
+        let source_name = source_name.format(formatter)?;
+
+        let export_as = export_as.format_with_or_empty(formatter, |export_as| {
+            format_elements![space_token(), export_as]
+        })?;
 
         Ok(format_elements![type_token, source_name, export_as])
     }

--- a/crates/rome_formatter/src/js/module/export_named_shorthand_specifier.rs
+++ b/crates/rome_formatter/src/js/module/export_named_shorthand_specifier.rs
@@ -5,15 +5,16 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportNamedShorthandSpecifier;
+use rslint_parser::ast::JsExportNamedShorthandSpecifierFields;
 
 impl ToFormatElement for JsExportNamedShorthandSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = self
-            .type_token()
-            .format_with_or_empty(formatter, |type_token| {
-                format_elements![type_token, space_token()]
-            })?;
-        let name = self.name().format(formatter)?;
+        let JsExportNamedShorthandSpecifierFields { type_token, name } = self.as_fields();
+
+        let type_token = type_token.format_with_or_empty(formatter, |type_token| {
+            format_elements![type_token, space_token()]
+        })?;
+        let name = name.format(formatter)?;
 
         Ok(format_elements![type_token, name])
     }

--- a/crates/rome_formatter/src/js/module/export_named_specifier.rs
+++ b/crates/rome_formatter/src/js/module/export_named_specifier.rs
@@ -5,17 +5,23 @@ use crate::{
 };
 
 use rslint_parser::ast::JsExportNamedSpecifier;
+use rslint_parser::ast::JsExportNamedSpecifierFields;
 
 impl ToFormatElement for JsExportNamedSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let type_token = self
-            .type_token()
-            .format_with_or_empty(formatter, |type_token| {
-                format_elements![type_token, space_token()]
-            })?;
-        let as_token = self.as_token().format(formatter)?;
-        let local_name = self.local_name().format(formatter)?;
-        let exported_name = self.exported_name().format(formatter)?;
+        let JsExportNamedSpecifierFields {
+            type_token,
+            local_name,
+            as_token,
+            exported_name,
+        } = self.as_fields();
+
+        let type_token = type_token.format_with_or_empty(formatter, |type_token| {
+            format_elements![type_token, space_token()]
+        })?;
+        let as_token = as_token.format(formatter)?;
+        let local_name = local_name.format(formatter)?;
+        let exported_name = exported_name.format(formatter)?;
 
         Ok(format_elements![
             type_token,

--- a/crates/rome_formatter/src/js/module/import.rs
+++ b/crates/rome_formatter/src/js/module/import.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImport;
+use rslint_parser::ast::JsImportFields;
 
 impl ToFormatElement for JsImport {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let import_token = self.import_token().format(formatter)?;
-        let import_clause = self.import_clause().format(formatter)?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let JsImportFields {
+            import_token,
+            import_clause,
+            semicolon_token,
+        } = self.as_fields();
+
+        let import_token = import_token.format(formatter)?;
+        let import_clause = import_clause.format(formatter)?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             import_token,

--- a/crates/rome_formatter/src/js/module/import_assertion.rs
+++ b/crates/rome_formatter/src/js/module/import_assertion.rs
@@ -5,16 +5,24 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportAssertion;
+use rslint_parser::ast::JsImportAssertionFields;
 
 impl ToFormatElement for JsImportAssertion {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let assert_token = self.assert_token().format(formatter)?;
-        let assertions = self.assertions().format(formatter)?;
+        let JsImportAssertionFields {
+            assert_token,
+            l_curly_token,
+            assertions,
+            r_curly_token,
+        } = self.as_fields();
+
+        let assert_token = assert_token.format(formatter)?;
+        let assertions = assertions.format(formatter)?;
 
         let result = formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
+            &l_curly_token?,
             assertions,
-            &self.r_curly_token()?,
+            &r_curly_token?,
         )?;
 
         Ok(format_elements![assert_token, space_token(), result])

--- a/crates/rome_formatter/src/js/module/import_assertion_entry.rs
+++ b/crates/rome_formatter/src/js/module/import_assertion_entry.rs
@@ -5,14 +5,21 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportAssertionEntry;
+use rslint_parser::ast::JsImportAssertionEntryFields;
 
 impl ToFormatElement for JsImportAssertionEntry {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsImportAssertionEntryFields {
+            key,
+            colon_token,
+            value_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.key().format(formatter)?,
-            self.colon_token().format(formatter)?,
+            key.format(formatter)?,
+            colon_token.format(formatter)?,
             space_token(),
-            self.value_token().format(formatter)?,
+            value_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/module/import_bare_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_bare_clause.rs
@@ -5,15 +5,16 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportBareClause;
+use rslint_parser::ast::JsImportBareClauseFields;
 
 impl ToFormatElement for JsImportBareClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let source = self.source().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
+        let JsImportBareClauseFields { source, assertion } = self.as_fields();
+
+        let source = source.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
 
         Ok(format_elements![source, assertion])
     }

--- a/crates/rome_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_default_clause.rs
@@ -5,17 +5,24 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportDefaultClause;
+use rslint_parser::ast::JsImportDefaultClauseFields;
 
 impl ToFormatElement for JsImportDefaultClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let local_name = self.local_name().format(formatter)?;
-        let from = self.from_token().format(formatter)?;
-        let source = self.source().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
+        let JsImportDefaultClauseFields {
+            type_token,
+            local_name,
+            from_token,
+            source,
+            assertion,
+        } = self.as_fields();
+
+        let local_name = local_name.format(formatter)?;
+        let from = from_token.format(formatter)?;
+        let source = source.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
 
         Ok(format_elements![
             local_name,

--- a/crates/rome_formatter/src/js/module/import_default_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_default_clause.rs
@@ -17,6 +17,8 @@ impl ToFormatElement for JsImportDefaultClause {
             assertion,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
         let local_name = local_name.format(formatter)?;
         let from = from_token.format(formatter)?;
         let source = source.format(formatter)?;
@@ -25,6 +27,7 @@ impl ToFormatElement for JsImportDefaultClause {
         })?;
 
         Ok(format_elements![
+            type_token,
             local_name,
             space_token(),
             from,

--- a/crates/rome_formatter/src/js/module/import_meta.rs
+++ b/crates/rome_formatter/src/js/module/import_meta.rs
@@ -3,13 +3,20 @@ use rslint_parser::ast::ImportMeta;
 use crate::formatter_traits::FormatTokenAndNode;
 
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::ImportMetaFields;
 
 impl ToFormatElement for ImportMeta {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let ImportMetaFields {
+            import_token,
+            dot_token,
+            meta_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.import_token().format(formatter)?,
-            self.dot_token().format(formatter)?,
-            self.meta_token().format(formatter)?,
+            import_token.format(formatter)?,
+            dot_token.format(formatter)?,
+            meta_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_named_clause.rs
@@ -5,23 +5,29 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportNamedClause;
+use rslint_parser::ast::JsImportNamedClauseFields;
 
 impl ToFormatElement for JsImportNamedClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let source = self.source().format(formatter)?;
+        let JsImportNamedClauseFields {
+            type_token,
+            default_specifier,
+            named_import,
+            from_token,
+            source,
+            assertion,
+        } = self.as_fields();
 
-        let default = self
-            .default_specifier()
-            .format_with_or_empty(formatter, |specifier| {
-                format_elements![specifier, space_token()]
-            })?;
-        let from = self.from_token().format(formatter)?;
-        let name = self.named_import().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
+        let source = source.format(formatter)?;
+
+        let default = default_specifier.format_with_or_empty(formatter, |specifier| {
+            format_elements![specifier, space_token()]
+        })?;
+        let from = from_token.format(formatter)?;
+        let name = named_import.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
         Ok(format_elements![
             default,
             name,

--- a/crates/rome_formatter/src/js/module/import_named_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_named_clause.rs
@@ -18,6 +18,9 @@ impl ToFormatElement for JsImportNamedClause {
             assertion,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let source = source.format(formatter)?;
 
         let default = default_specifier.format_with_or_empty(formatter, |specifier| {
@@ -29,6 +32,7 @@ impl ToFormatElement for JsImportNamedClause {
             format_elements![space_token(), assertion]
         })?;
         Ok(format_elements![
+            type_token,
             default,
             name,
             space_token(),

--- a/crates/rome_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_namespace_clause.rs
@@ -5,19 +5,28 @@ use crate::{
 };
 
 use rslint_parser::ast::JsImportNamespaceClause;
+use rslint_parser::ast::JsImportNamespaceClauseFields;
 
 impl ToFormatElement for JsImportNamespaceClause {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = self.star_token().format(formatter)?;
-        let as_token = self.as_token().format(formatter)?;
-        let local_name = self.local_name().format(formatter)?;
-        let source = self.source().format(formatter)?;
-        let from = self.from_token().format(formatter)?;
-        let assertion = self
-            .assertion()
-            .format_with_or_empty(formatter, |assertion| {
-                format_elements![space_token(), assertion]
-            })?;
+        let JsImportNamespaceClauseFields {
+            type_token,
+            star_token,
+            as_token,
+            local_name,
+            from_token,
+            source,
+            assertion,
+        } = self.as_fields();
+
+        let star = star_token.format(formatter)?;
+        let as_token = as_token.format(formatter)?;
+        let local_name = local_name.format(formatter)?;
+        let source = source.format(formatter)?;
+        let from = from_token.format(formatter)?;
+        let assertion = assertion.format_with_or_empty(formatter, |assertion| {
+            format_elements![space_token(), assertion]
+        })?;
         Ok(format_elements![
             star,
             space_token(),

--- a/crates/rome_formatter/src/js/module/import_namespace_clause.rs
+++ b/crates/rome_formatter/src/js/module/import_namespace_clause.rs
@@ -19,6 +19,9 @@ impl ToFormatElement for JsImportNamespaceClause {
             assertion,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let star = star_token.format(formatter)?;
         let as_token = as_token.format(formatter)?;
         let local_name = local_name.format(formatter)?;
@@ -28,6 +31,7 @@ impl ToFormatElement for JsImportNamespaceClause {
             format_elements![space_token(), assertion]
         })?;
         Ok(format_elements![
+            type_token,
             star,
             space_token(),
             as_token,

--- a/crates/rome_formatter/src/js/module/literal_export_name.rs
+++ b/crates/rome_formatter/src/js/module/literal_export_name.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsLiteralExportName;
+use rslint_parser::ast::JsLiteralExportNameFields;
 
 impl ToFormatElement for JsLiteralExportName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value().format(formatter)
+        let JsLiteralExportNameFields { value } = self.as_fields();
+
+        value.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/module/module_source.rs
+++ b/crates/rome_formatter/src/js/module/module_source.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsModuleSource;
+use rslint_parser::ast::JsModuleSourceFields;
 
 impl ToFormatElement for JsModuleSource {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value_token().format(formatter)
+        let JsModuleSourceFields { value_token } = self.as_fields();
+
+        value_token.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/named_import_specifier.rs
@@ -1,7 +1,7 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
-    format_elements, soft_line_break_or_space, FormatElement, FormatResult, Formatter,
+    format_elements, soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
 
@@ -17,11 +17,15 @@ impl ToFormatElement for JsNamedImportSpecifier {
             local_name,
         } = self.as_fields();
 
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
         let name = name.format(formatter)?;
         let as_token = as_token.format(formatter)?;
         let local_name = local_name.format(formatter)?;
 
         Ok(format_elements![
+            type_token,
             name,
             soft_line_break_or_space(),
             as_token,

--- a/crates/rome_formatter/src/js/module/named_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/named_import_specifier.rs
@@ -6,12 +6,20 @@ use crate::{
 };
 
 use rslint_parser::ast::JsNamedImportSpecifier;
+use rslint_parser::ast::JsNamedImportSpecifierFields;
 
 impl ToFormatElement for JsNamedImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let name = self.name().format(formatter)?;
-        let as_token = self.as_token().format(formatter)?;
-        let local_name = self.local_name().format(formatter)?;
+        let JsNamedImportSpecifierFields {
+            type_token,
+            name,
+            as_token,
+            local_name,
+        } = self.as_fields();
+
+        let name = name.format(formatter)?;
+        let as_token = as_token.format(formatter)?;
+        let local_name = local_name.format(formatter)?;
 
         Ok(format_elements![
             name,

--- a/crates/rome_formatter/src/js/module/named_import_specifiers.rs
+++ b/crates/rome_formatter/src/js/module/named_import_specifiers.rs
@@ -2,15 +2,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsNamedImportSpecifiers;
+use rslint_parser::ast::JsNamedImportSpecifiersFields;
 
 impl ToFormatElement for JsNamedImportSpecifiers {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let specifiers = self.specifiers().format(formatter)?;
-
-        formatter.format_delimited_soft_block_spaces(
-            &self.l_curly_token()?,
+        let JsNamedImportSpecifiersFields {
+            l_curly_token,
             specifiers,
-            &self.r_curly_token()?,
-        )
+            r_curly_token,
+        } = self.as_fields();
+
+        let specifiers = specifiers.format(formatter)?;
+
+        formatter.format_delimited_soft_block_spaces(&l_curly_token?, specifiers, &r_curly_token?)
     }
 }

--- a/crates/rome_formatter/src/js/module/namespace_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/namespace_import_specifier.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsNamespaceImportSpecifier;
+use rslint_parser::ast::JsNamespaceImportSpecifierFields;
 
 impl ToFormatElement for JsNamespaceImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let star = self.star_token().format(formatter)?;
-        let as_token = self.as_token().format(formatter)?;
-        let local_name = self.local_name().format(formatter)?;
+        let JsNamespaceImportSpecifierFields {
+            star_token,
+            as_token,
+            local_name,
+        } = self.as_fields();
+
+        let star = star_token.format(formatter)?;
+        let as_token = as_token.format(formatter)?;
+        let local_name = local_name.format(formatter)?;
 
         Ok(format_elements![
             star,

--- a/crates/rome_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -3,9 +3,15 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsShorthandNamedImportSpecifier;
+use rslint_parser::ast::JsShorthandNamedImportSpecifierFields;
 
 impl ToFormatElement for JsShorthandNamedImportSpecifier {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.local_name().format(formatter)
+        let JsShorthandNamedImportSpecifierFields {
+            type_token,
+            local_name,
+        } = self.as_fields();
+
+        local_name.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/module/shorthand_named_import_specifier.rs
+++ b/crates/rome_formatter/src/js/module/shorthand_named_import_specifier.rs
@@ -1,6 +1,8 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{
+    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
+};
 
 use rslint_parser::ast::JsShorthandNamedImportSpecifier;
 use rslint_parser::ast::JsShorthandNamedImportSpecifierFields;
@@ -12,6 +14,11 @@ impl ToFormatElement for JsShorthandNamedImportSpecifier {
             local_name,
         } = self.as_fields();
 
-        local_name.format(formatter)
+        let type_token = type_token
+            .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
+
+        let local_name = local_name.format(formatter)?;
+
+        Ok(format_elements![type_token, local_name])
     }
 }

--- a/crates/rome_formatter/src/js/objects/computed_member_name.rs
+++ b/crates/rome_formatter/src/js/objects/computed_member_name.rs
@@ -3,13 +3,20 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsComputedMemberName;
+use rslint_parser::ast::JsComputedMemberNameFields;
 
 impl ToFormatElement for JsComputedMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsComputedMemberNameFields {
+            l_brack_token,
+            expression,
+            r_brack_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.l_brack_token().format(formatter)?,
-            self.expression().format(formatter)?,
-            self.r_brack_token().format(formatter)?,
+            l_brack_token.format(formatter)?,
+            expression.format(formatter)?,
+            r_brack_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/getter_object_member.rs
@@ -1,4 +1,4 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -24,6 +24,7 @@ impl ToFormatElement for JsGetterObjectMember {
             name.format(formatter)?,
             l_paren_token.format(formatter)?,
             r_paren_token.format(formatter)?,
+            return_type.format_or_empty(formatter)?,
             space_token(),
             body.format(formatter)?
         ])

--- a/crates/rome_formatter/src/js/objects/getter_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/getter_object_member.rs
@@ -5,17 +5,27 @@ use crate::{
 };
 
 use rslint_parser::ast::JsGetterObjectMember;
+use rslint_parser::ast::JsGetterObjectMemberFields;
 
 impl ToFormatElement for JsGetterObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsGetterObjectMemberFields {
+            get_token,
+            name,
+            l_paren_token,
+            r_paren_token,
+            return_type,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.get_token().format(formatter)?,
+            get_token.format(formatter)?,
             space_token(),
-            self.name().format(formatter)?,
-            self.l_paren_token().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            name.format(formatter)?,
+            l_paren_token.format(formatter)?,
+            r_paren_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/objects/literal_member_name.rs
+++ b/crates/rome_formatter/src/js/objects/literal_member_name.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsLiteralMemberName;
+use rslint_parser::ast::JsLiteralMemberNameFields;
 
 impl ToFormatElement for JsLiteralMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.value().format(formatter)
+        let JsLiteralMemberNameFields { value } = self.as_fields();
+
+        value.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/method_object_member.rs
@@ -27,9 +27,9 @@ impl ToFormatElement for JsMethodObjectMember {
             async_token,
             star_token,
             name.format(formatter)?,
-            // TODO type_params
+            type_parameters.format_or_empty(formatter)?,
             parameters.format(formatter)?,
-            // TODO return_type
+            return_type_annotation.format_or_empty(formatter)?,
             space_token(),
             body.format(formatter)?,
         ])

--- a/crates/rome_formatter/src/js/objects/method_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/method_object_member.rs
@@ -5,24 +5,33 @@ use crate::{
 };
 
 use rslint_parser::ast::JsMethodObjectMember;
+use rslint_parser::ast::JsMethodObjectMemberFields;
 
 impl ToFormatElement for JsMethodObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let async_token = self
-            .async_token()
-            .format_with_or_empty(formatter, |async_token| {
-                format_elements![async_token, space_token()]
-            })?;
-        let star_token = self.star_token().format_or_empty(formatter)?;
+        let JsMethodObjectMemberFields {
+            async_token,
+            star_token,
+            name,
+            type_parameters,
+            parameters,
+            return_type_annotation,
+            body,
+        } = self.as_fields();
+
+        let async_token = async_token.format_with_or_empty(formatter, |async_token| {
+            format_elements![async_token, space_token()]
+        })?;
+        let star_token = star_token.format_or_empty(formatter)?;
         Ok(format_elements![
             async_token,
             star_token,
-            self.name().format(formatter)?,
-            // TODO self.type_params()
-            self.parameters().format(formatter)?,
-            // TODO self.return_type()
+            name.format(formatter)?,
+            // TODO type_params
+            parameters.format(formatter)?,
+            // TODO return_type
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/objects/private_class_member_name.rs
+++ b/crates/rome_formatter/src/js/objects/private_class_member_name.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsPrivateClassMemberName;
+use rslint_parser::ast::JsPrivateClassMemberNameFields;
 
 impl ToFormatElement for JsPrivateClassMemberName {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsPrivateClassMemberNameFields {
+            hash_token,
+            id_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.hash_token().format(formatter)?,
-            self.id_token().format(formatter)?,
+            hash_token.format(formatter)?,
+            id_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/objects/property_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/property_object_member.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsPropertyObjectMember;
+use rslint_parser::ast::JsPropertyObjectMemberFields;
 
 impl ToFormatElement for JsPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let key = self.name().format(formatter)?;
-        let colon = self.colon_token().format(formatter)?;
-        let value = self.value().format(formatter)?;
+        let JsPropertyObjectMemberFields {
+            name,
+            colon_token,
+            value,
+        } = self.as_fields();
+
+        let key = name.format(formatter)?;
+        let colon = colon_token.format(formatter)?;
+        let value = value.format(formatter)?;
         Ok(format_elements![key, colon, space_token(), value])
     }
 }

--- a/crates/rome_formatter/src/js/objects/setter_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/setter_object_member.rs
@@ -5,18 +5,28 @@ use crate::{
 };
 
 use rslint_parser::ast::JsSetterObjectMember;
+use rslint_parser::ast::JsSetterObjectMemberFields;
 
 impl ToFormatElement for JsSetterObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsSetterObjectMemberFields {
+            set_token,
+            name,
+            l_paren_token,
+            parameter,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.set_token().format(formatter)?,
+            set_token.format(formatter)?,
             space_token(),
-            self.name().format(formatter)?,
-            self.l_paren_token().format(formatter)?,
-            self.parameter().format(formatter)?,
-            self.r_paren_token().format(formatter)?,
+            name.format(formatter)?,
+            l_paren_token.format(formatter)?,
+            parameter.format(formatter)?,
+            r_paren_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/objects/shorthand_property_object_member.rs
+++ b/crates/rome_formatter/src/js/objects/shorthand_property_object_member.rs
@@ -3,9 +3,12 @@ use crate::formatter_traits::FormatTokenAndNode;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsShorthandPropertyObjectMember;
+use rslint_parser::ast::JsShorthandPropertyObjectMemberFields;
 
 impl ToFormatElement for JsShorthandPropertyObjectMember {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        self.name().format(formatter)
+        let JsShorthandPropertyObjectMemberFields { name } = self.as_fields();
+
+        name.format(formatter)
     }
 }

--- a/crates/rome_formatter/src/js/statements/block_statement.rs
+++ b/crates/rome_formatter/src/js/statements/block_statement.rs
@@ -6,24 +6,27 @@ use crate::{
 
 use rslint_parser::ast::JsBlockStatement;
 
+use rslint_parser::ast::JsBlockStatementFields;
 use rslint_parser::{AstNode, AstNodeList, JsSyntaxKind};
 
 impl ToFormatElement for JsBlockStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let stmts = formatter.format_list(self.statements());
+        let JsBlockStatementFields {
+            l_curly_token,
+            statements,
+            r_curly_token,
+        } = self.as_fields();
+
+        let stmts = formatter.format_list(statements);
 
         if is_non_collapsable_empty_block(self) {
             Ok(format_elements![
-                self.l_curly_token().format(formatter)?,
+                l_curly_token.format(formatter)?,
                 hard_line_break(),
-                self.r_curly_token().format(formatter)?
+                r_curly_token.format(formatter)?
             ])
         } else {
-            formatter.format_delimited_block_indent(
-                &self.l_curly_token()?,
-                stmts,
-                &self.r_curly_token()?,
-            )
+            formatter.format_delimited_block_indent(&l_curly_token?, stmts, &r_curly_token?)
         }
     }
 }

--- a/crates/rome_formatter/src/js/statements/break_statement.rs
+++ b/crates/rome_formatter/src/js/statements/break_statement.rs
@@ -5,17 +5,23 @@ use crate::{
 };
 
 use rslint_parser::ast::JsBreakStatement;
+use rslint_parser::ast::JsBreakStatementFields;
 
 impl ToFormatElement for JsBreakStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let label = self
-            .label_token()
+        let JsBreakStatementFields {
+            break_token,
+            label_token,
+            semicolon_token,
+        } = self.as_fields();
+
+        let label = label_token
             .format_with_or_empty(formatter, |label| format_elements![space_token(), label])?;
 
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
-            self.break_token().format(formatter)?,
+            break_token.format(formatter)?,
             label,
             semicolon,
         ])

--- a/crates/rome_formatter/src/js/statements/continue_statement.rs
+++ b/crates/rome_formatter/src/js/statements/continue_statement.rs
@@ -5,17 +5,23 @@ use crate::{
 };
 
 use rslint_parser::ast::JsContinueStatement;
+use rslint_parser::ast::JsContinueStatementFields;
 
 impl ToFormatElement for JsContinueStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let label = self
-            .label_token()
+        let JsContinueStatementFields {
+            continue_token,
+            label_token,
+            semicolon_token,
+        } = self.as_fields();
+
+        let label = label_token
             .format_with_or_empty(formatter, |token| format_elements![space_token(), token])?;
 
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
-            self.continue_token().format(formatter)?,
+            continue_token.format(formatter)?,
             label,
             semicolon
         ])

--- a/crates/rome_formatter/src/js/statements/debugger_statement.rs
+++ b/crates/rome_formatter/src/js/statements/debugger_statement.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsDebuggerStatement;
+use rslint_parser::ast::JsDebuggerStatementFields;
 
 impl ToFormatElement for JsDebuggerStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsDebuggerStatementFields {
+            debugger_token,
+            semicolon_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.debugger_token().format(formatter)?,
-            self.semicolon_token().format_or(formatter, || token(";"))?
+            debugger_token.format(formatter)?,
+            semicolon_token.format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/do_while_statement.rs
+++ b/crates/rome_formatter/src/js/statements/do_while_statement.rs
@@ -5,22 +5,33 @@ use crate::{
 };
 
 use rslint_parser::ast::JsDoWhileStatement;
+use rslint_parser::ast::JsDoWhileStatementFields;
 
 impl ToFormatElement for JsDoWhileStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsDoWhileStatementFields {
+            do_token,
+            body,
+            while_token,
+            l_paren_token,
+            test,
+            r_paren_token,
+            semicolon_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.do_token().format(formatter)?,
+            do_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
             space_token(),
-            self.while_token().format(formatter)?,
+            while_token.format(formatter)?,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
-                self.test().format(formatter)?,
-                &self.r_paren_token()?,
+                &l_paren_token?,
+                test.format(formatter)?,
+                &r_paren_token?,
             )?,
-            self.semicolon_token().format_or(formatter, || token(";"))?
+            semicolon_token.format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/empty_statement.rs
+++ b/crates/rome_formatter/src/js/statements/empty_statement.rs
@@ -1,9 +1,12 @@
 use crate::{empty_element, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsEmptyStatement;
+use rslint_parser::ast::JsEmptyStatementFields;
 
 impl ToFormatElement for JsEmptyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        formatter.format_replaced(&self.semicolon_token()?, empty_element())
+        let JsEmptyStatementFields { semicolon_token } = self.as_fields();
+
+        formatter.format_replaced(&semicolon_token?, empty_element())
     }
 }

--- a/crates/rome_formatter/src/js/statements/expression_statement.rs
+++ b/crates/rome_formatter/src/js/statements/expression_statement.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsExpressionStatement;
+use rslint_parser::ast::JsExpressionStatementFields;
 
 impl ToFormatElement for JsExpressionStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsExpressionStatementFields {
+            expression,
+            semicolon_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.expression().format(formatter)?,
-            self.semicolon_token().format_or(formatter, || token(";"))?
+            expression.format(formatter)?,
+            semicolon_token.format_or(formatter, || token(";"))?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/for_in_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_in_statement.rs
@@ -6,20 +6,31 @@ use crate::{
     format_elements, soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
+use rslint_parser::ast::JsForInStatementFields;
 
 impl ToFormatElement for JsForInStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let for_token = self.for_token().format(formatter)?;
-        let initializer = self.initializer().format(formatter)?;
-        let in_token = self.in_token().format(formatter)?;
-        let expression = self.expression().format(formatter)?;
-        let body = self.body().format(formatter)?;
+        let JsForInStatementFields {
+            for_token,
+            l_paren_token,
+            initializer,
+            in_token,
+            expression,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
+        let for_token = for_token.format(formatter)?;
+        let initializer = initializer.format(formatter)?;
+        let in_token = in_token.format(formatter)?;
+        let expression = expression.format(formatter)?;
+        let body = body.format(formatter)?;
 
         Ok(format_elements![
             for_token,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
+                &l_paren_token?,
                 format_elements![
                     initializer,
                     soft_line_break_or_space(),
@@ -27,7 +38,7 @@ impl ToFormatElement for JsForInStatement {
                     soft_line_break_or_space(),
                     expression,
                 ],
-                &self.r_paren_token()?
+                &r_paren_token?
             )?,
             space_token(),
             body

--- a/crates/rome_formatter/src/js/statements/for_of_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_of_statement.rs
@@ -6,24 +6,35 @@ use crate::{
     format_elements, soft_line_break_or_space, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
+use rslint_parser::ast::JsForOfStatementFields;
 
 impl ToFormatElement for JsForOfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let for_token = self.for_token().format(formatter)?;
-        let await_token = self
-            .await_token()
+        let JsForOfStatementFields {
+            for_token,
+            await_token,
+            l_paren_token,
+            initializer,
+            of_token,
+            expression,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
+        let for_token = for_token.format(formatter)?;
+        let await_token = await_token
             .format_with_or_empty(formatter, |token| format_elements![token, space_token()])?;
-        let initializer = self.initializer().format(formatter)?;
-        let of_token = self.of_token().format(formatter)?;
-        let expression = self.expression().format(formatter)?;
-        let body = self.body().format(formatter)?;
+        let initializer = initializer.format(formatter)?;
+        let of_token = of_token.format(formatter)?;
+        let expression = expression.format(formatter)?;
+        let body = body.format(formatter)?;
 
         Ok(format_elements![
             for_token,
             space_token(),
             await_token,
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
+                &l_paren_token?,
                 format_elements![
                     initializer,
                     soft_line_break_or_space(),
@@ -31,7 +42,7 @@ impl ToFormatElement for JsForOfStatement {
                     soft_line_break_or_space(),
                     expression,
                 ],
-                &self.r_paren_token()?
+                &r_paren_token?
             )?,
             space_token(),
             body

--- a/crates/rome_formatter/src/js/statements/for_statement.rs
+++ b/crates/rome_formatter/src/js/statements/for_statement.rs
@@ -6,37 +6,49 @@ use crate::{
 };
 
 use rslint_parser::ast::JsForStatement;
+use rslint_parser::ast::JsForStatementFields;
 
 impl ToFormatElement for JsForStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let inner =
-            if self.initializer().is_some() || self.test().is_some() || self.update().is_some() {
-                format_elements![
-                    self.initializer().format_or_empty(formatter)?,
-                    self.first_semi_token().format(formatter)?,
-                    soft_line_break_or_space(),
-                    self.test().format_or_empty(formatter)?,
-                    self.second_semi_token().format(formatter)?,
-                    soft_line_break_or_space(),
-                    self.update().format_or_empty(formatter)?,
-                ]
-            } else {
-                format_elements![
-                    self.first_semi_token().format(formatter)?,
-                    self.second_semi_token().format(formatter)?,
-                ]
-            };
+        let JsForStatementFields {
+            for_token,
+            l_paren_token,
+            initializer,
+            first_semi_token,
+            test,
+            second_semi_token,
+            update,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
+        let inner = if initializer.is_some() || test.is_some() || update.is_some() {
+            format_elements![
+                initializer.format_or_empty(formatter)?,
+                first_semi_token.format(formatter)?,
+                soft_line_break_or_space(),
+                test.format_or_empty(formatter)?,
+                second_semi_token.format(formatter)?,
+                soft_line_break_or_space(),
+                update.format_or_empty(formatter)?,
+            ]
+        } else {
+            format_elements![
+                first_semi_token.format(formatter)?,
+                second_semi_token.format(formatter)?,
+            ]
+        };
 
         Ok(group_elements(format_elements![
-            self.for_token().format(formatter)?,
+            for_token.format(formatter)?,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
+                &l_paren_token?,
                 inner,
-                &self.r_paren_token()?,
+                &r_paren_token?,
             )?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ]))
     }
 }

--- a/crates/rome_formatter/src/js/statements/if_statement.rs
+++ b/crates/rome_formatter/src/js/statements/if_statement.rs
@@ -6,27 +6,35 @@ use crate::{
 };
 
 use rslint_parser::ast::JsIfStatement;
+use rslint_parser::ast::JsIfStatementFields;
 
 impl ToFormatElement for JsIfStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let else_caluse = self
-            .else_clause()
-            .format_with_or_empty(formatter, |else_clause| {
-                format_elements![space_token(), else_clause]
-            })?;
+        let JsIfStatementFields {
+            if_token,
+            l_paren_token,
+            test,
+            r_paren_token,
+            consequent,
+            else_clause,
+        } = self.as_fields();
+
+        let else_caluse = else_clause.format_with_or_empty(formatter, |else_clause| {
+            format_elements![space_token(), else_clause]
+        })?;
 
         Ok(format_elements![
             group_elements(format_elements![
-                self.if_token().format(formatter)?,
+                if_token.format(formatter)?,
                 space_token(),
                 formatter.format_delimited_soft_block_indent(
-                    &self.l_paren_token()?,
-                    self.test().format(formatter)?,
-                    &self.r_paren_token()?,
+                    &l_paren_token?,
+                    test.format(formatter)?,
+                    &r_paren_token?,
                 )?,
                 space_token(),
             ]),
-            self.consequent().format(formatter)?,
+            consequent.format(formatter)?,
             else_caluse
         ])
     }

--- a/crates/rome_formatter/src/js/statements/labeled_statement.rs
+++ b/crates/rome_formatter/src/js/statements/labeled_statement.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsLabeledStatement;
+use rslint_parser::ast::JsLabeledStatementFields;
 
 impl ToFormatElement for JsLabeledStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let label = self.label_token().format(formatter)?;
-        let colon = self.colon_token().format(formatter)?;
-        let statement = self.body().format(formatter)?;
+        let JsLabeledStatementFields {
+            label_token,
+            colon_token,
+            body,
+        } = self.as_fields();
+
+        let label = label_token.format(formatter)?;
+        let colon = colon_token.format(formatter)?;
+        let statement = body.format(formatter)?;
 
         Ok(format_elements![label, colon, space_token(), statement])
     }

--- a/crates/rome_formatter/src/js/statements/return_statement.rs
+++ b/crates/rome_formatter/src/js/statements/return_statement.rs
@@ -7,18 +7,23 @@ use crate::{
 };
 
 use rslint_parser::ast::JsReturnStatement;
+use rslint_parser::ast::JsReturnStatementFields;
 
 impl ToFormatElement for JsReturnStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let return_token = self.return_token().format(formatter)?;
+        let JsReturnStatementFields {
+            return_token,
+            argument,
+            semicolon_token,
+        } = self.as_fields();
 
-        let argument = self
-            .argument()
-            .format_with_or_empty(formatter, |argument| {
-                format_elements![space_token(), argument]
-            })?;
+        let return_token = return_token.format(formatter)?;
 
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let argument = argument.format_with_or_empty(formatter, |argument| {
+            format_elements![space_token(), argument]
+        })?;
+
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![return_token, argument, semicolon])
     }

--- a/crates/rome_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/js/statements/switch_statement.rs
@@ -33,7 +33,12 @@ impl ToFormatElement for JsSwitchStatement {
             space_token(),
             formatter.format_delimited_block_indent(
                 &l_curly_token?,
-                join_elements_hard_line(cases.into_iter().zip(formatter.format_nodes(cases)?)),
+                join_elements_hard_line(
+                    cases
+                        .clone()
+                        .into_iter()
+                        .zip(formatter.format_nodes(cases)?)
+                ),
                 &r_curly_token?
             )?
         ])

--- a/crates/rome_formatter/src/js/statements/switch_statement.rs
+++ b/crates/rome_formatter/src/js/statements/switch_statement.rs
@@ -8,26 +8,33 @@ use crate::{
 };
 
 use rslint_parser::ast::JsSwitchStatement;
+use rslint_parser::ast::JsSwitchStatementFields;
 
 impl ToFormatElement for JsSwitchStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsSwitchStatementFields {
+            switch_token,
+            l_paren_token,
+            discriminant,
+            r_paren_token,
+            l_curly_token,
+            cases,
+            r_curly_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.switch_token().format(formatter)?,
+            switch_token.format(formatter)?,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
-                self.discriminant().format(formatter)?,
-                &self.r_paren_token()?,
+                &l_paren_token?,
+                discriminant.format(formatter)?,
+                &r_paren_token?,
             )?,
             space_token(),
             formatter.format_delimited_block_indent(
-                &self.l_curly_token()?,
-                join_elements_hard_line(
-                    self.cases()
-                        .into_iter()
-                        .zip(formatter.format_nodes(self.cases())?)
-                ),
-                &self.r_curly_token()?
+                &l_curly_token?,
+                join_elements_hard_line(cases.into_iter().zip(formatter.format_nodes(cases)?)),
+                &r_curly_token?
             )?
         ])
     }

--- a/crates/rome_formatter/src/js/statements/throw_statement.rs
+++ b/crates/rome_formatter/src/js/statements/throw_statement.rs
@@ -5,12 +5,19 @@ use crate::{
 };
 
 use rslint_parser::ast::JsThrowStatement;
+use rslint_parser::ast::JsThrowStatementFields;
 
 impl ToFormatElement for JsThrowStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let throw_token = self.throw_token().format(formatter)?;
-        let exception = self.argument().format(formatter)?;
-        let semicolon = self.semicolon_token().format_or(formatter, || token(";"))?;
+        let JsThrowStatementFields {
+            throw_token,
+            argument,
+            semicolon_token,
+        } = self.as_fields();
+
+        let throw_token = throw_token.format(formatter)?;
+        let exception = argument.format(formatter)?;
+        let semicolon = semicolon_token.format_or(formatter, || token(";"))?;
 
         Ok(format_elements![
             throw_token,

--- a/crates/rome_formatter/src/js/statements/try_finally_statement.rs
+++ b/crates/rome_formatter/src/js/statements/try_finally_statement.rs
@@ -5,22 +5,29 @@ use crate::{
 };
 
 use rslint_parser::ast::JsTryFinallyStatement;
+use rslint_parser::ast::JsTryFinallyStatementFields;
 
 impl ToFormatElement for JsTryFinallyStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let formatted_catch_clause = self
-            .catch_clause()
+        let JsTryFinallyStatementFields {
+            try_token,
+            body,
+            catch_clause,
+            finally_clause,
+        } = self.as_fields();
+
+        let formatted_catch_clause = catch_clause
             .format_with_or_empty(formatter, |catch_clause| {
                 format_elements![space_token(), catch_clause]
             })?;
 
         Ok(format_elements![
-            self.try_token().format(formatter)?,
+            try_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
             formatted_catch_clause,
             space_token(),
-            self.finally_clause().format(formatter)?
+            finally_clause.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/try_statement.rs
+++ b/crates/rome_formatter/src/js/statements/try_statement.rs
@@ -5,15 +5,22 @@ use crate::{
 };
 
 use rslint_parser::ast::JsTryStatement;
+use rslint_parser::ast::JsTryStatementFields;
 
 impl ToFormatElement for JsTryStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsTryStatementFields {
+            try_token,
+            body,
+            catch_clause,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.try_token().format(formatter)?,
+            try_token.format(formatter)?,
             space_token(),
-            self.body().format(formatter)?,
+            body.format(formatter)?,
             space_token(),
-            self.catch_clause().format(formatter)?,
+            catch_clause.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/variable_statement.rs
+++ b/crates/rome_formatter/src/js/statements/variable_statement.rs
@@ -3,12 +3,18 @@ use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{format_elements, token, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsVariableStatement;
+use rslint_parser::ast::JsVariableStatementFields;
 
 impl ToFormatElement for JsVariableStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsVariableStatementFields {
+            declaration,
+            semicolon_token,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.declaration().format(formatter)?,
-            self.semicolon_token().format_or(formatter, || token(";"))?,
+            declaration.format(formatter)?,
+            semicolon_token.format_or(formatter, || token(";"))?,
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/while_statement.rs
+++ b/crates/rome_formatter/src/js/statements/while_statement.rs
@@ -5,19 +5,28 @@ use crate::{
 };
 
 use rslint_parser::ast::JsWhileStatement;
+use rslint_parser::ast::JsWhileStatementFields;
 
 impl ToFormatElement for JsWhileStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsWhileStatementFields {
+            while_token,
+            l_paren_token,
+            test,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.while_token().format(formatter)?,
+            while_token.format(formatter)?,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
-                self.test().format(formatter)?,
-                &self.r_paren_token()?,
+                &l_paren_token?,
+                test.format(formatter)?,
+                &r_paren_token?,
             )?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rome_formatter/src/js/statements/with_statement.rs
+++ b/crates/rome_formatter/src/js/statements/with_statement.rs
@@ -5,19 +5,28 @@ use crate::{
 };
 
 use rslint_parser::ast::JsWithStatement;
+use rslint_parser::ast::JsWithStatementFields;
 
 impl ToFormatElement for JsWithStatement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let JsWithStatementFields {
+            with_token,
+            l_paren_token,
+            object,
+            r_paren_token,
+            body,
+        } = self.as_fields();
+
         Ok(format_elements![
-            self.with_token().format(formatter)?,
+            with_token.format(formatter)?,
             space_token(),
             formatter.format_delimited_soft_block_indent(
-                &self.l_paren_token()?,
-                self.object().format(formatter)?,
-                &self.r_paren_token()?,
+                &l_paren_token?,
+                object.format(formatter)?,
+                &r_paren_token?,
             )?,
             space_token(),
-            self.body().format(formatter)?
+            body.format(formatter)?
         ])
     }
 }

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -3011,8 +3011,8 @@ impl JsMethodClassMember {
     pub fn name(&self) -> SyntaxResult<JsAnyClassMemberName> {
         support::required_node(&self.syntax, 5usize)
     }
-    pub fn question_mark_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 6usize)
+    pub fn question_mark_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 6usize)
     }
     pub fn type_parameters(&self) -> Option<TsTypeParameters> {
         support::node(&self.syntax, 7usize)
@@ -3034,7 +3034,7 @@ pub struct JsMethodClassMemberFields {
     pub async_token: Option<SyntaxToken>,
     pub star_token: Option<SyntaxToken>,
     pub name: SyntaxResult<JsAnyClassMemberName>,
-    pub question_mark_token: SyntaxResult<SyntaxToken>,
+    pub question_mark_token: Option<SyntaxToken>,
     pub type_parameters: Option<TsTypeParameters>,
     pub parameters: SyntaxResult<JsParameters>,
     pub return_type_annotation: Option<TsReturnTypeAnnotation>,
@@ -11191,7 +11191,7 @@ impl std::fmt::Debug for JsMethodClassMember {
             .field("name", &support::DebugSyntaxResult(self.name()))
             .field(
                 "question_mark_token",
-                &support::DebugSyntaxResult(self.question_mark_token()),
+                &support::DebugOptionalElement(self.question_mark_token()),
             )
             .field(
                 "type_parameters",

--- a/crates/rslint_parser/test_data/inline/err/class_member_method_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/class_member_method_parameters.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@10..13 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@13..14 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
@@ -36,7 +36,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@17..23 "test" [Newline("\n"), Whitespace("\t")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@23..24 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/super_expression_err.rast
@@ -30,7 +30,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@22..29 "test" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@29..30 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/typescript_abstract_class_member_should_not_have_body.rast
+++ b/crates/rslint_parser/test_data/inline/err/typescript_abstract_class_member_should_not_have_body.rast
@@ -41,7 +41,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@77..84 "display" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@84..85 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/err/typescript_members_with_body_in_ambient_context_should_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/typescript_members_with_body_in_ambient_context_should_err.rast
@@ -24,7 +24,7 @@ JsModule {
                         name: JsLiteralMemberName {
                             value: IDENT@20..29 "name" [Newline("\n"), Whitespace("    ")] [],
                         },
-                        question_mark_token: missing (required),
+                        question_mark_token: missing (optional),
                         type_parameters: missing (optional),
                         parameters: JsParameters {
                             l_paren_token: L_PAREN@29..30 "(" [] [],
@@ -129,7 +129,7 @@ JsModule {
                                     name: JsLiteralMemberName {
                                         value: IDENT@133..147 "name" [Newline("\n"), Whitespace("         ")] [],
                                     },
-                                    question_mark_token: missing (required),
+                                    question_mark_token: missing (optional),
                                     type_parameters: missing (optional),
                                     parameters: JsParameters {
                                         l_paren_token: L_PAREN@147..148 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/async_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/async_method.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@19..22 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@22..23 "(" [] [],
@@ -46,7 +46,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@36..39 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@39..40 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/class_declare.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_declare.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@10..17 "declare" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@17..18 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/class_member_modifiers.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_member_modifiers.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@10..16 "public" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@16..17 "(" [] [],
@@ -60,7 +60,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@41..50 "protected" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@50..51 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/class_static_constructor_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/class_static_constructor_method.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@17..28 "constructor" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@28..29 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/getter_class_member.rast
@@ -173,7 +173,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@164..170 "get" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@170..171 "(" [] [],
@@ -197,7 +197,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@184..187 "get" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@187..188 "(" [] [],
@@ -221,7 +221,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@202..205 "get" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@205..206 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/method_class_member.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@12..21 "method" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@21..22 "(" [] [],
@@ -46,7 +46,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@35..46 "asyncMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@46..47 "(" [] [],
@@ -70,7 +70,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@61..81 "asyncGeneratorMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@81..82 "(" [] [],
@@ -94,7 +94,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@91..106 "generatorMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@106..107 "(" [] [],
@@ -118,7 +118,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: JS_STRING_LITERAL@111..119 "\"foo\"" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@119..120 "(" [] [],
@@ -152,7 +152,7 @@ JsModule {
                         },
                         r_brack_token: R_BRACK@141..142 "]" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@142..143 "(" [] [],
@@ -176,7 +176,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: JS_NUMBER_LITERAL@147..151 "5" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@151..152 "(" [] [],
@@ -201,7 +201,7 @@ JsModule {
                         hash_token: HASH@156..160 "#" [Newline("\n"), Whitespace("  ")] [],
                         id_token: IDENT@160..167 "private" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@167..168 "(" [] [],
@@ -239,7 +239,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@201..238 "static" [Newline("\n"), Whitespace("   "), Comments("// Methods called static"), Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@238..239 "(" [] [],
@@ -263,7 +263,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@252..258 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@258..259 "(" [] [],
@@ -287,7 +287,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@268..274 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@274..275 "(" [] [],
@@ -311,7 +311,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@289..295 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@295..296 "(" [] [],
@@ -335,7 +335,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@300..310 "declare" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@310..311 "(" [] [],
@@ -359,7 +359,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@315..321 "get" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@321..322 "(" [] [],
@@ -383,7 +383,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@347..353 "set" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@353..354 "(" [] [],
@@ -421,7 +421,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@406..412 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@412..413 "(" [] [],
@@ -445,7 +445,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@433..444 "asyncMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@444..445 "(" [] [],
@@ -469,7 +469,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@466..486 "asyncGeneratorMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@486..487 "(" [] [],
@@ -493,7 +493,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@503..518 "generatorMethod" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@518..519 "(" [] [],
@@ -517,7 +517,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@533..539 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@539..540 "(" [] [],
@@ -541,7 +541,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@560..566 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@566..567 "(" [] [],
@@ -565,7 +565,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@588..594 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@594..595 "(" [] [],
@@ -589,7 +589,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@611..617 "static" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@617..618 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/private_name_presence_check.rast
+++ b/crates/rslint_parser/test_data/inline/ok/private_name_presence_check.rast
@@ -36,7 +36,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@17..23 "test" [Newline("\n"), Whitespace("\t")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@23..24 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/setter_class_member.rast
@@ -222,7 +222,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@171..177 "set" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@177..178 "(" [] [],
@@ -255,7 +255,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@192..195 "set" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@195..196 "(" [] [],
@@ -288,7 +288,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@211..214 "set" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@214..215 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_generator_constructor_method.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@26..37 "constructor" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@37..38 "(" [] [],
@@ -46,7 +46,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@53..64 "constructor" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@64..65 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_member_expression.rast
@@ -120,7 +120,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@73..80 "test" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@80..81 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/static_method.rast
+++ b/crates/rslint_parser/test_data/inline/ok/static_method.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@20..23 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@23..24 "(" [] [],
@@ -55,7 +55,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@41..44 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@44..45 "(" [] [],
@@ -79,7 +79,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@64..67 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@67..68 "(" [] [],
@@ -103,7 +103,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@88..91 "foo" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@91..92 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rslint_parser/test_data/inline/ok/super_expression.rast
@@ -63,7 +63,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@57..64 "test" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@64..65 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_method_class_member.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@12..19 "test" [Newline("\n"), Whitespace("  ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: TsTypeParameters {
                         l_angle_token: L_ANGLE@19..20 "<" [] [],
                         items: TsTypeParameterList [

--- a/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_return_type_annotation.rast
@@ -238,7 +238,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@171..175 "test" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@175..176 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/ts_this_type.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_this_type.rast
@@ -22,7 +22,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@9..20 "method" [Newline("\n"), Whitespace("    ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@20..21 "(" [] [],
@@ -59,7 +59,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@53..67 "predicate" [Newline("\n"), Whitespace("    ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@67..68 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/typescript_abstract_classes.rast
+++ b/crates/rslint_parser/test_data/inline/ok/typescript_abstract_classes.rast
@@ -105,7 +105,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@122..134 "display" [Newline("\n"), Whitespace("    ")] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@134..135 "(" [] [],
@@ -247,7 +247,7 @@ JsModule {
                         hash_token: HASH@268..274 "#" [Newline("\n"), Whitespace("    ")] [],
                         id_token: IDENT@274..288 "private_method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@288..289 "(" [] [],
@@ -303,7 +303,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@370..377 "display" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@377..378 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/typescript_members_can_have_no_body_in_ambient_context.rast
+++ b/crates/rslint_parser/test_data/inline/ok/typescript_members_can_have_no_body_in_ambient_context.rast
@@ -24,7 +24,7 @@ JsModule {
                         name: JsLiteralMemberName {
                             value: IDENT@20..29 "name" [Newline("\n"), Whitespace("    ")] [],
                         },
-                        question_mark_token: missing (required),
+                        question_mark_token: missing (optional),
                         type_parameters: missing (optional),
                         parameters: JsParameters {
                             l_paren_token: L_PAREN@29..30 "(" [] [],
@@ -115,7 +115,7 @@ JsModule {
                                     name: JsLiteralMemberName {
                                         value: IDENT@115..129 "name" [Newline("\n"), Whitespace("         ")] [],
                                     },
-                                    question_mark_token: missing (required),
+                                    question_mark_token: missing (optional),
                                     type_parameters: missing (optional),
                                     parameters: JsParameters {
                                         l_paren_token: L_PAREN@129..130 "(" [] [],

--- a/crates/rslint_parser/test_data/inline/ok/unary_delete_nested.rast
+++ b/crates/rslint_parser/test_data/inline/ok/unary_delete_nested.rast
@@ -41,7 +41,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@34..40 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@40..41 "(" [] [],
@@ -130,7 +130,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@109..115 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@115..116 "(" [] [],
@@ -210,7 +210,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@180..186 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@186..187 "(" [] [],
@@ -296,7 +296,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@258..264 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@264..265 "(" [] [],
@@ -395,7 +395,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@340..346 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@346..347 "(" [] [],
@@ -492,7 +492,7 @@ JsModule {
                     name: JsLiteralMemberName {
                         value: IDENT@425..431 "method" [] [],
                     },
-                    question_mark_token: missing (required),
+                    question_mark_token: missing (optional),
                     type_parameters: missing (optional),
                     parameters: JsParameters {
                         l_paren_token: L_PAREN@431..432 "(" [] [],

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -712,7 +712,7 @@ JsMethodClassMember =
 	'async'?
 	'*'?
 	name: JsAnyClassMemberName
-	'?'
+	'?'?
 	type_parameters: TsTypeParameters?
 	parameters: JsParameters
 	return_type_annotation: TsReturnTypeAnnotation?


### PR DESCRIPTION
## Summary

This is an automated refactor of `rome_formatter/src/js` to use node destructuring (`as_fields`) instead of individual accessor methods, coupled with a few manual fixes for various and warnings in the second commit (mostly missing typescript nodes and tokens)