### PR TITLE
fix(rslint_lexer): `read_regex` binary size

### DIFF
--- a/crates/rslint_lexer/src/lib.rs
+++ b/crates/rslint_lexer/src/lib.rs
@@ -1072,67 +1072,68 @@ impl<'src> Lexer<'src> {
                     if !in_class {
                         let (mut g, mut i, mut m, mut s, mut u, mut y, mut d) = (false, false, false, false, false, false, false);
 
-                        unwind_loop! {
-                            let next = self.next_bounded().copied();
+                        while let Some(next) = self.next_bounded().copied() {
                             let chr_start = self.cur;
+
                             match next {
-                                Some(b'g') => {
+                                b'g' => {
                                     if g && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('g'))
                                     }
                                     g = true;
                                 },
-                                Some(b'i') => {
+                                b'i' => {
                                     if i && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('i'))
                                     }
                                     i = true;
                                 },
-                                Some(b'm') => {
+                                b'm' => {
                                     if m && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('m'))
                                     }
                                     m = true;
                                 },
-                                Some(b's') => {
+                                b's' => {
                                     if s && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('s'))
                                     }
                                     s = true;
                                 },
-                                Some(b'u') => {
+                                b'u' => {
                                     if u && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('u'))
                                     }
                                     u = true;
                                 },
-                                Some(b'y') => {
+                                b'y' => {
                                     if y && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('y'))
                                     }
                                     y = true;
                                 },
-                                Some(b'd') => {
+                                b'd' => {
                                     if d && diagnostic.is_none() {
                                         diagnostic = Some(self.flag_err('d'))
                                     }
                                     d = true;
                                 },
-                                Some(_) if self.cur_ident_part().is_some() => {
+                                _ if self.cur_ident_part().is_some() => {
                                     if diagnostic.is_none() {
                                         diagnostic = Some(Diagnostic::error(self.file_id, "", "invalid regex flag")
                                             .primary(chr_start .. self.cur + 1, "this is not a valid regex flag"));
                                     }
-                                },
-                                _ => {
-                                    return (
-                                        Token::new(JsSyntaxKind::JS_REGEX_LITERAL, self.cur - start),
-                                        diagnostic.map(Box::new)
-                                    )
                                 }
-                            }
+                                _ => {break}
+                            };
                         }
-                    }
+
+                        return (
+                            Token::new(
+                                JsSyntaxKind::JS_REGEX_LITERAL, self.cur - start),
+                                diagnostic.map(Box::new)
+                            );
+                        }
                 },
                 Some(b'\\') => {
                     if self.next_bounded().is_none() {

--- a/xtask/bench/src/libs-js.txt
+++ b/xtask/bench/src/libs-js.txt
@@ -9,3 +9,4 @@ https://cdn.jsdelivr.net/npm/pixi.js@6.2.0/dist/browser/pixi.min.js
 https://cdn.jsdelivr.net/npm/three@0.134.0/build/three.min.js
 https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-chtml-full.js
 https://cdn.jsdelivr.net/npm/mathjs@10.3.0/lib/browser/math.js
+https://www.unpkg.com/typescript@4.5.5/lib/typescript.js


### PR DESCRIPTION
## Summary

The lexer uses a `unwind_loop` macro that unwinds loops by repeating the same statement 5 times, then repeating it 5 times inside a `loop` statement:

https://github.com/rome/tools/blob/3a22852e9b129a59e0d3b8eb4dbc48bb9675be7a/crates/rslint_lexer/src/lib.rs#L41-L57

```
unwind_loop!(self.next_byte())
```

becomes

```
self.next_byte();
self.next_byte();
self.next_byte();
self.next_byte();
self.next_byte();

loop {
  self.next_byte();
  self.next_byte();
  self.next_byte();
  self.next_byte();
  self.next_byte();
}
```

I don't know how much this improves performance, but it causes a significant binary bloat in the case of `read_regex` that uses a nested `unwind_loop`: The outer for parsing the regex, the inner for parsing the flags.

This PR removes the inner unwind because:

- Regular expressions aren't that common
- Not all of them have flags

This reduces the lexer size almost to 1/5th of its previous size:

* before: 473.9KiB
* after: 108.8KiB

This will probably also help with compilation time.


## Test Plan

Compared `bench_parser`. No significant change in performance (may be different for a library that heavily uses regex).
