### PR TITLE
fix(rslint_parser): Allow private name only in `in` expessions

### DIFF
--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-record.js.snap
@@ -40,7 +40,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const record1 = #{
   │                  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ record-tuple-record.js:1:17
   │
 1 │ const record1 = #{
@@ -69,7 +69,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 7 │ const record2 = #{...record1, b: 5};
   │                  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ record-tuple-record.js:7:17
   │
 7 │ const record2 = #{...record1, b: 5};

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/record-tuple-tuple.js.snap
@@ -25,7 +25,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 1 │ const tuple1 = #[1, 2, 3];
   │                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ record-tuple-tuple.js:1:16
   │
 1 │ const tuple1 = #[1, 2, 3];

--- a/crates/rome_formatter/tests/specs/prettier/js/record/computed.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/computed.js.snap
@@ -40,7 +40,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ assert(#{ [key]: 1 } === #{ a: 1 })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:2:8
   │
 2 │ assert(#{ [key]: 1 } === #{ a: 1 })
@@ -58,7 +58,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ assert(#{ [key]: 1 } === #{ a: 1 })
   │                           ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:2:26
   │
 2 │ assert(#{ [key]: 1 } === #{ a: 1 })
@@ -76,7 +76,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:3:8
   │
 3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
@@ -94,7 +94,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
   │                                         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:3:40
   │
 3 │ assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
@@ -112,7 +112,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 5 │ assert(#{ [true]: 1 } === #{ true: 1 })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:5:8
   │
 5 │ assert(#{ [true]: 1 } === #{ true: 1 })
@@ -130,7 +130,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 5 │ assert(#{ [true]: 1 } === #{ true: 1 })
   │                            ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:5:27
   │
 5 │ assert(#{ [true]: 1 } === #{ true: 1 })
@@ -148,7 +148,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:6:8
   │
 6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
@@ -166,7 +166,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
   │                            ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:6:27
   │
 6 │ assert(#{ [true]: 1 } === #{ ["true"]: 1 })
@@ -184,7 +184,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:8:8
   │
 8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
@@ -202,7 +202,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
   │                                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:8:32
   │
 8 │ assert(#{ [1 + 1]: "two" } === #{ 2: "two" })
@@ -220,7 +220,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
   │         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:9:8
   │
 9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
@@ -238,7 +238,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
   │                                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ computed.js:9:32
   │
 9 │ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })

--- a/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/destructuring.js.snap
@@ -48,7 +48,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const { a, b } = #{ a: 1, b: 2 };
   │                   ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ destructuring.js:1:18
   │
 1 │ const { a, b } = #{ a: 1, b: 2 };
@@ -77,7 +77,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 5 │ const { a, ...rest } = #{ a: 1, b: 2, c: 3 };
   │                         ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ destructuring.js:5:24
   │
 5 │ const { a, ...rest } = #{ a: 1, b: 2, c: 3 };

--- a/crates/rome_formatter/tests/specs/prettier/js/record/record.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/record.js.snap
@@ -58,7 +58,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const record1 = #{
   │                  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ record.js:1:17
   │
 1 │ const record1 = #{
@@ -87,7 +87,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 7 │ const record2 = #{...record1, b: 5};
   │                  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ record.js:7:17
   │
 7 │ const record2 = #{...record1, b: 5};
@@ -113,7 +113,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 12 │ assert(record2 === #{ a: 1, c: 3, b: 5 });
    │                     ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
    ┌─ record.js:12:20
    │
 12 │ assert(record2 === #{ a: 1, c: 3, b: 5 });

--- a/crates/rome_formatter/tests/specs/prettier/js/record/shorthand.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/shorthand.js.snap
@@ -31,7 +31,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ const record = #{ url }
   │                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ shorthand.js:2:16
   │
 2 │ const record = #{ url }

--- a/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/spread.js.snap
@@ -44,7 +44,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 1 │ const formData = #{ title: "Implement all the things" }
   │                   ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ spread.js:1:18
   │
 1 │ const formData = #{ title: "Implement all the things" }
@@ -64,7 +64,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ const taskNow = #{ id: 42, status: "WIP", ...formData }
   │                  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ spread.js:2:17
   │
 2 │ const taskNow = #{ id: 42, status: "WIP", ...formData }
@@ -93,7 +93,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 3 │ const taskLater = #{ ...taskNow, status: "DONE" }
   │                    ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ spread.js:3:19
   │
 3 │ const taskLater = #{ ...taskNow, status: "DONE" }
@@ -119,7 +119,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 6 │ assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })
   │                       ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ spread.js:6:22
   │
 6 │ assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 })

--- a/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
@@ -55,7 +55,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 2 │ #{ a: 1, b: 2 }
   │  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ syntax.js:2:1
   │
 2 │ #{ a: 1, b: 2 }
@@ -85,7 +85,7 @@ error[SyntaxError]: expected `IDENT` but instead found `{`
 3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
   │  ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ syntax.js:3:1
   │
 3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/destructuring.js.snap
@@ -42,7 +42,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 1 │ const [a, b] = #[1, 2];
   │                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ destructuring.js:1:16
   │
 1 │ const [a, b] = #[1, 2];
@@ -62,7 +62,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 5 │ const [a, ...rest] = #[1, 2, 3];
   │                       ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ destructuring.js:5:22
   │
 5 │ const [a, ...rest] = #[1, 2, 3];

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple.js.snap
@@ -58,7 +58,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 1 │ const tuple1 = #[1, 2, 3];
   │                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ tuple.js:1:16
   │
 1 │ const tuple1 = #[1, 2, 3];
@@ -78,7 +78,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 7 │ assert(tuple2 === #[2, 2, 3]);
   │                    ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ tuple.js:7:19
   │
 7 │ assert(tuple2 === #[2, 2, 3]);
@@ -96,7 +96,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 9 │ const tuple3 = #[1, ...tuple2];
   │                 ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ tuple.js:9:16
   │
 9 │ const tuple3 = #[1, ...tuple2];
@@ -116,7 +116,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 10 │ assert(tuple3 === #[1, 2, 2, 3]);
    │                    ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
    ┌─ tuple.js:10:19
    │
 10 │ assert(tuple3 === #[1, 2, 2, 3]);
@@ -134,7 +134,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 13 │ assert(tuple4 === #[1, 2, 2, 3, 4]);
    │                    ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
    ┌─ tuple.js:13:19
    │
 13 │ assert(tuple4 === #[1, 2, 2, 3, 4]);
@@ -152,7 +152,7 @@ error[SyntaxError]: expected `IDENT` but instead found `[`
 17 │ assert(tuple5 === #[2, 2, 3, 4]);
    │                    ^ unexpected
 
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
    ┌─ tuple.js:17:19
    │
 17 │ assert(tuple5 === #[2, 2, 3, 4]);

--- a/crates/rslint_parser/src/parser.rs
+++ b/crates/rslint_parser/src/parser.rs
@@ -507,7 +507,7 @@ impl Marker {
 }
 
 /// A structure signifying a completed node
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CompletedMarker {
     pub(crate) start_pos: u32,
     // Hack for parsing completed markers which have been preceded

--- a/crates/rslint_parser/src/parser/parsed_syntax.rs
+++ b/crates/rslint_parser/src/parser/parsed_syntax.rs
@@ -27,7 +27,7 @@ use std::ops::Range;
 /// * A parse rule must not add any errors when it returns [ParsedSyntax::Absent]
 ///
 /// This is a custom enum over using `Option` because [ParsedSyntax::Absent] values must be handled by the caller.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 #[must_use = "this `ParsedSyntax` may be an `Absent` variant, which should be handled"]
 pub enum ParsedSyntax {
     /// A syntax that isn't present in the source code. Used when a parse rule can't match the current

--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -7,7 +7,7 @@ use super::typescript::*;
 use super::util::*;
 use crate::event::rewrite_events;
 use crate::event::RewriteParseEvents;
-use crate::parser::{expected_token, ParserProgress, RecoveryResult};
+use crate::parser::{ParserProgress, RecoveryResult};
 use crate::syntax::assignment::{
     expression_to_assignment, expression_to_assignment_pattern, parse_assignment,
     AssignmentExprPrecedence,

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -903,6 +903,8 @@ pub(crate) fn parse_formal_parameter(
     expression_context: ExpressionContext,
 ) -> ParsedSyntax {
     parse_binding_pattern(p, expression_context).map(|binding| {
+        let binding_kind = binding.kind();
+        let binding_range = binding.range(p);
         let m = binding.precede(p);
         let mut valid = true;
 
@@ -930,7 +932,7 @@ pub(crate) fn parse_formal_parameter(
 
         if valid
             && matches!(
-                binding.kind(),
+                binding_kind,
                 JS_OBJECT_BINDING_PATTERN | JS_ARRAY_BINDING_PATTERN
             )
         {
@@ -940,7 +942,7 @@ pub(crate) fn parse_formal_parameter(
                     p.err_builder(
                         "A parameter property may not be declared using a binding pattern.",
                     )
-                    .primary(binding.range(p), ""),
+                    .primary(binding_range, ""),
                 );
             } else if parameter_context.is_implementation() && is_optional {
                 valid = false;
@@ -948,7 +950,7 @@ pub(crate) fn parse_formal_parameter(
 					p.err_builder(
 						"A binding pattern parameter cannot be optional in an implementation signature.",
 					)
-						.primary(binding.range(p), ""),
+						.primary(binding_range, ""),
 				);
             }
         }

--- a/crates/rslint_parser/src/syntax/js_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/js_parse_error.rs
@@ -232,3 +232,11 @@ pub(crate) fn unexpected_body_inside_ambient_context(
     p.err_builder("members inside ambient contexts should not have a body")
         .primary(range, "")
 }
+
+pub(crate) fn private_names_only_allowed_on_left_side_of_in_expression(
+    p: &Parser,
+    private_name_range: Range<usize>,
+) -> Diagnostic {
+    p.err_builder("Private names are only allowed on the left side of a 'in' expression")
+        .primary(private_name_range, "")
+}

--- a/crates/rslint_parser/src/syntax/pattern.rs
+++ b/crates/rslint_parser/src/syntax/pattern.rs
@@ -229,10 +229,10 @@ fn validate_rest_pattern(
     }
 
     if p.at(T![=]) {
+        let kind = rest.kind();
         let rest_range = rest.range(p);
         let rest_marker = rest.undo_completion(p);
         let default_start = p.cur_tok().start();
-        let kind = rest.kind();
         p.bump(T![=]);
 
         if let Ok(recovered) = recovery.recover(p) {

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -1002,14 +1002,14 @@ fn parse_ts_literal_type(p: &mut Parser) -> ParsedSyntax {
             .or_else(|| parse_big_int_literal_expression(p))
             .unwrap();
 
-        // Inline the number or big int literal into the number/big int literal type
-        number_expr.undo_completion(p).abandon(p);
-
         let type_kind = match number_expr.kind() {
             JS_NUMBER_LITERAL_EXPRESSION => TS_NUMBER_LITERAL_TYPE,
             JS_BIG_INT_LITERAL_EXPRESSION => TS_BIG_INT_LITERAL_TYPE,
             _ => unreachable!(),
         };
+
+        // Inline the number or big int literal into the number/big int literal type
+        number_expr.undo_completion(p).abandon(p);
 
         return Present(m.complete(p, type_kind));
     }

--- a/crates/rslint_parser/test_data/inline/err/optional_chain_call_without_arguments.rast
+++ b/crates/rslint_parser/test_data/inline/err/optional_chain_call_without_arguments.rast
@@ -1,0 +1,157 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                kind: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: JsObjectExpression {
+                                l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+                                members: JsObjectMemberList [
+                                    JsPropertyObjectMember {
+                                        name: JsLiteralMemberName {
+                                            value: IDENT@10..14 "test" [] [],
+                                        },
+                                        colon_token: COLON@14..16 ":" [] [Whitespace(" ")],
+                                        value: JsNullLiteralExpression {
+                                            value_token: NULL_KW@16..21 "null" [] [Whitespace(" ")],
+                                        },
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@21..22 "}" [] [],
+                            },
+                        },
+                    },
+                ],
+            },
+            semicolon_token: SEMICOLON@22..23 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsStaticMemberExpression {
+                object: JsStaticMemberExpression {
+                    object: JsIdentifierExpression {
+                        name: JsReferenceIdentifier {
+                            value_token: IDENT@23..25 "a" [Newline("\n")] [],
+                        },
+                    },
+                    operator: DOT@25..26 "." [] [],
+                    member: JsName {
+                        value_token: IDENT@26..30 "test" [] [],
+                    },
+                },
+                operator: QUESTIONDOT@30..32 "?." [] [],
+                member: missing (required),
+            },
+            semicolon_token: SEMICOLON@32..33 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsBinaryExpression {
+                left: JsStaticMemberExpression {
+                    object: JsStaticMemberExpression {
+                        object: JsIdentifierExpression {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@33..35 "a" [Newline("\n")] [],
+                            },
+                        },
+                        operator: DOT@35..36 "." [] [],
+                        member: JsName {
+                            value_token: IDENT@36..40 "test" [] [],
+                        },
+                    },
+                    operator: QUESTIONDOT@40..42 "?." [] [],
+                    member: missing (required),
+                },
+                operator: L_ANGLE@42..43 "<" [] [],
+                right: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@43..45 "ab" [] [],
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@45..46 ";" [] [],
+        },
+    ],
+    eof_token: EOF@46..47 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..47
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..46
+    0: JS_VARIABLE_STATEMENT@0..23
+      0: JS_VARIABLE_DECLARATION@0..22
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATOR_LIST@4..22
+          0: JS_VARIABLE_DECLARATOR@4..22
+            0: JS_IDENTIFIER_BINDING@4..6
+              0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@6..22
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: JS_OBJECT_EXPRESSION@8..22
+                0: L_CURLY@8..10 "{" [] [Whitespace(" ")]
+                1: JS_OBJECT_MEMBER_LIST@10..21
+                  0: JS_PROPERTY_OBJECT_MEMBER@10..21
+                    0: JS_LITERAL_MEMBER_NAME@10..14
+                      0: IDENT@10..14 "test" [] []
+                    1: COLON@14..16 ":" [] [Whitespace(" ")]
+                    2: JS_NULL_LITERAL_EXPRESSION@16..21
+                      0: NULL_KW@16..21 "null" [] [Whitespace(" ")]
+                2: R_CURLY@21..22 "}" [] []
+      1: SEMICOLON@22..23 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@23..33
+      0: JS_STATIC_MEMBER_EXPRESSION@23..32
+        0: JS_STATIC_MEMBER_EXPRESSION@23..30
+          0: JS_IDENTIFIER_EXPRESSION@23..25
+            0: JS_REFERENCE_IDENTIFIER@23..25
+              0: IDENT@23..25 "a" [Newline("\n")] []
+          1: DOT@25..26 "." [] []
+          2: JS_NAME@26..30
+            0: IDENT@26..30 "test" [] []
+        1: QUESTIONDOT@30..32 "?." [] []
+        2: (empty)
+      1: SEMICOLON@32..33 ";" [] []
+    2: JS_EXPRESSION_STATEMENT@33..46
+      0: JS_BINARY_EXPRESSION@33..45
+        0: JS_STATIC_MEMBER_EXPRESSION@33..42
+          0: JS_STATIC_MEMBER_EXPRESSION@33..40
+            0: JS_IDENTIFIER_EXPRESSION@33..35
+              0: JS_REFERENCE_IDENTIFIER@33..35
+                0: IDENT@33..35 "a" [Newline("\n")] []
+            1: DOT@35..36 "." [] []
+            2: JS_NAME@36..40
+              0: IDENT@36..40 "test" [] []
+          1: QUESTIONDOT@40..42 "?." [] []
+          2: (empty)
+        1: L_ANGLE@42..43 "<" [] []
+        2: JS_IDENTIFIER_EXPRESSION@43..45
+          0: JS_REFERENCE_IDENTIFIER@43..45
+            0: IDENT@43..45 "ab" [] []
+      1: SEMICOLON@45..46 ";" [] []
+  3: EOF@46..47 "" [Newline("\n")] []
+--
+error[SyntaxError]: expected an identifier but instead found ';'
+  ┌─ optional_chain_call_without_arguments.ts:2:9
+  │
+2 │ a.test?.;
+  │         ^ Expected an identifier here
+
+--
+error[SyntaxError]: expected an identifier but instead found '<'
+  ┌─ optional_chain_call_without_arguments.ts:3:9
+  │
+3 │ a.test?.<ab;
+  │         ^ Expected an identifier here
+
+--
+let a = { test: null };
+a.test?.;
+a.test?.<ab;

--- a/crates/rslint_parser/test_data/inline/err/optional_chain_call_without_arguments.ts
+++ b/crates/rslint_parser/test_data/inline/err/optional_chain_call_without_arguments.ts
@@ -1,0 +1,3 @@
+let a = { test: null };
+a.test?.;
+a.test?.<ab;

--- a/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.js
+++ b/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.js
@@ -4,5 +4,6 @@ class A {
    #prop in #prop in this;
    5 + #prop;
    #prop
+   #prop + 5;
  }
 }

--- a/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
+++ b/crates/rslint_parser/test_data/inline/err/private_name_presence_check_recursive.rast
@@ -94,22 +94,37 @@ JsModule {
                                 },
                                 semicolon_token: missing (optional),
                             },
+                            JsExpressionStatement {
+                                expression: JsBinaryExpression {
+                                    left: JsUnknownExpression {
+                                        items: [
+                                            HASH@77..82 "#" [Newline("\n"), Whitespace("   ")] [],
+                                            IDENT@82..87 "prop" [] [Whitespace(" ")],
+                                        ],
+                                    },
+                                    operator: PLUS@87..89 "+" [] [Whitespace(" ")],
+                                    right: JsNumberLiteralExpression {
+                                        value_token: JS_NUMBER_LITERAL@89..90 "5" [] [],
+                                    },
+                                },
+                                semicolon_token: SEMICOLON@90..91 ";" [] [],
+                            },
                         ],
-                        r_curly_token: R_CURLY@77..80 "}" [Newline("\n"), Whitespace(" ")] [],
+                        r_curly_token: R_CURLY@91..94 "}" [Newline("\n"), Whitespace(" ")] [],
                     },
                 },
             ],
-            r_curly_token: R_CURLY@80..82 "}" [Newline("\n")] [],
+            r_curly_token: R_CURLY@94..96 "}" [Newline("\n")] [],
         },
     ],
-    eof_token: EOF@82..83 "" [Newline("\n")] [],
+    eof_token: EOF@96..97 "" [Newline("\n")] [],
 }
 
-0: JS_MODULE@0..83
+0: JS_MODULE@0..97
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
-  2: JS_MODULE_ITEM_LIST@0..82
-    0: JS_CLASS_DECLARATION@0..82
+  2: JS_MODULE_ITEM_LIST@0..96
+    0: JS_CLASS_DECLARATION@0..96
       0: (empty)
       1: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
       2: JS_IDENTIFIER_BINDING@6..8
@@ -118,7 +133,7 @@ JsModule {
       4: (empty)
       5: (empty)
       6: L_CURLY@8..9 "{" [] []
-      7: JS_CLASS_MEMBER_LIST@9..80
+      7: JS_CLASS_MEMBER_LIST@9..94
         0: JS_PROPERTY_CLASS_MEMBER@9..17
           0: (empty)
           1: (empty)
@@ -131,7 +146,7 @@ JsModule {
           6: (empty)
           7: (empty)
           8: SEMICOLON@16..17 ";" [] []
-        1: JS_METHOD_CLASS_MEMBER@17..80
+        1: JS_METHOD_CLASS_MEMBER@17..94
           0: (empty)
           1: (empty)
           2: (empty)
@@ -146,10 +161,10 @@ JsModule {
             1: JS_PARAMETER_LIST@24..24
             2: R_PAREN@24..26 ")" [] [Whitespace(" ")]
           9: (empty)
-          10: JS_FUNCTION_BODY@26..80
+          10: JS_FUNCTION_BODY@26..94
             0: L_CURLY@26..27 "{" [] []
             1: JS_DIRECTIVE_LIST@27..27
-            2: JS_STATEMENT_LIST@27..77
+            2: JS_STATEMENT_LIST@27..91
               0: JS_EXPRESSION_STATEMENT@27..54
                 0: JS_IN_EXPRESSION@27..53
                   0: JS_IN_EXPRESSION@27..46
@@ -178,28 +193,44 @@ JsModule {
                   0: HASH@68..73 "#" [Newline("\n"), Whitespace("   ")] []
                   1: IDENT@73..77 "prop" [] []
                 1: (empty)
-            3: R_CURLY@77..80 "}" [Newline("\n"), Whitespace(" ")] []
-      8: R_CURLY@80..82 "}" [Newline("\n")] []
-  3: EOF@82..83 "" [Newline("\n")] []
+              3: JS_EXPRESSION_STATEMENT@77..91
+                0: JS_BINARY_EXPRESSION@77..90
+                  0: JS_UNKNOWN_EXPRESSION@77..87
+                    0: HASH@77..82 "#" [Newline("\n"), Whitespace("   ")] []
+                    1: IDENT@82..87 "prop" [] [Whitespace(" ")]
+                  1: PLUS@87..89 "+" [] [Whitespace(" ")]
+                  2: JS_NUMBER_LITERAL_EXPRESSION@89..90
+                    0: JS_NUMBER_LITERAL@89..90 "5" [] []
+                1: SEMICOLON@90..91 ";" [] []
+            3: R_CURLY@91..94 "}" [Newline("\n"), Whitespace(" ")] []
+      8: R_CURLY@94..96 "}" [Newline("\n")] []
+  3: EOF@96..97 "" [Newline("\n")] []
 --
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ private_name_presence_check_recursive.js:4:13
   │
 4 │    #prop in #prop in this;
   │             ^^^^^
 
 --
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ private_name_presence_check_recursive.js:5:8
   │
 5 │    5 + #prop;
   │        ^^^^^
 
 --
-error[SyntaxError]: Private names are only allowed on the left side of a binary expression
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
   ┌─ private_name_presence_check_recursive.js:6:4
   │
 6 │    #prop
+  │    ^^^^^
+
+--
+error[SyntaxError]: Private names are only allowed on the left side of a 'in' expression
+  ┌─ private_name_presence_check_recursive.js:7:4
+  │
+7 │    #prop + 5;
   │    ^^^^^
 
 --
@@ -209,5 +240,6 @@ class A {
    #prop in #prop in this;
    5 + #prop;
    #prop
+   #prop + 5;
  }
 }


### PR DESCRIPTION
## Summary

#2163 fixed the precedence of private names in `in` expressions, but it doesn't catch the case where a private name is used as the left-hand side of any binary expression other than `in`.

This PR adds a check to verify that the operator is the `in` operator

This PR also fixes an issue with the TypeScript test runner. TypeScript supports running a test for different targets. The name of the `errors` file is then called `<test-case>(target=<target>).errors.txt` and a test is expected to fail if it is present. Our runner doesn't support running tests with different targets but we should assert that a test is expected to fail if an `.errors` file exists for any target (same as we currently do for `module`). This isn't perfect but works reasonably well. 

## Test Plan

Added a new parser test

The regressions come from tests that use multiple targets and the test runner so far expected that they should pass because it didn't test for the presence of `<test-case>(target=target).errors.txt` file.
