### PR TITLE
chore(coverage): Infer should error for ts/babel tests

### DIFF
--- a/crates/rome_formatter/tests/specs/prettier/typescript/class/constructor.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/class/constructor.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 119
+assertion_line: 125
 expression: constructor.ts
 
 ---
@@ -75,6 +75,12 @@ error[SyntaxError]: class properties may not be called `constructor`
    │
 10 │     'constructor': typeof A
    │     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ constructor.ts:17:15
+   │
+17 │   constructor<>() {}
+   │               ^ Expected a type parameter here
 
 error[SyntaxError]: constructors cannot have type parameters
    ┌─ constructor.ts:17:14

--- a/crates/rome_formatter/tests/specs/prettier/typescript/comments/type-parameters.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/comments/type-parameters.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 125
 expression: type-parameters.ts
 
 ---
@@ -67,6 +67,65 @@ interface Foo {
 type T = <
   // comment
 >(arg) => any;
+
+```
+
+# Errors
+```
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ type-parameters.ts:2:25
+  │
+2 │ const a: T</* comment */> = 1;
+  │                         ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ type-parameters.ts:3:27
+  │
+3 │ functionName</* comment */>();
+  │                           ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ type-parameters.ts:4:27
+  │
+4 │ function foo</* comment */>() {}
+  │                           ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ type-parameters.ts:6:16
+  │
+6 │  </* comment */>(arg): any;
+  │                ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ type-parameters.ts:8:24
+  │
+8 │ type T = </* comment */>(arg) => any;
+  │                        ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ type-parameters.ts:15:1
+   │
+15 │ > = 1;
+   │ ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ type-parameters.ts:18:1
+   │
+18 │ >();
+   │ ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ type-parameters.ts:21:1
+   │
+21 │ >() {}
+   │ ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ type-parameters.ts:29:1
+   │
+29 │ >(arg) => any;
+   │ ^ Expected a type parameter here
+
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 119
+assertion_line: 125
 expression: generic.ts
 
 ---
@@ -52,11 +52,65 @@ class f7<> {
 
 # Errors
 ```
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ generic.ts:1:4
+  │
+1 │ f1<>();
+  │    ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ generic.ts:3:8
+  │
+3 │ new f2<>();
+  │        ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ generic.ts:5:13
+  │
+5 │ function f3<>() {}
+  │             ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+  ┌─ generic.ts:8:17
+  │
+8 │     constructor<>() {}
+  │                 ^ Expected a type parameter here
+
 error[SyntaxError]: constructors cannot have type parameters
   ┌─ generic.ts:8:16
   │
 8 │     constructor<>() {}
   │                ^^
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ generic.ts:11:21
+   │
+11 │ const f5 = function<>() {}
+   │                     ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ generic.ts:13:14
+   │
+13 │ interface f6<> {
+   │              ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ generic.ts:14:10
+   │
+14 │     test<>();
+   │          ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ generic.ts:17:10
+   │
+17 │ class f7<> {
+   │          ^ Expected a type parameter here
+
+error[SyntaxError]: expected a type parameter but instead found '>'
+   ┌─ generic.ts:18:10
+   │
+18 │     test<>() {}
+   │          ^ Expected a type parameter here
 
 
 ```

--- a/crates/rslint_parser/src/syntax/auxiliary.rs
+++ b/crates/rslint_parser/src/syntax/auxiliary.rs
@@ -45,15 +45,16 @@ pub(crate) fn is_nth_at_declaration_clause(p: &Parser, n: usize) -> bool {
         return true;
     }
 
-    if is_nth_at_contextual_keyword(p, n, "type") | is_nth_at_contextual_keyword(p, n, "interface")
+    if p.has_linebreak_before_n(n + 1) {
+        return false;
+    }
+
+    if is_nth_at_contextual_keyword(p, n, "type") || is_nth_at_contextual_keyword(p, n, "interface")
     {
         return true;
     }
 
-    if is_nth_at_contextual_keyword(p, n, "async")
-        && !p.has_linebreak_before_n(n + 1)
-        && p.nth_at(n + 1, T![function])
-    {
+    if is_nth_at_contextual_keyword(p, n, "async") && p.nth_at(n + 1, T![function]) {
         return true;
     }
 
@@ -61,10 +62,7 @@ pub(crate) fn is_nth_at_declaration_clause(p: &Parser, n: usize) -> bool {
         return true;
     }
 
-    if is_nth_at_contextual_keyword(p, n, "abstract")
-        && !p.has_linebreak_before_n(n + 1)
-        && p.nth_at(n + 1, T![class])
-    {
+    if is_nth_at_contextual_keyword(p, n, "abstract") && p.nth_at(n + 1, T![class]) {
         return true;
     }
 

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -95,7 +95,11 @@ pub(crate) fn parse_ts_type_parameters(p: &mut Parser) -> ParsedSyntax {
 
     let m = p.start();
     p.bump(T![<]);
-    TsTypeParameterList.parse_list(p);
+    if p.at(T![>]) {
+        p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
+    } else {
+        TsTypeParameterList.parse_list(p);
+    }
     p.expect(T![>]);
 
     Present(m.complete(p, TS_TYPE_PARAMETERS))
@@ -1237,7 +1241,12 @@ pub(crate) fn parse_ts_type_arguments_impl(
 ) -> CompletedMarker {
     let m = p.start();
     p.bump(T![<]);
-    TypeArgumentsList { recover_on_errors }.parse_list(p);
+
+    if p.at(T![>]) {
+        p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
+    } else {
+        TypeArgumentsList { recover_on_errors }.parse_list(p);
+    }
     p.expect(T![>]);
     m.complete(p, TS_TYPE_ARGUMENTS)
 }

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -97,9 +97,8 @@ pub(crate) fn parse_ts_type_parameters(p: &mut Parser) -> ParsedSyntax {
     p.bump(T![<]);
     if p.at(T![>]) {
         p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
-    } else {
-        TsTypeParameterList.parse_list(p);
     }
+    TsTypeParameterList.parse_list(p);
     p.expect(T![>]);
 
     Present(m.complete(p, TS_TYPE_PARAMETERS))
@@ -1244,9 +1243,8 @@ pub(crate) fn parse_ts_type_arguments_impl(
 
     if p.at(T![>]) {
         p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
-    } else {
-        TypeArgumentsList { recover_on_errors }.parse_list(p);
     }
+    TypeArgumentsList { recover_on_errors }.parse_list(p);
     p.expect(T![>]);
     m.complete(p, TS_TYPE_ARGUMENTS)
 }

--- a/crates/rslint_parser/test_data/inline/err/ts_export_type.rast
+++ b/crates/rslint_parser/test_data/inline/err/ts_export_type.rast
@@ -4,14 +4,15 @@ JsModule {
     items: JsModuleItemList [
         JsExport {
             export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
-            export_clause: TsTypeAliasDeclaration {
-                type_token: TYPE_KW@7..11 "type" [] [],
-                binding_identifier: missing (required),
-                type_parameters: missing (optional),
-                eq_token: missing (required),
-                ty: missing (required),
-                semicolon_token: missing (optional),
+            export_clause: missing (required),
+        },
+        JsExpressionStatement {
+            expression: JsIdentifierExpression {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@7..11 "type" [] [],
+                },
             },
+            semicolon_token: missing (optional),
         },
     ],
     eof_token: EOF@11..12 "" [Newline("\n")] [],
@@ -21,22 +22,21 @@ JsModule {
   0: (empty)
   1: JS_DIRECTIVE_LIST@0..0
   2: JS_MODULE_ITEM_LIST@0..11
-    0: JS_EXPORT@0..11
+    0: JS_EXPORT@0..7
       0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
-      1: TS_TYPE_ALIAS_DECLARATION@7..11
-        0: TYPE_KW@7..11 "type" [] []
-        1: (empty)
-        2: (empty)
-        3: (empty)
-        4: (empty)
-        5: (empty)
+      1: (empty)
+    1: JS_EXPRESSION_STATEMENT@7..11
+      0: JS_IDENTIFIER_EXPRESSION@7..11
+        0: JS_REFERENCE_IDENTIFIER@7..11
+          0: IDENT@7..11 "type" [] []
+      1: (empty)
   3: EOF@11..12 "" [Newline("\n")] []
 --
-error[SyntaxError]: expected an identifier but instead found ''
-  ┌─ ts_export_type.ts:2:1
+error[SyntaxError]: expected a class, a function, or a variable declaration but instead found 'type'
+  ┌─ ts_export_type.ts:1:8
   │
-2 │ 
-  │ ^ Expected an identifier here
+1 │ export type
+  │        ^^^^ Expected a class, a function, or a variable declaration here
 
 --
 export type

--- a/xtask/coverage/src/jsx/jsx_babel.rs
+++ b/xtask/coverage/src/jsx/jsx_babel.rs
@@ -6,7 +6,7 @@ use crate::{
     check_file_encoding,
     runner::{TestCase, TestCaseFiles, TestRunOutcome, TestSuite},
 };
-use std::path::PathBuf;
+use std::path::Path;
 
 const OK_PATH: &str = "xtask/coverage/babel/packages/babel-parser/test/fixtures/jsx/basic";
 
@@ -16,7 +16,7 @@ struct BabelJsxTestCase {
 }
 
 impl BabelJsxTestCase {
-    fn new(path: PathBuf, code: String) -> Self {
+    fn new(path: &Path, code: String) -> Self {
         let name = path
             .components()
             .rev()
@@ -83,6 +83,6 @@ impl TestSuite for BabelJsxTestSuite {
 
     fn load_test(&self, path: &std::path::Path) -> Option<Box<dyn crate::runner::TestCase>> {
         let code = check_file_encoding(path)?;
-        Some(Box::new(BabelJsxTestCase::new(path.to_path_buf(), code)))
+        Some(Box::new(BabelJsxTestCase::new(path, code)))
     }
 }


### PR DESCRIPTION

## Summary
Not all tests in the `typescript` directory are expected to pass. A test is expected to fail if the `options.json` has a `throws` property or the `output.json` contains any `SyntaxError`

This PR infers the expected outcome by matching the content of the `options.json` and `output.json` (parsing the JSON feels overkill).

There are still plenty of tests that should pass but fail. However, these tests do contain syntax errors. I'm not sure if it's worth keeping this test set (example; modifiers-override)

## Test Plan

Verified that some tests now reported "Incorrectly passed"
