### PR TITLE
fix(rslint_parser): TS type annotation in `catch` declaration

### DIFF
--- a/crates/rome_formatter/src/js/declarations/catch_declaration.rs
+++ b/crates/rome_formatter/src/js/declarations/catch_declaration.rs
@@ -1,6 +1,6 @@
-use crate::formatter_traits::FormatTokenAndNode;
+use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
 
 use rslint_parser::ast::JsCatchDeclaration;
 use rslint_parser::ast::JsCatchDeclarationFields;
@@ -11,11 +11,15 @@ impl ToFormatElement for JsCatchDeclaration {
             l_paren_token,
             binding,
             r_paren_token,
+            type_annotation,
         } = self.as_fields();
 
         formatter.format_delimited_soft_block_indent(
             &l_paren_token?,
-            binding.format(formatter)?,
+            format_elements![
+                binding.format(formatter)?,
+                type_annotation.format_or_empty(formatter)?
+            ],
             &r_paren_token?,
         )
     }

--- a/crates/rome_formatter/tests/specs/prettier/typescript/catch-clause/type-annotation.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/catch-clause/type-annotation.ts.snap
@@ -16,31 +16,9 @@ catch (e: unknown) {}
 
 # Output
 ```js
-try {} catch (e
-: any)
-{}
+try {} catch (e: any) {}
 
-try {}
-catch (e
-: unknown) 
-{}
-
-```
-
-# Errors
-```
-error[SyntaxError]: expected `')'` but instead found `:`
-  ┌─ type-annotation.ts:1:16
-  │
-1 │ try {} catch (e: any)
-  │                ^ unexpected
-
-error[SyntaxError]: expected `')'` but instead found `:`
-  ┌─ type-annotation.ts:5:9
-  │
-5 │ catch (e: unknown) {}
-  │         ^ unexpected
-
+try {} catch (e: unknown) {}
 
 ```
 

--- a/crates/rslint_parser/src/ast/generated/nodes.rs
+++ b/crates/rslint_parser/src/ast/generated/nodes.rs
@@ -690,6 +690,7 @@ impl JsCatchDeclaration {
         JsCatchDeclarationFields {
             l_paren_token: self.l_paren_token(),
             binding: self.binding(),
+            type_annotation: self.type_annotation(),
             r_paren_token: self.r_paren_token(),
         }
     }
@@ -699,13 +700,17 @@ impl JsCatchDeclaration {
     pub fn binding(&self) -> SyntaxResult<JsAnyBindingPattern> {
         support::required_node(&self.syntax, 1usize)
     }
+    pub fn type_annotation(&self) -> Option<TsTypeAnnotation> {
+        support::node(&self.syntax, 2usize)
+    }
     pub fn r_paren_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 2usize)
