### PR TITLE
refactor: Streamline `Parser` API and use `TextSize/Range`

### DIFF
--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -30,18 +30,18 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum TriviaPiece {
-    Newline(u32),        // length
-    Whitespace(u32),     // length
-    Comments(u32, bool), // length, has_newline
+    Newline(TextSize),        // length
+    Whitespace(TextSize),     // length
+    Comments(TextSize, bool), // length, has_newline
 }
 
 impl TriviaPiece {
     #[inline]
     pub fn text_len(&self) -> TextSize {
         match self {
-            TriviaPiece::Newline(n) => (*n).into(),
-            TriviaPiece::Whitespace(n) => (*n).into(),
-            TriviaPiece::Comments(n, _) => (*n).into(),
+            TriviaPiece::Newline(n) => *n,
+            TriviaPiece::Whitespace(n) => *n,
+            TriviaPiece::Comments(n, _) => *n,
         }
     }
 }
@@ -136,8 +136,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -162,8 +162,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -184,8 +184,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -205,7 +205,7 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t/**/let",
-    ///         &[TriviaPiece::Newline(1), TriviaPiece::Whitespace(1), TriviaPiece::Comments(4, false)],
+    ///         &[TriviaPiece::Newline(TextSize::from(1)), TriviaPiece::Whitespace(TextSize::from(1)), TriviaPiece::Comments(TextSize::from(4), false)],
     ///         &[],
     ///     );
     /// });
@@ -226,7 +226,7 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t/**/let",
-    ///         &[TriviaPiece::Newline(1), TriviaPiece::Whitespace(1), TriviaPiece::Comments(4, false)],
+    ///         &[TriviaPiece::Newline(TextSize::from(1)), TriviaPiece::Whitespace(TextSize::from(1)), TriviaPiece::Comments(TextSize::from(4), false)],
     ///         &[],
     ///     );
     /// });
@@ -247,7 +247,7 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t/**/let",
-    ///         &[TriviaPiece::Newline(1), TriviaPiece::Whitespace(1), TriviaPiece::Comments(4, false)],
+    ///         &[TriviaPiece::Newline(TextSize::from(1)), TriviaPiece::Whitespace(TextSize::from(1)), TriviaPiece::Comments(TextSize::from(4), false)],
     ///         &[],
     ///     );
     /// });
@@ -268,8 +268,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n/**/let \t\t",
-    ///         &[TriviaPiece::Newline(1), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Newline(3)],
+    ///         &[TriviaPiece::Newline(TextSize::from(1)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Newline(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -295,8 +295,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(2), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(2)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -322,8 +322,8 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t /**/let \t\t",
-    ///         &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -525,8 +525,8 @@ impl<L: Language> SyntaxTrivia<L> {
     /// builder.token_with_trivia(
     ///     RawLanguageKind::LET_TOKEN,
     ///     "\n\t /**/let \t\t",
-    ///     &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-    ///     &[TriviaPiece::Whitespace(3)],
+    ///     &[TriviaPiece::Whitespace(TextSize::from(3)), TriviaPiece::Comments(TextSize::from(4), false)],
+    ///     &[TriviaPiece::Whitespace(TextSize::from(3))],
     /// );
     /// });
     /// let pieces: Vec<_> = node.first_leading_trivia().unwrap().pieces().collect();
@@ -576,15 +576,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// assert_eq!("\n\t let \t\ta; \t\t", node.text());
@@ -604,15 +604,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
     ///         &[],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// assert_eq!("let \t\ta;", node.text_trimmed());
@@ -630,15 +630,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
     ///         &[],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let range = node.text_range();
@@ -660,15 +660,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
     ///         &[],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let range = node.text_trimmed_range();
@@ -688,15 +688,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
     ///         &[],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let trivia = node.first_leading_trivia();
@@ -723,15 +723,15 @@ impl<L: Language> SyntaxNode<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     ///     builder.token(RawLanguageKind::STRING_TOKEN, "a");
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::SEMICOLON_TOKEN,
     ///         "; \t\t",
     ///         &[],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// });
     /// let trivia = node.last_trailing_trivia();
@@ -940,8 +940,8 @@ impl<L: Language> SyntaxToken<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// }).first_token().unwrap();
     /// assert_eq!("\n\t let \t\t", token.text());
@@ -959,8 +959,8 @@ impl<L: Language> SyntaxToken<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// }).first_token().unwrap();
     /// assert_eq!("let", token.text_trimmed());
@@ -1015,8 +1015,8 @@ impl<L: Language> SyntaxToken<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// }).first_token().unwrap();
     /// assert_eq!("\n\t ", token.leading_trivia().text());
