### PR TITLE
chore(coverage): Support multiple test files per test case

### DIFF
--- a/xtask/coverage/README.md
+++ b/xtask/coverage/README.md
@@ -23,8 +23,8 @@ You can filter the tests by passing an additional `--filter` so that only the te
 cargo coverage --filter=source
 ```
 
-The `--detailed` parameter enables a more detailed summary at the end of the test run that includes diagnostic and the `rast` (when using--detailed=rast`)
-for all failing tests. `--detailed` can also be useful if you want to pipe the results to a text file.
+The `--detailed` parameter enables a more detailed summary at the end of the test run that includes diagnostic.
+You can use `--detailed-=debug` if you're debugging a test (prints the AST and diagnostics, even for passing tests). `--detailed` can also be useful if you want to pipe the results to a text file.
 
 
 ```bash

--- a/xtask/coverage/README.md
+++ b/xtask/coverage/README.md
@@ -24,7 +24,7 @@ cargo coverage --filter=source
 ```
 
 The `--detailed` parameter enables a more detailed summary at the end of the test run that includes diagnostic.
-You can use `--detailed-=debug` if you're debugging a test (prints the AST and diagnostics, even for passing tests). `--detailed` can also be useful if you want to pipe the results to a text file.
+You can use `--detailed=debug` if you're debugging a test (prints the AST and diagnostics, even for passing tests). `--detailed` can also be useful if you want to pipe the results to a text file.
 
 
 ```bash

--- a/xtask/coverage/src/lib.rs
+++ b/xtask/coverage/src/lib.rs
@@ -17,14 +17,13 @@ use crate::typescript::TypeScriptTestSuite;
 use rslint_parser::ParserError;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
-use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestResult {
     #[serde(rename = "o")]
     pub outcome: Outcome,
     #[serde(rename = "h")]
-    pub path: PathBuf,
+    pub test_case: String,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Copy, Clone)]

--- a/xtask/coverage/src/main.rs
+++ b/xtask/coverage/src/main.rs
@@ -36,7 +36,7 @@ SUBCOMMANDS:
 OPTIONS
     --markdown          Emits supported output into markdown format. Supported by `compare` subcommand
     --json              Prints the test results in JSON. This mode will send all other test output and user messages to stderr.
-    --detailed=[rast]   Prints a detailed summary at the end for all failing tests. Includes the RAST output if `rast` is passed.
+    --detailed=[debug]  Prints a detailed summary at the end for all failing tests. Includes in depth details if set to `debug`
     --language=[js|ts]  Runs a specific test suite
     --filter=<file>     Filters out tests that don't match the query
     --help              Prints this help
@@ -57,6 +57,8 @@ OPTIONS
                 Some(SummaryDetailLevel::Coverage)
             }
         });
+
+    args.finish().unwrap();
 
     run(
         language.as_deref(),

--- a/xtask/coverage/src/reporters.rs
+++ b/xtask/coverage/src/reporters.rs
@@ -118,6 +118,7 @@ pub enum SummaryDetailLevel {
     /// Prints the coverage table as well as all failing tests with their diagnostics
     Failing,
 
+    /// Prints the RAST of the parsed syntax and the diagnostics for all tests (including tests that pass with expected diagnostics).
     Debug,
 }
 

--- a/xtask/coverage/src/reporters.rs
+++ b/xtask/coverage/src/reporters.rs
@@ -1,13 +1,11 @@
-use crate::runner::{TestRunOutcome, TestRunResult, TestSuite, TestSuiteInstance};
+use crate::runner::{TestCaseFiles, TestRunOutcome, TestRunResult, TestSuite, TestSuiteInstance};
 use crate::{Summary, TestResults};
 use ascii_table::{AsciiTable, Column};
 use atty::Stream;
 use colored::Colorize;
 use indicatif::ProgressBar;
-use rslint_errors::file::SimpleFile;
 use rslint_errors::termcolor::Buffer;
-use rslint_errors::Emitter;
-use rslint_parser::{parse, ParserError};
+use rslint_parser::ParserError;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io::Write;
@@ -98,11 +96,8 @@ impl TestReporter for DefaultReporter {
             | TestRunOutcome::Panicked(_) => "FAIL".bold().red(),
         };
 
-        self.pb.println(format!(
-            "{} {}",
-            label,
-            result.path.display().to_string().blue()
-        ));
+        self.pb
+            .println(format!("{} {}", label, result.test_case.blue()));
     }
 
     fn test_suite_completed(&mut self, suite: &TestSuiteInstance, _results: &TestResults) {
@@ -122,11 +117,8 @@ pub enum SummaryDetailLevel {
     Coverage,
     /// Prints the coverage table as well as all failing tests with their diagnostics
     Failing,
-    /// Prints the diagnostics of failing tests as well as of tests that are supposed to fail and correct
-    /// emitted diagnostics
-    AllDiagnostics,
-    /// Prints all failing tests with their RAST output
-    FailingWithRast,
+
+    Debug,
 }
 
 impl FromStr for SummaryDetailLevel {
@@ -136,8 +128,7 @@ impl FromStr for SummaryDetailLevel {
         Ok(match s {
             "coverage" => SummaryDetailLevel::Coverage,
             "failing" => SummaryDetailLevel::Failing,
-            "rast" => SummaryDetailLevel::FailingWithRast,
-            "diagnostics" => SummaryDetailLevel::AllDiagnostics,
+            "debug" => SummaryDetailLevel::Debug,
             _ => return Err(String::from(
                 "Unknown summary detail level. Valid values are: 'coverage', 'failing, and 'rast'.",
             )),
@@ -146,16 +137,12 @@ impl FromStr for SummaryDetailLevel {
 }
 
 impl SummaryDetailLevel {
-    fn is_rast_enabled(&self) -> bool {
-        matches!(self, SummaryDetailLevel::FailingWithRast)
-    }
-
     fn is_coverage_only(&self) -> bool {
         matches!(self, SummaryDetailLevel::Coverage)
     }
 
-    fn is_all_diagnostics(&self) -> bool {
-        matches!(self, SummaryDetailLevel::AllDiagnostics)
+    fn is_debug(&self) -> bool {
+        matches!(self, SummaryDetailLevel::Debug)
     }
 }
 
@@ -217,7 +204,7 @@ impl SummaryReporter {
         }
     }
 
-    fn writeln(&mut self, msg: String) {
+    fn writeln(&mut self, msg: &str) {
         writeln!(self.buffer, "{}", msg).unwrap();
     }
 
@@ -279,17 +266,9 @@ impl SummaryReporter {
         table.format(rows)
     }
 
-    fn write_errors(&mut self, errors: &[ParserError], result: &TestRunResult) {
-        let file = SimpleFile::new(result.path.display().to_string(), result.code.to_string());
-        let mut emitter = Emitter::new(&file);
-
-        for error in errors {
-            if let Err(err) = emitter.emit_with_writer(error, &mut self.buffer) {
-                eprintln!("Failed to print diagnostic: {}", err);
-            }
-        }
-
-        self.writeln("".to_string());
+    fn write_errors(&mut self, errors: &[ParserError], files: &TestCaseFiles) {
+        files.emit_errors(errors, &mut self.buffer);
+        self.writeln("");
     }
 }
 
@@ -300,55 +279,59 @@ impl TestReporter for SummaryReporter {
         }
 
         match &result.outcome {
-            TestRunOutcome::Passed(syntax) => {
-                if self.detail_level.is_all_diagnostics() || self.detail_level.is_rast_enabled() {
-                    self.writeln(format!(
-                        "{} {}",
-                        "[PASS]".bold().green(),
-                        result.path.display()
-                    ));
-                }
+            TestRunOutcome::Passed(files) => {
+                if self.detail_level.is_debug() {
+                    self.writeln(&format!("{} {}", "[PASS]".bold().green(), result.test_case));
 
-                if self.detail_level.is_all_diagnostics() {
-                    let errors = parse(&result.code, 0, *syntax).ok().err();
+                    let mut all_errors = Vec::new();
+                    for file in files {
+                        if let Some(errors) = file.parse().ok().err() {
+                            all_errors.extend(errors);
+                        }
+                    }
 
-                    if let Some(errors) = errors {
-                        self.write_errors(&errors, result);
+                    if !all_errors.is_empty() {
+                        self.write_errors(&all_errors, files);
                     }
                 }
             }
             TestRunOutcome::Panicked(_) => {
                 let panic = result.outcome.panic_message();
-                self.writeln(format!(
+                self.writeln(&format!(
                     "{} {}: {}",
                     "[PANIC]".bold().red(),
-                    result.path.display(),
+                    result.test_case,
                     panic.unwrap_or("Unknown panic reason")
                 ));
             }
             TestRunOutcome::IncorrectlyPassed(_) => {
-                self.writeln(format!(
+                self.writeln(&format!(
                     "{} {}: Incorrectly passed",
                     "[FAIL]".bold().red(),
-                    result.path.display()
+                    result.test_case
                 ));
             }
-            TestRunOutcome::IncorrectlyErrored { errors, .. } => {
-                self.writeln(format!(
+            TestRunOutcome::IncorrectlyErrored { errors, files } => {
+                self.writeln(&format!(
                     "{} {}: Incorrectly errored:",
                     "[FAIL]".bold().red(),
-                    result.path.display()
+                    result.test_case
                 ));
 
-                self.write_errors(errors, result);
+                self.write_errors(errors, files);
             }
         }
 
-        if self.detail_level.is_rast_enabled() {
-            if let Some(syntax) = result.outcome.syntax() {
-                let program = parse(&result.code, 0, *syntax);
-                self.writeln(format!("{:#?}", program.syntax()));
-                self.writeln("".to_string());
+        if self.detail_level.is_debug() {
+            if let Some(files) = result.outcome.files() {
+                for file in files {
+                    let program = file.parse();
+                    self.writeln(&format!(
+                        "RAST Output for {}:\n{:#?}\n",
+                        &file.name().bold(),
+                        program.syntax()
+                    ));
+                }
             }
         }
     }

--- a/xtask/coverage/src/results.rs
+++ b/xtask/coverage/src/results.rs
@@ -1,7 +1,6 @@
 use ascii_table::{AsciiTable, Column};
 use colored::Colorize;
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
 
 use crate::{Outcome, TestResult, TestResults};
 
@@ -136,13 +135,10 @@ pub fn emit_compare(
                     tests.len()
                 );
                 println!("\n```");
