### PR TITLE
feat(lsp): add settings for diagnostics and actions

### DIFF
--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -14,11 +14,25 @@ pub struct FormatterWorkspaceSettings {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// Settings for Rome Analysis
+pub struct AnalysisWorkspaceSettings {
+    /// Allows rome to compute and publish diagnostics
+    pub enable_diagnostics: bool,
+    /// Allows rome to compute and provide code actions
+    pub enable_code_actions: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 /// The settings applied to the workspace by the LSP
 pub struct WorkspaceSettings {
     /// Formatter settings
     #[serde(default)]
     pub formatter: FormatterWorkspaceSettings,
+
+    /// Analysis settings
+    #[serde(default)]
+    pub analysis: AnalysisWorkspaceSettings,
 }
 
 #[derive(Debug)]

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -90,6 +90,10 @@ impl LanguageServer for LSPServer {
     }
 
     async fn code_action(&self, params: CodeActionParams) -> LspResult<Option<CodeActionResponse>> {
+        let workspace_settings = self.session.config.read().get_workspace_settings();
+        if !workspace_settings.analysis.enable_code_actions {
+            return Ok(None);
+        }
         let url = params.text_document.uri.clone();
         let doc = self.session.document(&url)?;
 

--- a/crates/rome_lsp/src/session.rs
+++ b/crates/rome_lsp/src/session.rs
@@ -104,6 +104,10 @@ impl Session {
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
     pub(crate) async fn update_diagnostics(&self, url: lsp::Url) -> anyhow::Result<()> {
+        let workspace_settings = self.config.read().get_workspace_settings();
+        if !workspace_settings.analysis.enable_diagnostics {
+            return Ok(());
+        }
         let doc = self.document(&url)?;
 
         let file_id = doc.file_id();

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -41,6 +41,16 @@
 						true,
 						false
 					]
+				},
+				"rome.analysis.enableDiagnostics": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Allows rome to compute and publish diagnostics"
+				},
+				"rome.analysis.enableCodeActions": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Allows rome to compute and provide code actions"
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

This adds config for diagnostics and code actions so that they're disabled by default. Once we resume work on analysis and there are some worthwhile diagnostics/actions, we can change the defaults (and likely put more thought into our config structure).