### PR TITLE
feat(rome_formatter): format simple expressions in templates

### DIFF
--- a/crates/rome_formatter/src/js/expressions/template_chunk_element.rs
+++ b/crates/rome_formatter/src/js/expressions/template_chunk_element.rs
@@ -1,8 +1,5 @@
-use crate::{
-    format_element::{normalize_newlines, Token},
-    FormatElement, FormatResult, Formatter, ToFormatElement,
-};
-
+use crate::utils::format_template_chunk;
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::JsTemplateChunkElement;
 use rslint_parser::ast::JsTemplateChunkElementFields;
 
@@ -12,15 +9,7 @@ impl ToFormatElement for JsTemplateChunkElement {
             template_chunk_token,
         } = self.as_fields();
 
-        // Per https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-static-semantics-trv:
-        // In template literals, the '\r' and '\r\n' line terminators are normalized to '\n'
         let chunk = template_chunk_token?;
-        formatter.format_replaced(
-            &chunk,
-            FormatElement::from(Token::new_dynamic(
-                normalize_newlines(chunk.text_trimmed(), ['\r']).into_owned(),
-                chunk.text_trimmed_range(),
-            )),
-        )
+        format_template_chunk(chunk, formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_formatter/src/js/expressions/template_element.rs
@@ -1,67 +1,9 @@
-use crate::formatter_traits::FormatTokenAndNode;
-use crate::utils::is_simple_function_expression;
-use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::ast::JsTemplateElementFields;
-use rslint_parser::ast::{JsAnyExpression, JsAnyFunction, JsAnyName, JsTemplateElement};
-use rslint_parser::{AstNode, SyntaxNode, SyntaxNodeExt};
+use crate::utils::{format_template_literal, TemplateElement};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rslint_parser::ast::JsTemplateElement;
 
 impl ToFormatElement for JsTemplateElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsTemplateElementFields {
-            dollar_curly_token,
-            expression,
-            r_curly_token,
-        } = self.as_fields();
-
-        let expression = expression?;
-        let r_curly_token = r_curly_token?;
-        let dollar_curly_token = dollar_curly_token?;
-        let has_comments = expression.syntax().contains_comments()
-            || r_curly_token.has_leading_comments()
-            || dollar_curly_token.has_trailing_comments();
-        let expression_is_simple = is_plain_expression(&expression)?;
-        let expression = expression.format(formatter)?;
-
-        if expression_is_simple && !has_comments {
-            Ok(format_elements![
-                dollar_curly_token.format(formatter)?,
-                expression,
-                r_curly_token.format(formatter)?
-            ])
-        } else {
-            formatter.format_delimited_soft_block_indent(
-                &dollar_curly_token,
-                expression,
-                &r_curly_token,
-            )
-        }
-    }
-}
-
-/// We want to break the template element only when we have articulated expressions inside it.
-///
-/// We a plain expression is when it's one of the following:
-/// - `loreum ${this.something} ipsum`
-/// - `loreum ${a.b.c} ipsum`
-/// - `loreum ${a} ipsum`
-fn is_plain_expression(current_expression: &JsAnyExpression) -> FormatResult<bool> {
-    match current_expression {
-        JsAnyExpression::JsStaticMemberExpression(_)
-        | JsAnyExpression::JsComputedMemberExpression(_)
-        | JsAnyExpression::JsIdentifierExpression(_)
-        | JsAnyExpression::JsAnyLiteralExpression(_)
-        | JsAnyExpression::JsCallExpression(_)
-        | JsAnyExpression::JsParenthesizedExpression(_) => Ok(true),
-        JsAnyExpression::JsFunctionExpression(function_expression) => {
-            Ok(is_simple_function_expression(
-                JsAnyFunction::JsFunctionExpression(function_expression.clone()),
-            )?)
-        }
-        JsAnyExpression::JsArrowFunctionExpression(function_expression) => {
-            Ok(is_simple_function_expression(
-                JsAnyFunction::JsArrowFunctionExpression(function_expression.clone()),
-            )?)
-        }
-        _ => Ok(false),
+        format_template_literal(TemplateElement::Js(self.clone()), formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/template_element.rs
+++ b/crates/rome_formatter/src/js/expressions/template_element.rs
@@ -1,7 +1,9 @@
 use crate::formatter_traits::FormatTokenAndNode;
+use crate::utils::is_simple_function_expression;
 use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
-use rslint_parser::ast::JsTemplateElement;
 use rslint_parser::ast::JsTemplateElementFields;
+use rslint_parser::ast::{JsAnyExpression, JsAnyFunction, JsAnyName, JsTemplateElement};
+use rslint_parser::{AstNode, SyntaxNode, SyntaxNodeExt};
 
 impl ToFormatElement for JsTemplateElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -11,9 +13,55 @@ impl ToFormatElement for JsTemplateElement {
             r_curly_token,
         } = self.as_fields();
 
-        let dollar_curly = dollar_curly_token.format(formatter)?;
+        let expression = expression?;
+        let r_curly_token = r_curly_token?;
+        let dollar_curly_token = dollar_curly_token?;
+        let has_comments = expression.syntax().contains_comments()
+            || r_curly_token.has_leading_comments()
+            || dollar_curly_token.has_trailing_comments();
+        let expression_is_simple = is_plain_expression(&expression)?;
         let expression = expression.format(formatter)?;
-        let r_curly = r_curly_token.format(formatter)?;
-        Ok(format_elements![dollar_curly, expression, r_curly])
+
+        if expression_is_simple && !has_comments {
+            Ok(format_elements![
+                dollar_curly_token.format(formatter)?,
+                expression,
+                r_curly_token.format(formatter)?
+            ])
+        } else {
+            formatter.format_delimited_soft_block_indent(
+                &dollar_curly_token,
+                expression,
+                &r_curly_token,
+            )
+        }
+    }
+}
+
+/// We want to break the template element only when we have articulated expressions inside it.
+///
+/// We a plain expression is when it's one of the following:
+/// - `loreum ${this.something} ipsum`
+/// - `loreum ${a.b.c} ipsum`
+/// - `loreum ${a} ipsum`
+fn is_plain_expression(current_expression: &JsAnyExpression) -> FormatResult<bool> {
+    match current_expression {
+        JsAnyExpression::JsStaticMemberExpression(_)
+        | JsAnyExpression::JsComputedMemberExpression(_)
+        | JsAnyExpression::JsIdentifierExpression(_)
+        | JsAnyExpression::JsAnyLiteralExpression(_)
+        | JsAnyExpression::JsCallExpression(_)
+        | JsAnyExpression::JsParenthesizedExpression(_) => Ok(true),
+        JsAnyExpression::JsFunctionExpression(function_expression) => {
+            Ok(is_simple_function_expression(
+                JsAnyFunction::JsFunctionExpression(function_expression.clone()),
+            )?)
+        }
+        JsAnyExpression::JsArrowFunctionExpression(function_expression) => {
+            Ok(is_simple_function_expression(
+                JsAnyFunction::JsArrowFunctionExpression(function_expression.clone()),
+            )?)
+        }
+        _ => Ok(false),
     }
 }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -605,7 +605,8 @@ mod test {
     #[ignore]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
-        let src = r#"somethingThatsAReallyLongPropName1 ? somethingThatsAReallyLongPropName2 ? somethingThatsAReallyLongPropName3 : somethingThatsAReallyLongPropName4 : somethingThatsAReallyLongPropName6
+        let src = r#"
+        `something ${ () => { var hey; const looooooooooong_expression = "loooooooooong_expression" }} something else ${ ehy }`;
 "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax);

--- a/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
+++ b/crates/rome_formatter/src/ts/expressions/template_chunk_element.rs
@@ -1,5 +1,5 @@
-use crate::format_element::normalize_newlines;
-use crate::{FormatElement, FormatResult, Formatter, ToFormatElement, Token};
+use crate::utils::format_template_chunk;
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::TsTemplateChunkElement;
 use rslint_parser::ast::TsTemplateChunkElementFields;
 
@@ -9,15 +9,7 @@ impl ToFormatElement for TsTemplateChunkElement {
             template_chunk_token,
         } = self.as_fields();
 
-        // Per https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-static-semantics-trv:
-        // In template literals, the '\r' and '\r\n' line terminators are normalized to '\n'
         let chunk = template_chunk_token?;
-        formatter.format_replaced(
-            &chunk,
-            FormatElement::from(Token::new_dynamic(
-                normalize_newlines(chunk.text_trimmed(), ['\r']).into_owned(),
-                chunk.text_trimmed_range(),
-            )),
-        )
+        format_template_chunk(chunk, formatter)
     }
 }

