### PR TITLE
ci: move `package.json` version change next to packaging and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,7 @@ jobs:
         id: prerelease
         if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
         working-directory: editors/vscode
-        run: |
-          CURRENT_VERSION=$(cat package.json | grep version |  awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
-          NEW_VERSION=${{ steps.version.outputs.version }}-$(date +"pre-release-%F-%s")}
-          cat package.json | sed "s/'"version": "${CURRENT_VERSION}"'/'"version": "${NEW_VERSION}"'/g" >  temp
-          mv temp package.json
+        run: echo "prerelease=true" >> $GITHUB_ENV
 
       - name: Check version status
         if: steps.version.outputs.changed == 'true'
@@ -124,6 +120,16 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Check prerelease status
+        id: prerelease
+        if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
+        working-directory: editors/vscode
+        run: |
+          CURRENT_VERSION=$(cat package.json | grep version |  awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
+          NEW_VERSION=${{ steps.version.outputs.version }}-$(date +"pre-release-%F-%s")}
+          cat package.json | sed "s/'"version": "${CURRENT_VERSION}"'/'"version": "${NEW_VERSION}"'/g" >  temp
+          mv temp package.json
+
       - name: Package extension
         run: |
           npm ci
@@ -163,6 +169,17 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: vscode_packages
+
+      - name: Check prerelease status
+        id: prerelease
+        if: env.nightly == 'true' || steps.version.outputs.type == 'prerelease' || steps.version.outputs.type == 'prepatch' || steps.version.outputs.type == 'premajor' || steps.version.outputs.type == 'preminor'
+        working-directory: editors/vscode
+        run: |
+          CURRENT_VERSION=$(cat package.json | grep version |  awk '{print $2}' | sed 's/"//g' | sed 's/,//g')
+          NEW_VERSION=${{ steps.version.outputs.version }}-$(date +"pre-release-%F-%s")}
+          cat package.json | sed "s/'"version": "${CURRENT_VERSION}"'/'"version": "${NEW_VERSION}"'/g" >  temp
+          mv temp package.json
+        
 
       - name: Publish extension (pre-release)
         run: npx vsce publish --pre-release --packagePath rome_lsp-*.vsix


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

In the last PR, myself and @leops  missed an important part, where the inline change of the version has be done next to packaging and publishing. This PR moves that logic

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge and kick off a release

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
