### PR TITLE
fix(rslint_parser): comments detection on nodes

### DIFF
--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -1,5 +1,7 @@
 use crate::ast::{JsAnyRoot, JsCallArguments};
-use crate::{parse, parse_module, AstNode, Parse, SourceType, SyntaxNode, SyntaxToken};
+use crate::{
+    parse, parse_module, AstNode, Parse, SourceType, SyntaxNode, SyntaxNodeExt, SyntaxToken,
+};
 use expect_test::expect_file;
 use rome_rowan::{SyntaxKind, TextSize};
 use rslint_errors::file::SimpleFile;
@@ -312,4 +314,13 @@ pub fn just_trivia_must_be_appended_to_eof() {
 
     assert_eq!(TextSize::from(0), start);
     assert_eq!(TextSize::from(34), end);
+}
+
+#[test]
+pub fn node_contains_comments() {
+    let text = "true && true // comment";
+    let root = parse_module(text, 0);
+    let syntax = root.syntax();
+
+    assert!(syntax.contains_comments());
 }

--- a/crates/rslint_parser/src/util.rs
+++ b/crates/rslint_parser/src/util.rs
@@ -160,7 +160,7 @@ pub trait SyntaxNodeExt {
     fn contains_comments(&self) -> bool {
         self.tokens()
             .iter()
-            .any(|tok| tok.kind() == JsSyntaxKind::COMMENT)
+            .any(|tok| tok.has_leading_comments() || tok.has_trailing_comments())
     }
 
     /// Get the first child with a specific kind.


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Our `SyntaxNodeExt::contains_comments` was still using an old check to detect comments.

I stumbled across this bug while working on something else, so I wanted to fix it separately to avoid too much jargon.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Created a new test and checked that the test failing before the change of code.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