--- a/crates/rome_formatter/src/ts/expressions/template_element.rs
+++ b/crates/rome_formatter/src/ts/expressions/template_element.rs
@@ -1,20 +1,9 @@
-use crate::formatter_traits::FormatTokenAndNode;
-use crate::{format_elements, FormatElement, FormatResult, Formatter, ToFormatElement};
+use crate::utils::{format_template_literal, TemplateElement};
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rslint_parser::ast::TsTemplateElement;
-use rslint_parser::ast::TsTemplateElementFields;
 
 impl ToFormatElement for TsTemplateElement {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let TsTemplateElementFields {
-            dollar_curly_token,
-            ty,
-            r_curly_token,
-        } = self.as_fields();
-
-        Ok(format_elements![
-            dollar_curly_token.format(formatter)?,
-            ty.format(formatter)?,
-            r_curly_token.format(formatter)?,
-        ])
+        format_template_literal(TemplateElement::Ts(self.clone()), formatter)
     }
 }

--- a/crates/rome_formatter/src/utils/simple.rs
+++ b/crates/rome_formatter/src/utils/simple.rs
@@ -62,7 +62,7 @@ pub(crate) fn is_simple_expression(node: JsAnyExpression) -> SyntaxResult<bool> 
 
 /// Returns true if the passed [JsAnyFunction] does not have any comment, type
 /// parameters, return type annotation and simple parameters (see [is_simple_function_parameters])
