### PR TITLE
fix(rslint_parser): Fix ASI for return type `is`/`assert` predicates

### DIFF
--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -1146,13 +1146,20 @@ fn parse_ts_function_type(p: &mut Parser) -> ParsedSyntax {
     Present(m.complete(p, TS_FUNCTION_TYPE))
 }
 
+// test ts ts_return_type_asi
+// interface I {
+//  foo(test: string): I
+//  is(): boolean;
+//  bar(test: string): I
+//  asserts(): boolean;
+// }
 fn parse_ts_return_type(p: &mut Parser) -> ParsedSyntax {
     let is_asserts_predicate = is_at_contextual_keyword(p, "asserts")
         && (is_nth_at_identifier(p, 1) || p.nth_at(1, T![this]));
     let is_is_predicate =
         (is_at_identifier(p) || p.at(T![this])) && is_nth_at_contextual_keyword(p, 1, "is");
 
-    if is_asserts_predicate || is_is_predicate {
+    if !p.has_linebreak_before_n(1) && (is_asserts_predicate || is_is_predicate) {
         parse_ts_type_predicate(p)
     } else {
         parse_ts_type(p)

--- a/crates/rslint_parser/test_data/inline/ok/ts_return_type_asi.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_return_type_asi.rast
@@ -1,0 +1,222 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsInterfaceDeclaration {
+            interface_token: INTERFACE_KW@0..10 "interface" [] [Whitespace(" ")],
+            id: TsIdentifierBinding {
+                name_token: IDENT@10..12 "I" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            l_curly_token: L_CURLY@12..13 "{" [] [],
+            members: TsTypeMemberList [
+                TsMethodSignatureTypeMember {
+                    name: JsLiteralMemberName {
+                        value: IDENT@13..18 "foo" [Newline("\n"), Whitespace(" ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@18..19 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@19..23 "test" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                                    ty: TsStringType {
+                                        string_token: STRING_KW@25..31 "string" [] [],
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@31..32 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@32..34 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@34..35 "I" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    separator_token: missing (optional),
+                },
+                TsMethodSignatureTypeMember {
+                    name: JsLiteralMemberName {
+                        value: IDENT@35..39 "is" [Newline("\n"), Whitespace(" ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@39..40 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@40..41 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@41..43 ":" [] [Whitespace(" ")],
+                        ty: TsBooleanType {
+                            boolean_token: BOOLEAN_KW@43..50 "boolean" [] [],
+                        },
+                    },
+                    separator_token: SEMICOLON@50..51 ";" [] [],
+                },
+                TsMethodSignatureTypeMember {
+                    name: JsLiteralMemberName {
+                        value: IDENT@51..56 "bar" [Newline("\n"), Whitespace(" ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@56..57 "(" [] [],
+                        items: JsParameterList [
+                            JsFormalParameter {
+                                binding: JsIdentifierBinding {
+                                    name_token: IDENT@57..61 "test" [] [],
+                                },
+                                question_mark_token: missing (optional),
+                                type_annotation: TsTypeAnnotation {
+                                    colon_token: COLON@61..63 ":" [] [Whitespace(" ")],
+                                    ty: TsStringType {
+                                        string_token: STRING_KW@63..69 "string" [] [],
+                                    },
+                                },
+                                initializer: missing (optional),
+                            },
+                        ],
+                        r_paren_token: R_PAREN@69..70 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@70..72 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@72..73 "I" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    separator_token: missing (optional),
+                },
+                TsMethodSignatureTypeMember {
+                    name: JsLiteralMemberName {
+                        value: IDENT@73..82 "asserts" [Newline("\n"), Whitespace(" ")] [],
+                    },
+                    optional_token: missing (optional),
+                    type_parameters: missing (optional),
+                    parameters: JsParameters {
+                        l_paren_token: L_PAREN@82..83 "(" [] [],
+                        items: JsParameterList [],
+                        r_paren_token: R_PAREN@83..84 ")" [] [],
+                    },
+                    return_type_annotation: TsReturnTypeAnnotation {
+                        colon_token: COLON@84..86 ":" [] [Whitespace(" ")],
+                        ty: TsBooleanType {
+                            boolean_token: BOOLEAN_KW@86..93 "boolean" [] [],
+                        },
+                    },
+                    separator_token: SEMICOLON@93..94 ";" [] [],
+                },
+            ],
+            r_curly_token: R_CURLY@94..96 "}" [Newline("\n")] [],
+        },
+    ],
+    eof_token: EOF@96..97 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..97
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..96
+    0: TS_INTERFACE_DECLARATION@0..96
+      0: INTERFACE_KW@0..10 "interface" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@10..12
+        0: IDENT@10..12 "I" [] [Whitespace(" ")]
+      2: (empty)
+      3: (empty)
+      4: L_CURLY@12..13 "{" [] []
+      5: TS_TYPE_MEMBER_LIST@13..94
+        0: TS_METHOD_SIGNATURE_TYPE_MEMBER@13..35
+          0: JS_LITERAL_MEMBER_NAME@13..18
+            0: IDENT@13..18 "foo" [Newline("\n"), Whitespace(" ")] []
+          1: (empty)
+          2: (empty)
+          3: JS_PARAMETERS@18..32
+            0: L_PAREN@18..19 "(" [] []
+            1: JS_PARAMETER_LIST@19..31
+              0: JS_FORMAL_PARAMETER@19..31
+                0: JS_IDENTIFIER_BINDING@19..23
+                  0: IDENT@19..23 "test" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@23..31
+                  0: COLON@23..25 ":" [] [Whitespace(" ")]
+                  1: TS_STRING_TYPE@25..31
+                    0: STRING_KW@25..31 "string" [] []
+                3: (empty)
+            2: R_PAREN@31..32 ")" [] []
+          4: TS_RETURN_TYPE_ANNOTATION@32..35
+            0: COLON@32..34 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@34..35
+              0: JS_REFERENCE_IDENTIFIER@34..35
+                0: IDENT@34..35 "I" [] []
+              1: (empty)
+          5: (empty)
+        1: TS_METHOD_SIGNATURE_TYPE_MEMBER@35..51
+          0: JS_LITERAL_MEMBER_NAME@35..39
+            0: IDENT@35..39 "is" [Newline("\n"), Whitespace(" ")] []
+          1: (empty)
+          2: (empty)
+          3: JS_PARAMETERS@39..41
+            0: L_PAREN@39..40 "(" [] []
+            1: JS_PARAMETER_LIST@40..40
+            2: R_PAREN@40..41 ")" [] []
+          4: TS_RETURN_TYPE_ANNOTATION@41..50
+            0: COLON@41..43 ":" [] [Whitespace(" ")]
+            1: TS_BOOLEAN_TYPE@43..50
+              0: BOOLEAN_KW@43..50 "boolean" [] []
+          5: SEMICOLON@50..51 ";" [] []
+        2: TS_METHOD_SIGNATURE_TYPE_MEMBER@51..73
+          0: JS_LITERAL_MEMBER_NAME@51..56
+            0: IDENT@51..56 "bar" [Newline("\n"), Whitespace(" ")] []
+          1: (empty)
+          2: (empty)
+          3: JS_PARAMETERS@56..70
+            0: L_PAREN@56..57 "(" [] []
+            1: JS_PARAMETER_LIST@57..69
+              0: JS_FORMAL_PARAMETER@57..69
+                0: JS_IDENTIFIER_BINDING@57..61
+                  0: IDENT@57..61 "test" [] []
+                1: (empty)
+                2: TS_TYPE_ANNOTATION@61..69
+                  0: COLON@61..63 ":" [] [Whitespace(" ")]
+                  1: TS_STRING_TYPE@63..69
+                    0: STRING_KW@63..69 "string" [] []
+                3: (empty)
+            2: R_PAREN@69..70 ")" [] []
+          4: TS_RETURN_TYPE_ANNOTATION@70..73
+            0: COLON@70..72 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@72..73
+              0: JS_REFERENCE_IDENTIFIER@72..73
+                0: IDENT@72..73 "I" [] []
+              1: (empty)
+          5: (empty)
+        3: TS_METHOD_SIGNATURE_TYPE_MEMBER@73..94
+          0: JS_LITERAL_MEMBER_NAME@73..82
+            0: IDENT@73..82 "asserts" [Newline("\n"), Whitespace(" ")] []
+          1: (empty)
+          2: (empty)
+          3: JS_PARAMETERS@82..84
+            0: L_PAREN@82..83 "(" [] []
+            1: JS_PARAMETER_LIST@83..83
+            2: R_PAREN@83..84 ")" [] []
+          4: TS_RETURN_TYPE_ANNOTATION@84..93
+            0: COLON@84..86 ":" [] [Whitespace(" ")]
+            1: TS_BOOLEAN_TYPE@86..93
+              0: BOOLEAN_KW@86..93 "boolean" [] []
+          5: SEMICOLON@93..94 ";" [] []
+      6: R_CURLY@94..96 "}" [Newline("\n")] []
+  3: EOF@96..97 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_return_type_asi.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_return_type_asi.ts
@@ -1,0 +1,6 @@
+interface I {
+ foo(test: string): I
+ is(): boolean;
+ bar(test: string): I
+ asserts(): boolean;
+}


### PR DESCRIPTION
## Summary
TypeScript supports `: <ident> is <condition>` and `asserts <ident>` predicates on function return types.

This PR ensures that our Parser correctly respects ASI if there's a line break right before the `is` or `asserts` token:

```ts
interface I {
    foo(callback: (a: any, b: any) => void): I
    is(): boolean;
    bar(test: string): I
    asserts(): boolean
}
```

`is` and `asserts` are both methods in this example and shouldn't be parsed as return type predicates (`I is...` or `I asserts...`).

## Test Plan

Added a new parser test with the above example. 