### PR TITLE
ci: change version name for pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Check prerelease status
         id: prerelease
         if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
-        run: echo "prerelease=true" >> $GITHUB_ENV
+        run: |
+          echo "prerelease=true" >> $GITHUB_ENV
+          echo "version=(date +"pre-release-%F")" >> $GITHUB_ENV
 
       - name: Check version status
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
         run: |
           echo "prerelease=true" >> $GITHUB_ENV
-          echo "version=(date +"pre-release-%F")" >> $GITHUB_ENV
+          echo "version=$(date +"pre-release-%F")" >> $GITHUB_ENV
 
       - name: Check version status
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

When releasing the VS Code extension in `nightly` mode, we change version/tag to: `pre-release-{YYYY}-{MM}-{DD}`, e.g: `pre-release-2022-03-04`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
