### PR TITLE
feat(rslint_parser): eq2, eq3, neq and neq2 in is_before_expr

### DIFF
--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -324,3 +324,16 @@ pub fn node_contains_comments() {
 
     assert!(syntax.contains_comments());
 }
+
+#[test]
+fn parser_regexp_after_operator() {
+    fn assert_no_errors(src: &str) {
+        let module = parse(src, 0, SourceType::js_script());
+        assert_errors_are_absent(&module, Path::new("parser_regexp_after_operator"));
+    }
+    assert_no_errors(r#"a=/a/"#);
+    assert_no_errors(r#"a==/a/"#);
+    assert_no_errors(r#"a===/a/"#);
+    assert_no_errors(r#"a!=/a/"#);
+    assert_no_errors(r#"a!==/a/"#);
+}

--- a/crates/rslint_syntax/src/generated.rs
+++ b/crates/rslint_syntax/src/generated.rs
@@ -549,9 +549,8 @@ impl JsSyntaxKind {
             | MINUS2 | TILDE | CASE_KW | DEFAULT_KW | DO_KW | ELSE_KW | RETURN_KW | THROW_KW
             | NEW_KW | EXTENDS_KW | YIELD_KW | IN_KW | TYPEOF_KW | VOID_KW | DELETE_KW | PLUSEQ
             | INSTANCEOF_KW | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ
-            | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS | AWAIT_KW => {
-                true
-            }
+            | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | EQ2 | EQ3 | NEQ | NEQ2 | FAT_ARROW
+            | MINUS | PLUS | AWAIT_KW => true,
             _ => false,
         }
     }

--- a/xtask/codegen/src/generate_syntax_kinds.rs
+++ b/xtask/codegen/src/generate_syntax_kinds.rs
@@ -134,7 +134,7 @@ pub fn generate_syntax_kinds(grammar: KindsSrc) -> Result<String> {
                     | MINUS2 | TILDE | CASE_KW | DEFAULT_KW | DO_KW | ELSE_KW | RETURN_KW | THROW_KW
                     | NEW_KW | EXTENDS_KW | YIELD_KW | IN_KW | TYPEOF_KW | VOID_KW | DELETE_KW | PLUSEQ
                     | INSTANCEOF_KW | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ
-                    | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | FAT_ARROW | MINUS | PLUS | AWAIT_KW => true,
+                    | AMP2 | PIPE2 | SHLEQ | SHREQ | USHREQ | EQ | EQ2 | EQ3 | NEQ | NEQ2 | FAT_ARROW | MINUS | PLUS | AWAIT_KW => true,
                     _ => false,
                 }
             }


### PR DESCRIPTION
Currently we have a problem with RegExp. Sometimes we are not expecting them and endup parse regexp literals as multiple operators. For example:

```js
a=/a/
a==/a/
a===/a/
a!=/a/
a!==/a/
```

Although these expressions do not always make sense, we are totally getting lost:

```
error[SyntaxError]: Expected an expression for the right hand side of a `==`, but found an operator instead
  ┌─ parser_smoke_test:1:4
  │
1 │ a==/a/
  │  --^ But this operator was encountered instead
  │  │
  │  This operator requires a right hand side value

error[SyntaxError]: expected an expression but instead found ''
  ┌─ parser_smoke_test:1:7
  │
1 │ a==/a/
  │       ^ Expected an expression here
```

This PR solves this specifically for "==", "===", "!=" and "!==".


Another example is that this PR allows us to correctly parse [mathjs](https://cdn.jsdelivr.net/npm/mathjs/). Which today is failing with:

![image](https://user-images.githubusercontent.com/83425/156578916-a98c480a-1a82-4cdb-89d0-f31f31589d56.png)
