### PR TITLE
feat(rome_formatter): implement suppression comments and improve the formatting of verbatim nodes

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -1,5 +1,5 @@
 use rome_rowan::api::SyntaxTriviaPieceComments;
-use rome_rowan::{Language, SyntaxToken, TextRange, TextSize};
+use rome_rowan::{Language, SyntaxToken, TextRange};
 use rslint_parser::{AstNode, SyntaxNode};
 
 use crate::format_elements;
@@ -1003,62 +1003,6 @@ impl List {
     fn new(content: Vec<FormatElement>) -> Self {
         Self { content }
     }
-
-    fn trim_start(&self) -> Self {
-        let mut content: Vec<_> = self
-            .iter()
-            .skip_while(|e| match e {
-                FormatElement::Empty => true,
-                FormatElement::Space => true,
-                FormatElement::Line(_) => true,
-                FormatElement::Indent(_) => true,
-                FormatElement::Token(t) => {
-                    let s = t.trim_start();
-                    s.is_empty()
-                }
-                _ => false,
-            })
-            .map(Clone::clone)
-            .collect();
-
-        if let Some(FormatElement::Token(s)) = content.get_mut(0) {
-            *s = s.trim_start();
-        }
-
-        Self::new(content)
-    }
-
-    fn trim_end(&self) -> Self {
-        let idx_first_non_empty = self.iter().rev().position(|e| match e {
-            FormatElement::Empty => false,
-            FormatElement::Space => false,
-            FormatElement::Line(_) => false,
-            FormatElement::Indent(_) => false,
-            FormatElement::Token(t) => {
-                let s = t.trim_end();
-                !s.is_empty()
-            }
-            _ => true,
-        });
-
-        match idx_first_non_empty {
-            Some(idx_first_non_empty) => {
-                let idx_first_non_empty = self.len() - idx_first_non_empty;
-                let mut content: Vec<_> = self
-                    .iter()
-                    .take(idx_first_non_empty)
-                    .map(Clone::clone)
-                    .collect();
-
-                if let Some(FormatElement::Token(s)) = content.last_mut() {
-                    *s = s.trim_end();
-                }
-
-                Self::new(content)
-            }
-            None => Self::new(vec![]),
-        }
-    }
 }
 
 impl Deref for List {
@@ -1158,42 +1102,6 @@ impl Token {
             Token::Dynamic { source, .. } => Some(source),
         }
     }
-
-    fn trim_start(&self) -> Self {
-        match self {
-            Token::Static { text } => Self::Static {
-                text: text.trim_start(),
-            },
-            Token::Dynamic { text, source } => {
-                let prev_len = TextSize::from(text.len() as u32);
-                let text = text.trim_start();
-                let next_len = TextSize::from(text.len() as u32);
-                let diff = prev_len - next_len;
-                Self::Dynamic {
-                    text: text.into(),
-                    source: TextRange::new(source.start() + diff, source.end()),
-                }
-            }
-        }
-    }
-
-    fn trim_end(&self) -> Self {
-        match self {
-            Token::Static { text } => Self::Static {
-                text: text.trim_end(),
-            },
-            Token::Dynamic { text, source } => {
-                let prev_len = TextSize::from(text.len() as u32);
-                let text = text.trim_end();
-                let next_len = TextSize::from(text.len() as u32);
-                let diff = prev_len - next_len;
-                Self::Dynamic {
-                    text: text.into(),
-                    source: TextRange::new(source.start(), source.end() - diff),
-                }
-            }
-        }
-    }
 }
 
 // Token equality only compares the text content
