### PR TITLE
fix(rslint_parser): Private name precedence

### DIFF
--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/private-fields-in-in.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/private-fields-in-in.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: private-fields-in-in.js
 
 ---
@@ -109,7 +109,7 @@ class C3 {
   get #getter() {}
 
   static isC(obj) {
-    return #brand in obj && #method  in obj && #getter  in obj;
+    return #brand in obj && #method in obj && #getter in obj;
   }
 }// Invalid https://github.com/tc39/proposal-private-fields-in-in#try-statement
 // class C {
@@ -119,23 +119,6 @@ class C3 {
 //     return try obj.#brand;
 //   }
 // }
-
-```
-
-# Errors
-```
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
-   ┌─ private-fields-in-in.js:44:29
-   │
-44 │     return #brand in obj && #method in obj && #getter in obj;
-   │                             ^^^^^^^
-
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
-   ┌─ private-fields-in-in.js:44:47
-   │
-44 │     return #brand in obj && #method in obj && #getter in obj;
-   │                                               ^^^^^^^
-
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: record-tuple-record.js
 
 ---
@@ -18,16 +18,14 @@ const record2 = #{...record1, b: 5};
 
 # Output
 ```js
-const record1 = #
+const record1 = #;
 {
   a: 1, b;
   : 2,
     c: 3,
 }
 
-
-
-const record2 = #
+const record2 = #;
 {
   ...record1, b: 5;
 }
@@ -41,6 +39,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 1 │ const record1 = #{
   │                  ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ record-tuple-record.js:1:17
+  │
+1 │ const record1 = #{
+  │                 ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ record-tuple-record.js:1:18
+  │
+1 │ const record1 = #{
+  │ -----------------^ An explicit or implicit semicolon is expected here...
+  │ │                 
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ record-tuple-record.js:3:6
@@ -56,6 +68,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 7 │ const record2 = #{...record1, b: 5};
   │                  ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ record-tuple-record.js:7:17
+  │
+7 │ const record2 = #{...record1, b: 5};
+  │                 ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ record-tuple-record.js:7:18
+  │
+7 │ const record2 = #{...record1, b: 5};
+  │ -----------------^ An explicit or implicit semicolon is expected here...
+  │ │                 
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: expected an expression but instead found '...record1, b: 5'
   ┌─ record-tuple-record.js:7:19

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: record-tuple-tuple.js
 
 ---
@@ -12,7 +12,7 @@ const tuple1 = #[1, 2, 3];
 
 # Output
 ```js
-const tuple1 = #
+const tuple1 = #;
 [1, 2, 3];
 
 ```
@@ -24,6 +24,20 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
   │
 1 │ const tuple1 = #[1, 2, 3];
   │                 ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ record-tuple-tuple.js:1:16
+  │
+1 │ const tuple1 = #[1, 2, 3];
+  │                ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ record-tuple-tuple.js:1:17
+  │
+1 │ const tuple1 = #[1, 2, 3];
+  │ ----------------^ An explicit or implicit semicolon is expected here...
+  │ │                
+  │ ...Which is required to end this statement
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/record/computed.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/computed.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: computed.js
 
 ---
@@ -21,28 +21,32 @@ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
 # Output
 ```js
 const key = "a";
+assert(#{ [key]: 1 } === #{ a: 1 })
+assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
 
-assert(#{ [key]: 1 } === #{ a: 1 });
+assert(#{ [true]: 1 } === #{ true: 1 })
+assert(#{ [true]: 1 } === #{ ["true"]: 1 })
 
-assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 });
-
-
-
-assert(#{ [true]: 1 } === #{ true: 1 });
-
-assert(#{ [true]: 1 } === #{ ["true"]: 1 });
-
-
-
-assert(#{ [1 + 1]: "two" } === #{ 2: "two" });
-
-assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" });
+assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
+assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
 
 ```
 
 # Errors
 ```
 error[SyntaxError]: expected `IDENT` but instead found `{`
+  ┌─ computed.js:2:9
+  │
+2 │ assert(#{ [key]: 1 } === #{ a: 1 })
+  │         ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:2:8
+  │
+2 │ assert(#{ [key]: 1 } === #{ a: 1 })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
   ┌─ computed.js:2:9
   │
 2 │ assert(#{ [key]: 1 } === #{ a: 1 })
@@ -72,6 +76,18 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
   │         ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:3:8
+  │
+3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
+  ┌─ computed.js:3:9
+  │
+3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
+  │         ^ unexpected
+
 error[SyntaxError]: expected `IDENT` but instead found `{`
   ┌─ computed.js:3:41
   │
@@ -91,6 +107,18 @@ error[SyntaxError]: expected `,` but instead found `{`
   │                                         ^ unexpected
 
 error[SyntaxError]: expected `IDENT` but instead found `{`
+  ┌─ computed.js:5:9
+  │
+5 │ assert(#{ [true]: 1 } === #{ true: 1 })
+  │         ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:5:8
+  │
+5 │ assert(#{ [true]: 1 } === #{ true: 1 })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
   ┌─ computed.js:5:9
   │
 5 │ assert(#{ [true]: 1 } === #{ true: 1 })
@@ -120,6 +148,18 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
   │         ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:6:8
+  │
+6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
+  ┌─ computed.js:6:9
+  │
+6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
+  │         ^ unexpected
+
 error[SyntaxError]: expected `IDENT` but instead found `{`
   ┌─ computed.js:6:28
   │
@@ -144,6 +184,18 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
   │         ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:8:8
+  │
+8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
+  ┌─ computed.js:8:9
+  │
+8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
+  │         ^ unexpected
+
 error[SyntaxError]: expected `IDENT` but instead found `{`
   ┌─ computed.js:8:33
   │
@@ -163,6 +215,18 @@ error[SyntaxError]: expected `,` but instead found `{`
   │                                 ^ unexpected
 
 error[SyntaxError]: expected `IDENT` but instead found `{`
+  ┌─ computed.js:9:9
+  │
+9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
+  │         ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ computed.js:9:8
+  │
+9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
+  │        ^
+
+error[SyntaxError]: expected `,` but instead found `{`
   ┌─ computed.js:9:9
   │
 9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })

--- a/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: destructuring.js
 
 ---
@@ -20,7 +20,7 @@ assert(rest.c === 3);
 
 # Output
 ```js
-const { a, b } = #
+const { a, b } = #;
 {
   a: 1, b;
   : 2 
@@ -28,9 +28,7 @@ const { a, b } = #
 assert(a === 1);
 assert(b === 2);
 
-
-
-const { a, ...rest } = #
+const { a, ...rest } = #;
 {
   a: 1, b;
   : 2, c: 3 
@@ -50,6 +48,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const { a, b } = #{ a: 1, b: 2 };
   │                   ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ destructuring.js:1:18
+  │
+1 │ const { a, b } = #{ a: 1, b: 2 };
+  │                  ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ destructuring.js:1:19
+  │
+1 │ const { a, b } = #{ a: 1, b: 2 };
+  │ ------------------^ An explicit or implicit semicolon is expected here...
+  │ │                  
+  │ ...Which is required to end this statement
+
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ destructuring.js:1:28
   │
@@ -64,6 +76,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 5 │ const { a, ...rest } = #{ a: 1, b: 2, c: 3 };
   │                         ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ destructuring.js:5:24
+  │
+5 │ const { a, ...rest } = #{ a: 1, b: 2, c: 3 };
+  │                        ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ destructuring.js:5:25
+  │
+5 │ const { a, ...rest } = #{ a: 1, b: 2, c: 3 };
+  │ ------------------------^ An explicit or implicit semicolon is expected here...
+  │ │                        
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ destructuring.js:5:34

--- a/crates/rome_formatter/tests/specs/prettier/js/record/record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/record.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: record.js
 
 ---
@@ -27,16 +27,14 @@ assert(record1.d?.a === undefined);
 
 # Output
 ```js
-const record1 = #
+const record1 = #;
 {
   a: 1, b;
   : 2,
     c: 3,
 }
 
-
-
-const record2 = #
+const record2 = #;
 {
   ...record1, b: 5;
 }
@@ -60,6 +58,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const record1 = #{
   │                  ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ record.js:1:17
+  │
+1 │ const record1 = #{
+  │                 ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ record.js:1:18
+  │
+1 │ const record1 = #{
+  │ -----------------^ An explicit or implicit semicolon is expected here...
+  │ │                 
+  │ ...Which is required to end this statement
+
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ record.js:3:6
   │  
@@ -74,6 +86,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 7 │ const record2 = #{...record1, b: 5};
   │                  ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ record.js:7:17
+  │
+7 │ const record2 = #{...record1, b: 5};
+  │                 ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ record.js:7:18
+  │
+7 │ const record2 = #{...record1, b: 5};
+  │ -----------------^ An explicit or implicit semicolon is expected here...
+  │ │                 
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: expected an expression but instead found '...record1, b: 5'
   ┌─ record.js:7:19

--- a/crates/rome_formatter/tests/specs/prettier/js/record/shorthand.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/shorthand.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: shorthand.js
 
 ---
@@ -15,8 +15,7 @@ console.log(record.url) // https://github.com/tc39/proposal-record-tuple
 # Output
 ```js
 const url = "https://github.com/tc39/proposal-record-tuple";
-
-const record = #
+const record = #;
 {
   url;
 }
@@ -31,6 +30,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 2 │ const record = #{ url }
   │                 ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ shorthand.js:2:16
+  │
+2 │ const record = #{ url }
+  │                ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ shorthand.js:2:17
+  │
+2 │ const record = #{ url }
+  │ ----------------^ An explicit or implicit semicolon is expected here...
+  │ │                
+  │ ...Which is required to end this statement
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: spread.js
 
 ---
@@ -17,18 +17,16 @@ assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })
 
 # Output
 ```js
-const formData = #
+const formData = #;
 {
   title: "Implement all the things";
 }
-
-const taskNow = #
+const taskNow = #;
 {
   id: 42, status;
   : "WIP", ...formData 
 }
-
-const taskLater = #
+const taskLater = #;
 {
   ...taskNow, status: "DONE" ;
 }
@@ -46,11 +44,39 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const formData = #{ title: "Implement all the things" }
   │                   ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ spread.js:1:18
+  │
+1 │ const formData = #{ title: "Implement all the things" }
+  │                  ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ spread.js:1:19
+  │
+1 │ const formData = #{ title: "Implement all the things" }
+  │ ------------------^ An explicit or implicit semicolon is expected here...
+  │ │                  
+  │ ...Which is required to end this statement
+
 error[SyntaxError]: expected `IDENT` but instead found `{`
   ┌─ spread.js:2:18
   │
 2 │ const taskNow = #{ id: 42, status: "WIP", ...formData }
   │                  ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ spread.js:2:17
+  │
+2 │ const taskNow = #{ id: 42, status: "WIP", ...formData }
+  │                 ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ spread.js:2:18
+  │
+2 │ const taskNow = #{ id: 42, status: "WIP", ...formData }
+  │ -----------------^ An explicit or implicit semicolon is expected here...
+  │ │                 
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ spread.js:2:34
@@ -66,6 +92,20 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 3 │ const taskLater = #{ ...taskNow, status: "DONE" }
   │                    ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ spread.js:3:19
+  │
+3 │ const taskLater = #{ ...taskNow, status: "DONE" }
+  │                   ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ spread.js:3:20
+  │
+3 │ const taskLater = #{ ...taskNow, status: "DONE" }
+  │ -------------------^ An explicit or implicit semicolon is expected here...
+  │ │                   
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: expected an expression but instead found '...taskNow, status: "DONE"'
   ┌─ spread.js:3:22

--- a/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: syntax.js
 
 ---
@@ -17,13 +17,13 @@ expression: syntax.js
 #
 {}
 
-#
+#;
 {
   a: 1, b;
   : 2 
 }
 
-#
+#;
 {
   a: 1, b;
   : #[2, 3, #
@@ -55,6 +55,21 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ #{ a: 1, b: 2 }
   │  ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ syntax.js:2:1
+  │
+2 │ #{ a: 1, b: 2 }
+  │ ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ syntax.js:2:2
+  │
+2 │ #{ a: 1, b: 2 }
+  │ -^
+  │ ││
+  │ │An explicit or implicit semicolon is expected here...
+  │ ...Which is required to end this statement
+
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ syntax.js:2:11
   │
@@ -69,6 +84,21 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
   │
 3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
   │  ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ syntax.js:3:1
+  │
+3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
+  │ ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ syntax.js:3:2
+  │
+3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
+  │ -^
+  │ ││
+  │ │An explicit or implicit semicolon is expected here...
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
   ┌─ syntax.js:3:11

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: destructuring.js
 
 ---
@@ -20,14 +20,12 @@ assert(rest[1] === 3);
 
 # Output
 ```js
-const [a, b] = #
+const [a, b] = #;
 [1, 2];
 assert(a === 1);
 assert(b === 2);
 
-
-
-const [a, ...rest] = #
+const [a, ...rest] = #;
 [1, 2, 3];
 assert(a === 1);
 assert(Array.isArray(rest));
@@ -44,11 +42,39 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 1 │ const [a, b] = #[1, 2];
   │                 ^ unexpected
 
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ destructuring.js:1:16
+  │
+1 │ const [a, b] = #[1, 2];
+  │                ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ destructuring.js:1:17
+  │
+1 │ const [a, b] = #[1, 2];
+  │ ----------------^ An explicit or implicit semicolon is expected here...
+  │ │                
+  │ ...Which is required to end this statement
+
 error[SyntaxError]: expected `IDENT` but instead found `[`
   ┌─ destructuring.js:5:23
   │
 5 │ const [a, ...rest] = #[1, 2, 3];
   │                       ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ destructuring.js:5:22
+  │
+5 │ const [a, ...rest] = #[1, 2, 3];
+  │                      ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ destructuring.js:5:23
+  │
+5 │ const [a, ...rest] = #[1, 2, 3];
+  │ ----------------------^ An explicit or implicit semicolon is expected here...
+  │ │                      
+  │ ...Which is required to end this statement
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: tuple.js
 
 ---
@@ -28,7 +28,7 @@ assert(tuple5 === #[2, 2, 3, 4]);
 
 # Output
 ```js
-const tuple1 = #
+const tuple1 = #;
 [1, 2, 3];
 
 assert(tuple1[0] === 1);
@@ -37,9 +37,7 @@ const tuple2 = tuple1.with(0, 2);
 assert(tuple1 !== tuple2);
 assert(tuple2 === #[2, 2, 3]);
 
-
-
-const tuple3 = #
+const tuple3 = #;
 [1, ...tuple2];
 assert(tuple3 === #[1, 2, 2, 3]);
 
@@ -59,6 +57,20 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
   │
 1 │ const tuple1 = #[1, 2, 3];
   │                 ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ tuple.js:1:16
+  │
+1 │ const tuple1 = #[1, 2, 3];
+  │                ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ tuple.js:1:17
+  │
+1 │ const tuple1 = #[1, 2, 3];
+  │ ----------------^ An explicit or implicit semicolon is expected here...
+  │ │                
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: expected `IDENT` but instead found `[`
   ┌─ tuple.js:7:20
@@ -83,6 +95,20 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
   │
 9 │ const tuple3 = #[1, ...tuple2];
   │                 ^ unexpected
+
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ tuple.js:9:16
+  │
+9 │ const tuple3 = #[1, ...tuple2];
+  │                ^
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+  ┌─ tuple.js:9:17
+  │
+9 │ const tuple3 = #[1, ...tuple2];
+  │ ----------------^ An explicit or implicit semicolon is expected here...
+  │ │                
+  │ ...Which is required to end this statement
 
 error[SyntaxError]: expected `IDENT` but instead found `[`
    ┌─ tuple.js:10:20

--- a/crates/rome_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: basic.ts
 
 ---
@@ -33,21 +33,9 @@ class Person {
   }
 
   equals(other: unknown) {
-    return (other && typeof other === "object" && 
-      #name  in other && this.#name === other.#name); // <- this is new!
+    return (other && typeof other === "object" && #name in other && this.#name === other.#name); // <- this is new!
   }
 }
-
-```
-
-# Errors
-```
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
-   ┌─ basic.ts:11:7
-   │
-11 │       #name in other && // <- this is new!
-   │       ^^^^^
-
 
 ```
 

--- a/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.js
+++ b/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.js
@@ -1,6 +1,8 @@
 class A {
 	#prop;
 	test() {
-   #prop in #prop in this
+   #prop in #prop in this;
+   5 + #prop;
+   #prop
  }
 }

--- a/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
@@ -68,24 +68,48 @@ JsModule {
                                         this_token: THIS_KW@49..53 "this" [] [],
                                     },
                                 },
+                                semicolon_token: SEMICOLON@53..54 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsBinaryExpression {
+                                    left: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@54..60 "5" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
+                                    },
+                                    operator: PLUS@60..62 "+" [] [Whitespace(" ")],
+                                    right: JsUnknownExpression {
+                                        items: [
+                                            HASH@62..63 "#" [] [],
+                                            IDENT@63..67 "prop" [] [],
+                                        ],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@67..68 ";" [] [],
+                            },
+                            JsExpressionStatement {
+                                expression: JsUnknownExpression {
+                                    items: [
+                                        HASH@68..73 "#" [Newline("\n"), Whitespace("   ")] [],
+                                        IDENT@73..77 "prop" [] [],
+                                    ],
+                                },
                                 semicolon_token: missing (optional),
                             },
                         ],
-                        r_curly_token: R_CURLY@53..56 "}" [Newline("\n"), Whitespace(" ")] [],
+                        r_curly_token: R_CURLY@77..80 "}" [Newline("\n"), Whitespace(" ")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@56..58 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@80..82 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@58..59 "" [Newline("\n")] [],
+    eof_token: EOF@82..83 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..59
+0: JS_MODULE@0..83
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..58
-    0: JS_CLASS_DECLARATION@0..58
+  2: JS_MODULE_ITEM_LIST@0..82
+    0: JS_CLASS_DECLARATION@0..82
       0: (empty)
       1: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@6..8
@@ -94,7 +118,7 @@ JsModule {
       4: (empty)
       5: (empty)
       6: L_CURLY@8..9 "{" [] []
-      7: JS_CLASS_MEMBER_LIST@9..56
+      7: JS_CLASS_MEMBER_LIST@9..80
         0: JS_PROPERTY_CLASS_MEMBER@9..17
           0: (empty)
           1: (empty)
@@ -107,7 +131,7 @@ JsModule {
           6: (empty)
           7: (empty)
           8: SEMICOLON@16..17 ";" [] []
-        1: JS_METHOD_CLASS_MEMBER@17..56
+        1: JS_METHOD_CLASS_MEMBER@17..80
           0: (empty)
           1: (empty)
           2: (empty)
@@ -122,11 +146,11 @@ JsModule {
             1: JS_PARAMETER_LIST@24..24
             2: R_PAREN@24..26 ")" [] [Whitespace(" ")]
           9: (empty)
-          10: JS_FUNCTION_BODY@26..56
+          10: JS_FUNCTION_BODY@26..80
             0: L_CURLY@26..27 "{" [] []
             1: JS_DIRECTIVE_LIST@27..27
-            2: JS_STATEMENT_LIST@27..53
-              0: JS_EXPRESSION_STATEMENT@27..53
+            2: JS_STATEMENT_LIST@27..77
+              0: JS_EXPRESSION_STATEMENT@27..54
                 0: JS_IN_EXPRESSION@27..53
                   0: JS_IN_EXPRESSION@27..46
                     0: JS_PRIVATE_NAME@27..37
@@ -139,21 +163,51 @@ JsModule {
                   1: IN_KW@46..49 "in" [] [Whitespace(" ")]
                   2: JS_THIS_EXPRESSION@49..53
                     0: THIS_KW@49..53 "this" [] []
+                1: SEMICOLON@53..54 ";" [] []
+              1: JS_EXPRESSION_STATEMENT@54..68
+                0: JS_BINARY_EXPRESSION@54..67
+                  0: JS_NUMBER_LITERAL_EXPRESSION@54..60
+                    0: JS_NUMBER_LITERAL@54..60 "5" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")]
+                  1: PLUS@60..62 "+" [] [Whitespace(" ")]
+                  2: JS_UNKNOWN_EXPRESSION@62..67
+                    0: HASH@62..63 "#" [] []
+                    1: IDENT@63..67 "prop" [] []
+                1: SEMICOLON@67..68 ";" [] []
+              2: JS_EXPRESSION_STATEMENT@68..77
+                0: JS_UNKNOWN_EXPRESSION@68..77
+                  0: HASH@68..73 "#" [Newline("\n"), Whitespace("   ")] []
+                  1: IDENT@73..77 "prop" [] []
                 1: (empty)
-            3: R_CURLY@53..56 "}" [Newline("\n"), Whitespace(" ")] []
-      8: R_CURLY@56..58 "}" [Newline("\n")] []
-  3: EOF@58..59 "" [Newline("\n")] []
+            3: R_CURLY@77..80 "}" [Newline("\n"), Whitespace(" ")] []
+      8: R_CURLY@80..82 "}" [Newline("\n")] []
+  3: EOF@82..83 "" [Newline("\n")] []
 --
 error[SyntaxError]: Private names are only allowed on the left side of a binary expression
   ┌─ private_name_presence_check_recursive.js:4:13
   │
-4 │    #prop in #prop in this
+4 │    #prop in #prop in this;
   │             ^^^^^
+
+--
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ private_name_presence_check_recursive.js:5:8
+  │
+5 │    5 + #prop;
+  │        ^^^^^
+
+--
+error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+  ┌─ private_name_presence_check_recursive.js:6:4
+  │
+6 │    #prop
+  │    ^^^^^
 
 --
 class A {
 	#prop;
 	test() {
-   #prop in #prop in this
+   #prop in #prop in this;
+   5 + #prop;
+   #prop
  }
 }

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.js
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.js
@@ -10,3 +10,4 @@ a >> b
 a >>> b
 1 + 1 + 1 + 1
 5 + 6 - 1 * 2 / 1 ** 6
+class Test { #name; test() { true && #name in {} } }

--- a/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rslint_parser/test_data/inline/ok/binary_expressions.rast
@@ -225,14 +225,88 @@ JsModule {
             },
             semicolon_token: missing (optional),
         },
+        JsClassDeclaration {
+            abstract_token: missing (optional),
+            class_token: CLASS_KW@139..146 "class" [Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@146..151 "Test" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@151..153 "{" [] [Whitespace(" ")],
+            members: JsClassMemberList [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsPrivateClassMemberName {
+                        hash_token: HASH@153..154 "#" [] [],
+                        id_token: IDENT@154..158 "name" [] [],
+                    },
+                    property_annotation: missing (optional),
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@158..160 ";" [] [Whitespace(" ")],
+                },
+                JsMethodClassMember {
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    abstract_token: missing (optional),
+                    async_token: missing (optional),
+                    star_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@160..164 "test" [] [],
+                    },
+                    question_mark_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@164..165 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@165..167 ")" [] [Whitespace(" ")],
+                    },
+                    return_type_annotation: missing (optional),
+                    body: JsFunctionBody {
+                        l_curly_token: L_CURLY@167..169 "{" [] [Whitespace(" ")],
+                        directives: JsDirectiveList [],
+                        statements: JsStatementList [
+                            JsExpressionStatement {
+                                expression: JsLogicalExpression {
+                                    left: JsBooleanLiteralExpression {
+                                        value_token: TRUE_KW@169..174 "true" [] [Whitespace(" ")],
+                                    },
+                                    operator: AMP2@174..177 "&&" [] [Whitespace(" ")],
+                                    right: JsInExpression {
+                                        property: JsPrivateName {
+                                            hash_token: HASH@177..178 "#" [] [],
+                                            value_token: IDENT@178..183 "name" [] [Whitespace(" ")],
+                                        },
+                                        in_token: IN_KW@183..186 "in" [] [Whitespace(" ")],
+                                        object: JsObjectExpression {
+                                            l_curly_token: L_CURLY@186..187 "{" [] [],
+                                            members: JsObjectMemberList [],
+                                            r_curly_token: R_CURLY@187..189 "}" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                },
+                                semicolon_token: missing (optional),
+                            },
+                        ],
+                        r_curly_token: R_CURLY@189..191 "}" [] [Whitespace(" ")],
+                    },
+                },
+            ],
+            r_curly_token: R_CURLY@191..192 "}" [] [],
+        },
     ],
-    eof_token: EOF@139..140 "" [Newline("\n")] [],
+    eof_token: EOF@192..193 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..140
+0: JS_MODULE@0..193
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..139
+  2: JS_MODULE_ITEM_LIST@0..192
     0: JS_EXPRESSION_STATEMENT@0..5
       0: JS_BINARY_EXPRESSION@0..5
         0: JS_NUMBER_LITERAL_EXPRESSION@0..2
@@ -379,4 +453,62 @@ JsModule {
             2: JS_NUMBER_LITERAL_EXPRESSION@138..139
               0: JS_NUMBER_LITERAL@138..139 "6" [] []
       1: (empty)
-  3: EOF@139..140 "" [Newline("\n")] []
+    11: JS_CLASS_DECLARATION@139..192
+      0: (empty)
+      1: CLASS_KW@139..146 "class" [Newline("\n")] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@146..151
+        0: IDENT@146..151 "Test" [] [Whitespace(" ")]
+      3: (empty)
+      4: (empty)
+      5: (empty)
+      6: L_CURLY@151..153 "{" [] [Whitespace(" ")]
+      7: JS_CLASS_MEMBER_LIST@153..191
+        0: JS_PROPERTY_CLASS_MEMBER@153..160
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_PRIVATE_CLASS_MEMBER_NAME@153..158
+            0: HASH@153..154 "#" [] []
+            1: IDENT@154..158 "name" [] []
+          6: (empty)
+          7: (empty)
+          8: SEMICOLON@158..160 ";" [] [Whitespace(" ")]
+        1: JS_METHOD_CLASS_MEMBER@160..191
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@160..164
+            0: IDENT@160..164 "test" [] []
+          6: (empty)
+          7: (empty)
+          8: JS_PARAMETERS@164..167
+            0: L_PAREN@164..165 "(" [] []
+            1: JS_PARAMETER_LIST@165..165
+            2: R_PAREN@165..167 ")" [] [Whitespace(" ")]
+          9: (empty)
+          10: JS_FUNCTION_BODY@167..191
+            0: L_CURLY@167..169 "{" [] [Whitespace(" ")]
+            1: JS_DIRECTIVE_LIST@169..169
+            2: JS_STATEMENT_LIST@169..189
+              0: JS_EXPRESSION_STATEMENT@169..189
+                0: JS_LOGICAL_EXPRESSION@169..189
+                  0: JS_BOOLEAN_LITERAL_EXPRESSION@169..174
+                    0: TRUE_KW@169..174 "true" [] [Whitespace(" ")]
+                  1: AMP2@174..177 "&&" [] [Whitespace(" ")]
+                  2: JS_IN_EXPRESSION@177..189
+                    0: JS_PRIVATE_NAME@177..183
+                      0: HASH@177..178 "#" [] []
+                      1: IDENT@178..183 "name" [] [Whitespace(" ")]
+                    1: IN_KW@183..186 "in" [] [Whitespace(" ")]
+                    2: JS_OBJECT_EXPRESSION@186..189
+                      0: L_CURLY@186..187 "{" [] []
+                      1: JS_OBJECT_MEMBER_LIST@187..187
+                      2: R_CURLY@187..189 "}" [] [Whitespace(" ")]
+                1: (empty)
+            3: R_CURLY@189..191 "}" [] [Whitespace(" ")]
+      8: R_CURLY@191..192 "}" [] []
+  3: EOF@192..193 "" [Newline("\n")] []


### PR DESCRIPTION
## Summary

Fixes the precedence of private names. Rome's parser incorrectly parsed `this && #name in this` as

```
BinaryExpression(
  BinaryExpression(this && #name),
  'in'
  `this`
)
```

instead of

```
BinaryExpression(
  this,
  '&&'
  BinaryExpression(#name in this)
)
```

It further fixes an issue where the parser incorrectly emitted a diagnostic for `true && #name in this` that `#name` is only allowed on the left-hand side of a binary expression.

Part of #2113 

## Test Plan

Added new parser tests