### PR TITLE
chore(coverage): assert no unknown in coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,6 +2233,7 @@ dependencies = [
  "once_cell",
  "pico-args",
  "regex",
+ "rome_rowan",
  "rslint_errors",
  "rslint_parser",
  "serde",

--- a/crates/rome_formatter/tests/specs/prettier/js/strings/strings.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/strings/strings.js.snap
@@ -38,42 +38,29 @@ expression: strings.js
 ```js
 [
   "abc",
-  'abc',
+  "abc",
 
-  '\'',
+  "\'",
 
-  '"',
-  '\"',
-  '\\"',
+  """,
+  "\"",
+  "\\"",
 
   "'",
   "\'",
   "\\'",
 
   "'\"",
-  '\'"',
+  "\'"",
 
-  '\\',
+  "\\",
   "\\",
 
-  '\0',
-  '🐶',
+  "\0",
+  "🐶",
 
-  '\uD801\uDC28',
+  "\uD801\uDC28",
 ];
-
-```
-
-# Errors
-```
-error: invalid digits after unicode escape sequence
-   ┌─ strings.js:24:4
-   │
-24 │   '\uD801\uDC28',
-   │    ^^^^^^^^^^^^ expected valid unicode escape sequence
-   │    │      
-   │    expected valid unicode escape sequence
-
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/strings/strings.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/strings/strings.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 119
 expression: strings.js
 
 ---
@@ -66,11 +66,11 @@ expression: strings.js
 
 # Errors
 ```
-warning: invalid digits after unicode escape sequence
+error: invalid digits after unicode escape sequence
    ┌─ strings.js:24:4
    │
 24 │   '\uD801\uDC28',
-   │    ------------ expected valid unicode escape sequence
+   │    ^^^^^^^^^^^^ expected valid unicode escape sequence
    │    │      
    │    expected valid unicode escape sequence
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/import-export/type-modifier.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/import-export/type-modifier.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 119
 expression: type-modifier.ts
 
 ---
@@ -42,6 +42,17 @@ import type * as foo from './bar';
 import type foo from 'bar';
 
 import type foo, { bar } from 'bar';
+
+```
+
+# Errors
+```
+error[SyntaxError]: A type-only import can specify a default import or named bindings, but not both.
+   ┌─ type-modifier.ts:15:8
+   │
+15 │ import type foo, { bar } from 'bar';
+   │        ^^^^^^^^^^^^^^^^^
+
 
 ```
 

--- a/crates/rslint_lexer/src/errors.rs
+++ b/crates/rslint_lexer/src/errors.rs
@@ -5,7 +5,7 @@ pub fn invalid_digits_after_unicode_escape_sequence(
     start: usize,
     end: usize,
 ) -> Box<Diagnostic> {
-    let err = Diagnostic::warning(file_id, "", "invalid digits after unicode escape sequence")
+    let err = Diagnostic::error(file_id, "", "invalid digits after unicode escape sequence")
         .primary(start..end, "expected valid unicode escape sequence");
     Box::new(err)
 }

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -319,13 +319,7 @@ impl<'src> Lexer<'src> {
                 if !advance {
                     self.cur -= 4;
                 }
-                std::char::from_u32(digits).ok_or_else(|| {
-                    invalid_digits_after_unicode_escape_sequence(
-                        self.file_id,
-                        self.cur - 5,
-                        self.cur + 1,
-                    )
-                })
+                Ok(std::char::from_u32_unchecked(digits))
             } else {
                 // Safety: we know this is unreachable because 4 hexdigits cannot make an out of bounds char,
                 // and we make sure that the chars are actually hex digits

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -14,7 +14,9 @@ use crate::syntax::js_parse_error;
 use crate::syntax::js_parse_error::{
     ts_accessor_type_parameters_error, ts_only_syntax_error, ts_set_accessor_return_type_error,
 };
-use crate::syntax::typescript::{parse_ts_return_type_annotation, parse_ts_type_parameters};
+use crate::syntax::typescript::{
+    parse_ts_return_type_annotation, parse_ts_type_annotation, parse_ts_type_parameters,
+};
 use crate::JsSyntaxFeature::TypeScript;
 use crate::{ParseRecovery, ParseSeparatedList, Parser, SyntaxFeature};
 use rslint_errors::Span;
@@ -269,8 +271,8 @@ fn parse_getter_object_member(p: &mut Parser) -> ParsedSyntax {
     p.expect(T![')']);
 
     TypeScript
-        .parse_exclusive_syntax(p, parse_ts_return_type_annotation, |p, annotation| {
-            ts_only_syntax_error(p, "return type annotation", annotation.range(p).as_range())
+        .parse_exclusive_syntax(p, parse_ts_type_annotation, |p, annotation| {
+            ts_only_syntax_error(p, "type annotation", annotation.range(p).as_range())
         })
         .ok();
 

--- a/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_object_getter_type_parameters.rast
@@ -29,7 +29,7 @@ JsModule {
                                 },
                                 L_PAREN@11..12 "(" [] [],
                                 R_PAREN@12..13 ")" [] [],
-                                TsReturnTypeAnnotation {
+                                TsTypeAnnotation {
                                     colon_token: COLON@13..15 ":" [] [Whitespace(" ")],
                                     ty: TsReferenceType {
                                         name: JsReferenceIdentifier {
@@ -82,7 +82,7 @@ JsModule {
                 2: R_ANGLE@10..11 ">" [] []
               3: L_PAREN@11..12 "(" [] []
               4: R_PAREN@12..13 ")" [] []
-              5: TS_RETURN_TYPE_ANNOTATION@13..17
+              5: TS_TYPE_ANNOTATION@13..17
                 0: COLON@13..15 ":" [] [Whitespace(" ")]
                 1: TS_REFERENCE_TYPE@15..17
                   0: JS_REFERENCE_IDENTIFIER@15..17

--- a/crates/rslint_parser/test_data/inline/err/ts_typed_default_import_with_named.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_typed_default_import_with_named.rast
@@ -1,0 +1,89 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsUnknownStatement {
+            items: [
+                IMPORT_KW@0..7 "import" [] [Whitespace(" ")],
+                JsUnknown {
+                    items: [
+                        JsUnknown {
+                            items: [
+                                TYPE_KW@7..12 "type" [] [Whitespace(" ")],
+                                JsIdentifierBinding {
+                                    name_token: IDENT@12..13 "A" [] [],
+                                },
+                                COMMA@13..15 "," [] [Whitespace(" ")],
+                            ],
+                        },
+                        JsNamedImportSpecifiers {
+                            l_curly_token: L_CURLY@15..17 "{" [] [Whitespace(" ")],
+                            specifiers: JsNamedImportSpecifierList [
+                                JsShorthandNamedImportSpecifier {
+                                    type_token: missing (optional),
+                                    local_name: JsIdentifierBinding {
+                                        name_token: IDENT@17..18 "B" [] [],
+                                    },
+                                },
+                                COMMA@18..20 "," [] [Whitespace(" ")],
+                                JsShorthandNamedImportSpecifier {
+                                    type_token: missing (optional),
+                                    local_name: JsIdentifierBinding {
+                                        name_token: IDENT@20..22 "C" [] [Whitespace(" ")],
+                                    },
+                                },
+                            ],
+                            r_curly_token: R_CURLY@22..24 "}" [] [Whitespace(" ")],
+                        },
+                        FROM_KW@24..29 "from" [] [Whitespace(" ")],
+                        JsModuleSource {
+                            value_token: JS_STRING_LITERAL@29..34 "'./a'" [] [],
+                        },
+                    ],
+                },
+                SEMICOLON@34..35 ";" [] [],
+            ],
+        },
+    ],
+    eof_token: EOF@35..36 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..36
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..35
+    0: JS_UNKNOWN_STATEMENT@0..35
+      0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
+      1: JS_UNKNOWN@7..34
+        0: JS_UNKNOWN@7..15
+          0: TYPE_KW@7..12 "type" [] [Whitespace(" ")]
+          1: JS_IDENTIFIER_BINDING@12..13
+            0: IDENT@12..13 "A" [] []
+          2: COMMA@13..15 "," [] [Whitespace(" ")]
+        1: JS_NAMED_IMPORT_SPECIFIERS@15..24
+          0: L_CURLY@15..17 "{" [] [Whitespace(" ")]
+          1: JS_NAMED_IMPORT_SPECIFIER_LIST@17..22
+            0: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@17..18
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@17..18
+                0: IDENT@17..18 "B" [] []
+            1: COMMA@18..20 "," [] [Whitespace(" ")]
+            2: JS_SHORTHAND_NAMED_IMPORT_SPECIFIER@20..22
+              0: (empty)
+              1: JS_IDENTIFIER_BINDING@20..22
+                0: IDENT@20..22 "C" [] [Whitespace(" ")]
+          2: R_CURLY@22..24 "}" [] [Whitespace(" ")]
+        2: FROM_KW@24..29 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@29..34
+          0: JS_STRING_LITERAL@29..34 "'./a'" [] []
+      2: SEMICOLON@34..35 ";" [] []
+  3: EOF@35..36 "" [Newline("\n")] []
+--
+error[SyntaxError]: A type-only import can specify a default import or named bindings, but not both.
+  ┌─ ts_typed_default_import_with_named.ts:1:8
+  │
+1 │ import type A, { B, C } from './a';
+  │        ^^^^^^^^^^^^^^^^
+
+--
+import type A, { B, C } from './a';

--- a/crates/rslint_parser/test_data/inline/err/ts_typed_default_import_with_named.ts
+++ b/crates/rslint_parser/test_data/inline/err/ts_typed_default_import_with_named.ts
@@ -1,0 +1,1 @@
+import type A, { B, C } from './a';

--- a/xtask/coverage/Cargo.toml
+++ b/xtask/coverage/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 xtask = { path = '../', version = "0.0" }
 rslint_parser = { path = "../../crates/rslint_parser", version = "0.3" }
+rome_rowan = { path = "../../crates/rome_rowan" }
 rslint_errors = { path = "../../crates/rslint_errors", version = "0.2.0" }
 
 pico-args = "0.3.4"

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -1,10 +1,11 @@
 use super::*;
 use crate::reporters::TestReporter;
+use rome_rowan::SyntaxKind;
 use rslint_errors::file::{FileId, SimpleFiles};
 use rslint_errors::termcolor::Buffer;
-use rslint_errors::Emitter;
+use rslint_errors::{Diagnostic, Emitter, Severity};
 use rslint_parser::ast::JsAnyRoot;
-use rslint_parser::{parse, Parse, SourceType};
+use rslint_parser::{parse, Parse, SourceType, SyntaxNode};
 use std::fmt::Debug;
 use std::panic::RefUnwindSafe;
 use std::path::Path;
@@ -91,6 +92,19 @@ impl TestCaseFile {
     pub(crate) fn id(&self) -> FileId {
         self.id
     }
+}
+
+pub(crate) fn create_unknown_node_in_tree_diagnostic(
+    file_id: FileId,
+    node: SyntaxNode,
+) -> Diagnostic {
+    assert!(node.kind().is_unknown());
+    Diagnostic::new(
+        file_id,
+        Severity::Bug,
+        "There are no parse errors but the parsed tree contains unknown nodes.",
+    )
+        .primary(node.text_trimmed_range(), "This unknown node is present in the parsed tree but the parser didn't emit a diagnostic for it. Change the parser to either emit a diagnostic, fix the grammar, or the parsing.")
 }
 
 #[derive(Clone, Debug)]

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::reporters::TestReporter;
-use rslint_errors::file::SimpleFiles;
+use rslint_errors::file::{FileId, SimpleFiles};
 use rslint_errors::termcolor::Buffer;
 use rslint_errors::Emitter;
 use rslint_parser::ast::JsAnyRoot;
@@ -76,7 +76,7 @@ pub(crate) struct TestCaseFile {
     /// The source type used to parse the file
     source_type: SourceType,
 
-    id: usize,
+    id: FileId,
 }
 
 impl TestCaseFile {
@@ -86,6 +86,10 @@ impl TestCaseFile {
 
     pub(crate) fn name(&self) -> &str {
         &self.name
+    }
+
+    pub(crate) fn id(&self) -> FileId {
+        self.id
     }
 }
 

--- a/xtask/coverage/src/test262.rs
+++ b/xtask/coverage/src/test262.rs
@@ -1,7 +1,8 @@
-use crate::runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite};
+use crate::runner::{
+    create_unknown_node_in_tree_diagnostic, TestCase, TestCaseFiles, TestRunOutcome, TestSuite,
+};
 use regex::Regex;
 use rome_rowan::api::SyntaxKind;
-use rslint_errors::{Diagnostic, Severity};
 use rslint_parser::{parse, AstNode, SourceType};
 use serde::Deserialize;
 use std::io;
@@ -105,12 +106,7 @@ impl Test262TestCase {
                     .find(|descendant| descendant.kind().is_unknown())
                 {
                     TestRunOutcome::IncorrectlyErrored {
-                        errors: vec![Diagnostic::new(
-                            0,
-                            Severity::Bug,
-                            "Unknown node in test that should pass",
-                        )
-                        .primary(unknown.text_trimmed_range(), "")],
+                        errors: vec![create_unknown_node_in_tree_diagnostic(0, unknown)],
                         files,
                     }
                 } else {

--- a/xtask/coverage/src/test262.rs
+++ b/xtask/coverage/src/test262.rs
@@ -87,8 +87,6 @@ impl Test262TestCase {
             self.code.clone()
         };
 
-        let parse_result = parse(&code, 0, source_type.clone()).ok();
-
         let should_fail = self
             .meta
             .negative
@@ -96,9 +94,10 @@ impl Test262TestCase {
             .filter(|neg| neg.phase == Phase::Parse)
             .is_some();
 
-        let files = TestCaseFiles::single(self.name.clone(), self.code.clone(), source_type);
+        let files =
+            TestCaseFiles::single(self.name.clone(), self.code.clone(), source_type.clone());
 
-        match parse_result {
+        match parse(&code, 0, source_type).ok() {
             Ok(root) if !should_fail => {
                 if let Some(unknown) = root
                     .syntax()
@@ -111,7 +110,7 @@ impl Test262TestCase {
                             Severity::Bug,
                             "Unknown node in test that should pass",
                         )
-                        .primary(unknown.text_range(), "")],
+                        .primary(unknown.text_trimmed_range(), "")],
                         files,
                     }
                 } else {

--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -1,10 +1,11 @@
 use regex::Regex;
 use rome_rowan::SyntaxKind;
-use rslint_errors::{Diagnostic, Severity};
 use rslint_parser::{AstNode, ModuleKind, SourceType};
 use std::path::Path;
 
-use crate::runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite};
+use crate::runner::{
+    create_unknown_node_in_tree_diagnostic, TestCase, TestCaseFiles, TestRunOutcome, TestSuite,
+};
 use crate::util::decode_maybe_utf16_string;
 
 const CASES_PATH: &str = "xtask/coverage/Typescript/tests/cases";
@@ -42,14 +43,8 @@ impl TestCase for TypeScriptTestCase {
                         .descendants()
                         .find(|descendant| descendant.kind().is_unknown())
                     {
-                        unknowns_errors.push(
-                            Diagnostic::new(
-                                file.id(),
-                                Severity::Bug,
-                                "Unknown node in test that should pass",
-                            )
-                            .primary(unknown.text_trimmed_range(), ""),
-                        );
+                        unknowns_errors
+                            .push(create_unknown_node_in_tree_diagnostic(file.id(), unknown));
                     }
                 }
                 Err(errors) => all_errors.extend(errors),

--- a/xtask/coverage/src/typescript.rs
+++ b/xtask/coverage/src/typescript.rs
@@ -42,11 +42,14 @@ impl TestCase for TypeScriptTestCase {
                         .descendants()
                         .find(|descendant| descendant.kind().is_unknown())
                     {
-                        unknowns_errors.push(Diagnostic::new(
-                            file.id(),
-                            Severity::Bug,
-                            "Unknown node in test that should pass",
-                        ));
+                        unknowns_errors.push(
+                            Diagnostic::new(
+                                file.id(),
+                                Severity::Bug,
+                                "Unknown node in test that should pass",
+                            )
+                            .primary(unknown.text_trimmed_range(), ""),
+                        );
                     }
                 }
                 Err(errors) => all_errors.extend(errors),


### PR DESCRIPTION
## Summary

Extends the coverage tests to assert that the parsed result contains no `Unknown` nodes for tests that are expected to pass. 

This revealed that our Unicode escape sequence parsing is too strict. The validation if Unicode escape sequences are valid (form a valid character) is only necessary in export-name positions (see T262 regressions) but not any others. This check was added in #1938 and is reverted in this PR because I believe it's more important that we parse valid files correctly. We can correctly implement the check once the work on #2035 is done. 

This PR further fixes the parsing of `getter` object members to parse out a normal type annotation and not a return type annotation.

## Test Plan

Verified that the regressions are specific to the revert of the Unicode verification.