@@ -1271,54 +1179,6 @@ impl FormatElement {
     pub fn is_empty(&self) -> bool {
         self == &FormatElement::Empty
     }
-
-    /// Remove all spaces, line breaks, indents from the start of
-    /// the [FormatElement].
-    /// Including "whitespace" characters of the [FormatElement::Token] variant.
-    pub fn trim_start(&self) -> FormatElement {
-        match self {
-            FormatElement::Empty => FormatElement::Empty,
-            FormatElement::Space => FormatElement::Empty,
-            FormatElement::Line(_) => FormatElement::Empty,
-            FormatElement::Indent(i) => i.content.trim_start(),
-            FormatElement::Group(g) => g.content.trim_start(),
-            FormatElement::HardGroup(g) => g.content.trim_start(),
-            FormatElement::Fill(list) => FormatElement::Fill(list.trim_start()),
-            FormatElement::ConditionalGroupContent(g) => g.content.trim_start(),
-            FormatElement::List(list) => FormatElement::List(list.trim_start()),
-            FormatElement::Token(s) => FormatElement::Token(s.trim_start()),
-            FormatElement::LineSuffix(s) => FormatElement::LineSuffix(Box::new(s.trim_start())),
-            FormatElement::Verbatim(v) => FormatElement::Verbatim(Verbatim::new(
-                v.element.trim_start(),
-                v.text.clone(),
-                v.range,
-            )),
-        }
-    }
-
-    /// Remove all spaces, line breaks, indents from the end of
-    /// the [FormatElement].
-    /// Including "whitespace" characters of the [FormatElement::Token] variant.
-    pub fn trim_end(&self) -> FormatElement {
-        match self {
-            FormatElement::Empty => FormatElement::Empty,
-            FormatElement::Space => FormatElement::Empty,
-            FormatElement::Line(_) => FormatElement::Empty,
-            FormatElement::Indent(i) => i.content.trim_end(),
-            FormatElement::Group(g) => g.content.trim_end(),
-            FormatElement::HardGroup(g) => g.content.trim_end(),
-            FormatElement::ConditionalGroupContent(g) => g.content.trim_end(),
-            FormatElement::Fill(list) => FormatElement::Fill(list.trim_end()),
-            FormatElement::List(list) => FormatElement::List(list.trim_end()),
-            FormatElement::Token(s) => FormatElement::Token(s.trim_end()),
-            FormatElement::LineSuffix(s) => FormatElement::LineSuffix(Box::new(s.trim_end())),
-            FormatElement::Verbatim(v) => FormatElement::Verbatim(Verbatim::new(
-                v.element.trim_end(),
-                v.text.clone(),
-                v.range,
-            )),
-        }
-    }
 }
 
 impl From<Token> for FormatElement {
@@ -1366,7 +1226,9 @@ impl From<Option<FormatElement>> for FormatElement {
 #[cfg(test)]
 mod tests {
 
-    use crate::format_element::{empty_element, join_elements, List};
+    use crate::format_element::{
+        empty_element, join_elements, normalize_newlines, List, LINE_TERMINATORS,
+    };
     use crate::{concat_elements, space_token, token, FormatElement};
 
     #[test]
@@ -1476,24 +1338,11 @@ mod tests {
     }
 
     #[test]
-    fn format_element_trim() {
-        use crate::format_element::*;
-        let f = concat_elements([
-            FormatElement::Empty,
-            FormatElement::Indent(Indent::new(FormatElement::Empty)),
-            FormatElement::Line(Line::new(LineMode::Hard)),
-            FormatElement::Space,
-            FormatElement::Token(Token::new_static(" \t \n")),
-            FormatElement::List(List::new(vec![FormatElement::Empty])),
-            FormatElement::Group(Group::new(FormatElement::Empty)),
-            FormatElement::ConditionalGroupContent(ConditionalGroupContent::new(
-                FormatElement::Empty,
-                GroupPrintMode::Flat,
-            )),
-        ]);
-
-        let f = f.trim_start();
-        matches!(f.trim_start(), FormatElement::Empty);
-        matches!(f.trim_end(), FormatElement::Empty);
+    fn test_normalize_newlines() {
+        assert_eq!(normalize_newlines("a\nb", LINE_TERMINATORS), "a\nb");
+        assert_eq!(normalize_newlines("a\rb", LINE_TERMINATORS), "a\nb");
+        assert_eq!(normalize_newlines("a\r\nb", LINE_TERMINATORS), "a\nb");
+        assert_eq!(normalize_newlines("a\u{2028}b", LINE_TERMINATORS), "a\nb");
+        assert_eq!(normalize_newlines("a\u{2029}b", LINE_TERMINATORS), "a\nb");
     }
 }

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -361,9 +361,9 @@ where
         // Then add the newlines in the leading trivia of the next node
         if let Some(leading_trivia) = next_node.first_leading_trivia() {
             for piece in leading_trivia.pieces() {
-                if piece.as_newline().is_some() {
+                if piece.is_newline() {
                     line_count += 1;
-                } else if piece.as_comments().is_some() {
+                } else if piece.is_comments() {
                     // Stop at the first comment piece, the comment printer
                     // will handle newlines between the comment and the node
                     break;

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -2,6 +2,7 @@
 use std::cell::RefCell;
 #[cfg(debug_assertions)]
 use std::collections::HashSet;
+use std::iter::once;
 
 use crate::format_element::Verbatim;
 use crate::formatter_traits::FormatTokenAndNode;
@@ -13,7 +14,8 @@ use crate::{
     soft_line_break_or_space, space_token, FormatElement, FormatOptions, FormatResult,
     ToFormatElement,
 };
-use rome_rowan::SyntaxElement;
+use rome_rowan::api::SyntaxTriviaPiece;
+use rome_rowan::Language;
 #[cfg(debug_assertions)]
 use rslint_parser::SyntaxNodeExt;
 use rslint_parser::{AstNode, AstNodeList, AstSeparatedList, SyntaxNode, SyntaxToken};
@@ -333,8 +335,6 @@ impl Formatter {
                     // Lists that yield errors are formatted as they were unknown nodes.
                     // Doing so, the formatter formats the nodes/tokens as is.
                     self.format_unknown(module_item.syntax())
-                        .trim_start()
-                        .trim_end()
                 }
             };
 
@@ -435,28 +435,53 @@ impl Formatter {
     }
 
     fn format_verbatim_node_or_token(&self, node: &SyntaxNode) -> FormatElement {
-        concat_elements(node.children_with_tokens().map(|child| {
-            match child {
-                SyntaxElement::Node(child_node) => {
-                    // Here we call `format_unknown` because we don't want to track it as [FormatElement::Verbatim]
-                    // all the possible children. The first node to call `format_verbatim` should be node to be tracked
-                    self.format_verbatim_node_or_token(&child_node)
-                }
-                SyntaxElement::Token(syntax_token) => {
-                    cfg_if::cfg_if! {
-                        if #[cfg(debug_assertions)] {
-                            assert!(self.printed_tokens.borrow_mut().insert(syntax_token.clone()));
-                        }
-                    }
-
-                    // Print the full (not trimmed) text of the token
-                    FormatElement::from(Token::new_dynamic(
-                        normalize_newlines(syntax_token.text(), LINE_TERMINATORS).into_owned(),
-                        syntax_token.text_range(),
-                    ))
+        cfg_if::cfg_if! {
+            if #[cfg(debug_assertions)] {
+                for token in node.tokens() {
+                    assert!(self.printed_tokens.borrow_mut().insert(token.clone()));
                 }
             }
-        }))
+        }
+
+        fn skip_whitespace<L: Language>(piece: &SyntaxTriviaPiece<L>) -> bool {
+            piece.as_newline().is_some() || piece.as_whitespace().is_some()
+        }
+
+        fn trivia_token<L: Language>(piece: SyntaxTriviaPiece<L>) -> Token {
+            Token::new_dynamic(
+                normalize_newlines(piece.text(), LINE_TERMINATORS).into_owned(),
+                piece.text_range(),
+            )
+        }
+
+        let leading_trivia = node
+            .first_leading_trivia()
+            .into_iter()
+            .flat_map(|trivia| trivia.pieces())
+            .skip_while(skip_whitespace)
+            .map(trivia_token);
+
+        let content = Token::new_dynamic(
+            normalize_newlines(&node.text_trimmed().to_string(), LINE_TERMINATORS).into_owned(),
+            node.text_trimmed_range(),
+        );
+
+        // Clippy false positive: SkipWhile does not implement DoubleEndedIterator
+        #[allow(clippy::needless_collect)]
+        let trailing_trivia = node
+            .last_trailing_trivia()
+            .into_iter()
+            .flat_map(|trivia| trivia.pieces().rev())
+            .skip_while(skip_whitespace)
+            .map(trivia_token)
+            .collect::<Vec<_>>();
+
+        concat_elements(
+            leading_trivia
+                .chain(once(content))
+                .chain(trailing_trivia.into_iter().rev())
+                .map(FormatElement::from),
+        )
     }
 }
 

--- a/crates/rome_formatter/src/formatter.rs
+++ b/crates/rome_formatter/src/formatter.rs
@@ -359,7 +359,7 @@ impl Formatter {
 
                 line_count = 0;
                 trim_mode = TriviaPrintMode::Full;
-            } else if piece.as_newline().is_some() && trim_mode == TriviaPrintMode::Full {
+            } else if piece.is_newline() && trim_mode == TriviaPrintMode::Full {
                 line_count += 1;
             }
         }
@@ -439,7 +439,7 @@ impl Formatter {
         }
 
         fn skip_whitespace<L: Language>(piece: &SyntaxTriviaPiece<L>) -> bool {
-            piece.as_newline().is_some() || piece.as_whitespace().is_some()
+            piece.is_newline() || piece.is_whitespace()
         }
 
         fn trivia_token<L: Language>(piece: SyntaxTriviaPiece<L>) -> Token {

--- a/crates/rome_formatter/src/formatter_traits.rs
+++ b/crates/rome_formatter/src/formatter_traits.rs
@@ -1,4 +1,5 @@
 use crate::formatter::TriviaPrintMode;
+use crate::utils::has_formatter_suppressions;
 use crate::Token;
 use crate::{
     empty_element, format_elements, FormatElement, FormatResult, Formatter, ToFormatElement,
@@ -279,14 +280,14 @@ impl<N: AstNode + ToFormatElement> FormatTokenAndNode for N {
         With: FnOnce(FormatElement) -> WithResult,
         WithResult: IntoFormatResult,
     {
-        let leading = formatter.format_node_start(self.syntax());
-        let trailing = formatter.format_node_end(self.syntax());
-        with(format_elements![
-            leading,
-            self.to_format_element(formatter)?,
-            trailing,
-        ])
-        .into_format_result()
+        let node = self.syntax();
+        let element = if has_formatter_suppressions(node) {
+            formatter.format_suppressed(node)
+        } else {
+            self.to_format_element(formatter)?
+        };
+
+        with(element).into_format_result()
     }
 }
 

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -445,8 +445,8 @@ pub fn format_node(options: FormatOptions, root: &SyntaxNode) -> FormatResult<Fo
         .chain(next_tokens_trivias)
         .filter(|piece| {
             // We're only interested in newline and whitespace trivias, skip over comments
-            let is_newline = piece.as_newline().is_some();
-            let is_whitespace = piece.as_whitespace().is_some();
+            let is_newline = piece.is_newline();
+            let is_whitespace = piece.is_whitespace();
             is_newline || is_whitespace
         });
 

--- a/crates/rome_formatter/src/utils/mod.rs
+++ b/crates/rome_formatter/src/utils/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     FormatElement, FormatResult, Formatter,
 };
 pub use call_expression::format_call_expression;
-use rslint_parser::ast::{JsAnyStatement, JsInitializerClause};
-use rslint_parser::{JsSyntaxKind, SyntaxNode, SyntaxNodeExt, SyntaxToken};
+use rslint_parser::ast::{JsAnyRoot, JsAnyStatement, JsInitializerClause};
+use rslint_parser::{AstNode, SyntaxNode, SyntaxNodeExt, SyntaxToken};
 
 /// Utility function to format the separators of the nodes that belong to the unions
 /// of [rslint_parser::ast::TsAnyTypeMember].
@@ -53,9 +53,9 @@ pub(crate) fn has_formatter_trivia(node: &SyntaxNode) -> bool {
 
     for token in node.tokens() {
         for trivia in token.leading_trivia().pieces() {
-            if trivia.as_comments().is_some() {
+            if trivia.is_comments() {
                 return true;
-            } else if trivia.as_newline().is_some() {
+            } else if trivia.is_newline() {
                 line_count += 1;
                 if line_count >= 2 {
                     return true;
@@ -68,9 +68,9 @@ pub(crate) fn has_formatter_trivia(node: &SyntaxNode) -> bool {
         line_count = 0;
 
         for trivia in token.trailing_trivia().pieces() {
-            if trivia.as_comments().is_some() {
+            if trivia.is_comments() {
                 return true;
-            } else if trivia.as_newline().is_some() {
+            } else if trivia.is_newline() {
                 line_count += 1;
                 if line_count >= 2 {
                     return true;
@@ -105,21 +105,43 @@ pub(crate) fn format_head_body_statement(
     }
 }
 
+/// Single instance of a suppression comment, with the following syntax:
+///
+/// `// rome-ignore { <category> { (<value>) }? }+: <reason>`
+///
+/// The category broadly describes what feature is being suppressed (formatting,
+/// linting, ...) with the value being and optional, category-specific name of
+/// a specific element to disable (for instance a specific lint name). A single
+/// suppression may specify one or more categories + values, for instance to
+/// disable multiple lints at once
+///
+/// A suppression must specify a reason: this part has no semantic meaning but
+/// is required to document why a particular feature is being disable for this
+/// line (lint false-positive, specific formatting requirements, ...)
 #[derive(Debug, PartialEq, Eq)]
 struct Suppression<'a> {
+    /// List of categories for this suppression
+    ///
+    /// Categories are pair of the category name +
+    /// an optional category value
     categories: Vec<(&'a str, Option<&'a str>)>,
+    /// Reason for this suppression comment to exist
     reason: &'a str,
 }
+
+const CATEGORY_FORMAT: &str = "format";
 
 fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression> {
     let (head, mut comment) = comment.split_at(2);
     let is_block_comment = match head {
         "//" => false,
         "/*" => {
-            comment = comment.strip_suffix("*/").unwrap();
+            comment = comment
+                .strip_suffix("*/")
+                .expect("block comment with no closing token");
             true
         }
-        _ => panic!(),
+        token => panic!("comment with unknown opening token {token:?}"),
     };
 
     comment.lines().filter_map(move |line| {
@@ -131,24 +153,14 @@ fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression>
             line = line.trim_start_matches('*').trim_start()
         }
 
-        // TODO: While we do want to detect these, it should
-        // only be enabled in a special "migration" mode where
-        // they get rewritten as rome-ignore
-        if line.trim_end() == "prettier-ignore" {
-            return Some(Suppression {
-                categories: vec![("format", None)],
-                reason: "",
-            });
-        }
-
         // Check for the rome-ignore token or skip the line entirely
         line = line.strip_prefix("rome-ignore")?.trim_start();
 
         let mut categories = Vec::new();
 
         loop {
-            // Find either a colon or opening parenthesis
-            let separator = line.find([':', '('])?;
+            // Find either a colon opening parenthesis or space
+            let separator = line.find(|c: char| c == ':' || c == '(' || c.is_whitespace())?;
 
             let (category, rest) = line.split_at(separator);
             let category = category.trim_end();
@@ -156,23 +168,36 @@ fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression>
             // Skip over and match the separator
             let (separator, rest) = rest.split_at(1);
 
-            if separator == ":" {
-                if !category.is_empty() {
-                    categories.push((category, None));
+            match separator {
+                // Colon token: stop parsing categories
+                ":" => {
+                    if !category.is_empty() {
+                        categories.push((category, None));
+                    }
+
+                    line = rest.trim_start();
+                    break;
                 }
+                // Paren token: parse a category + value
+                "(" => {
+                    let paren = rest.find(')')?;
 
-                line = rest.trim_start();
-                break;
+                    let (value, rest) = rest.split_at(paren);
+                    let value = value.trim();
+
+                    categories.push((category, Some(value)));
+
+                    line = rest.strip_prefix(')').unwrap().trim_start();
+                }
+                // Whitespace: push a category without value
+                _ => {
+                    if !category.is_empty() {
+                        categories.push((category, None));
+                    }
+
+                    line = rest.trim_start();
+                }
             }
-
-            let paren = rest.find(')')?;
-
-            let (value, rest) = rest.split_at(paren);
-            let value = value.trim();
-
-            categories.push((category, Some(value)));
-
-            line = rest.strip_prefix(')').unwrap().trim_start();
         }
 
         let reason = line.trim_end();
@@ -183,11 +208,9 @@ fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression>
 pub(crate) fn has_formatter_suppressions(node: &SyntaxNode) -> bool {
     // Lists cannot have a suppression comment attached, it must
     // belong to either the entire parent node or one of the children
-    match node.kind() {
-        // Files are a special kind of list
-        JsSyntaxKind::JS_MODULE | JsSyntaxKind::JS_SCRIPT => return false,
-        kind if kind.is_list() => return false,
-        _ => {}
+    let kind = node.kind();
+    if JsAnyRoot::can_cast(kind) || kind.is_list() {
+        return false;
     }
 
     let first_token = match node.first_token() {
@@ -202,7 +225,7 @@ pub(crate) fn has_formatter_suppressions(node: &SyntaxNode) -> bool {
         .any(|comment| {
             for suppression in parse_suppression_comment(comment.text()) {
                 for (category, _) in suppression.categories {
-                    if category == "format" {
+                    if category == CATEGORY_FORMAT {
                         return true;
                     }
                 }
@@ -237,8 +260,8 @@ mod tests {
         assert_eq!(
             parse_suppression_comment(
                 "/**
-				  * rome-ignore parse: explanation3
-				  */"
+                  * rome-ignore parse: explanation3
+                  */"
             )
             .collect::<Vec<_>>(),
             vec![Suppression {
@@ -250,9 +273,9 @@ mod tests {
         assert_eq!(
             parse_suppression_comment(
                 "/**
-				  * hello
-				  * rome-ignore parse: explanation4
-				  */"
+                  * hello
+                  * rome-ignore parse: explanation4
+                  */"
             )
             .collect::<Vec<_>>(),
             vec![Suppression {
@@ -285,8 +308,8 @@ mod tests {
         assert_eq!(
             parse_suppression_comment(
                 "/**
-				  * rome-ignore parse(yes) parse(frog): explanation
-				  */"
+                  * rome-ignore parse(yes) parse(frog): explanation
+                  */"
             )
             .collect::<Vec<_>>(),
             vec![Suppression {
@@ -298,13 +321,25 @@ mod tests {
         assert_eq!(
             parse_suppression_comment(
                 "/**
-				  * hello
-				  * rome-ignore parse(wow) parse(fish): explanation
-				  */"
+                  * hello
+                  * rome-ignore parse(wow) parse(fish): explanation
+                  */"
             )
             .collect::<Vec<_>>(),
             vec![Suppression {
                 categories: vec![("parse", Some("wow")), ("parse", Some("fish"))],
+                reason: "explanation"
+            }],
+        );
+    }
+
+    #[test]
+    fn parse_multiple_suppression_categories() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore format lint: explanation")
+                .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("format", None), ("lint", None)],
                 reason: "explanation"
             }],
         );

--- a/crates/rome_formatter/src/utils/mod.rs
+++ b/crates/rome_formatter/src/utils/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 pub use call_expression::format_call_expression;
 use rslint_parser::ast::{JsAnyStatement, JsInitializerClause};
-use rslint_parser::{SyntaxNode, SyntaxNodeExt, SyntaxToken};
+use rslint_parser::{JsSyntaxKind, SyntaxNode, SyntaxNodeExt, SyntaxToken};
 
 /// Utility function to format the separators of the nodes that belong to the unions
 /// of [rslint_parser::ast::TsAnyTypeMember].
@@ -102,5 +102,211 @@ pub(crate) fn format_head_body_statement(
             hard_group_elements(head),
             body.format(formatter)?
         ])
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Suppression<'a> {
+    categories: Vec<(&'a str, Option<&'a str>)>,
+    reason: &'a str,
+}
+
+fn parse_suppression_comment(comment: &str) -> impl Iterator<Item = Suppression> {
+    let (head, mut comment) = comment.split_at(2);
+    let is_block_comment = match head {
+        "//" => false,
+        "/*" => {
+            comment = comment.strip_suffix("*/").unwrap();
+            true
+        }
+        _ => panic!(),
+    };
+
+    comment.lines().filter_map(move |line| {
+        // Eat start of line whitespace
+        let mut line = line.trim_start();
+
+        // If we're in a block comment eat stars, then whitespace again
+        if is_block_comment {
+            line = line.trim_start_matches('*').trim_start()
+        }
+
+        // TODO: While we do want to detect these, it should
+        // only be enabled in a special "migration" mode where
+        // they get rewritten as rome-ignore
+        if line.trim_end() == "prettier-ignore" {
+            return Some(Suppression {
+                categories: vec![("format", None)],
+                reason: "",
+            });
+        }
+
+        // Check for the rome-ignore token or skip the line entirely
+        line = line.strip_prefix("rome-ignore")?.trim_start();
+
+        let mut categories = Vec::new();
+
+        loop {
+            // Find either a colon or opening parenthesis
+            let separator = line.find([':', '('])?;
+
+            let (category, rest) = line.split_at(separator);
+            let category = category.trim_end();
+
+            // Skip over and match the separator
+            let (separator, rest) = rest.split_at(1);
+
+            if separator == ":" {
+                if !category.is_empty() {
+                    categories.push((category, None));
+                }
+
+                line = rest.trim_start();
+                break;
+            }
+
+            let paren = rest.find(')')?;
+
+            let (value, rest) = rest.split_at(paren);
+            let value = value.trim();
+
+            categories.push((category, Some(value)));
+
+            line = rest.strip_prefix(')').unwrap().trim_start();
+        }
+
+        let reason = line.trim_end();
+        Some(Suppression { categories, reason })
+    })
+}
+
+pub(crate) fn has_formatter_suppressions(node: &SyntaxNode) -> bool {
+    // Lists cannot have a suppression comment attached, it must
+    // belong to either the entire parent node or one of the children
+    match node.kind() {
+        // Files are a special kind of list
+        JsSyntaxKind::JS_MODULE | JsSyntaxKind::JS_SCRIPT => return false,
+        kind if kind.is_list() => return false,
+        _ => {}
+    }
+
+    let first_token = match node.first_token() {
+        Some(token) => token,
+        None => return false,
+    };
+
+    first_token
+        .leading_trivia()
+        .pieces()
+        .filter_map(|trivia| trivia.as_comments())
+        .any(|comment| {
+            for suppression in parse_suppression_comment(comment.text()) {
+                for (category, _) in suppression.categories {
+                    if category == "format" {
+                        return true;
+                    }
+                }
+            }
+
+            false
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_suppression_comment, Suppression};
+
+    #[test]
+    fn parse_simple_suppression() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore parse: explanation1").collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", None)],
+                reason: "explanation1"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment("/** rome-ignore parse: explanation2 */").collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", None)],
+                reason: "explanation2"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment(
+                "/**
+				  * rome-ignore parse: explanation3
+				  */"
+            )
+            .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", None)],
+                reason: "explanation3"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment(
+                "/**
+				  * hello
+				  * rome-ignore parse: explanation4
+				  */"
+            )
+            .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", None)],
+                reason: "explanation4"
+            }],
+        );
+    }
+
+    #[test]
+    fn parse_multiple_suppression() {
+        assert_eq!(
+            parse_suppression_comment("// rome-ignore parse(foo) parse(dog): explanation")
+                .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", Some("foo")), ("parse", Some("dog"))],
+                reason: "explanation"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment("/** rome-ignore parse(bar) parse(cat): explanation */")
+                .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", Some("bar")), ("parse", Some("cat"))],
+                reason: "explanation"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment(
+                "/**
+				  * rome-ignore parse(yes) parse(frog): explanation
+				  */"
+            )
+            .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", Some("yes")), ("parse", Some("frog"))],
+                reason: "explanation"
+            }],
+        );
+
+        assert_eq!(
+            parse_suppression_comment(
+                "/**
+				  * hello
+				  * rome-ignore parse(wow) parse(fish): explanation
+				  */"
+            )
+            .collect::<Vec<_>>(),
+            vec![Suppression {
+                categories: vec![("parse", Some("wow")), ("parse", Some("fish"))],
+                reason: "explanation"
+            }],
+        );
     }
 }

--- a/crates/rome_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 157
+assertion_line: 168
 expression: default_import.js
 
 ---
@@ -33,7 +33,7 @@ import foo from "foo.json" assert { type: "json" };
 import foo2 from "foo.json" assert {
 	"type": "json",
 	type: "html",
-	"type": "js" ,
+	"type": "js",
 };
 import a, * as b from "foo";
 

--- a/crates/rome_formatter/tests/specs/js/module/suppression.js
+++ b/crates/rome_formatter/tests/specs/js/module/suppression.js
@@ -1,0 +1,25 @@
+// rome-ignore format: the following if should print inline
+if(true) statement();
+
+/** rome-ignore format: the following if should print inline */
+if (true) statement();
+
+/**
+ * rome-ignore format: the following if should print inline
+ */
+if (true) statement();
+
+const   expr   =   
+// rome-ignore format: the array should not be formatted
+[
+    (2*n)/(r-l), 0,            (r+l)/(r-l),  0,
+    0,           (2*n)/(t-b),  (t+b)/(t-b),  0,
+    0,           0,           -(f+n)/(f-n), -(2*f*n)/(f-n),
+    0,           0,           -1,            0,
+];
+
+const    expr2    =    {
+    key:
+        // rome-ignore format: only skip formatting the value
+        'single quoted string'
+}

--- a/crates/rome_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/suppression.js.snap
@@ -1,0 +1,66 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 168
+expression: suppression.js
+
+---
+# Input
+// rome-ignore format: the following if should print inline
+if(true) statement();
+
+/** rome-ignore format: the following if should print inline */
+if (true) statement();
+
+/**
+ * rome-ignore format: the following if should print inline
+ */
+if (true) statement();
+
+const   expr   =   
+// rome-ignore format: the array should not be formatted
+[
+    (2*n)/(r-l), 0,            (r+l)/(r-l),  0,
+    0,           (2*n)/(t-b),  (t+b)/(t-b),  0,
+    0,           0,           -(f+n)/(f-n), -(2*f*n)/(f-n),
+    0,           0,           -1,            0,
+];
+
+const    expr2    =    {
+    key:
+        // rome-ignore format: only skip formatting the value
+        'single quoted string'
+}
+
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+-----
+// rome-ignore format: the following if should print inline
+if(true) statement();
+
+/** rome-ignore format: the following if should print inline */
+if (true) statement();
+
+/**
+ * rome-ignore format: the following if should print inline
+ */
+if (true) statement();
+
+const expr =
+// rome-ignore format: the array should not be formatted
+[
+    (2*n)/(r-l), 0,            (r+l)/(r-l),  0,
+    0,           (2*n)/(t-b),  (t+b)/(t-b),  0,
+    0,           0,           -(f+n)/(f-n), -(2*f*n)/(f-n),
+    0,           0,           -1,            0,
+];
+
+const expr2 = {
+	key:
+	// rome-ignore format: only skip formatting the value
+        'single quoted string',
+};
+

--- a/crates/rome_formatter/tests/specs/prettier/js/arrows/newline-before-arrow/newline-before-arrow.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/arrows/newline-before-arrow/newline-before-arrow.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: newline-before-arrow.js
 
 ---
@@ -15,7 +15,6 @@ async x
 ```js
 async;
 x;
-
 => x
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decimal.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decimal.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: decimal.js
 
 ---
@@ -40,56 +40,37 @@ typeof 1m === "decimal128";
 // https://github.com/babel/babel/pull/11640
 
 100m
-
 9223372036854775807m
-
 0.m
-
 3.1415926535897932m
-
 100.000m
-
 .1m
 ({ 0m: 0, .1m() {}, get
 0.2m()
 {}
 , set 3m(_)
 {}
-, async 4m() 
+, async 4m()
 {}
-, *.5m() 
+, *.5m()
 {}
 })
-
 1.m
-
 100m
-
 9223372036854775807m
-
 100.m
-
-
 
 // Invalid decimal
 2e9m
-
 016432m
-
 089m
-
-
 
 // https://github.com/tc39/proposal-decimal
 .1m + .2m === .3m
-
 2.00m
-
 -0m;
-
-typeof 1m  === "bigdecimal";
-
-typeof 1m  === "decimal128";
+typeof 1m === "bigdecimal";
+typeof 1m === "decimal128";
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decorators.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decorators.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: decorators.js
 
 ---
@@ -48,8 +48,6 @@ class MyClass {}
 function annotation(target) {
   target.annotated = true;
 }
-
-
 
 @isTestable(true)
 class MyClass {}

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/module-blocks.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/module-blocks.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: module-blocks.js
 
 ---
@@ -17,9 +17,7 @@ let m = module {
 ```js
 let m = module;
 {
-  
   export let m = 2;
-  
   export let n = 3;
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/throw-expressions.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/throw-expressions.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: throw-expressions.js
 
 ---
@@ -19,7 +19,7 @@ function test(param = throw new Error('required!')) {
 // https://babeljs.io/docs/en/babel-plugin-proposal-throw-expressions
 
 function test(param = throw new Error('required!')
-) 
+)
 {
   const test = param === true ||
   throw new Error("Falsy!");

--- a/crates/rome_formatter/tests/specs/prettier/js/bind-expressions/bind_parens.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/bind-expressions/bind_parens.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: bind_parens.js
 
 ---
@@ -49,7 +49,6 @@ f[a::b()];
 ::c
 a || (b
 ::c)
-
 ::obj.prop
 (void 0);
 ::func()

--- a/crates/rome_formatter/tests/specs/prettier/js/bind-expressions/method_chain.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/bind-expressions/method_chain.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: method_chain.js
 
 ---
@@ -37,8 +37,7 @@ import { takeUntil } from 'rxjs/operator/takeUntil';
 
 function test(observable) {
   return observable;
-  
-        ::filter(data => data.someTest)
+  ::filter(data => data.someTest)
         ::throttle(() =>
             interval(10)
                 ::take(1)

--- a/crates/rome_formatter/tests/specs/prettier/js/comments/issue-3532.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/comments/issue-3532.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: issue-3532.js
 
 ---
@@ -95,7 +95,6 @@ const AspectRatioBox = ({
 }
 </div>
   </div>
-
 )
 
 export default AspectRatioBox;

--- a/crates/rome_formatter/tests/specs/prettier/js/comments/last-arg.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/comments/last-arg.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: last-arg.js
 
 ---
@@ -62,13 +62,24 @@ class Foo {
   d(lol /*string*/ , lol2 /*string*/ , lol3 /*string*/ , lol4 /*string*/ ) /*string*/ {}
 
   // prettier-ignore
-  c(lol /*string*/ ) {}
+  c(lol /*string*/
+  ) {}
 
   // prettier-ignore
-  d(lol /*string*/ , lol2 /*string*/ , lol3 /*string*/ , lol4 /*string*/ ) {}
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
 
   // prettier-ignore
-  e(lol /*string*/ , lol2 /*string*/ , lol3 /*string*/ , lol4 /*string*/ ) {} /* string*/
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators-export/after_export.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators-export/after_export.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: after_export.js
 
 ---
@@ -15,11 +15,11 @@ export default @decorator class {}
 # Output
 ```js
 export
-@decorator 
+@decorator
 class Foo {}
 
 export default
-@decorator 
+@decorator
 class {}
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators-export/before_export.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators-export/before_export.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: before_export.js
 
 ---
@@ -18,8 +18,6 @@ export default class {}
 ```js
 @decorator
 export class Foo {}
-
-
 
 @decorator
 export default class {}

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/classes.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/classes.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: classes.js
 
 ---
@@ -26,28 +26,23 @@ const bar =
 
 # Output
 ```js
-@deco 
+@deco
 class Foo {}
 
-
-
-@deco 
+@deco
 export class Bar {}
 
-
-
-@deco 
+@deco
 export default class Baz {}
 
 const foo =
-@deco 
+@deco
 class {
   //
 }
 
 const bar =
-
-  @deco
+@deco
 class {
     //
   }

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: comments.js
 
 ---
@@ -44,8 +44,6 @@ export class Bar{}
 ```js
 var x = 100;
 
-
-
 @Hello(
 {
   a: "a", // test // Comment is in the wrong place
@@ -54,9 +52,6 @@ var x = 100;
 }
 )
 class X {}
-
-
-
 
 @NgModule(
 {
@@ -72,8 +67,6 @@ class X {}
 }
 )
 export class AppModule {}
-
-
 
 // A
 @Foo()

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/mixed.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/mixed.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: mixed.js
 
 ---
@@ -22,7 +22,6 @@ export default class MyComponent {
 
 @foo
 export default class MyComponent {
-  
   @
   task;
   *foo() {}

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/mobx.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: mobx.js
 
 ---
@@ -49,15 +49,11 @@ import {observable} from "mobx";
 ```js
 import { observable } from "mobx";
 
-
-
-@observer 
+@observer
 class OrderLine {
-  
   @
   observable;
   price:number = 0;
-  
   @
   observable;
   amount:number = 1;
@@ -66,15 +62,11 @@ class OrderLine {
     this.price = price;
   }
 
-  
-
   @
   computed;
   get total() {
     return this.price * this.amount;
   }
-
-  
 
   @
   action;
@@ -84,15 +76,11 @@ class OrderLine {
     this.price = price;
   }
 
-  
-
   @
   computed;
   get total() {
     return this.price * this.amount;
   }
-
-  
 
   @
   action;
@@ -102,8 +90,6 @@ class OrderLine {
     this.price = price;
   }
 
-  
-  
   @
   computed;
   @
@@ -121,15 +107,11 @@ class OrderLine {
   get total() {
     return this.price * this.amount;
   }
-
-  
 
   @
   action;
   handleDecrease = (event: React.ChangeEvent<HTMLInputElement>) => this.count--;
 
-  
-  
   @
   action;
   handleSomething = (event: React.ChangeEvent<HTMLInputElement>) =>

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/multiple.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/multiple.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: multiple.js
 
 ---
@@ -27,8 +27,7 @@ const foo = {
 # Output
 ```js
 const dog = {
-
-  @readonly
+@readonly
   @nonenumerable
   @doubledValue
   legs: 4,
@@ -40,8 +39,7 @@ const dog = {
 }
 
 const foo = {
-
-  @multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
+@multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/decorators/redux.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/decorators/redux.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: redux.js
 
 ---
@@ -18,8 +18,6 @@ export class Home extends React.Component {}
 ```js
 @connect(mapStateToProps, mapDispatchToProps)
 export class MyApp extends React.Component {}
-
-
 
 @connect(state => (
 {

--- a/crates/rome_formatter/tests/specs/prettier/js/destructuring-ignore/ignore.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/destructuring-ignore/ignore.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 119
 expression: ignore.js
 
 ---
@@ -55,29 +55,29 @@ const {
 ```js
 const {
   // prettier-ignore
-  bar = 1,
+  bar =           1,
 } = foo;
 
 const {
   _,
   // prettier-ignore
-  bar2 = 1,
+  bar2 =           1,
 } = foo;
 
 /* comments */
 const {
   // prettier-ignore
-  bar3 = 1, // comment
+  bar3 =           1, // comment
 } = foo;
 
 const {
   // prettier-ignore
-  bar4 = 1, /* comment */
+  bar4 =           1, /* comment */
 } = foo;
 
 const {
   // prettier-ignore
-  bar5 = 1, /* comment */
+  bar5 =           /* comment */          1,
 } = foo;
 
 /* RestElement */
@@ -90,10 +90,10 @@ const {
 const {
   baz: {
     // prettier-ignore
-    foo2 = [1, 2, 3],
+  foo2 = [1, 2,    3],
   },
   // prettier-ignore
-  bar7 = 1,
+  bar7 =            1,
 } = foo;
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/do/call-arguments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/do/call-arguments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: call-arguments.js
 
 ---
@@ -95,8 +95,7 @@ expect(
       var bar = "foo";
     };
 bar;
-
-  }
+}
 ).toThrow(ReferenceError)
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/do/do.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/do/do.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: do.js
 
 ---
@@ -69,13 +69,11 @@ const envSpecific = {
   domain:
     do {
       if(env === 'production') 'https://abc.mno.com/';
-
-      else 
+else
 if (env === "development") {
   "http://localhost:4000";
 }
-
-    }
+}
 }
 
 let x =

--- a/crates/rome_formatter/tests/specs/prettier/js/export-extension/export.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/export-extension/export.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: export.js
 
 ---
@@ -34,7 +34,7 @@ c, { foo };
 from;
 "mod";
 export * as d
-, 
+,
 {
   bar;
 }

--- a/crates/rome_formatter/tests/specs/prettier/js/for/in.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/for/in.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: in.js
 
 ---
@@ -24,22 +24,22 @@ for (a in b) 0;
 # Output
 ```js
 for ((x in a);
-) 
+)
 {}
-for (a=(a  in b)
-) 
+for (a=(a in b)
+)
 {}
 for (let a = (b in c);
 )
-for (a && (b  in c)
+for (a && (b in c)
 )
 for ((a) => (b in c); ; )
 function* g() {
-  for (yield (a  in b)
+  for (yield (a in b)
   )
 }
 async function f() {
-  for (await (a  in b)
+  for (await (a in b)
   )
 }
 for (a in b) 0;

--- a/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore-2.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore-2.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: ignore-2.js
 
 ---
@@ -41,7 +41,6 @@ function HelloWorld() {
     >
       test
     </div>
-  
   )
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore-2.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore-2.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 119
+assertion_line: 125
 expression: ignore-2.js
 
 ---
@@ -46,7 +46,9 @@ function HelloWorld() {
 
 a = <div {.../* prettier-ignore */b};
 />
-a = <div {...b/* prettier-ignore */
+a = <div {...b/ * rome - ignore;
+format: prettier;
+ignore */
 }/>
 a = <div {.../* prettier-ignore */
 {}
@@ -61,8 +63,8 @@ a = <div {...{}/* prettier-ignore */}/>
 error: unterminated regex literal
    ┌─ ignore-2.js:20:1
    │
-19 │ a = <div {...{}/* prettier-ignore */}/>
-   │                                      - a regex literal starts there...
+19 │ a = <div {...{}/* rome-ignore format: prettier ignore */}/>
+   │                                                          - a regex literal starts there...
 20 │ 
    │ ^ ...but the file ends here
 
@@ -71,8 +73,8 @@ error[SyntaxError]: type assertion are a TypeScript only feature. Convert your f
   │  
 5 │ ┌     <div
 6 │ │       {...{} /*
-7 │ │       // @ts-ignore */ /* prettier-ignore */}
-  │ └─────────────────────────────────────────────^ TypeScript only syntax
+7 │ │       // @ts-ignore */ /* rome-ignore format: prettier ignore */}
+  │ └─────────────────────────────────────────────────────────────────^ TypeScript only syntax
 
 error[SyntaxError]: expected `')'` but instead found `invalidProp`
   ┌─ ignore-2.js:8:7
@@ -97,42 +99,60 @@ error[SyntaxError]: expected an expression but instead found ')'
 error[SyntaxError]: type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
    ┌─ ignore-2.js:15:5
    │
-15 │ a = <div {.../* prettier-ignore */b}/>
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TypeScript only syntax
+15 │ a = <div {.../* rome-ignore format: prettier ignore */b}/>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TypeScript only syntax
 
 error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
-   ┌─ ignore-2.js:15:37
+   ┌─ ignore-2.js:15:57
    │    
-15 │ ┌   a = <div {.../* prettier-ignore */b}/>
-   │ │ ┌─────────────────────────────────────^
-16 │ │ │ a = <div {...b/* prettier-ignore */}/>
+15 │ ┌   a = <div {.../* rome-ignore format: prettier ignore */b}/>
+   │ │ ┌─────────────────────────────────────────────────────────^
+16 │ │ │ a = <div {...b/* rome-ignore format: prettier ignore */}/>
    │ └─│───────────────' ...Which is required to end this statement
    │   └───────────────^ An explicit or implicit semicolon is expected here...
 
-error[SyntaxError]: Expected an expression for the right hand side of a `*`, but found an operator instead
-   ┌─ ignore-2.js:16:35
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+   ┌─ ignore-2.js:16:30
+   │  
+15 │   a = <div {.../* rome-ignore format: prettier ignore */b}/>
+   │ ┌─────────────────────────────────────────────────────────'
+16 │ │ a = <div {...b/* rome-ignore format: prettier ignore */}/>
+   │ │                              ^^^^^^ An explicit or implicit semicolon is expected here...
+   │ └───────────────────────────────────' ...Which is required to end this statement
+
+error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statement, but found none
+   ┌─ ignore-2.js:16:47
    │
-16 │ a = <div {...b/* prettier-ignore */}/>
-   │                                  -^ But this operator was encountered instead
-   │                                  │ 
-   │                                  This operator requires a right hand side value
+16 │ a = <div {...b/* rome-ignore format: prettier ignore */}/>
+   │                                      ---------^^^^^^
+   │                                      │        │
+   │                                      │        An explicit or implicit semicolon is expected here...
+   │                                      ...Which is required to end this statement
+
+error[SyntaxError]: Expected an expression for the right hand side of a `*`, but found an operator instead
+   ┌─ ignore-2.js:16:55
+   │
+16 │ a = <div {...b/* rome-ignore format: prettier ignore */}/>
+   │                                                      -^ But this operator was encountered instead
+   │                                                      │ 
+   │                                                      This operator requires a right hand side value
 
 error[SyntaxError]: expected an expression but instead found '}'
-   ┌─ ignore-2.js:16:36
+   ┌─ ignore-2.js:16:56
    │
-16 │ a = <div {...b/* prettier-ignore */}/>
-   │                                    ^ Expected an expression here
+16 │ a = <div {...b/* rome-ignore format: prettier ignore */}/>
+   │                                                        ^ Expected an expression here
 
 error[SyntaxError]: expected a statement but instead found '}/>
-a = <div {...{/* prettier-ignore */}}/>
-a = <div {...{}/* prettier-ignore */}/>
+a = <div {...{/* rome-ignore format: prettier ignore */}}/>
+a = <div {...{}/* rome-ignore format: prettier ignore */}/>
 '
-   ┌─ ignore-2.js:17:37
+   ┌─ ignore-2.js:17:57
    │  
-17 │   a = <div {.../* prettier-ignore */{}}/>
-   │ ┌─────────────────────────────────────^
-18 │ │ a = <div {...{/* prettier-ignore */}}/>
-19 │ │ a = <div {...{}/* prettier-ignore */}/>
+17 │   a = <div {.../* rome-ignore format: prettier ignore */{}}/>
+   │ ┌─────────────────────────────────────────────────────────^
+18 │ │ a = <div {...{/* rome-ignore format: prettier ignore */}}/>
+19 │ │ a = <div {...{}/* rome-ignore format: prettier ignore */}/>
 20 │ │ 
    │ └^ Expected a statement here
 

--- a/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/ignore/ignore.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: ignore.js
 
 ---
@@ -71,18 +71,28 @@ const response = {
 ```js
 function a() {
   // prettier-ignore
-  var fnString = """ + this.USE + " " + this.STRICT + "";\n" + this.filterPrefix() + "var fn=" + this.generateFunction(
-    "fn",
-    "s,l,a,i",
-  ) + extra + this.watchFns() + "return fn;";
+  var fnString =
+    '"' + this.USE + ' ' + this.STRICT + '";\n' +
+    this.filterPrefix() +
+    'var fn=' + this.generateFunction('fn', 's,l,a,i') +
+    extra +
+    this.watchFns() +
+    'return fn;';
 
   // prettier-ignore
-  const identity = Matrix.create(1, 0, 0, 0, 1, 0, 0, 0, 0);
+  const identity = Matrix.create(
+    1, 0, 0,
+    0, 1, 0,
+    0, 0, 0
+  );
 
   // Let's make sure that this comment doesn't interfere
 
   // prettier-ignore
-  const commentsWithPrettierIgnore = { "ewww": "gross-formatting" };
+  const commentsWithPrettierIgnore =   {
+    "ewww":
+            "gross-formatting",
+  };
 
   function giveMeSome() {
     a(a); // prettier-ignore
@@ -91,13 +101,30 @@ function a() {
 
   // prettier-ignore
   console.error(
-    "In order to use " + prompt + ", you need to configure a " + "few environment variables to be able to commit to the " + "repository. Follow those steps to get you setup:\n" + "\n" + "Go to https://github.com/settings/tokens/new\n" + " - Fill "Token description" with "" + prompt + " for " + repoSlug + ""\n" + " - Check "public_repo"\n" + " - Press "Generate Token"\n" + "\n" + "In a different tab, go to https://travis-ci.org/" + repoSlug + "/settings\n" + " - Make sure "Build only if .travis.yml is present" is ON\n" + " - Fill "Name" with "GITHUB_USER" and "Value" with the name of the " + "account you generated the token with. Press "Add"\n" + "\n" + "Once this is done, commit anything to the repository to restart " + "Travis and it should work :)",
+    'In order to use ' + prompt + ', you need to configure a ' +
+    'few environment variables to be able to commit to the ' +
+    'repository. Follow those steps to get you setup:\n' +
+    '\n' +
+    'Go to https://github.com/settings/tokens/new\n' +
+    ' - Fill "Token description" with "' + prompt + ' for ' +
+      repoSlug + '"\n' +
+    ' - Check "public_repo"\n' +
+    ' - Press "Generate Token"\n' +
+    '\n' +
+    'In a different tab, go to https://travis-ci.org/' +
+      repoSlug + '/settings\n' +
+    ' - Make sure "Build only if .travis.yml is present" is ON\n' +
+    ' - Fill "Name" with "GITHUB_USER" and "Value" with the name of the ' +
+      'account you generated the token with. Press "Add"\n' +
+    '\n' +
+    'Once this is done, commit anything to the repository to restart ' +
+      'Travis and it should work :)'
   );
 }
 
 const response = {
   // prettier-ignore
-  '_text': "Turn on the lights",
+  '_text': 'Turn on the lights',
   intent: "lights",
 };
 

--- a/crates/rome_formatter/tests/specs/prettier/js/ignore/issue-10661.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/ignore/issue-10661.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 119
 expression: issue-10661.js
 
 ---
@@ -45,8 +45,9 @@ verylongidentifierthatwillwrap123123123123123(
 
 call(
   // comment
-  a.// prettier-ignore
-  b,
+  a.
+  // prettier-ignore
+    b,
 );
 
 call(

--- a/crates/rome_formatter/tests/specs/prettier/js/ignore/semi/directive.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/ignore/semi/directive.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: directive.js
 
 ---
@@ -26,7 +26,7 @@ function foo() {
 
 function foo() {
   // prettier-ignore
-  'use strict';
+'use strict';
   [].forEach();
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/js/import-assertions/multi-types.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/import-assertions/multi-types.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: multi-types.js
 
 ---
@@ -12,7 +12,7 @@ import json from "./foo.json" assert { type: "json", type: "bar" };
 
 # Output
 ```js
-import json from "./foo.json" assert { type: "json", type: "bar"  };
+import json from "./foo.json" assert { type: "json", type: "bar" };
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/last-argument-expansion/edge_case.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/last-argument-expansion/edge_case.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: edge_case.js
 
 ---
@@ -93,8 +93,7 @@ exports.examples = [
           </div>
         );
       }
-
-    )
+)
   }
 ]
 

--- a/crates/rome_formatter/tests/specs/prettier/js/module-blocks/comments.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/module-blocks/comments.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: comments.js
 
 ---
@@ -24,10 +24,8 @@ const m2 = module/* B1 */{
 const m = /*A1*/ module /*A2*/ ;
 {
   /*A3*/
-  
   /*A4*/
   export const foo = "foo";
-  
   export { foo }; /*A5*/
   /*A6*/
 } /*A7*/

--- a/crates/rome_formatter/tests/specs/prettier/js/module-blocks/module-blocks.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/module-blocks/module-blocks.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: module-blocks.js
 
 ---
@@ -67,15 +67,12 @@ class B {
 
 const m = module;
 {
-  
   export const foo = "foo";
-  
   export { foo };
 }
 
 module;
 {
-  
   export { foo }
 }
 
@@ -84,26 +81,24 @@ const m = module;
 
 const worker = new Worker(module {
   export const foo = "foo";
-
 })
 
 let m = module;
 {
   module;
   {
-    
     export let foo = "foo";
   }
 }
 
 const m = module;
 {
-  export const foo = "foo" 
+  export const foo = "foo"
 }
 
 let moduleBlock = module;
 {
-  export let y = 1; 
+  export let y = 1;
 }
 
 foo(module { export let foo = "foo";

--- a/crates/rome_formatter/tests/specs/prettier/js/no-semi/class.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/no-semi/class.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: class.js
 
 ---
@@ -148,7 +148,6 @@ class C2 {
 // The semicolon is *not* necessary
 x();
 {}
-
 }
 class C3 {
   set; // The semicolon *is* necessary
@@ -159,7 +158,6 @@ class C4 {
 // The semicolon is *not* necessary
 x();
 {}
-
 }
 
 class A1 {

--- a/crates/rome_formatter/tests/specs/prettier/js/non-strict/keywords.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/non-strict/keywords.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: keywords.js
 
 ---
@@ -19,7 +19,7 @@ function myFunction() {
 
 # Output
 ```js
-var package  = require("../package");
+var package = require("../package");
 
 /**
  * My amazing comment

--- a/crates/rome_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 119
 expression: ignore.js
 
 ---
@@ -60,14 +60,14 @@ foo = {
 foo =
   {
     // prettier-ignore
-    bar: 1,
+  bar:            1,
   };
 
 foo =
   {
     _: "",
     // prettier-ignore
-    bar: 1,
+  bar:            1,
   };
 
 /* comments */
@@ -75,21 +75,21 @@ foo =
   {
     _: "",
     // prettier-ignore
-    bar: 1, // comment
+  bar:            1, // comment
   };
 
 foo =
   {
     _: "",
     // prettier-ignore
-    bar: 1, /* comment */
+  bar:            1, /* comment */
   };
 
 foo =
   {
     _: "",
     // prettier-ignore
-    bar: 1, /* comment */
+  bar:            /* comment */          1,
   };
 
 /* SpreadElement */
@@ -97,7 +97,7 @@ foo =
   {
     _: "",
     // prettier-ignore
-    ...bar,
+  ...bar,
   };
 
 // Nested
@@ -105,10 +105,10 @@ foo =
   {
     baz: {
       // prettier-ignore
-      foo: [1, 2, 3],
+  foo: [1, 2,    3],
     },
     // prettier-ignore
-    bar: 1,
+  bar:            1,
   };
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/object-property-ignore/issue-5678.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/object-property-ignore/issue-5678.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 119
 expression: issue-5678.js
 
 ---
@@ -69,27 +69,51 @@ const refreshTokenPayload = {
   sub: this._id,
   role: this.role,
   // prettier-ignore
-  exp: now + (60 * 60 * 24 * 90), // (90 days)
+    exp: now + (60 * 60 * 24 * 90), // (90 days)
 };
 
 export default {
   // prettier-ignore
-  protagonist: "  0\r\n" + "0 00\r\n" + "00000\r\n" + "0 0\r\n" + "0 0",
+  protagonist: "  0\r\n" +
+               "0 00\r\n" +
+               "00000\r\n" +
+               "0 0\r\n" +
+               "0 0",
 
   // prettier-ignore
-  wall: "00000\r\n" + "00000\r\n" + "00000\r\n" + "00000\r\n" + "00000",
+  wall: "00000\r\n" +
+        "00000\r\n" +
+        "00000\r\n" +
+        "00000\r\n" +
+        "00000",
 
   // prettier-ignore
-  cheese: "0\r\n" + " 0\r\n" + "000\r\n" + "00 0\r\n" + "00000",
+  cheese: "0\r\n" +
+          " 0\r\n" +
+          "000\r\n" +
+          "00 0\r\n" +
+          "00000",
 
   // prettier-ignore
-  enemy: "0   0\r\n" + "00 00\r\n" + "00000\r\n" + "0 0 0\r\n" + "00000",
+  enemy: "0   0\r\n" +
+         "00 00\r\n" +
+         "00000\r\n" +
+         "0 0 0\r\n" +
+         "00000",
 
   // prettier-ignore
-  home: "00000\r\n" + "0   0\r\n" + "0   0\r\n" + "0   0\r\n" + "00000",
+  home: "00000\r\n" +
+        "0   0\r\n" +
+        "0   0\r\n" +
+        "0   0\r\n" +
+        "00000",
 
   // prettier-ignore
-  dog: "00 00\r\n" + "00000\r\n" + "0   0\r\n" + "0 0 0\r\n" + " 000 ",
+  dog: "00 00\r\n" +
+       "00000\r\n" +
+       "0   0\r\n" +
+       "0 0 0\r\n" +
+       " 000 ",
 };
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/pipeline-operator/fsharp_style_pipeline_operator.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/pipeline-operator/fsharp_style_pipeline_operator.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: fsharp_style_pipeline_operator.js
 
 ---
@@ -106,14 +106,12 @@ const _g = (x) => x
 
 const __g = (x) => x
   |> (
-    y => 
+    y =>
 {
-  
-      return (y + 1 |> (z) 
+  return (y + 1 |> (z)
   => z * y)
 }
-
-  )
+)
 
 const f = x + ((f) => (f |> f))
 const f = x |> (f)

--- a/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
@@ -23,7 +23,7 @@ assert(rest.c === 3);
 const { a, b } = #;
 {
   a: 1, b;
-  : 2 
+  : 2
 }
 assert(a === 1);
 assert(b === 2);
@@ -31,7 +31,7 @@ assert(b === 2);
 const { a, ...rest } = #;
 {
   a: 1, b;
-  : 2, c: 3 
+  : 2, c: 3
 }
 assert(a === 1);
 assert(typeof rest === "object");

--- a/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
@@ -24,11 +24,11 @@ const formData = #;
 const taskNow = #;
 {
   id: 42, status;
-  : "WIP", ...formData 
+  : "WIP", ...formData
 }
 const taskLater = #;
 {
-  ...taskNow, status: "DONE" ;
+  ...taskNow, status: "DONE";
 }
 
 // A reminder: The ordering of keys in record literals does not affect equality (and is not retained)

--- a/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
@@ -16,13 +16,11 @@ expression: syntax.js
 ```js
 #
 {}
-
 #;
 {
   a: 1, b;
-  : 2 
+  : 2
 }
-
 #;
 {
   a: 1, b;
@@ -30,7 +28,7 @@ expression: syntax.js
   {
     c: 4;
   }
-  ] 
+  ]
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/reserved-word/interfaces.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/reserved-word/interfaces.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: interfaces.js
 
 ---
@@ -19,13 +19,12 @@ const interface = "foo";
 # Output
 ```js
 foo.interface;
-
 interface.foo;
 new interface();
 ({ interface: "foo" });
 (interface, "foo");
 void interface;
-const interface  = "foo";
+const interface = "foo";
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/sloppy-mode/delete-variable.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/sloppy-mode/delete-variable.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: delete-variable.js
 
 ---
@@ -16,7 +16,6 @@ function foo() {
 ```js
 function foo() {
   var bar = 1;
-  
   delete bar;
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/js/throw_expressions/throw_expression.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/throw_expressions/throw_expression.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: throw_expression.js
 
 ---
@@ -29,7 +29,7 @@ class Product {
 # Output
 ```js
 function save(filename = throw new TypeError("Argument required")
-) 
+)
 {}
 
 lint(ast, {

--- a/crates/rome_formatter/tests/specs/prettier/js/v8_intrinsic/intrinsic_call.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/v8_intrinsic/intrinsic_call.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 119
 expression: intrinsic_call.js
 
 ---
@@ -36,8 +36,7 @@ function doSmth()     {
 # Output
 ```js
 function doSmth() {
-  
-            %DebugPrint
+  %DebugPrint
         (
                 foo )
 }

--- a/crates/rome_formatter/tests/specs/prettier/js/with/indent.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/with/indent.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: indent.js
 
 ---
@@ -15,8 +15,6 @@ with (0) 1;
 # Output
 ```js
 with (0) {}
-
-
 
 with (0) 1;
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/class/abstract-method.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/class/abstract-method.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: abstract-method.ts
 
 ---
@@ -23,14 +23,12 @@ abstract class Bar {
 # Output
 ```js
 class Foo {
-  
   abstract foo();
 }
 
 abstract class Bar {
   method() {
     return class {
-      
       abstract m();
     };
   }

--- a/crates/rome_formatter/tests/specs/prettier/typescript/class/constructor.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/class/constructor.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: constructor.ts
 
 ---
@@ -38,15 +38,13 @@ class foo {
 }
 
 class A {
-  
-    'constructor': typeof A
+  'constructor': typeof A
   static Foo() {
     return new A();
   }
 }
 
 class B {
-  
   constructor<>() {}
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/class/duplicates-access-modifier.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/class/duplicates-access-modifier.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: duplicates-access-modifier.ts
 
 ---
@@ -19,15 +19,10 @@ class Foo {
 # Output
 ```js
 class Foo {
-  
   public public a;
-  
   private public b;
-  
   protected private c;
-  
   public protected d;
-  
   public protected private e;
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/compiler/decrementAndIncrementOperators.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/compiler/decrementAndIncrementOperators.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: decrementAndIncrementOperators.ts
 
 ---
@@ -50,10 +50,8 @@ x[x++]++;
 ```js
 var x = 0;
 
-
-
 // errors
-1 ++;
+1++;
 
 (1)++;
 (1)--;

--- a/crates/rome_formatter/tests/specs/prettier/typescript/compiler/errorOnInitializerInInterfaceProperty.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/compiler/errorOnInitializerInInterfaceProperty.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: errorOnInitializerInInterfaceProperty.ts
 
 ---
@@ -16,7 +16,6 @@ interface Foo {
 ```js
 interface Foo {
     bar: number = 5
-
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 124
+assertion_line: 119
 expression: modifiersOnInterfaceIndexSignature1.ts
 
 ---
@@ -13,10 +13,7 @@ interface I {
 
 # Output
 ```js
-interface I {
-  
-  public [a: string]: number;,
-}
+interface I { public [a: string]: number; }
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts.snap
@@ -113,8 +113,7 @@ abstract class G {
 }
 
 class H {
-  
-    abstract baz() : number;
+  abstract baz() : number;
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: classAbstractMethodInNonAbstractClass.ts
 
 ---
@@ -14,8 +14,7 @@ class A {
 # Output
 ```js
 class A {
-  
-    abstract foo();
+  abstract foo();
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts.snap
@@ -30,24 +30,15 @@ abstract class A {
 
   public abstract foo_b();
   protected abstract foo_c();
-  
-    private abstract foo_d();
+  private abstract foo_d();
 
-  
-    
-    abstract public foo_bb();
-  
-    abstract protected foo_cc();
-  
-    abstract private foo_dd();
+  abstract public foo_bb();
+  abstract protected foo_cc();
+  abstract private foo_dd();
 
-  
-    
-    abstract static foo_d();
+  abstract static foo_d();
 
-  
-    
-    static abstract foo_e();
+  static abstract foo_e();
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts.snap
@@ -27,16 +27,14 @@ abstract class A {
   abstract x: number;
   public abstract y: number;
   protected abstract z: number;
-  
-    private abstract w : number;
+  private abstract w : number;
 
   abstract m: () => void;
 
   abstract foo_x(): number;
   public abstract foo_y(): number;
   protected abstract foo_z(): number;
-  
-    private abstract foo_w() : number;
+  private abstract foo_w() : number;
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts.snap
@@ -38,8 +38,7 @@ class DD extends AA {
 # Output
 ```js
 class A {
-  
-    abstract foo();
+  abstract foo();
 }
 
 class B extends A {}

--- a/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: readonlyReadonly.ts
 
 ---
@@ -15,8 +15,7 @@ class C {
 # Output
 ```js
 class C {
-  
-    readonly readonly x: number;
+  readonly readonly x: number;
   constructor(readonly readonly y: number) {}
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/custom/abstract/abstractProperties.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/custom/abstract/abstractProperties.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: abstractProperties.ts
 
 ---
@@ -20,18 +20,12 @@ abstract class Foo {
 # Output
 ```js
 abstract class Foo {
-  
-    abstract private a: 1;
-  
-    private abstract b: 2;
-  
-    static abstract c: 3;
-  
-    abstract private ['g'];
-  
-    private abstract ['h'];
-  
-    static abstract ['i'];
+  abstract private a: 1;
+  private abstract b: 2;
+  static abstract c: 3;
+  abstract private ['g'];
+  private abstract ['h'];
+  static abstract ['i'];
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare-get-set-field.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare-get-set-field.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: declare-get-set-field.ts
 
 ---
@@ -16,9 +16,7 @@ class C {
 # Output
 ```js
 class C {
-  
   declare get: string
-  
   declare set: string
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare_function_with_body.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare_function_with_body.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: declare_function_with_body.ts
 
 ---
@@ -18,7 +18,6 @@ declare function bar() {
 ```js
 // Invalid, but recoverable
 declare function foo() {}
-
 declare function bar() {
   // comment
 }

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators-ts/mobx.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators-ts/mobx.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: mobx.ts
 
 ---
@@ -20,14 +20,12 @@ class X {
 # Output
 ```js
 class X {
-  
-	@
+  @
   deco;
   x() {
     return this.count * 2;
   }
-  
-	@
+  @
   deco;
   get x() {
     return this.count * 2;

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators/argument-list-preserve-line.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators/argument-list-preserve-line.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: argument-list-preserve-line.ts
 
 ---
@@ -36,7 +36,6 @@ class Foo {
 
         private readonly anotherThing: IAnotherThing | undefined,
     ) { }
-
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorator-type-assertion.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorator-type-assertion.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: decorator-type-assertion.ts
 
 ---
@@ -22,8 +22,6 @@ class Decorated {
 ```js
 @(bind as ClassDecorator)
 class Decorated {}
-
-
 
 @(<ClassDecorator>bind)
 class Decorated {}

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorators-comments.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: decorators-comments.ts
 
 ---
@@ -54,32 +54,28 @@ class Something3 {
 # Output
 ```js
 class Foo1 {
-  
-    @
+  @
   foo;
   // comment
   async method() {}
 }
 
 class Foo2 {
-  
-    @
+  @
   foo;
   // comment
   private method() {}
 }
 
 class Foo3 {
-  
-    @
+  @
   foo;
   // comment
   *method() {}
 }
 
 class Foo4 {
-  
-    @
+  @
   foo;
   // comment
   async *method() {}

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators/decorators.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: decorators.ts
 
 ---
@@ -93,13 +93,10 @@ export class TestTextFileService {
 		@ILifecycleService lifecycleService,
 	) {
 	}
-
 }
 
 @commonEditorContribution
 export class TabCompletionController {}
-
-
 
 @Component(
 {
@@ -115,11 +112,10 @@ class Class {
     @Decorator
     { prop1, prop2 }
 : Type
-  ) 
+  )
 {
   doSomething();
 }
-
 }
 
 class Class2 {
@@ -128,11 +124,10 @@ class Class2 {
     @Decorator2
     { prop1, prop2 }
 : Type
-  ) 
+  )
 {
   doSomething();
 }
-
 }
 
 class Class3 {
@@ -144,11 +139,10 @@ class Class3 {
   prop2_1, prop2_2;
 }
 : Type
-  ) 
+  )
 {
   doSomething();
 }
-
 }
 
 class Class4 {
@@ -157,18 +151,16 @@ class Class4 {
     @Decorator
     { prop1, prop2 }
 : Type
-  ) 
+  )
 {}
-
 }
 
 class Class5 {
   method(
     @Decorator { prop1 }
 : Type
-  ) 
+  )
 {}
-
 }
 
 class Class6 {
@@ -176,36 +168,32 @@ class Class6 {
     @Decorator({}) { prop1 }: Type
   ) {}
 method(
-
-    @Decorator(
+@Decorator(
 {}
-) 
+)
 {
   prop1;
 }
 : Type
-  ) 
+  )
 {}
 method(
-
-    @Decorator([]) 
+@Decorator([])
 {
   prop1;
 }
 : Type
-  ) 
+  )
 {}
 method(
-
-    @Decorator(
-      []) 
+@Decorator(
+      [])
 {
   prop1;
 }
 : Type
-  ) 
+  )
 {}
-
 }
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators/inline-decorators.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators/inline-decorators.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: inline-decorators.ts
 
 ---
@@ -60,7 +60,6 @@ class MyContainerComponent {
 
 # Output
 ```js
-
 @d1
 @d2(foo)
 @d3.bar
@@ -98,15 +97,13 @@ class Class3 {
             x: string
         }) private a: string,
     ) {}
-
 }
 
-@decorated 
+@decorated
 class Foo {}
 
 class Bar {
-  
-    @
+  @
   decorated;
   method() {}
 }

--- a/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: generic.ts
 
 ---
@@ -37,8 +37,7 @@ new f2<>();
 function f3<>() {}
 
 class f4 {
-  
-    constructor<>() {}
+  constructor<>() {}
 }
 
 const f5 = function <>() {};

--- a/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/index-signature.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/index-signature.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: index-signature.ts
 
 ---
@@ -32,35 +32,26 @@ type TooLongSingleParam = {
 ```js
 type A = { [key: string] };
 
-
-
 type TwoParams = {
   [a: string, b: string]: string;
-
 }
-
 type ThreeParams = {
   [a: string, b: string, c: string]: string;
-
 }
-
-
 
 type TooLong = {
   [loooooooooooooooooooooooooong: string, looooooooooooooooooooooooooooooooooooooong: string]: string;
-
 }
-type TooLong81 = 
+type TooLong81 =
 {
   [loooooooooooooooooooooooooong: string, loooooooooooooooooong: string]
   : string
 }
-
-type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string; 
+type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string;
 }
 
 // note lack of trailing comma in the index signature
-type TooLongSingleParam = 
+type TooLongSingleParam =
 {
   [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]
   : string

--- a/crates/rome_formatter/tests/specs/prettier/typescript/export/export-class.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/export/export-class.ts.snap
@@ -18,7 +18,6 @@ export default abstract class D {}
 export class A {}
 export default class B {}
 export abstract class C {}
-
 export default abstract class D {}
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/import-export/type-modifier.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/import-export/type-modifier.ts.snap
@@ -40,7 +40,6 @@ import type { foo, bar } from 'baz';
 import type { foo as bar } from 'baz';
 import type * as foo from './bar';
 import type foo from 'bar';
-
 import type foo, { bar } from 'bar';
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/keywords/keywords.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/keywords/keywords.ts.snap
@@ -52,8 +52,7 @@ module YYY4 {
 // All of these should be an error
 
 module Y3 {
-  
-    public ;
+  public;
   module Module {
     class A {
       s: string;
@@ -62,10 +61,10 @@ module Y3 {
 
   // Apparently this parses :P
     export
-  private ;
-  public ;
-  protected ;
-  static ;
+  private;
+  public;
+  protected;
+  static;
   readonly;
   abstract;
   async;
@@ -75,14 +74,12 @@ module Y3 {
 }
 
 module Y4 {
-  
-    public ;
+  public;
   enum Color { Blue, Red }
 }
 
 module YY3 {
-  
-    private ;
+  private;
   module Module {
     class A {
       s: string;
@@ -91,14 +88,12 @@ module YY3 {
 }
 
 module YY4 {
-  
-    private ;
+  private;
   enum Color { Blue, Red }
 }
 
 module YYY3 {
-  
-    static ;
+  static;
   module Module {
     class A {
       s: string;
@@ -107,8 +102,7 @@ module YYY3 {
 }
 
 module YYY4 {
-  
-    static ;
+  static;
   enum Color { Blue, Red }
 }
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/keywords/module.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/keywords/module.ts.snap
@@ -24,8 +24,7 @@ module Y3 {
 # Output
 ```js
 module Y3 {
-  
-  public ;
+  public;
   module Module {
     class A {
       s: string;
@@ -34,10 +33,10 @@ module Y3 {
 
   // Apparently this parses :P
   export
-  private ;
-  public ;
-  protected ;
-  static ;
+  private;
+  public;
+  protected;
+  static;
   readonly;
   abstract;
   async;

--- a/crates/rome_formatter/tests/specs/prettier/typescript/override-modifiers/override-modifier.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/override-modifiers/override-modifier.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: override-modifier.ts
 
 ---
@@ -28,8 +28,7 @@ class MyClass extends BaseClass {
   size = 5;
   override;
   readonly size = 5;
-  
-  abstract override 
+  abstract override
   foo: string;
   static override;
   foo: string;

--- a/crates/rome_formatter/tests/specs/prettier/typescript/prettier-ignore/mapped-types.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/prettier-ignore/mapped-types.ts.snap
@@ -85,37 +85,39 @@ type a = {
 };
 
 type a = {
-  [// prettier-ignore
-  A in B]: C | D;
+  [
+  // prettier-ignore
+      A in B]: C | D;
 };
 
 type a = {
-  [A in // prettier-ignore
-  B]: C | D;
-};
-
-type a = {
-  [A in B]:
-    | // prettier-ignore
-    C
-    | D;
-};
-
-type a = {
-  [/* prettier-ignore */
-  A in B]: C | D;
-};
-
-type a = {
-  [A in /* prettier-ignore */
-  B]: C | D;
+  [A in
+  // prettier-ignore
+      B]: C | D;
 };
 
 type a = {
   [A in B]:
-    | /* prettier-ignore */
-    C
-    | D;
+  // prettier-ignore
+      C  |  D;
+};
+
+type a = {
+  [
+  /* prettier-ignore */
+      A in B]: C | D;
+};
+
+type a = {
+  [A in
+  /* prettier-ignore */
+      B]: C | D;
+};
+
+type a = {
+  [A in B]:
+  /* prettier-ignore */
+      C  |  D;
 };
 
 type a = {

--- a/crates/rome_formatter/tests/specs/prettier/typescript/union/prettier-ignore.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/union/prettier-ignore.ts.snap
@@ -55,12 +55,12 @@ export type a =
   | baz1 & baz2;
 
 export type a =
-  // prettier-ignore
-  | foo1 & foo2
+// prettier-ignore
+  | foo1&foo2
   // bar
-  | bar1 & bar2
+  | bar1&bar2
   // qux
-  | qux1 & qux2;
+  | qux1&qux2;
 
 ```
 

--- a/crates/rslint_syntax/src/generated.rs
+++ b/crates/rslint_syntax/src/generated.rs
@@ -489,6 +489,40 @@ impl JsSyntaxKind {
             _ => false,
         }
     }
+    pub fn is_list(self) -> bool {
+        match self {
+            JS_MODULE_ITEM_LIST
+            | JS_DIRECTIVE_LIST
+            | JS_STATEMENT_LIST
+            | JS_VARIABLE_DECLARATOR_LIST
+            | JS_SWITCH_CASE_LIST
+            | JS_PARAMETER_LIST
+            | JS_ARRAY_ELEMENT_LIST
+            | JS_OBJECT_MEMBER_LIST
+            | JS_CALL_ARGUMENT_LIST
+            | JS_TEMPLATE_ELEMENT_LIST
+            | JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
+            | JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
+            | JS_CLASS_MEMBER_LIST
+            | JS_CONSTRUCTOR_PARAMETER_LIST
+            | JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST
+            | JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST
+            | JS_NAMED_IMPORT_SPECIFIER_LIST
+            | JS_IMPORT_ASSERTION_ENTRY_LIST
+            | JS_EXPORT_NAMED_SPECIFIER_LIST
+            | JS_EXPORT_NAMED_FROM_SPECIFIER_LIST
+            | TS_UNION_TYPE_VARIANT_LIST
+            | TS_INTERSECTION_TYPE_ELEMENT_LIST
+            | TS_TYPE_MEMBER_LIST
+            | TS_TUPLE_TYPE_ELEMENT_LIST
+            | TS_TYPE_PARAMETER_LIST
+            | TS_TEMPLATE_ELEMENT_LIST
+            | TS_TYPE_ARGUMENT_LIST
+            | TS_TYPE_LIST
+            | TS_ENUM_MEMBER_LIST => true,
+            _ => false,
+        }
+    }
     pub fn is_before_expr(self) -> bool {
         match self {
             BANG | L_PAREN | L_BRACK | L_CURLY | SEMICOLON | COMMA | COLON | QUESTION | PLUS2

--- a/xtask/codegen/src/generate_syntax_kinds.rs
+++ b/xtask/codegen/src/generate_syntax_kinds.rs
@@ -62,6 +62,18 @@ pub fn generate_syntax_kinds(grammar: KindsSrc) -> Result<String> {
         .map(|name| format_ident!("{}", name))
         .collect::<Vec<_>>();
 
+    let lists = grammar
+        .nodes
+        .iter()
+        .filter_map(|name| {
+            if name.ends_with("_LIST") {
+                Some(format_ident!("{}", name))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
     let ast = quote! {
         #![allow(clippy::all)]
         #![allow(bad_style, missing_docs, unreachable_pub)]
@@ -105,6 +117,13 @@ pub fn generate_syntax_kinds(grammar: KindsSrc) -> Result<String> {
             pub fn is_literal(self) -> bool {
                 match self {
                     #(#literals)|* => true,
+                    _ => false,
+                }
+            }
+
+            pub fn is_list(self) -> bool {
+                match self {
+                    #(#lists)|* => true,
                     _ => false,
                 }
             }


### PR DESCRIPTION
## Summary

This PR introduces two complementary changes. The first one is a revision of how whitespace and newlines are printed around verbatim nodes: as the formatter already inserts line breaks and empty lines between statements based on the trivias attached to the nodes, verbatim nodes are now printed with their first leading and last trailing trivias trimmed up to the first comment or token. This brings the printing behavior of verbatim trivias in line with how trivia pieces are printed for non-verbatim nodes. This also means the use of `trim_start` and `trim_end` in `format_list` has become redundant, and since this was the only usage of these functions and their implementation added an additional cost to the maintenance and evolution of `FormatElement` I opted to remove them.

The second revision is the implementation of suppression comments in the formatter, using the same syntax found in Rome Classic (`// rome-ignore formatter: reason`). The parsing of this comments is currently implemented only for the formatter but it should be possible to move this utility to a common crate for it to be reused in other parts of the project. One limitation that's imposed by the current implementation of the suppression detection code is that these comments must be on a separate line (specifically be a leading trivia for the node they want to suppress formatting on), this is to limit the overhead of the detection and make reasoning about the formatting of these nodes easier but we may be able to lift that limitation in the future. As part of this I also removed the `format_node_start` and `format_node_end` placeholders as there doesn't seems to be any use for them at the moment (trivias and sourcemaps are all handled at the token level) and the cost of adding them back if needed should be minimal.