### PR TITLE
fix(rslint_parser): error when tutple type is rest and optional

### DIFF
--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -26,6 +26,7 @@ use crate::syntax::util::{
 use crate::JsSyntaxFeature::TypeScript;
 use crate::{Absent, ParsedSyntax, Parser};
 use crate::{JsSyntaxKind::*, *};
+use rslint_errors::Span;
 use rslint_syntax::T;
 
 pub(crate) fn is_reserved_type_name(name: &str) -> bool {
@@ -952,12 +953,25 @@ impl ParseSeparatedList for TsTupleTypeElementList {
     fn parse_element(&mut self, p: &mut Parser) -> ParsedSyntax {
         if is_at_named_tuple_type_element(p) {
             let m = p.start();
-            p.eat(T![...]);
+            let has_ellipsis = p.eat(T![...]);
             parse_name(p).or_add_diagnostic(p, expected_identifier);
-            p.eat(T![?]);
+            let has_question_mark = p.eat(T![?]);
             p.bump(T![:]);
             parse_ts_type(p).or_add_diagnostic(p, expected_ts_type);
-            return Present(m.complete(p, TS_NAMED_TUPLE_TYPE_ELEMENT));
+
+            let mut syntax = m.complete(p, TS_NAMED_TUPLE_TYPE_ELEMENT);
+
+            // test_err ts ts_tuple_type_cannot_be_optional_and_rest
+            // type A = [ ...name?: string[] ]
+            if has_ellipsis && has_question_mark {
+                let err = p
+                    .err_builder("A tuple member cannot be both optional and rest.")
+                    .primary(syntax.range(p).as_range(), "");
+                p.error(err);
+                syntax.change_to_unknown(p);
+            }
+
+            return Present(syntax);
         }
 
         if p.at(T![...]) {

--- a/crates/rslint_parser/test_data/inline/err/ts_tuple_type_cannot_be_optional_and_rest.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_tuple_type_cannot_be_optional_and_rest.rast
@@ -1,0 +1,78 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsUnknownStatement {
+            items: [
+                TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+                TsIdentifierBinding {
+                    name_token: IDENT@5..7 "A" [] [Whitespace(" ")],
+                },
+                EQ@7..9 "=" [] [Whitespace(" ")],
+                JsUnknown {
+                    items: [
+                        L_BRACK@9..11 "[" [] [Whitespace(" ")],
+                        JsUnknown {
+                            items: [
+                                JsUnknown {
+                                    items: [
+                                        DOT2@11..14 "..." [] [],
+                                        JsName {
+                                            value_token: IDENT@14..18 "name" [] [],
+                                        },
+                                        QUESTION@18..19 "?" [] [],
+                                        COLON@19..21 ":" [] [Whitespace(" ")],
+                                        TsArrayType {
+                                            element_type: TsStringType {
+                                                string_token: STRING_KW@21..27 "string" [] [],
+                                            },
+                                            l_brack_token: L_BRACK@27..28 "[" [] [],
+                                            r_brack_token: R_BRACK@28..30 "]" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        R_BRACK@30..31 "]" [] [],
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@31..32 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..32
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..31
+    0: JS_UNKNOWN_STATEMENT@0..31
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..7
+        0: IDENT@5..7 "A" [] [Whitespace(" ")]
+      2: EQ@7..9 "=" [] [Whitespace(" ")]
+      3: JS_UNKNOWN@9..31
+        0: L_BRACK@9..11 "[" [] [Whitespace(" ")]
+        1: JS_UNKNOWN@11..30
+          0: JS_UNKNOWN@11..30
+            0: DOT2@11..14 "..." [] []
+            1: JS_NAME@14..18
+              0: IDENT@14..18 "name" [] []
+            2: QUESTION@18..19 "?" [] []
+            3: COLON@19..21 ":" [] [Whitespace(" ")]
+            4: TS_ARRAY_TYPE@21..30
+              0: TS_STRING_TYPE@21..27
+                0: STRING_KW@21..27 "string" [] []
+              1: L_BRACK@27..28 "[" [] []
+              2: R_BRACK@28..30 "]" [] [Whitespace(" ")]
+        2: R_BRACK@30..31 "]" [] []
+  3: EOF@31..32 "" [Newline("\n")] []
+--
+error[SyntaxError]: A tuple member cannot be both optional and rest.
+  ┌─ ts_tuple_type_cannot_be_optional_and_rest.ts:1:12
+  │
+1 │ type A = [ ...name?: string[] ]
+  │            ^^^^^^^^^^^^^^^^^^
+
+--
+type A = [ ...name?: string[] ]

--- a/crates/rslint_parser/test_data/inline/err/ts_tuple_type_cannot_be_optional_and_rest.ts
+++ b/crates/rslint_parser/test_data/inline/err/ts_tuple_type_cannot_be_optional_and_rest.ts
@@ -1,0 +1,1 @@
+type A = [ ...name?: string[] ]


### PR DESCRIPTION
fixing https://github.com/rome/tools/issues/2135

# Before

The code below would parse fine.

```ts
type A = [ ...name?: string[] ]
```

# Now

```
error[SyntaxError]: A tuple member cannot be both optional and rest.
  ┌─ ts_tuple_type_cannot_be_optional_and_rest.ts:1:12
  │
1 │ type A = [ ...name?: string[] ]
  │            ^^^^^^^^^^^^^^^^^^
```