+        support::required_token(&self.syntax, 3usize)
     }
 }
 pub struct JsCatchDeclarationFields {
     pub l_paren_token: SyntaxResult<SyntaxToken>,
     pub binding: SyntaxResult<JsAnyBindingPattern>,
+    pub type_annotation: Option<TsTypeAnnotation>,
     pub r_paren_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -9198,6 +9203,10 @@ impl std::fmt::Debug for JsCatchDeclaration {
                 &support::DebugSyntaxResult(self.l_paren_token()),
             )
             .field("binding", &support::DebugSyntaxResult(self.binding()))
+            .field(
+                "type_annotation",
+                &support::DebugOptionalElement(self.type_annotation()),
+            )
             .field(
                 "r_paren_token",
                 &support::DebugSyntaxResult(self.r_paren_token()),

--- a/crates/rslint_parser/src/ast/generated/syntax_factory.rs
+++ b/crates/rslint_parser/src/ast/generated/syntax_factory.rs
@@ -721,7 +721,7 @@ impl SyntaxFactory for JsSyntaxFactory {
             }
             JS_CATCH_DECLARATION => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
                     if element.kind() == T!['('] {
@@ -732,6 +732,13 @@ impl SyntaxFactory for JsSyntaxFactory {
                 slots.next_slot();
                 if let Some(element) = &current_element {
                     if JsAnyBindingPattern::can_cast(element.kind()) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element {
+                    if TsTypeAnnotation::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -1787,12 +1787,33 @@ fn parse_catch_declaration(p: &mut Parser) -> ParsedSyntax {
     p.bump_any(); // bump (
     parse_binding_pattern(p, ExpressionContext::default()).or_add_diagnostic(p, expected_binding);
 
-    let type_annotation = parse_ts_type_parameters(p);
-    JsSyntaxFeature::TypeScript
-        .exclusive_syntax(p, type_annotation, |p, annotation| {
-            ts_only_syntax_error(p, "type annotation", annotation.range(p).as_range())
-        })
-        .ok();
+    // test ts ts_catch_declaration
+    // try {} catch (error: any) {}
+    // try {} catch (error: unknown) {}
+    if p.at(T![:]) && is_nth_at_identifier(p, 1) {
+        let type_name_token = p.nth_tok(1);
+
+        // test_err ts ts_catch_declaration_non_any_unknown_type_annotation
+        // try {} catch (error: Error) {}
+        if TypeScript.is_supported(p)
+            && !matches!(
+                p.source(type_name_token.range().as_text_range()),
+                "any" | "unknown"
+            )
+        {
+            p.error(
+                p
+                    .err_builder("Catch clause variable type annotation must be 'any' or 'unknown' if specified.")
+                    .primary(type_name_token.range(), "")
+            );
+        }
+
+        JsSyntaxFeature::TypeScript
+            .parse_exclusive_syntax(p, parse_ts_type_annotation, |p, annotation| {
+                ts_only_syntax_error(p, "type annotation", annotation.range(p).as_range())
+            })
+            .ok();
+    }
 
     p.expect(T![')']);
 

--- a/crates/rslint_parser/test_data/inline/err/ts_catch_declaration_non_any_unknown_type_annotation.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_catch_declaration_non_any_unknown_type_annotation.rast
@@ -1,0 +1,77 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsTryStatement {
+            try_token: TRY_KW@0..4 "try" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@4..5 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@5..7 "}" [] [Whitespace(" ")],
+            },
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@7..13 "catch" [] [Whitespace(" ")],
+                declaration: JsCatchDeclaration {
+                    l_paren_token: L_PAREN@13..14 "(" [] [],
+                    binding: JsIdentifierBinding {
+                        name_token: IDENT@14..19 "error" [] [],
+                    },
+                    type_annotation: TsTypeAnnotation {
+                        colon_token: COLON@19..21 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@21..26 "Error" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    r_paren_token: R_PAREN@26..28 ")" [] [Whitespace(" ")],
+                },
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@28..29 "{" [] [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@29..30 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@30..31 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..31
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..30
+    0: JS_TRY_STATEMENT@0..30
+      0: TRY_KW@0..4 "try" [] [Whitespace(" ")]
+      1: JS_BLOCK_STATEMENT@4..7
+        0: L_CURLY@4..5 "{" [] []
+        1: JS_STATEMENT_LIST@5..5
+        2: R_CURLY@5..7 "}" [] [Whitespace(" ")]
+      2: JS_CATCH_CLAUSE@7..30
+        0: CATCH_KW@7..13 "catch" [] [Whitespace(" ")]
+        1: JS_CATCH_DECLARATION@13..28
+          0: L_PAREN@13..14 "(" [] []
+          1: JS_IDENTIFIER_BINDING@14..19
+            0: IDENT@14..19 "error" [] []
+          2: TS_TYPE_ANNOTATION@19..26
+            0: COLON@19..21 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@21..26
+              0: JS_REFERENCE_IDENTIFIER@21..26
+                0: IDENT@21..26 "Error" [] []
+              1: (empty)
+          3: R_PAREN@26..28 ")" [] [Whitespace(" ")]
+        2: JS_BLOCK_STATEMENT@28..30
+          0: L_CURLY@28..29 "{" [] []
+          1: JS_STATEMENT_LIST@29..29
+          2: R_CURLY@29..30 "}" [] []
+  3: EOF@30..31 "" [Newline("\n")] []
+--
+error[SyntaxError]: Catch clause variable type annotation must be 'any' or 'unknown' if specified.
+  ┌─ ts_catch_declaration_non_any_unknown_type_annotation.ts:1:22
+  │
+1 │ try {} catch (error: Error) {}
+  │                      ^^^^^
+
+--
+try {} catch (error: Error) {}

--- a/crates/rslint_parser/test_data/inline/err/ts_catch_declaration_non_any_unknown_type_annotation.ts
+++ b/crates/rslint_parser/test_data/inline/err/ts_catch_declaration_non_any_unknown_type_annotation.ts
@@ -1,0 +1,1 @@
+try {} catch (error: Error) {}

--- a/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
+++ b/crates/rslint_parser/test_data/inline/ok/try_stmt.rast
@@ -33,6 +33,7 @@ JsModule {
                     binding: JsIdentifierBinding {
                         name_token: IDENT@30..31 "e" [] [],
                     },
+                    type_annotation: missing (optional),
                     r_paren_token: R_PAREN@31..33 ")" [] [Whitespace(" ")],
                 },
                 body: JsBlockStatement {
@@ -81,6 +82,7 @@ JsModule {
                     binding: JsIdentifierBinding {
                         name_token: IDENT@77..78 "e" [] [],
                     },
+                    type_annotation: missing (optional),
                     r_paren_token: R_PAREN@78..80 ")" [] [Whitespace(" ")],
                 },
                 body: JsBlockStatement {
@@ -148,7 +150,8 @@ JsModule {
           0: L_PAREN@29..30 "(" [] []
           1: JS_IDENTIFIER_BINDING@30..31
             0: IDENT@30..31 "e" [] []
-          2: R_PAREN@31..33 ")" [] [Whitespace(" ")]
+          2: (empty)
+          3: R_PAREN@31..33 ")" [] [Whitespace(" ")]
         2: JS_BLOCK_STATEMENT@33..35
           0: L_CURLY@33..34 "{" [] []
           1: JS_STATEMENT_LIST@34..34
@@ -184,7 +187,8 @@ JsModule {
           0: L_PAREN@76..77 "(" [] []
           1: JS_IDENTIFIER_BINDING@77..78
             0: IDENT@77..78 "e" [] []
-          2: R_PAREN@78..80 ")" [] [Whitespace(" ")]
+          2: (empty)
+          3: R_PAREN@78..80 ")" [] [Whitespace(" ")]
         2: JS_BLOCK_STATEMENT@80..83
           0: L_CURLY@80..81 "{" [] []
           1: JS_STATEMENT_LIST@81..81

--- a/crates/rslint_parser/test_data/inline/ok/ts_catch_declaration.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_catch_declaration.rast
@@ -1,0 +1,113 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsTryStatement {
+            try_token: TRY_KW@0..4 "try" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@4..5 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@5..7 "}" [] [Whitespace(" ")],
+            },
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@7..13 "catch" [] [Whitespace(" ")],
+                declaration: JsCatchDeclaration {
+                    l_paren_token: L_PAREN@13..14 "(" [] [],
+                    binding: JsIdentifierBinding {
+                        name_token: IDENT@14..19 "error" [] [],
+                    },
+                    type_annotation: TsTypeAnnotation {
+                        colon_token: COLON@19..21 ":" [] [Whitespace(" ")],
+                        ty: TsAnyType {
+                            any_token: ANY_KW@21..24 "any" [] [],
+                        },
+                    },
+                    r_paren_token: R_PAREN@24..26 ")" [] [Whitespace(" ")],
+                },
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@26..27 "{" [] [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@27..28 "}" [] [],
+                },
+            },
+        },
+        JsTryStatement {
+            try_token: TRY_KW@28..33 "try" [Newline("\n")] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@33..34 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@34..36 "}" [] [Whitespace(" ")],
+            },
+            catch_clause: JsCatchClause {
+                catch_token: CATCH_KW@36..42 "catch" [] [Whitespace(" ")],
+                declaration: JsCatchDeclaration {
+                    l_paren_token: L_PAREN@42..43 "(" [] [],
+                    binding: JsIdentifierBinding {
+                        name_token: IDENT@43..48 "error" [] [],
+                    },
+                    type_annotation: TsTypeAnnotation {
+                        colon_token: COLON@48..50 ":" [] [Whitespace(" ")],
+                        ty: TsUnknownType {
+                            unknown_token: UNKNOWN_KW@50..57 "unknown" [] [],
+                        },
+                    },
+                    r_paren_token: R_PAREN@57..59 ")" [] [Whitespace(" ")],
+                },
+                body: JsBlockStatement {
+                    l_curly_token: L_CURLY@59..60 "{" [] [],
+                    statements: JsStatementList [],
+                    r_curly_token: R_CURLY@60..61 "}" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@61..62 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..62
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..61
+    0: JS_TRY_STATEMENT@0..28
+      0: TRY_KW@0..4 "try" [] [Whitespace(" ")]
+      1: JS_BLOCK_STATEMENT@4..7
+        0: L_CURLY@4..5 "{" [] []
+        1: JS_STATEMENT_LIST@5..5
+        2: R_CURLY@5..7 "}" [] [Whitespace(" ")]
+      2: JS_CATCH_CLAUSE@7..28
+        0: CATCH_KW@7..13 "catch" [] [Whitespace(" ")]
+        1: JS_CATCH_DECLARATION@13..26
+          0: L_PAREN@13..14 "(" [] []
+          1: JS_IDENTIFIER_BINDING@14..19
+            0: IDENT@14..19 "error" [] []
+          2: TS_TYPE_ANNOTATION@19..24
+            0: COLON@19..21 ":" [] [Whitespace(" ")]
+            1: TS_ANY_TYPE@21..24
+              0: ANY_KW@21..24 "any" [] []
+          3: R_PAREN@24..26 ")" [] [Whitespace(" ")]
+        2: JS_BLOCK_STATEMENT@26..28
+          0: L_CURLY@26..27 "{" [] []
+          1: JS_STATEMENT_LIST@27..27
+          2: R_CURLY@27..28 "}" [] []
+    1: JS_TRY_STATEMENT@28..61
+      0: TRY_KW@28..33 "try" [Newline("\n")] [Whitespace(" ")]
+      1: JS_BLOCK_STATEMENT@33..36
+        0: L_CURLY@33..34 "{" [] []
+        1: JS_STATEMENT_LIST@34..34
+        2: R_CURLY@34..36 "}" [] [Whitespace(" ")]
+      2: JS_CATCH_CLAUSE@36..61
+        0: CATCH_KW@36..42 "catch" [] [Whitespace(" ")]
+        1: JS_CATCH_DECLARATION@42..59
+          0: L_PAREN@42..43 "(" [] []
+          1: JS_IDENTIFIER_BINDING@43..48
+            0: IDENT@43..48 "error" [] []
+          2: TS_TYPE_ANNOTATION@48..57
+            0: COLON@48..50 ":" [] [Whitespace(" ")]
+            1: TS_UNKNOWN_TYPE@50..57
+              0: UNKNOWN_KW@50..57 "unknown" [] []
+          3: R_PAREN@57..59 ")" [] [Whitespace(" ")]
+        2: JS_BLOCK_STATEMENT@59..61
+          0: L_CURLY@59..60 "{" [] []
+          1: JS_STATEMENT_LIST@60..60
+          2: R_CURLY@60..61 "}" [] []
+  3: EOF@61..62 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_catch_declaration.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_catch_declaration.ts
@@ -1,0 +1,2 @@
+try {} catch (error: any) {}
+try {} catch (error: unknown) {}

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -255,7 +255,10 @@ JsCatchClause =
     body: JsBlockStatement
 
 JsCatchDeclaration =
-    '(' binding: JsAnyBindingPattern ')'
+    '('
+    binding: JsAnyBindingPattern
+    type_annotation: TsTypeAnnotation?
+    ')'
 
 JsFinallyClause =
     'finally'


### PR DESCRIPTION
## Summary
TS supports annotating the type in a catch declaration with either `any` or `unknown`.

This PR adds the optional type annotation to the grammar and
fixes the implementation to call `parse_ts_type_annotation` instead of `parse_ts_type_parameters`

Part of #2113

## Test Plan

Added new parser tests

Regressions. This is a bit surprising but `useUnknownInCatchVariables01` actually tests for many other compile errors but it's now failing because the parser correctly parsing the catch declaration.