-                let mut paths = tests
-                    .iter()
-                    .map(|test| test.path.as_os_str().to_str().unwrap())
-                    .collect::<Vec<&str>>();
-                paths.sort_unstable();
-                for path in paths {
-                    println!("{}", path);
+                let mut test_cases = tests.iter().map(|test| &test.test_case).collect::<Vec<_>>();
+                test_cases.sort_unstable();
+                for test_case in test_cases {
+                    println!("{}", test_case);
                 }
                 println!("```");
                 println!("</details>");
@@ -223,23 +219,22 @@ fn compare_diffs<'a>(
 ) -> ReportDiff<'a> {
     let mut report_diff = ReportDiff::new();
 
-    let mut all_paths: HashSet<&PathBuf> = HashSet::new();
-
-    let mut base_by_path: HashMap<&PathBuf, &TestResult> = HashMap::new();
+    let mut all_test_cases: HashSet<&str> = HashSet::new();
+    let mut base_by_test_case: HashMap<&str, &TestResult> = HashMap::new();
     for detail in base_results.details.iter() {
-        all_paths.insert(&detail.path);
-        base_by_path.insert(&detail.path, detail);
+        all_test_cases.insert(&detail.test_case);
+        base_by_test_case.insert(&detail.test_case, detail);
     }
 