@@ -1038,8 +1038,8 @@ impl<L: Language> SyntaxToken<L> {
     ///     builder.token_with_trivia(
     ///         RawLanguageKind::LET_TOKEN,
     ///         "\n\t let \t\t",
-    ///         &[TriviaPiece::Whitespace(3)],
-    ///         &[TriviaPiece::Whitespace(3)],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
+    ///         &[TriviaPiece::Whitespace(TextSize::from(3))],
     ///     );
     /// }).first_token().unwrap();
     /// assert_eq!(" \t\t", token.trailing_trivia().text());
@@ -1411,7 +1411,7 @@ impl<L: Language> IntoIterator for SyntaxList<L> {
 
 #[cfg(test)]
 mod tests {
-    use text_size::TextRange;
+    use text_size::{TextRange, TextSize};
 
     use crate::api::TriviaPiece;
     use crate::raw_language::{RawLanguageKind, RawSyntaxTreeBuilder};
@@ -1645,8 +1645,8 @@ mod tests {
         builder.token_with_trivia(
             RawLanguageKind::LET_TOKEN,
             "\n\t let \t\t",
-            &[TriviaPiece::Whitespace(3)],
-            &[TriviaPiece::Whitespace(3)],
+            &[TriviaPiece::Whitespace(TextSize::from(3))],
+            &[TriviaPiece::Whitespace(TextSize::from(3))],
         );
         builder.finish_node();
 
@@ -1674,27 +1674,27 @@ mod tests {
         builder.token_with_trivia(
             RawLanguageKind::LET_TOKEN,
             "\n\t let \t\t",
-            &[TriviaPiece::Whitespace(3)],
-            &[TriviaPiece::Whitespace(3)],
+            &[TriviaPiece::Whitespace(TextSize::from(3))],
+            &[TriviaPiece::Whitespace(TextSize::from(3))],
         );
         builder.token_with_trivia(
             RawLanguageKind::LET_TOKEN,
             "a ",
-            &[TriviaPiece::Whitespace(0)],
-            &[TriviaPiece::Whitespace(1)],
+            &[TriviaPiece::Whitespace(TextSize::from(0))],
+            &[TriviaPiece::Whitespace(TextSize::from(1))],
         );
         builder.token_with_trivia(
             RawLanguageKind::EQUAL_TOKEN,
             "\n=\n",
-            &[TriviaPiece::Whitespace(1)],
-            &[TriviaPiece::Whitespace(1)],
+            &[TriviaPiece::Whitespace(TextSize::from(1))],
+            &[TriviaPiece::Whitespace(TextSize::from(1))],
         );
         builder.token(RawLanguageKind::NUMBER_TOKEN, "1");
         builder.token_with_trivia(
             RawLanguageKind::SEMICOLON_TOKEN,
             ";\t\t",
             &[],
-            &[TriviaPiece::Whitespace(2)],
+            &[TriviaPiece::Whitespace(TextSize::from(2))],
         );
         builder.finish_node();
 
@@ -1762,8 +1762,11 @@ mod tests {
             builder.token_with_trivia(
                 RawLanguageKind::LET_TOKEN,
                 "\n\t /**/let \t\t",
-                &[TriviaPiece::Whitespace(3), TriviaPiece::Comments(4, false)],
-                &[TriviaPiece::Whitespace(3)],
+                &[
+                    TriviaPiece::Whitespace(TextSize::from(3)),
+                    TriviaPiece::Comments(TextSize::from(4), false),
+                ],
+                &[TriviaPiece::Whitespace(TextSize::from(3))],
             );
         });
 

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -243,33 +243,41 @@ impl<'a> VacantNodeEntry<'a> {
     }
 }
 
-#[test]
-fn green_token_hash() {
-    let kind = RawSyntaxKind(0);
-    let text = " let ";
-    let t1 = GreenToken::with_trivia(
-        kind,
-        text,
-        GreenTokenTrivia::Whitespace(1),
-        GreenTokenTrivia::Whitespace(1),
-    );
-    let t2 = GreenToken::with_trivia(
-        kind,
-        text,
-        GreenTokenTrivia::Whitespace(1),
-        GreenTokenTrivia::Whitespace(1),
-    );
+#[cfg(test)]
+mod tests {
+    use crate::green::node_cache::token_hash;
+    use crate::green::token::GreenTokenTrivia;
+    use crate::{GreenToken, RawSyntaxKind};
+    use text_size::TextSize;
 
-    assert_eq!(token_hash(&t1), token_hash(&t2));
+    #[test]
+    fn green_token_hash() {
+        let kind = RawSyntaxKind(0);
+        let text = " let ";
+        let t1 = GreenToken::with_trivia(
+            kind,
+            text,
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+        );
+        let t2 = GreenToken::with_trivia(
+            kind,
+            text,
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+        );
 
-    let t3 = GreenToken::new(kind, "let");
-    assert_ne!(token_hash(&t1), token_hash(&t3));
+        assert_eq!(token_hash(&t1), token_hash(&t2));
 
-    let t4 = GreenToken::with_trivia(
-        kind,
-        "\tlet ",
-        GreenTokenTrivia::Whitespace(1),
-        GreenTokenTrivia::Whitespace(1),
-    );
-    assert_ne!(token_hash(&t1), token_hash(&t4));
+        let t3 = GreenToken::new(kind, "let");
+        assert_ne!(token_hash(&t1), token_hash(&t3));
+
+        let t4 = GreenToken::with_trivia(
+            kind,
+            "\tlet ",
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+        );
+        assert_ne!(token_hash(&t1), token_hash(&t4));
+    }
 }

--- a/crates/rslint_lexer/src/highlight.rs
+++ b/crates/rslint_lexer/src/highlight.rs
@@ -64,8 +64,11 @@ impl<'s> Highlighter<'s> {
     }
 
     fn src(&self) -> &'s str {
-        let end = self.cur_idx + self.tokens.get(self.cur).unwrap().len as usize;
-        &self.source[self.cur_idx..end]
+        let range = TextRange::at(
+            TextSize::from(self.cur_idx as u32),
+            self.tokens.get(self.cur).unwrap().len,
+        );
+        &self.source[range]
     }
 }
 
@@ -134,7 +137,8 @@ impl<'s> Iterator for Highlighter<'s> {
         };
 
         let string = self.src();
-        self.cur_idx += self.tokens.get(self.cur).unwrap().len as usize;
+        let token_len: usize = self.tokens.get(self.cur).unwrap().len.into();
+        self.cur_idx += token_len;
         self.cur += 1;
         Some(color.paint(string))
     }

--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -1570,7 +1570,7 @@ impl<'src> Lexer<'src> {
             Some(token) => match diagnostic {
                 None => (token, None),
                 Some(diagnostic) => (
-                    Token::new(JsSyntaxKind::ERROR_TOKEN, token.len as usize),
+                    Token::new(JsSyntaxKind::ERROR_TOKEN, token.len.into()),
                     Some(diagnostic),
                 ),
             },
@@ -1591,7 +1591,7 @@ impl Iterator for Lexer<'_> {
             if !self.returned_eof {
                 self.returned_eof = true;
                 let mut token = tok!(EOF, 0);
-                token.0.offset = self.cur as u32;
+                token.0.offset = TextSize::from(self.cur as u32);
                 token.0.after_newline = self.state.after_newline;
                 return Some(token);
             }
@@ -1611,7 +1611,7 @@ impl Iterator for Lexer<'_> {
             _ => false,
         };
 
-        token.0.offset = self.cur as u32 - token.0.len;
+        token.0.offset = TextSize::from(self.cur as u32) - token.0.len;
         token.0.after_newline = std::mem::replace(&mut self.state.after_newline, after_newline);
 
         if !matches!(

--- a/crates/rslint_lexer/src/token.rs
+++ b/crates/rslint_lexer/src/token.rs
@@ -1,6 +1,7 @@
 //! Token definitions for the lexer
 
-use crate::JsSyntaxKind;
+use crate::{JsSyntaxKind, TextSize};
+use rome_js_syntax::TextRange;
 
 /// A single raw token such as `>>` or `||` or `"abc"`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -10,10 +11,10 @@ pub struct Token {
     /// Indicates if there is a newline between this token and the previous non-trivia token.
     pub after_newline: bool,
     /// Offset from the start of the file, in bytes.
-    pub offset: u32,
+    pub offset: TextSize,
     /// How long the token is in bytes. For tokens with escape sequences
     /// like strings with `\uXXXX` escapes, the length is the raw length, not considering the char backed by the escape.
-    pub len: u32,
+    pub len: TextSize,
 }
 
 impl Token {
@@ -21,8 +22,8 @@ impl Token {
     pub fn single(kind: JsSyntaxKind, offset: usize) -> Self {
         Self {
             kind,
-            len: 1,
-            offset: offset as u32,
+            len: TextSize::from(1),
+            offset: TextSize::from(offset as u32),
             after_newline: false,
         }
     }
@@ -31,29 +32,28 @@ impl Token {
     pub fn new(kind: JsSyntaxKind, len: usize) -> Self {
         Self {
             kind,
-            len: len as u32,
-            offset: 0,
+            len: TextSize::from(len as u32),
+            offset: TextSize::from(0),
             after_newline: false,
         }
     }
 
     /// Range from the start of the file, in bytes.
     #[inline(always)]
-    pub fn range(&self) -> std::ops::Range<usize> {
-        let end = self.offset as usize + self.len as usize;
-        (self.offset as usize)..end
+    pub fn range(&self) -> TextRange {
+        TextRange::at(self.offset, self.len)
     }
 
     /// Same as [Token::range()].start.
     #[inline(always)]
-    pub fn start(&self) -> usize {
-        self.offset as usize
+    pub fn start(&self) -> TextSize {
+        self.offset
     }
 
     /// Same as [Token::range()].end.
     #[inline(always)]
-    pub fn end(&self) -> usize {
-        self.offset as usize + self.len as usize
+    pub fn end(&self) -> TextSize {
+        self.offset + self.len
     }
 }
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -89,16 +89,14 @@ impl<'a> LosslessTreeSink<'a> {
         self.trivia.clear();
         let (leading_range, leading_end) = self.get_trivia(false);
 
-        let len = TextSize::from(
-            (if token_count == 1 {
-                self.tokens[self.token_pos].len
-            } else {
-                self.tokens[self.token_pos..self.token_pos + token_count as usize]
-                    .iter()
-                    .map(|x| x.len)
-                    .sum()
-            }) as u32,
-        );
+        let len = if token_count == 1 {
+            self.tokens[self.token_pos].len
+        } else {
+            self.tokens[self.token_pos..self.token_pos + token_count as usize]
+                .iter()
+                .map(|x| x.len)
+                .sum()
+        };
 
         let token_range = TextRange::at(self.text_pos, len);
 
@@ -134,9 +132,8 @@ impl<'a> LosslessTreeSink<'a> {
             }
 
             self.token_pos += 1;
-            let len = TextSize::from(token.len as u32);
-            self.text_pos += len;
-            length += len;
+            self.text_pos += token.len;
+            length += token.len;
 
             let current_trivia = match token.kind {
                 NEWLINE => TriviaPiece::Newline(token.len),

--- a/crates/rslint_parser/src/state.rs
+++ b/crates/rslint_parser/src/state.rs
@@ -1,6 +1,7 @@
 use crate::{Language, Parser, SourceType};
 use bitflags::bitflags;
 use indexmap::IndexMap;
+use rome_rowan::TextRange;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut, Range};
 
@@ -8,12 +9,12 @@ type LabelSet = IndexMap<String, LabelledItem>;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum LabelledItem {
-    Iteration(Range<usize>),
-    Other(Range<usize>),
+    Iteration(TextRange),
+    Other(TextRange),
 }
 
 impl LabelledItem {
-    pub(crate) fn range(&self) -> &Range<usize> {
+    pub(crate) fn range(&self) -> &TextRange {
         match self {
             LabelledItem::Iteration(range) | LabelledItem::Other(range) => range,
         }
@@ -90,8 +91,8 @@ pub(crate) struct ParserState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StrictMode {
     Module,
-    Explicit(Range<usize>),
-    Class(Range<usize>),
+    Explicit(TextRange),
+    Class(TextRange),
 }
 
 impl ParserState {

--- a/crates/rslint_parser/src/syntax/assignment.rs
+++ b/crates/rslint_parser/src/syntax/assignment.rs
@@ -13,8 +13,7 @@ use crate::syntax::pattern::{ParseArrayPattern, ParseObjectPattern, ParseWithDef
 use crate::ParsedSyntax::{Absent, Present};
 use crate::{Checkpoint, CompletedMarker, Marker, Parser};
 use rome_js_syntax::{JsSyntaxKind::*, *};
-use rslint_errors::{Diagnostic, Span};
-use std::ops::Range;
+use rslint_errors::Diagnostic;
 
 // test assignment_target
 // foo += bar = b ??= 3;
@@ -150,7 +149,7 @@ impl ParseWithDefaultPattern for AssignmentPatternWithDefault {
     }
 
     #[inline]
-    fn expected_pattern_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_pattern_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_assignment_target(p, range)
     }
 
@@ -208,7 +207,7 @@ impl ParseArrayPattern<AssignmentPatternWithDefault> for ArrayAssignmentPattern 
     }
 
     #[inline]
-    fn expected_element_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_element_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_any(&["assignment target", "rest element", "comma"], range).to_diagnostic(p)
     }
 
@@ -240,7 +239,7 @@ impl ParseObjectPattern for ObjectAssignmentPattern {
     }
 
     #[inline]
-    fn expected_property_pattern_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_property_pattern_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_any(&["assignment target", "rest property"], range).to_diagnostic(p)
     }
 
@@ -440,7 +439,7 @@ impl RewriteParseEvents for ReparseAssignment {
             let completed = m.complete(p, kind);
 
             if kind == JS_UNKNOWN_ASSIGNMENT {
-                p.error(invalid_assignment_error(p, completed.range(p).as_range()));
+                p.error(invalid_assignment_error(p, completed.range(p)));
             }
             self.result = Some(completed);
         }
@@ -484,7 +483,7 @@ impl RewriteParseEvents for ReparseAssignment {
                         "Illegal use of `{}` as an identifier in strict mode",
                         src
                     ))
-                    .primary(p.cur_tok().range(), ""),
+                    .primary(p.cur_range(), ""),
                 );
             }
         }
@@ -503,7 +502,7 @@ fn wrap_expression_in_invalid_assignment(p: &mut Parser, expression_end: usize) 
 
     let completed = unknown.complete(p, JS_UNKNOWN_ASSIGNMENT);
 
-    p.error(invalid_assignment_error(p, completed.range(p).as_range()));
+    p.error(invalid_assignment_error(p, completed.range(p)));
 
     completed
 }

--- a/crates/rslint_parser/src/syntax/auxiliary.rs
+++ b/crates/rslint_parser/src/syntax/auxiliary.rs
@@ -12,6 +12,7 @@ use crate::syntax::typescript::{
 use crate::{Absent, ParsedSyntax, Parser};
 use rome_js_syntax::JsSyntaxKind::JS_VARIABLE_DECLARATION_CLAUSE;
 use rome_js_syntax::T;
+use rome_rowan::{TextRange, TextSize};
 
 // test export_variable_clause
 // export let a;
@@ -23,11 +24,11 @@ use rome_js_syntax::T;
 // export const b;
 // export let d, c;
 pub(crate) fn parse_variable_declaration_clause(p: &mut Parser) -> ParsedSyntax {
-    let start = p.cur_tok().start();
+    let start = p.cur_range().start();
 
     parse_variable_declaration(p, VariableDeclarationParent::Clause).map(|declaration| {
         let m = declaration.precede(p);
-        semi(p, start..p.cur_tok().end());
+        semi(p, TextRange::new(start, p.cur_range().end()));
         m.complete(p, JS_VARIABLE_DECLARATION_CLAUSE)
     })
 }
@@ -67,7 +68,7 @@ pub(crate) fn is_nth_at_declaration_clause(p: &Parser, n: usize) -> bool {
     false
 }
 
-pub(crate) fn parse_declaration_clause(p: &mut Parser, stmt_start_pos: usize) -> ParsedSyntax {
+pub(crate) fn parse_declaration_clause(p: &mut Parser, stmt_start_pos: TextSize) -> ParsedSyntax {
     match p.cur() {
         T![function] => parse_function_declaration(p, StatementContext::StatementList),
         T![class] => parse_class_declaration(p, StatementContext::StatementList),

--- a/crates/rslint_parser/src/syntax/binding.rs
+++ b/crates/rslint_parser/src/syntax/binding.rs
@@ -12,7 +12,6 @@ use crate::{ParsedSyntax, Parser, SyntaxFeature};
 use rome_js_syntax::{JsSyntaxKind::*, *};
 use rome_rowan::SyntaxKind as SyntaxKindTrait;
 use rslint_errors::{Diagnostic, Span};
-use std::ops::Range;
 
 pub(crate) fn parse_binding_pattern(p: &mut Parser, context: ExpressionContext) -> ParsedSyntax {
     match p.cur() {
@@ -138,7 +137,7 @@ impl ParseWithDefaultPattern for BindingPatternWithDefault {
     }
 
     #[inline]
-    fn expected_pattern_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_pattern_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_binding(p, range)
     }
 
@@ -194,7 +193,7 @@ impl ParseArrayPattern<BindingPatternWithDefault> for ArrayBindingPattern {
     }
 
     #[inline]
-    fn expected_element_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_element_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_any(
             &[
                 "identifier",
@@ -236,7 +235,7 @@ impl ParseObjectPattern for ObjectBindingPattern {
     }
 
     #[inline]
-    fn expected_property_pattern_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+    fn expected_property_pattern_error(p: &Parser, range: TextRange) -> Diagnostic {
         expected_any(&["identifier", "member name", "rest pattern"], range).to_diagnostic(p)
     }
 

--- a/crates/rslint_parser/src/syntax/js_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/js_parse_error.rs
@@ -2,15 +2,14 @@ use crate::parser::{expected_any, expected_node, ToDiagnostic};
 use crate::Parser;
 use rome_js_syntax::TextRange;
 use rslint_errors::{Diagnostic, Span};
-use std::ops::Range;
 
 ///! Provides factory function to create common diagnostics for the JavaScript syntax
 
-pub(crate) fn expected_function_body(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_function_body(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("function body", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_class_member_name(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_class_member_name(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(
         &[
             "identifier",
@@ -24,11 +23,11 @@ pub(crate) fn expected_class_member_name(p: &Parser, range: Range<usize>) -> Dia
     .to_diagnostic(p)
 }
 
-pub(crate) fn expected_arrow_body(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_arrow_body(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["function body", "expression"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_object_member(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_object_member(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(
         &[
             "property",
@@ -41,11 +40,11 @@ pub(crate) fn expected_object_member(p: &Parser, range: Range<usize>) -> Diagnos
     )
     .to_diagnostic(p)
 }
-pub(crate) fn expected_array_element(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_array_element(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["property", "expression", "method"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_object_member_name(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_object_member_name(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(
         &[
             "identifier",
@@ -58,118 +57,118 @@ pub(crate) fn expected_object_member_name(p: &Parser, range: Range<usize>) -> Di
     .to_diagnostic(p)
 }
 
-pub(crate) fn expected_block_statement(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_block_statement(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("block statement", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_catch_clause(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_catch_clause(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("catch clause", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_parameter(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_parameter(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("parameter", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_parameters(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_parameters(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("parenthesis '('", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_case_or_default(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_case_or_default(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["default", "case"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_case(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_case(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("case", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_assignment_target(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_assignment_target(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["identifier", "assignment target"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_simple_assignment_target(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_simple_assignment_target(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["identifier", "member expression"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_identifier(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_identifier(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("identifier", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_statement(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_statement(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("statement", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_binding(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_binding(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["identifier", "array pattern", "object pattern"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_class_member(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_class_member(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["property ", "method", "getter", "setter"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_class_parameters(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_class_parameters(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("class parameters", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_constructor_parameters(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_constructor_parameters(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("constructor parameters", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_class_method_body(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_class_method_body(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("class method body", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_module_source(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_module_source(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("string literal", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_named_import(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_named_import(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["namespace import", "named imports"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_literal_export_name(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_literal_export_name(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["string literal", "identifier"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_export_clause(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_export_clause(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["class", "function", "variable declaration"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_export_name_specifier(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_export_name_specifier(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("export name", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_named_import_specifier(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_named_import_specifier(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("identifier", range).to_diagnostic(p)
 }
 
 pub(crate) fn duplicate_assertion_keys_error(
     p: &Parser,
     key: &str,
-    first_use: Range<usize>,
-    duplicate_range: Range<usize>,
+    first_use: TextRange,
+    duplicate_range: TextRange,
 ) -> Diagnostic {
     p.err_builder("Duplicate assertion keys are not allowed")
         .primary(&first_use, &format!("First use of the key `{}`", key))
         .secondary(duplicate_range, "second use here")
 }
 
-pub(crate) fn expected_expression(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_expression(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("expression", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_expression_assignment(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_expression_assignment(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["expression", "assignment"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_unary_expression(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_unary_expression(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("unary expression", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_property_or_signature(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_property_or_signature(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["property", "signature"], range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_declaration(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_declaration(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(
         &[
             "function",
@@ -184,23 +183,20 @@ pub(crate) fn expected_declaration(p: &Parser, range: Range<usize>) -> Diagnosti
     .to_diagnostic(p)
 }
 
-pub(crate) fn unexpected_body_inside_ambient_context(
-    p: &Parser,
-    range: Range<usize>,
-) -> Diagnostic {
+pub(crate) fn unexpected_body_inside_ambient_context(p: &Parser, range: TextRange) -> Diagnostic {
     p.err_builder("members inside ambient contexts should not have a body")
         .primary(range, "")
 }
 
 pub(crate) fn private_names_only_allowed_on_left_side_of_in_expression(
     p: &Parser,
-    private_name_range: Range<usize>,
+    private_name_range: TextRange,
 ) -> Diagnostic {
     p.err_builder("Private names are only allowed on the left side of a 'in' expression")
         .primary(private_name_range, "")
 }
 
-pub(crate) fn invalid_assignment_error(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn invalid_assignment_error(p: &Parser, range: TextRange) -> Diagnostic {
     p.err_builder(&format!(
         "Invalid assignment to `{}`",
         p.source(range.as_text_range())
@@ -213,7 +209,7 @@ pub(crate) fn modifier_already_seen(
     second_range: TextRange,
     first_range: TextRange,
 ) -> Diagnostic {
-    let modifier = p.span_text(second_range);
+    let modifier = p.source(second_range);
     p.err_builder(&format!("'{modifier}' already seen"))
         .primary(second_range, "duplicate modifier")
         .secondary(first_range, "first seen here")
@@ -224,8 +220,8 @@ pub(crate) fn modifier_cannot_be_used_with_modifier(
     range: TextRange,
     other_modifier_range: TextRange,
 ) -> Diagnostic {
-    let modifier = p.span_text(range);
-    let other_modifier = p.span_text(other_modifier_range);
+    let modifier = p.source(range);
+    let other_modifier = p.source(other_modifier_range);
 
     p.err_builder(&format!(
         "'{modifier}' cannot be used with '{other_modifier}' modifier."
@@ -242,8 +238,8 @@ pub(crate) fn modifier_must_precede_modifier(
     range: TextRange,
     to_precede_modifier_range: TextRange,
 ) -> Diagnostic {
-    let modifier_name = p.span_text(range);
-    let to_precede_name = p.span_text(to_precede_modifier_range);
+    let modifier_name = p.source(range);
+    let to_precede_name = p.source(to_precede_modifier_range);
 
     p.err_builder(&format!(
         "'{modifier_name}' must precede '{to_precede_name}'"

--- a/crates/rslint_parser/src/syntax/module.rs
+++ b/crates/rslint_parser/src/syntax/module.rs
@@ -27,10 +27,9 @@ use crate::{
     Present, SyntaxFeature,
 };
 use rome_js_syntax::JsSyntaxKind::*;
-use rome_js_syntax::{JsSyntaxKind, T};
-use rslint_errors::Span;
+use rome_js_syntax::{JsSyntaxKind, TextRange, T};
+use rslint_lexer::TextSize;
 use std::collections::HashMap;
-use std::ops::Range;
 
 use super::auxiliary::{is_nth_at_declaration_clause, parse_declaration_clause};
 
@@ -122,7 +121,7 @@ pub(crate) fn parse_import_or_import_equals_declaration(p: &mut Parser) -> Parse
         return Absent;
     }
 
-    let start = p.cur_tok().start();
+    let start = p.cur_range().start();
     let import = p.start();
     p.expect_keyword(T![import], "import");
 
@@ -154,9 +153,9 @@ pub(crate) fn parse_import_or_import_equals_declaration(p: &mut Parser) -> Parse
             .to_diagnostic(p)
         });
 
-        let end = p.cur_tok().start();
+        let end = p.cur_range().start();
 
-        semi(p, start..end);
+        semi(p, TextRange::new(start, end));
         Present(import.complete(p, JS_IMPORT))
     };
 
@@ -237,12 +236,12 @@ fn parse_import_default_or_named_clause_rest(
                     .tokens
                     .last_tok()
                     .map(|t| t.end())
-                    .unwrap_or_else(|| p.cur_tok().start());
+                    .unwrap_or_else(|| p.cur_range().start());
 
                 // test_err ts ts_typed_default_import_with_named
                 // import type A, { B, C } from './a';
                 p.error(p.err_builder("A type-only import can specify a default import or named bindings, but not both.")
-                    .primary(default_start.into()..end, ""))
+                    .primary(default_start..end, ""))
             }
 
             p.expect_keyword(T![from], "from");
@@ -416,7 +415,7 @@ fn parse_any_named_import_specifier(p: &mut Parser) -> ParsedSyntax {
                 // import { as c } from "test";
                 p.error(expected_literal_export_name(
                     p,
-                    p.cur_tok().start()..p.cur_tok().start(),
+                    TextRange::new(p.cur_range().start(), p.cur_range().start()),
                 ));
             } else {
                 // test import_as_as_as_identifier
@@ -480,7 +479,7 @@ fn parse_import_assertion(p: &mut Parser) -> ParsedSyntax {
 
 #[derive(Default)]
 struct ImportAssertionList {
-    assertion_keys: HashMap<String, Range<usize>>,
+    assertion_keys: HashMap<String, TextRange>,
 }
 
 impl ParseSeparatedList for ImportAssertionList {
@@ -519,10 +518,10 @@ impl ParseSeparatedList for ImportAssertionList {
 
 fn parse_import_assertion_entry(
     p: &mut Parser,
-    seen_assertion_keys: &mut HashMap<String, Range<usize>>,
+    seen_assertion_keys: &mut HashMap<String, TextRange>,
 ) -> ParsedSyntax {
     let m = p.start();
-    let key_range = p.cur_tok().range();
+    let key_range = p.cur_range();
 
     let key = match p.cur() {
         JS_STRING_LITERAL => Some(p.cur_src().trim_matches(&['\'', '"'][..])),
@@ -541,8 +540,7 @@ fn parse_import_assertion_entry(
         }
         T![:] => {
             p.error(
-                expected_any(&["identifier", "string literal"], p.cur_tok().range())
-                    .to_diagnostic(p),
+                expected_any(&["identifier", "string literal"], p.cur_range()).to_diagnostic(p),
             );
         }
         _ => {
@@ -599,7 +597,7 @@ pub(super) fn parse_export(p: &mut Parser) -> ParsedSyntax {
         return Absent;
     }
 
-    let stmt_start = p.cur_tok().start();
+    let stmt_start = p.cur_range().start();
     let m = p.start();
     p.expect_keyword(T![export], "export");
 
@@ -688,7 +686,7 @@ fn parse_export_named_clause(p: &mut Parser) -> ParsedSyntax {
         return Absent;
     }
 
-    let start = p.cur_tok().range().start;
+    let start = p.cur_range().start();
     let m = p.start();
 
     let has_type = p.eat_keyword(T![type], "type");
@@ -696,7 +694,7 @@ fn parse_export_named_clause(p: &mut Parser) -> ParsedSyntax {
     ExportNamedSpecifierList.parse_list(p);
     p.expect(T!['}']);
 
-    semi(p, start..p.cur_tok().range().start);
+    semi(p, TextRange::new(start, p.cur_range().start()));
 
     let clause = m.complete(p, JS_EXPORT_NAMED_CLAUSE);
 
@@ -772,7 +770,7 @@ fn parse_any_export_named_specifier(p: &mut Parser) -> ParsedSyntax {
     if metadata.is_local_name_missing {
         p.error(expected_identifier(
             p,
-            p.cur_tok().start()..p.cur_tok().start(),
+            TextRange::new(p.cur_range().start(), p.cur_range().start()),
         ));
     } else {
         parse_reference_identifier(p).or_add_diagnostic(p, expected_identifier);
@@ -896,7 +894,7 @@ fn parse_export_from_clause(p: &mut Parser) -> ParsedSyntax {
         return Absent;
     }
 
-    let start = p.cur_tok().range().start;
+    let start = p.cur_range().start();
     let m = p.start();
 
     p.expect(T![*]);
@@ -905,7 +903,7 @@ fn parse_export_from_clause(p: &mut Parser) -> ParsedSyntax {
     p.expect_keyword(T![from], "from");
     parse_module_source(p).or_add_diagnostic(p, expected_module_source);
     parse_import_assertion(p).ok();
-    semi(p, start..p.cur_tok().range().end);
+    semi(p, TextRange::new(start, p.cur_range().end()));
 
     Present(m.complete(p, JS_EXPORT_FROM_CLAUSE))
 }
@@ -934,7 +932,7 @@ fn parse_export_named_from_clause(p: &mut Parser) -> ParsedSyntax {
         return Absent;
     }
 
-    let start = p.cur_tok().range().start;
+    let start = p.cur_range().start();
     let m = p.start();
 
     let has_type = p.eat_keyword(T![type], "type");
@@ -948,7 +946,7 @@ fn parse_export_named_from_clause(p: &mut Parser) -> ParsedSyntax {
     parse_module_source(p).or_add_diagnostic(p, expected_module_source);
     parse_import_assertion(p).ok();
 
-    semi(p, start..p.cur_tok().range().start);
+    semi(p, TextRange::new(start, p.cur_range().start()));
 
     let clause = m.complete(p, JS_EXPORT_NAMED_FROM_CLAUSE);
 
@@ -1019,7 +1017,7 @@ fn parse_export_named_from_specifier(p: &mut Parser) -> ParsedSyntax {
     if metadata.is_local_name_missing {
         p.error(expected_literal_export_name(
             p,
-            p.cur_tok().start()..p.cur_tok().start(),
+            TextRange::new(p.cur_range().start(), p.cur_range().start()),
         ));
     } else {
         parse_literal_export_name(p).or_add_diagnostic(p, expected_literal_export_name);
@@ -1139,7 +1137,7 @@ fn parse_export_default_declaration_clause(
         // export default interface A { }
         ExportDefaultDeclarationKind::Interface => {
             TypeScript.parse_exclusive_syntax(p, parse_ts_interface_declaration, |p, interface| {
-                ts_only_syntax_error(p, "interface", interface.range(p).as_range())
+                ts_only_syntax_error(p, "interface", interface.range(p))
             })
         }
         ExportDefaultDeclarationKind::Enum => {
@@ -1195,14 +1193,14 @@ fn parse_export_default_expression_clause(p: &mut Parser) -> ParsedSyntax {
         return Absent;
     }
 
-    let start = p.cur_tok().range().start;
+    let start = p.cur_range().start();
     let m = p.start();
     p.expect_keyword(T![default], "default");
 
     parse_assignment_expression_or_higher(p, ExpressionContext::default())
         .or_add_diagnostic(p, expected_expression);
 
-    semi(p, start..p.cur_tok().range().start);
+    semi(p, TextRange::new(start, p.cur_range().start()));
     Present(m.complete(p, JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE))
 }
 
@@ -1228,11 +1226,11 @@ fn parse_ts_export_namespace_clause(p: &mut Parser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    let start_pos = p.cur_tok().start();
+    let start_pos = p.cur_range().start();
     p.expect_keyword(T![as], "as");
     p.expect_keyword(T![namespace], "namespace");
     parse_name(p).or_add_diagnostic(p, expected_identifier);
-    semi(p, start_pos..p.cur_tok().end());
+    semi(p, TextRange::new(start_pos, p.cur_range().end()));
 
     Present(m.complete(p, TS_EXPORT_AS_NAMESPACE_CLAUSE))
 }
@@ -1253,11 +1251,11 @@ fn parse_ts_export_assignment_clause(p: &mut Parser) -> ParsedSyntax {
     }
 
     let m = p.start();
-    let start_pos = p.cur_tok().start();
+    let start_pos = p.cur_range().start();
     p.bump(T![=]);
     parse_assignment_expression_or_higher(p, ExpressionContext::default())
         .or_add_diagnostic(p, expected_expression);
-    semi(p, start_pos..p.cur_tok().end());
+    semi(p, TextRange::new(start_pos, p.cur_range().end()));
     Present(m.complete(p, TS_EXPORT_ASSIGNMENT_CLAUSE))
 }
 
@@ -1268,7 +1266,7 @@ fn parse_ts_export_assignment_clause(p: &mut Parser) -> ParsedSyntax {
 // export declare type C = string;
 // export declare class D {}
 // export declare function e()
-fn parse_ts_export_declare_clause(p: &mut Parser, stmt_start: usize) -> ParsedSyntax {
+fn parse_ts_export_declare_clause(p: &mut Parser, stmt_start: TextSize) -> ParsedSyntax {
     if !p.at(T![declare]) {
         return Absent;
     }

--- a/crates/rslint_parser/src/syntax/object.rs
+++ b/crates/rslint_parser/src/syntax/object.rs
@@ -21,7 +21,6 @@ use crate::JsSyntaxFeature::TypeScript;
 use crate::{ParseRecovery, ParseSeparatedList, Parser, SyntaxFeature};
 use rome_js_syntax::JsSyntaxKind::*;
 use rome_js_syntax::{JsSyntaxKind, T};
-use rslint_errors::Span;
 
 // test object_expr
 // let a = {};
@@ -172,7 +171,7 @@ fn parse_object_member(p: &mut Parser) -> ParsedSyntax {
                     // test_err object_shorthand_with_initializer
                     // ({ arrow = () => {} })
                     p.error(p.err_builder("Did you mean to use a `:`? An `=` can only follow a property name when the containing object literal is part of a destructuring pattern.")
-						.primary(p.cur_tok().range(), ""));
+						.primary(p.cur_range(), ""));
                     p.bump(T![=]);
                     parse_assignment_expression_or_higher(p, ExpressionContext::default()).ok();
                     return Present(m.complete(p, JS_UNKNOWN_MEMBER));
@@ -264,7 +263,7 @@ fn parse_getter_object_member(p: &mut Parser) -> ParsedSyntax {
 
     TypeScript
         .parse_exclusive_syntax(p, parse_ts_type_annotation, |p, annotation| {
-            ts_only_syntax_error(p, "type annotation", annotation.range(p).as_range())
+            ts_only_syntax_error(p, "type annotation", annotation.range(p))
         })
         .ok();
 
@@ -430,7 +429,7 @@ fn parse_method_object_member(p: &mut Parser) -> ParsedSyntax {
 fn parse_method_object_member_body(p: &mut Parser, flags: SignatureFlags) {
     TypeScript
         .parse_exclusive_syntax(p, parse_ts_type_parameters, |p, type_parameters| {
-            ts_only_syntax_error(p, "type parameters", type_parameters.range(p).as_range())
+            ts_only_syntax_error(p, "type parameters", type_parameters.range(p))
         })
         .ok();
 
@@ -439,7 +438,7 @@ fn parse_method_object_member_body(p: &mut Parser, flags: SignatureFlags) {
 
     TypeScript
         .parse_exclusive_syntax(p, parse_ts_return_type_annotation, |p, annotation| {
-            ts_only_syntax_error(p, "return type annotation", annotation.range(p).as_range())
+            ts_only_syntax_error(p, "return type annotation", annotation.range(p))
         })
         .ok();
 

--- a/crates/rslint_parser/src/syntax/typescript.rs
+++ b/crates/rslint_parser/src/syntax/typescript.rs
@@ -84,12 +84,12 @@ fn expect_ts_type_list(p: &mut Parser, clause_name: &str) -> CompletedMarker {
     if parse_ts_name_with_type_arguments(p).is_absent() {
         p.error(
             p.err_builder(&format!("'{}' list cannot be empty.", clause_name))
-                .primary(p.cur_tok().start()..p.cur_tok().start(), ""),
+                .primary(p.cur_range().start()..p.cur_range().start(), ""),
         )
     }
 
     while p.at(T![,]) {
-        let comma_range = p.cur_tok().range();
+        let comma_range = p.cur_range();
         p.bump(T![,]);
         // test_err ts ts_extends_trailing_comma
         // interface A {}
@@ -170,7 +170,7 @@ pub(crate) fn expect_ts_index_signature_member(
         } else {
             p.error(ts_member_cannot_be(
                 p,
-                p.cur_tok().range(),
+                p.cur_range(),
                 "index signature",
                 p.cur_src(),
             ));
@@ -216,7 +216,7 @@ fn eat_members_separator(p: &mut Parser, parent: MemberParent) {
     if !separator_eaten {
         if semi_colon {
             let err = p.err_builder("';' expected'").primary(
-                p.cur_tok().range(),
+                p.cur_range(),
                 "An explicit or implicit semicolon is expected here...",
             );
             p.error(err);

--- a/crates/rslint_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/rslint_parser/src/syntax/typescript/ts_parse_error.rs
@@ -5,13 +5,12 @@ use crate::{
 };
 use rome_rowan::TextRange;
 use rslint_errors::{Diagnostic, Span};
-use std::ops::Range;
 
-pub(crate) fn expected_ts_enum_member(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_ts_enum_member(p: &Parser, range: TextRange) -> Diagnostic {
     expected_any(&["identifier", "string literal", "computed name"], range).to_diagnostic(p)
 }
 
-pub(crate) fn unexpected_abstract_member_with_body(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn unexpected_abstract_member_with_body(p: &Parser, range: TextRange) -> Diagnostic {
     p.err_builder("abstract members should not have a body")
         .primary(range, "")
 }
@@ -35,7 +34,7 @@ pub(crate) fn ts_modifier_cannot_appear_on_a_constructor_declaration(
     p: &Parser,
     modifier_range: TextRange,
 ) -> Diagnostic {
-    let modifier = p.span_text(modifier_range);
+    let modifier = p.source(modifier_range);
     p.err_builder(&format!(
         "'{modifier}' cannot appear on a constructor declaration."
     ))
@@ -46,7 +45,7 @@ pub(crate) fn ts_modifier_cannot_appear_on_a_parameter(
     p: &Parser,
     modifier_range: TextRange,
 ) -> Diagnostic {
-    let modifier = p.span_text(modifier_range);
+    let modifier = p.source(modifier_range);
     p.err_builder(&format!("'{modifier}' cannot appear on a parameter."))
         .primary(modifier_range, "")
 }
@@ -61,7 +60,7 @@ pub(crate) fn ts_accessibility_modifier_already_seen(
         .secondary(first_range, "first modifier")
 }
 
-pub(crate) fn ts_only_syntax_error(p: &Parser, syntax: &str, range: impl Span) -> Diagnostic {
+pub(crate) fn ts_only_syntax_error(p: &Parser, syntax: &str, range: TextRange) -> Diagnostic {
     p.err_builder(&format!("{} are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.", syntax))
         .primary(range, "TypeScript only syntax")
 }
@@ -90,10 +89,10 @@ pub(crate) fn ts_set_accessor_return_type_error(
         .primary(type_annotation.range(p), "")
 }
 
-pub(crate) fn expected_ts_type(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_ts_type(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("type", range).to_diagnostic(p)
 }
 
-pub(crate) fn expected_ts_type_parameter(p: &Parser, range: Range<usize>) -> Diagnostic {
+pub(crate) fn expected_ts_type_parameter(p: &Parser, range: TextRange) -> Diagnostic {
     expected_node("type parameter", range).to_diagnostic(p)
 }

--- a/crates/rslint_parser/src/syntax/typescript/types.rs
+++ b/crates/rslint_parser/src/syntax/typescript/types.rs
@@ -98,7 +98,7 @@ pub(crate) fn parse_ts_type_parameters(p: &mut Parser) -> ParsedSyntax {
     let m = p.start();
     p.bump(T![<]);
     if p.at(T![>]) {
-        p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
+        p.error(expected_ts_type_parameter(p, p.cur_range()));
     }
     TsTypeParameterList.parse_list(p);
     p.expect(T![>]);
@@ -765,7 +765,7 @@ fn parse_ts_property_or_method_signature_type_member(p: &mut Parser) -> ParsedSy
 
     let m = p.start();
     let readonly_range = if p.at(T![readonly]) && is_nth_at_type_member_name(p, 1) {
-        let range = p.cur_tok().range();
+        let range = p.cur_range();
         p.expect_keyword(T![readonly], "readonly");
         Some(range)
     } else {
@@ -1249,7 +1249,7 @@ pub(crate) fn parse_ts_type_arguments_impl(
     p.bump(T![<]);
 
     if p.at(T![>]) {
-        p.error(expected_ts_type_parameter(p, p.cur_tok().range()));
+        p.error(expected_ts_type_parameter(p, p.cur_range()));
     }
     TypeArgumentsList { recover_on_errors }.parse_list(p);
     p.expect(T![>]);
@@ -1320,7 +1320,7 @@ fn parse_ts_type_member_semi(p: &mut Parser) {
     // or a semicolon (possibly ASI)
     if !optional_semi(p) {
         let err = p.err_builder("';' expected'").primary(
-            p.cur_tok().range(),
+            p.cur_range(),
             "An explicit or implicit semicolon is expected here...",
         );
 

--- a/crates/rslint_parser/src/token_source.rs
+++ b/crates/rslint_parser/src/token_source.rs
@@ -1,4 +1,5 @@
 use rome_js_syntax::JsSyntaxKind::EOF;
+use rome_rowan::TextSize;
 use std::iter::FusedIterator;
 
 /// The source of tokens for the parser
@@ -120,8 +121,8 @@ impl<'t> TokenSource<'t> {
     }
 
     #[inline(always)]
-    pub fn cur_pos(&self) -> usize {
-        self.current().offset as usize
+    pub fn cur_pos(&self) -> TextSize {
+        self.current().offset
     }
 
     #[inline(always)]


### PR DESCRIPTION
## Summary

Streamlines the Parser API by:

* Merging `token_src`, `span_text` and `source` into a single `source` method
* Removing `cur_tok` and replacing the calls with `cur_range`.
* Removing `nth_tok` and `nth_src` by rewriting the two usages to no longer need it
* Removing `marker_range` and `marker_vec_range` (unused)

... and uses `TextSize` and `TextRange` consistently throughout the code base (simplifies a few calls). We may want to fork `text-size` in the future to add some more helper methods or consider contributing to it.


## Benchmark

Using `TextRange` instead of `Range<usize>` results in a small performance win:

```
group                                 main                                   text-range
-----                                 ----                                   ----------
parser/checker.ts                     1.05     87.0±1.73ms    30.1 MB/sec    1.00     82.6±1.83ms    31.6 MB/sec
parser/compiler.js                    1.06     54.4±1.38ms    19.3 MB/sec    1.00     51.1±1.38ms    20.5 MB/sec
parser/d3.min.js                      1.07     33.6±0.59ms     7.8 MB/sec    1.00     31.5±0.54ms     8.3 MB/sec
parser/dojo.js                        1.02      2.6±0.05ms    26.0 MB/sec    1.00      2.6±0.05ms    26.6 MB/sec
parser/ios.d.ts                       1.08     86.0±2.25ms    21.7 MB/sec    1.00     79.4±1.52ms    23.5 MB/sec
parser/jquery.min.js                  1.07      9.6±0.18ms     8.6 MB/sec    1.00      8.9±0.13ms     9.3 MB/sec
parser/math.js                        1.07     65.2±1.30ms     9.9 MB/sec    1.00     60.9±1.13ms    10.6 MB/sec
parser/parser.ts                      1.03  1761.9±29.92µs    26.2 MB/sec    1.00  1717.2±36.92µs    26.9 MB/sec
parser/pixi.min.js                    1.08     41.9±1.04ms    10.5 MB/sec    1.00     38.6±0.65ms    11.4 MB/sec
parser/react-dom.production.min.js    1.06     12.2±0.18ms     9.4 MB/sec    1.00     11.5±0.17ms    10.0 MB/sec
parser/react.production.min.js        1.02   569.3±11.03µs    10.8 MB/sec    1.00   556.3±16.16µs    11.1 MB/sec
parser/router.ts                      1.03  1486.6±20.45µs    40.8 MB/sec    1.00  1444.8±27.39µs    42.0 MB/sec
parser/tex-chtml-full.js              1.05     89.3±1.71ms    10.2 MB/sec    1.00     85.1±2.56ms    10.7 MB/sec
parser/three.min.js                   1.06     47.0±0.98ms    12.5 MB/sec    1.00     44.4±2.94ms    13.2 MB/sec
parser/vue.global.prod.js             1.07     15.2±0.39ms     7.9 MB/sec    1.00     14.2±0.26ms     8.5 MB/sec
```



## Test Plan

`cargo test`