### PR TITLE
feat(rslint_parser): allow ts property named get and set

### DIFF
--- a/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare-get-set-field.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/declare/declare-get-set-field.ts.snap
@@ -16,38 +16,9 @@ class C {
 # Output
 ```js
 class C {
-  declare get: string
-  declare set: string
+  declare get: string;
+  declare set: string;
 }
-
-```
-
-# Errors
-```
-error[SyntaxError]: expected an identifier, a string literal, a number literal, a private field name, or a computed name but instead found ':'
-  ┌─ declare-get-set-field.ts:2:14
-  │
-2 │   declare get: string
-  │              ^ Expected an identifier, a string literal, a number literal, a private field name, or a computed name here
-
-error[SyntaxError]: expected a class method body but instead found 'declare'
-  ┌─ declare-get-set-field.ts:3:3
-  │
-3 │   declare set: string;
-  │   ^^^^^^^ Expected a class method body here
-
-error[SyntaxError]: expected an identifier, a string literal, a number literal, a private field name, or a computed name but instead found ':'
-  ┌─ declare-get-set-field.ts:3:14
-  │
-3 │   declare set: string;
-  │              ^ Expected an identifier, a string literal, a number literal, a private field name, or a computed name here
-
-error[SyntaxError]: expected a class method body but instead found ';'
-  ┌─ declare-get-set-field.ts:3:22
-  │
-3 │   declare set: string;
-  │                      ^ Expected a class method body here
-
 
 ```
 

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -711,7 +711,7 @@ fn parse_class_member_impl(
                     && !is_at_line_break_or_generator
                     && matches!(member_name_text, "get" | "set")
                 {
-                    let is_getter = dbg!(member_name_text == "get");
+                    let is_getter = member_name_text == "get";
 
                     // test getter_class_member
                     // class Getters {

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -704,10 +704,14 @@ fn parse_class_member_impl(
     match member_name {
         Some(member_name) => {
             if member_name.kind() == JS_LITERAL_MEMBER_NAME {
+                let is_at_semicolon = p.at(T![:]);
                 let is_at_line_break_or_generator = p.has_linebreak_before_n(0) && p.at(T![*]);
                 let member_name_text = member_name.text(p);
-                if matches!(member_name_text, "get" | "set") && !is_at_line_break_or_generator {
-                    let is_getter = member_name_text == "get";
+                if !is_at_semicolon
+                    && !is_at_line_break_or_generator
+                    && matches!(member_name_text, "get" | "set")
+                {
+                    let is_getter = dbg!(member_name_text == "get");
 
                     // test getter_class_member
                     // class Getters {
@@ -854,6 +858,9 @@ fn parse_class_member_impl(
             //
             // test_err class_declare_member
             // class B { declare foo }
+
+            // test ts ts_property_class_member_can_be_named_set_or_get
+            // class B { set: String; get: Number }
             let property = if modifiers.has(ModifierKind::Declare) {
                 property_declaration_class_member_body(
                     p,

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -704,10 +704,10 @@ fn parse_class_member_impl(
     match member_name {
         Some(member_name) => {
             if member_name.kind() == JS_LITERAL_MEMBER_NAME {
-                let is_at_semicolon = p.at(T![:]);
+                let is_at_colon = p.at(T![:]);
                 let is_at_line_break_or_generator = p.has_linebreak_before_n(0) && p.at(T![*]);
                 let member_name_text = member_name.text(p);
-                if !is_at_semicolon
+                if !is_at_colon
                     && !is_at_line_break_or_generator
                     && matches!(member_name_text, "get" | "set")
                 {

--- a/crates/rslint_parser/src/syntax/class.rs
+++ b/crates/rslint_parser/src/syntax/class.rs
@@ -1035,7 +1035,6 @@ fn parse_property_class_member_body(
 //   c!: string;
 // }
 fn parse_ts_property_annotation(p: &mut Parser, modifiers: &ClassMemberModifiers) -> ParsedSyntax {
-    dbg!(p.cur_src());
     if !p.at(T![?]) && !p.at(T![!]) {
         return parse_ts_type_annotation_or_error(p);
     }

--- a/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.rast
@@ -18,7 +18,6 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     readonly_token: missing (optional),
-                    abstract_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@10..13 "set" [] [],
                     },
@@ -39,7 +38,6 @@ JsModule {
                     access_modifier: missing (optional),
                     static_token: missing (optional),
                     readonly_token: missing (optional),
-                    abstract_token: missing (optional),
                     name: JsLiteralMemberName {
                         value: IDENT@23..26 "get" [] [],
                     },
@@ -81,32 +79,30 @@ JsModule {
           1: (empty)
           2: (empty)
           3: (empty)
-          4: (empty)
-          5: JS_LITERAL_MEMBER_NAME@10..13
+          4: JS_LITERAL_MEMBER_NAME@10..13
             0: IDENT@10..13 "set" [] []
-          6: TS_TYPE_ANNOTATION@13..21
+          5: TS_TYPE_ANNOTATION@13..21
             0: COLON@13..15 ":" [] [Whitespace(" ")]
             1: TS_REFERENCE_TYPE@15..21
               0: JS_REFERENCE_IDENTIFIER@15..21
                 0: IDENT@15..21 "String" [] []
               1: (empty)
-          7: (empty)
-          8: SEMICOLON@21..23 ";" [] [Whitespace(" ")]
+          6: (empty)
+          7: SEMICOLON@21..23 ";" [] [Whitespace(" ")]
         1: JS_PROPERTY_CLASS_MEMBER@23..35
           0: (empty)
           1: (empty)
           2: (empty)
           3: (empty)
-          4: (empty)
-          5: JS_LITERAL_MEMBER_NAME@23..26
+          4: JS_LITERAL_MEMBER_NAME@23..26
             0: IDENT@23..26 "get" [] []
-          6: TS_TYPE_ANNOTATION@26..35
+          5: TS_TYPE_ANNOTATION@26..35
             0: COLON@26..28 ":" [] [Whitespace(" ")]
             1: TS_REFERENCE_TYPE@28..35
               0: JS_REFERENCE_IDENTIFIER@28..35
                 0: IDENT@28..35 "Number" [] [Whitespace(" ")]
               1: (empty)
+          6: (empty)
           7: (empty)
-          8: (empty)
       8: R_CURLY@35..36 "}" [] []
   3: EOF@36..37 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.rast
+++ b/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.rast
@@ -1,0 +1,112 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassDeclaration {
+            abstract_token: missing (optional),
+            class_token: CLASS_KW@0..6 "class" [] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@6..8 "B" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@8..10 "{" [] [Whitespace(" ")],
+            members: JsClassMemberList [
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@10..13 "set" [] [],
+                    },
+                    property_annotation: TsTypeAnnotation {
+                        colon_token: COLON@13..15 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@15..21 "String" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    value: missing (optional),
+                    semicolon_token: SEMICOLON@21..23 ";" [] [Whitespace(" ")],
+                },
+                JsPropertyClassMember {
+                    declare_token: missing (optional),
+                    access_modifier: missing (optional),
+                    static_token: missing (optional),
+                    readonly_token: missing (optional),
+                    abstract_token: missing (optional),
+                    name: JsLiteralMemberName {
+                        value: IDENT@23..26 "get" [] [],
+                    },
+                    property_annotation: TsTypeAnnotation {
+                        colon_token: COLON@26..28 ":" [] [Whitespace(" ")],
+                        ty: TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@28..35 "Number" [] [Whitespace(" ")],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                    },
+                    value: missing (optional),
+                    semicolon_token: missing (optional),
+                },
+            ],
+            r_curly_token: R_CURLY@35..36 "}" [] [],
+        },
+    ],
+    eof_token: EOF@36..37 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..37
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..36
+    0: JS_CLASS_DECLARATION@0..36
+      0: (empty)
+      1: CLASS_KW@0..6 "class" [] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@6..8
+        0: IDENT@6..8 "B" [] [Whitespace(" ")]
+      3: (empty)
+      4: (empty)
+      5: (empty)
+      6: L_CURLY@8..10 "{" [] [Whitespace(" ")]
+      7: JS_CLASS_MEMBER_LIST@10..35
+        0: JS_PROPERTY_CLASS_MEMBER@10..23
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@10..13
+            0: IDENT@10..13 "set" [] []
+          6: TS_TYPE_ANNOTATION@13..21
+            0: COLON@13..15 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@15..21
+              0: JS_REFERENCE_IDENTIFIER@15..21
+                0: IDENT@15..21 "String" [] []
+              1: (empty)
+          7: (empty)
+          8: SEMICOLON@21..23 ";" [] [Whitespace(" ")]
+        1: JS_PROPERTY_CLASS_MEMBER@23..35
+          0: (empty)
+          1: (empty)
+          2: (empty)
+          3: (empty)
+          4: (empty)
+          5: JS_LITERAL_MEMBER_NAME@23..26
+            0: IDENT@23..26 "get" [] []
+          6: TS_TYPE_ANNOTATION@26..35
+            0: COLON@26..28 ":" [] [Whitespace(" ")]
+            1: TS_REFERENCE_TYPE@28..35
+              0: JS_REFERENCE_IDENTIFIER@28..35
+                0: IDENT@28..35 "Number" [] [Whitespace(" ")]
+              1: (empty)
+          7: (empty)
+          8: (empty)
+      8: R_CURLY@35..36 "}" [] []
+  3: EOF@36..37 "" [Newline("\n")] []

--- a/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.ts
+++ b/crates/rslint_parser/test_data/inline/ok/ts_property_class_member_can_be_named_set_or_get.ts
@@ -1,0 +1,1 @@
+class B { set: String; get: Number }


### PR DESCRIPTION
I am creating the Typescript bench and searching for holes in our implementation. This fixes the problem I found at https://github.com/PanayotCankov/nativescript-big-dts/blob/master/ios.d.ts

```
error[SyntaxError]: expected an identifier, a string literal, a number literal, a private field name, or a computed name but instead found ':'
     ┌─ ios.d.ts:2270:5
     │
2270 │     set: NSSet;
     │        ^ Expected an identifier, a string literal, a number literal, a private field name, or a computed name here
```