### PR TITLE
refactor(rome_analyze): remove dependency on once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,6 @@ name = "rome_analyze"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "once_cell",
  "rome_js_syntax",
  "rslint_errors",
  "rslint_parser",

--- a/crates/rome_analyze/Cargo.toml
+++ b/crates/rome_analyze/Cargo.toml
@@ -9,6 +9,5 @@ edition = "2021"
 rome_js_syntax = { path = "../rome_js_syntax" }
 rslint_parser = { path = "../rslint_parser" }
 anyhow = "1.0.52"
-once_cell = "1.9.0"
 tracing = { version = "0.1.31", features = ["max_level_trace", "release_max_level_warn"] }
 rslint_errors = { path = "../rslint_errors", version = "0.2.0" }

--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -3,24 +3,21 @@ pub(crate) mod no_var;
 pub(crate) mod use_single_case_statement;
 pub(crate) mod use_while;
 
-use once_cell::sync::Lazy;
 use rome_js_syntax::{AstNode, SyntaxNode, TextRange};
 use rslint_errors::{Diagnostic, Span};
 
 use crate::{analysis_server::AnalysisServer, ActionCategory, Analysis, FileId};
 
-static ALL_ANALYZERS: Lazy<Vec<Analyzer>> = Lazy::new(|| {
-    vec![
-        no_double_equals::create(),
-        no_var::create(),
-        use_while::create(),
-        use_single_case_statement::create(),
-    ]
-});
+const ALL_ANALYZERS: &[Analyzer] = &[
+    no_double_equals::ANALYZER,
+    no_var::ANALYZER,
+    use_while::ANALYZER,
+    use_single_case_statement::ANALYZER,
+];
 
 pub struct Analyzer {
     pub name: &'static str,
-    pub action_categories: Vec<ActionCategory>,
+    pub action_categories: &'static [ActionCategory],
     pub(crate) analyze: fn(&AnalyzerContext) -> Option<Analysis>,
 }
 

--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -3,13 +3,11 @@ use rome_js_syntax::{AstNode, JsAnyExpression, JsBinaryExpression, SyntaxResult}
 
 use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
-pub fn create() -> Analyzer {
-    Analyzer {
-        name: "noDoubleEquals",
-        action_categories: vec![],
-        analyze,
-    }
-}
+pub const ANALYZER: Analyzer = Analyzer {
+    name: "noDoubleEquals",
+    action_categories: &[],
+    analyze,
+};
 
 fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
     ctx.query_nodes::<JsBinaryExpression>()

--- a/crates/rome_analyze/src/analyzers/no_var.rs
+++ b/crates/rome_analyze/src/analyzers/no_var.rs
@@ -1,13 +1,11 @@
 use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 use rome_js_syntax::{AstNode, JsVariableDeclaration};
 
-pub fn create() -> Analyzer {
-    Analyzer {
-        name: "noVar",
-        action_categories: vec![],
-        analyze,
-    }
-}
+pub const ANALYZER: Analyzer = Analyzer {
+    name: "noVar",
+    action_categories: &[],
+    analyze,
+};
 
 fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
     ctx.query_nodes::<JsVariableDeclaration>()

--- a/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
+++ b/crates/rome_analyze/src/analyzers/use_single_case_statement.rs
@@ -2,13 +2,11 @@ use rome_js_syntax::{AstNode, AstNodeList, JsCaseClause};
 
 use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
-pub fn create() -> Analyzer {
-    Analyzer {
-        name: "useSingleCaseStatement",
-        action_categories: vec![],
-        analyze,
-    }
-}
+pub const ANALYZER: Analyzer = Analyzer {
+    name: "useSingleCaseStatement",
+    action_categories: &[],
+    analyze,
+};
 
 fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
     ctx.query_nodes::<JsCaseClause>()

--- a/crates/rome_analyze/src/analyzers/use_while.rs
+++ b/crates/rome_analyze/src/analyzers/use_while.rs
@@ -2,13 +2,11 @@ use rome_js_syntax::{AstNode, JsForStatement};
 
 use crate::{signals::DiagnosticExt, Analysis, Analyzer, AnalyzerContext};
 
-pub fn create() -> Analyzer {
-    Analyzer {
-        name: "useWhile",
-        action_categories: vec![],
-        analyze,
-    }
-}
+pub const ANALYZER: Analyzer = Analyzer {
+    name: "useWhile",
+    action_categories: &[],
+    analyze,
+};
 
 fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
     ctx.query_nodes::<JsForStatement>()

--- a/crates/rome_analyze/src/assists.rs
+++ b/crates/rome_analyze/src/assists.rs
@@ -2,18 +2,18 @@
 
 pub mod flip_bin_exp;
 
-use once_cell::sync::Lazy;
 use rome_js_syntax::{AstNode, SyntaxNode, SyntaxToken, TextRange, TextSize, TokenAtOffset};
 
 use crate::{ActionCategory, Analysis, AnalysisServer, AnalyzerContext, FileId};
 
-static ALL_ASSIST_PROVIDERS: Lazy<Vec<AssistProvider>> = Lazy::new(|| vec![flip_bin_exp::create()]);
+static ALL_ASSIST_PROVIDERS: &[AssistProvider] = &[flip_bin_exp::ASSIST];
 
 pub struct AssistProvider {
     pub name: &'static str,
-    pub action_categories: Vec<ActionCategory>,
+    pub action_categories: &'static [ActionCategory],
     pub analyze: fn(&AssistContext) -> Option<Analysis>,
 }
+
 pub fn all() -> impl Iterator<Item = &'static AssistProvider> {
     ALL_ASSIST_PROVIDERS.iter()
 }

--- a/crates/rome_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_analyze/src/assists/flip_bin_exp.rs
@@ -4,13 +4,11 @@ use crate::{Action, ActionCategory, Analysis, AssistContext, SyntaxEdit};
 
 use super::AssistProvider;
 
-pub fn create() -> AssistProvider {
-    AssistProvider {
-        name: "flipBinExp",
-        action_categories: vec![ActionCategory::Refactor],
-        analyze,
-    }
-}
+pub const ASSIST: AssistProvider = AssistProvider {
+    name: "flipBinExp",
+    action_categories: &[ActionCategory::Refactor],
+    analyze,
+};
 
 fn analyze(ctx: &AssistContext) -> Option<Analysis> {
     let node = ctx.find_node_at_cursor_range::<JsBinaryExpression>()?;


### PR DESCRIPTION
By using `const` over lazily built statics, we can remove the dependency
on `once_cell`.

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

We do not require `once_cell` in this scenario because Rust's `const` can achieve better results: compile-time evaluation, in-built language feature, no extra dependency.

## Test Plan

Public API remains the same.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
