### PR TITLE
ci: update `package.json` for pre release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,12 @@ jobs:
       - name: Check prerelease status
         id: prerelease
         if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
+        working-directory: editors/vscode
         run: |
-          echo "prerelease=true" >> $GITHUB_ENV
-          echo "version=$(date +"pre-release-%F")" >> $GITHUB_ENV
+          CURRENT_VERSION=$(cat package.json | grep version |  awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
+          NEW_VERSION=${{ steps.version.outputs.version }}-$(date +"pre-release-%F-%s")
+          cat package.json | sed "s/"${CURRENT_VERSION}"/"${NEW_VERSION}"/g" >  temp
+          mv temp package.json
 
       - name: Check version status
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR does two things:

- in case of prerelease, we update the `"version"` field of the `package.json`. It seems that while publishing the extension, the the tool read the version from the `package.json`;
- updates how we construct the version number in case of prerelease, which is now something like this: `pre-release-2022-03-09-1646822342`
	1. `pre-release` is always the same
	2. the current date
	3. the current milliseconds from `1970-01-01 00:00:00`, this would allow use to push multiple prerelease at the same date


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

To merge it and kick a prerelease

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