-    let mut new_by_path: HashMap<&PathBuf, &TestResult> = HashMap::new();
+    let mut new_by_test_case: HashMap<&str, &TestResult> = HashMap::new();
     for detail in new_results.details.iter() {
-        all_paths.insert(&detail.path);
-        new_by_path.insert(&detail.path, detail);
+        all_test_cases.insert(&detail.test_case);
+        new_by_test_case.insert(&detail.test_case, detail);
     }
 
-    for path in all_paths {
-        let base_result = base_by_path.get(path);
-        let new_result = new_by_path.get(path);
+    for path in all_test_cases {
+        let base_result = base_by_test_case.get(path);
+        let new_result = new_by_test_case.get(path);
 
         match (base_result, new_result) {
             (None, Some(new)) => {

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -120,7 +120,7 @@ impl TestCaseFiles {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        return self.files.is_empty();
+        self.files.is_empty()
     }
 
     pub(crate) fn emit_errors(&self, errors: &[ParserError], buffer: &mut Buffer) {

--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -1,8 +1,8 @@
-use super::*;
-use rslint_parser::{parse, Syntax};
+use regex::Regex;
+use rslint_parser::Syntax;
 use std::path::Path;
 
-use crate::runner::{TestCase, TestRunOutcome, TestSuite};
+use crate::runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite};
 
 const CASES_PATH: &str = "xtask/coverage/Typescript/tests/cases";
 const REFERENCE_PATH: &str = "xtask/coverage/Typescript/tests/baselines/reference";
@@ -10,34 +10,49 @@ const REFERENCE_PATH: &str = "xtask/coverage/Typescript/tests/baselines/referenc
 #[derive(Debug)]
 struct TypeScriptTestCase {
     code: String,
-    path: PathBuf,
+    name: String,
+}
+
+impl TypeScriptTestCase {
+    fn new(path: &Path, code: String) -> Self {
+        let name = path.strip_prefix(CASES_PATH).unwrap().display().to_string();
+        Self { name, code }
+    }
 }
 
 impl TestCase for TypeScriptTestCase {
-    fn path(&self) -> &Path {
-        self.path.strip_prefix(CASES_PATH).unwrap()
-    }
-
-    fn code(&self) -> &str {
-        &self.code
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn run(&self) -> TestRunOutcome {
-        let syntax = Syntax::default().typescript();
-        let r = parse(self.code(), 0, syntax);
+        let files = extract_files(&self.code, &self.name);
+        let mut all_errors = Vec::new();
 
-        let error_reference_file = Path::new(REFERENCE_PATH)
-            .join(self.path.with_extension("errors.txt").file_name().unwrap());
+        for file in &files {
+            if let Some(errors) = file.parse().ok().err() {
+                all_errors.extend(errors);
+            }
+        }
+
+        let error_reference_file = Path::new(REFERENCE_PATH).join(
+            Path::new(&self.name)
+                .with_extension("errors.txt")
+                .file_name()
+                .unwrap(),
+        );
 
         let expected_errors = error_reference_file.exists();
 
-        match r.ok() {
-            Err(errors) if !expected_errors => {
-                TestRunOutcome::IncorrectlyErrored { errors, syntax }
+        if all_errors.is_empty() && expected_errors {
+            TestRunOutcome::IncorrectlyPassed(files)
+        } else if !all_errors.is_empty() && !expected_errors {
+            TestRunOutcome::IncorrectlyErrored {
+                errors: all_errors,
+                files,
             }
-            Err(_) => TestRunOutcome::Passed(syntax),
-            _ if expected_errors => TestRunOutcome::IncorrectlyPassed(syntax),
-            _ => TestRunOutcome::Passed(syntax),
+        } else {
+            TestRunOutcome::Passed(files)
         }
     }
 }
@@ -61,14 +76,13 @@ impl TestSuite for TypeScriptTestSuite {
         }
     }
 
-    fn load_test(&self, path: PathBuf) -> Option<Box<dyn TestCase>> {
-        let code = check_file_encoding(&path)?;
-
-        Some(Box::new(TypeScriptTestCase { path, code }))
+    fn load_test(&self, path: &Path) -> Option<Box<dyn TestCase>> {
+        let code = check_file_encoding(path)?;
+        Some(Box::new(TypeScriptTestCase::new(path, code)))
     }
 }
 
-pub fn check_file_encoding(path: &std::path::Path) -> Option<String> {
+fn check_file_encoding(path: &std::path::Path) -> Option<String> {
     let buffer = std::fs::read(path).unwrap();
     let bom = buffer.get(0..3);
     //Utf16Be or // Utf16Le
@@ -78,5 +92,93 @@ pub fn check_file_encoding(path: &std::path::Path) -> Option<String> {
         std::str::from_utf8(buffer.as_slice())
             .ok()
             .map(str::to_string)
+    }
+}
+
+/// TypeScript supports multiple files in a single test case.
+/// These files start with `// @<option-name>: <option-value>` and are followed by the file's content.
+/// This function extracts the individual files with their content and drops unsupported files.
+fn extract_files(code: &str, path: &str) -> TestCaseFiles {
+    // Returns a match for a test option. Test options have the form `// @name: value`
+    let options_regex =
+        Regex::new(r"(?m)^/{2}\s*@(?P<name>\w+)\s*:\s*(?P<value>[^\r\n]*)").unwrap();
+
+    let mut files = TestCaseFiles::new();
+    let line_ending = infer_line_ending(code);
+    let mut current_file_content = String::new();
+    let mut current_file_name: Option<String> = None;
+
+    for line in code.lines() {
+        if let Some(option) = options_regex.captures(line) {
+            let option_name = option.name("name").unwrap().as_str();
+            let option_value = option.name("value").unwrap().as_str();
+
+            // TODO support @declaration
+            if option_name.to_lowercase() != "filename" {
+                continue; // omit options from the file content
+            }
+
+            if let Some(current_name) = current_file_name.take() {
+                add_file_if_supported(
+                    &mut files,
+                    current_name,
+                    std::mem::take(&mut current_file_content),
+                );
+            }
+
+            current_file_name = Some(option_value.trim().to_string());
+        } else {
+            // regular content line
+            if current_file_content.is_empty() && line.trim().is_empty() {
+                // skip leading whitespace
+                continue;
+            }
+
+            current_file_content.push_str(&format!("{}{}", line, line_ending));
+        }
+    }
+
+    if let Some(current_name) = current_file_name.take() {
+        add_file_if_supported(&mut files, current_name, current_file_content)
+    } else if files.is_empty() {
+        // Single file case without any options
+        files.add(
+            Path::new(path)
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
+            code.to_string(),
+            Syntax::default().typescript(),
+        )
+    }
+
+    files
+}
+
+fn add_file_if_supported(files: &mut TestCaseFiles, name: String, content: String) {
+    let syntax = if name.ends_with(".json") {
+        // Don't add files that we don't support parsing (like JSON)
+        return;
+    } else if name.ends_with(".js") {
+        Syntax::default().module()
+    } else {
+        Syntax::default().typescript()
+    };
+
+    files.add(name, content, syntax);
+}
+
+/// Detect the line ending used in the file
+fn infer_line_ending(code: &str) -> &'static str {
+    if let Some(index) = code.find('\r') {
+        if index + 1 < code.len() && code.as_bytes()[index + 1] == b'\n' {
+            "\r\n"
+        } else {
+            "\r"
+        }
+    } else {
+        "\n"
     }
 }


### PR DESCRIPTION
## Summary

A TypeScript test file can define multiple files:

```
// @Filename: tsconfig.json
{
  "compilerOptions": {
    "allowJs": true,
    "outDir": "foo",
    "isolatedModules": true,
  }
}

// @Filename: index.js
module.exports = {}
var x = 1
```

This test defines 2 files, a `tsconfig.json` and an `index.js`.

This PR adds support for multiple files to our test runner and extracts the different files for the TypeScript test suite. The test runner parses each individual file and aggregates the diagnostics when asserting the outcome.

This will enable us to extract more metadata in the future, for example, respect the `@declaration` flag once the parser supports a TypeScript declaration file kind.

## Regressions

These are tests that are expected to fail and used to fail because they contain a `.json` file (that our parser can't parse). This PR now skips the JSON files so that all files can now be parsed correctly (and thus, no longer fail with an unrelated error).