-fn is_simple_function_expression(func: JsAnyFunction) -> SyntaxResult<bool> {
+pub(crate) fn is_simple_function_expression(func: JsAnyFunction) -> SyntaxResult<bool> {
     if let Some(token) = func.async_token() {
         if token_has_comments(token) {
             return Ok(false);

--- a/crates/rome_formatter/tests/specs/js/module/template/template.js
+++ b/crates/rome_formatter/tests/specs/js/module/template/template.js
@@ -16,3 +16,26 @@ output
   abcd ${ () => { var hey; const looooooooooong_expression = "loooooooooong_expression"; return hey; }}
 output
 `;
+
+// don't break
+const bar =`but where will ${this.fanta} wrap ${baz} ${"hello"} template literal? ${bar.ff.sss} long long long long ${foo.[3]} long long long long long long`;
+
+const foo = `but where will ${a && b && bar || c && d && g} wrap long long long long long long`;
+
+const foo = `but where will ${lorem && loremlorem && loremlorem || loremc && lorem && loremlorem} wrap long long long long long long`;
+
+const a = `
+let expression_is_simple = is_plain_expression(&expression)?;
+${loooooong || loooooong || loooooong || loooooong || loooooong || loooooong || loooooong || loooooong }       
+let expression_is_simple = is_plain_expression(&expression)?;
+`;
+
+const foo = `but where will ${
+    // with comment
+    this.fanta} wrap long long long long long long`;
+
+`<div>${this.set && this.set.artist
+    /* avoid console errors if `this.set` is undefined */}</div>`;
+
+`<div>${ /* avoid console errors if `this.set` is undefined */
+    this.set && this.set.artist}</div>`;

--- a/crates/rome_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/template/template.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 157
+assertion_line: 168
 expression: template.js
 
 ---
@@ -23,6 +23,29 @@ output
   abcd ${ () => { var hey; const looooooooooong_expression = "loooooooooong_expression"; return hey; }}
 output
 `;
+
+// don't break
+const bar =`but where will ${this.fanta} wrap ${baz} ${"hello"} template literal? ${bar.ff.sss} long long long long ${foo.[3]} long long long long long long`;
+
+const foo = `but where will ${a && b && bar || c && d && g} wrap long long long long long long`;
+
+const foo = `but where will ${lorem && loremlorem && loremlorem || loremc && lorem && loremlorem} wrap long long long long long long`;
+
+const a = `
+let expression_is_simple = is_plain_expression(&expression)?;
+${loooooong || loooooong || loooooong || loooooong || loooooong || loooooong || loooooong || loooooong }       
+let expression_is_simple = is_plain_expression(&expression)?;
+`;
+
+const foo = `but where will ${
+    // with comment
+    this.fanta} wrap long long long long long long`;
+
+`<div>${this.set && this.set.artist
+    /* avoid console errors if `this.set` is undefined */}</div>`;
+
+`<div>${ /* avoid console errors if `this.set` is undefined */
+    this.set && this.set.artist}</div>`;
 =============================
 # Outputs
 ## Output 1
@@ -57,4 +80,43 @@ output
 }}
 output
 `;
+
+// don't break
+const bar =`but where will ${this.fanta} wrap ${baz} ${"hello"} template literal? ${bar.ff.sss} long long long long ${foo.[3]} long long long long long long`;
+
+const foo = `but where will ${a && b && bar || c && d && g} wrap long long long long long long`;
+
+const foo = `but where will ${
+	lorem && loremlorem && loremlorem || loremc && lorem && loremlorem
+} wrap long long long long long long`;
+
+const a = `
+let expression_is_simple = is_plain_expression(&expression)?;
+${
+	loooooong ||
+		loooooong ||
+		loooooong ||
+		loooooong ||
+		loooooong ||
+		loooooong ||
+		loooooong ||
+		loooooong
+}       
+let expression_is_simple = is_plain_expression(&expression)?;
+`;
+
+const foo = `but where will ${
+	// with comment
+	this.fanta
+} wrap long long long long long long`;
+
+`<div>${
+	this.set && this.set.artist
+	/* avoid console errors if `this.set` is undefined */
+}</div>`;
+
+`<div>${
+	/* avoid console errors if `this.set` is undefined */
+	this.set && this.set.artist
+}</div>`;
 

--- a/crates/rome_formatter/tests/specs/prettier/js/comments/template-literal.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/comments/template-literal.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 125
 expression: template-literal.js
 
 ---
@@ -24,14 +24,19 @@ d //comment
 # Output
 ```js
 `
-${a}
+${
+  a // comment
+}
 
-${b}
+${b /* comment */ }
 
-${c}
+${ /* comment */ c /* comment */ }
 
-${d};
-`; // comment /* comment */ /* comment */ /* comment */ // comment //comment
+${
+  // comment
+  d //comment
+};
+`;
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/line-suffix-boundary/boundary.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/line-suffix-boundary/boundary.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 125
 expression: boundary.js
 
 ---
@@ -35,18 +35,28 @@ ExampleStory.getFragment('story')}
 
 # Output
 ```js
-`${a + a}
+`${
+  a + a // a
+}
 
-${a}
+${
+  a // comment
+}
 
-${b}
+${b /* comment */ }
 
-${c}
+${ /* comment */ c /* comment */ }
 
-${d}
+${
+  // comment
+  d //comment
+}
 
-${ExampleStory.getFragment("story")}
-`; // a // comment /* comment */ /* comment */ /* comment */ // comment //comment // $FlowFixMe found when converting React.createClass to ES6
+${
+  // $FlowFixMe found when converting React.createClass to ES6
+  ExampleStory.getFragment("story")
+}
+`;
 
 <div>
 {ExampleStory.getFragment('story') // $FlowFixMe found when converting React.createClass to ES6

--- a/crates/rome_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
@@ -75,46 +75,43 @@ expr1 = html`
 // #9274
 html`
   <div>
-    ${this.set && this.set.artist /* avoid console errors if `this.set` is undefined */ }
+    ${
+  this.set && this.set.artist
+  /* avoid console errors if `this.set` is undefined */
+}
   </div>
 `;
 
-html`${foo /* comment */
-}`;
+html`${foo /* comment */ }`;
 html`
-${foo /* comment */
-}
+${foo /* comment */ }
 `;
 
-graphql`${foo /* comment */
-}`;
+graphql`${foo /* comment */ }`;
 graphql`
-${foo /* comment */
-}
+${foo /* comment */ }
 `;
 
-css`${foo /* comment */
-}`;
+css`${foo /* comment */ }`;
 css`
-${foo /* comment */
-}
+${foo /* comment */ }
 `;
 
-markdown`${foo /* comment */
-}`;
+markdown`${foo /* comment */ }`;
 markdown`
-${foo /* comment */
-}
+${foo /* comment */ }
 `;
 
 // https://github.com/prettier/prettier/pull/9278#issuecomment-700589195
 expr1 =
   html`
   <div>
-    ${x(
-    foo, // fg
-    bar,
-  )}</div>
+    ${
+    x(
+      foo, // fg
+      bar,
+    )
+  }</div>
 `;
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/multiparser-css/issue-5697.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/multiparser-css/issue-5697.js.snap
@@ -34,14 +34,16 @@ const StyledH1 = styled.div`
   font-family: ${constants.text.displayFont.fontFamily};
   letter-spacing: ${(props) => (props.light ? "0.04em" : 0)};
   color: ${(props) => props.textColor};
-  ${(props) =>
-  props.center ? ` display: flex;
+  ${
+  (props) =>
+    props.center ? ` display: flex;
                 align-items: center;
                 justify-content: center;
-                text-align: center;` : ""}
-  @media (max-width: ${(props) => (
-  props.noBreakPoint ? "0" : constants.layout.breakpoint.break1
-)}px) {
+                text-align: center;` : ""
+}
+  @media (max-width: ${
+  (props) => (props.noBreakPoint ? "0" : constants.layout.breakpoint.break1)
+}px) {
     font-size: 2em;
   }
 `;

--- a/crates/rome_formatter/tests/specs/prettier/js/multiparser-css/styled-components.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/multiparser-css/styled-components.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 125
 expression: styled-components.js
 
 ---
@@ -470,10 +470,12 @@ const bar = styled.div`
   height: 40px;
   width: 40px;
 
-  ${(props) =>
-  (props.complete || props.inProgress) && css`
+  ${
+  (props) =>
+    (props.complete || props.inProgress) && css`
       border-color: rgba(var(--green-rgb), 0.15);
-    `}
+    `
+}
 
   div {
     background-color: var(--purpleTT);
@@ -482,36 +484,44 @@ const bar = styled.div`
     color: var(--purpleTT);
     display: inline-flex;
 
-    ${(props) =>
-  props.complete && css`
+    ${
+  (props) =>
+    props.complete && css`
         background-color: var(--green);
         border-width: 7px;
-      `}
+      `
+}
 
-    ${(props) =>
-  (props.complete || props.inProgress) && css`
+    ${
+  (props) =>
+    (props.complete || props.inProgress) && css`
         border-color: var(--green);
-      `}
+      `
+}
   }
 `;
 
 const A = styled.a`
   display: inline-block;
   color: #fff;
-  ${(props) =>
-  props.a && css`
+  ${
+  (props) =>
+    props.a && css`
     display: none;
-  `}
+  `
+}
    height: 30px;
 `;
 
 const Foo = styled.p`
   max-width: 980px;
-  ${mediaBreakpointOnlyXs`
+  ${
+  mediaBreakpointOnlyXs`
     && {
       font-size: 0.8rem;
     }
-  `}
+  `
+}
 
   &.bottom {
     margin-top: 3rem;

--- a/crates/rome_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
@@ -69,48 +69,13 @@ const Bar = styled.div`
 # Output
 ```js
 foo(
-  `a long string ${1 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3 +
-    2 +
-    3} with expr`,
+  `a long string ${
+    1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3
+  } with expr`,
 );
 
-const x = `a long string ${1 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  (function () {
-    return 3;
-  })() +
-  3 +
-  2 +
-  3 +
-  2 +
-  3} with expr`;
-
-foo(
-  `a long string ${1 +
+const x = `a long string ${
+  1 +
     2 +
     3 +
     2 +
@@ -123,15 +88,40 @@ foo(
     3 +
     2 +
     (function () {
-      const x = 5;
-
-      return x;
+      return 3;
     })() +
     3 +
     2 +
     3 +
     2 +
-    3} with expr`,
+    3
+} with expr`;
+
+foo(
+  `a long string ${
+    1 +
+      2 +
+      3 +
+      2 +
+      3 +
+      2 +
+      3 +
+      2 +
+      3 +
+      2 +
+      3 +
+      2 +
+      (function () {
+        const x = 5;
+
+        return x;
+      })() +
+      3 +
+      2 +
+      3 +
+      2 +
+      3
+  } with expr`,
 );
 
 pipe.write(
@@ -180,11 +170,13 @@ const makeBody = (store, assets, html) =>
 
 // https://github.com/prettier/prettier/issues/1626#issue-229655106
 const Bar = styled.div`
-  color: ${(props) => (
-  props.highlight.length > 0 ? palette(["text", "dark", "tertiary"])(props) : palette([
-    "text", "dark", "primary",
-  ])(props)
-)} !important;
+  color: ${
+  (props) => (
+    props.highlight.length > 0 ? palette(["text", "dark", "tertiary"])(props) : palette([
+      "text", "dark", "primary",
+    ])(props)
+  )
+} !important;
 `;
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/template-literals/conditional-expressions.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/template-literals/conditional-expressions.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 125
 expression: conditional-expressions.js
 
 ---
@@ -14,7 +14,9 @@ expression: conditional-expressions.js
 
 # Output
 ```js
-`111111111 222222222 333333333 444444444 555555555 666666666 777777777 ${1 ? 1 : 2}`;
+`111111111 222222222 333333333 444444444 555555555 666666666 777777777 ${
+  1 ? 1 : 2
+}`;
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 125
 expression: expressions.js
 
 ---
@@ -57,7 +57,9 @@ throw new Error(`pretty-format: Option "theme" has a key "${key}" whose value "$
 
 # Output
 ```js
-const long1 = `long ${a.b} long longlong ${a.b.c.d.e} long longlong ${a.b.c.d.e} long longlong ${a.b.c.d.e} long long`; //comment
+const long1 = `long ${
+  a.b //comment
+} long longlong ${a.b.c.d.e} long longlong ${a.b.c.d.e} long longlong ${a.b.c.d.e} long long`;
 const long2 = `long ${a.b.c.d.e} long longlong ${loooooooooooooooooong} long longlong ${loooooooooooooooooong} long longlong ${loooooooooooooooooong} long long`;
 
 const long3 = `long long long long long long long long long long long ${a.b.c.d.e} long long long long long long long long long long long long long`;
@@ -77,7 +79,9 @@ console.log(
 );
 
 x =
-  `mdl-textfield mdl-js-textfield ${className} ${content.length > 0 ? "is-dirty" : ""} combo-box__input`;
+  `mdl-textfield mdl-js-textfield ${className} ${
+    content.length > 0 ? "is-dirty" : ""
+  } combo-box__input`;
 
 function testing() {
   const p = {};

--- a/crates/rome_formatter/tests/specs/prettier/js/template/comment.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/template/comment.js.snap
@@ -24,13 +24,19 @@ g
 # Output
 ```js
 `
-(?:${escapeChar}[\\S\\s]|(?:(?!${ // Intentionally not passing `basicFlags` to `XRegExp.union` since any syntax // Using `XRegExp.union` safely rewrites backreferences in `left` and `right`.
-// transformation resulting from those flags was already applied to `left` and
-// `right` when they were passed through the XRegExp constructor above.
-XRegExp.union([left, right], "", { conjunction: "or" }).source})[^${escapeChar}])+)+
+(?:${escapeChar}[\\S\\s]|(?:(?!${
+  // Using `XRegExp.union` safely rewrites backreferences in `left` and `right`.
+  // Intentionally not passing `basicFlags` to `XRegExp.union` since any syntax
+  // transformation resulting from those flags was already applied to `left` and
+  // `right` when they were passed through the XRegExp constructor above.
+  XRegExp.union([left, right], "", { conjunction: "or" }).source
+})[^${escapeChar}])+)+
 `;
 
-`a${c}e${g // h /* b */ /* d */ // f
+`a${ /* b */ c /* d */ }e${
+  // f
+  g
+  // h
 }`;
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/template-literals/as-expression.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/template-literals/as-expression.ts.snap
@@ -17,12 +17,20 @@ const b = `${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVery
 # Output
 ```js
 const a = `${(foo + bar) as baz}`;
-const b = `${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz}`;
-const b = `${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz}`;
-const b = `${(foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}`;
-const b = `${(
-  veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
-) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}`;
+const b = `${
+  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz
+}`;
+const b = `${
+  (foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz
+}`;
+const b = `${
+  (foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}`;
+const b = `${
+  (
+    veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar
+  ) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}`;
 
 ```
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #2203 

I created a unified function to print both template literals and template literal types. 

There, I introduced the concept of "plain" expression. The main reason why I didn't include that check with `is_simple_expression` is because the checks needed template literals a different (even though some overlap, which is where I used a `simple::` function.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
