### PR TITLE
chore(ci): add the CLI to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,18 +100,42 @@ jobs:
         if: matrix.code-target == 'linux-x64'
         run: cargo audit
 
-      - name: Build LSP
-        run: cargo build -p rome_lsp --release --target ${{ matrix.target }}
+      # Build the LSP and CLI binaries
+      - name: Build binaries
+        run: cargo build -p rome_lsp -p rome_cli --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          CARGO_PROFILE_RELEASE_LTO: thin
+          # Perform full Link-Time Optimizations
+          CARGO_PROFILE_RELEASE_LTO: "true"
+          # Strip all debug symbols from the resulting binaries
+          RUSTFLAGS: "-C strip=symbols"
 
-      - name: Copy binary
+      # Copy the CLI binary and rename it to include the name of the target platform
+      - name: Copy CLI binary
+        if: matrix.os == 'windows-2022'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/cli.exe ./dist/rome_cli-${{ matrix.code-target }}.exe
+      - name: Copy CLI binary
+        if: matrix.os != 'windows-2022'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/cli ./dist/rome_cli-${{ matrix.code-target }}
+
+      # Upload the CLI binary as a build artifact
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: cli
+          path: ./dist/rome_cli-*
+          if-no-files-found: error
+
+      - name: Copy LSP binary
         if: matrix.os == 'windows-2022'
         run: |
           mkdir editors/vscode/server
           cp target/${{ matrix.target }}/release/rome_lsp.exe editors/vscode/server/rome_lsp.exe
-      - name: Copy binary
+      - name: Copy LSP binary
         if: matrix.os != 'windows-2022'
         run: |
           mkdir editors/vscode/server
@@ -125,13 +149,19 @@ jobs:
       - name: Update package.json version
         if: needs.check.outputs.prerelease == 'true'
         working-directory: editors/vscode
-        run: node ./scripts/updateVersionForPrerelease.js
+        run: |
+          node ./scripts/updateVersionForPrerelease.mjs >> $GITHUB_ENV
+          echo "prerelease=true" >> $GITHUB_ENV
+      - name: Set release infos
+        if: needs.check.outputs.prerelease != 'true'
+        run: |
+          echo "version=${{ needs.check.outputs.version }}" >> $GITHUB_ENV
+          echo "prerelease=${{ needs.check.outputs.prerelease }}" >> $GITHUB_ENV
 
       - name: Package extension
         run: |
           npm ci
           npm run compile
-          mkdir ../../dist
           npx vsce package -o "../../dist/rome_lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
         working-directory: editors/vscode
         if: needs.check.outputs.prerelease != 'true'
@@ -139,22 +169,16 @@ jobs:
         run: |
           npm ci
           npm run compile
-          mkdir ../../dist
           npx vsce package --pre-release -o "../../dist/rome_lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
         working-directory: editors/vscode
         if: needs.check.outputs.prerelease == 'true'
 
-      - name: Upload artifacts
+      - name: Upload VSCode extension artifact
         uses: actions/upload-artifact@v2
         with:
           name: vscode_packages
           path: ./dist/rome_lsp-${{ matrix.code-target }}.vsix
           if-no-files-found: error
-
-      - name: Set release infos
-        run: |
-          echo "version=${{ needs.check.outputs.version }}" >> $GITHUB_ENV
-          echo "prerelease=${{ needs.check.outputs.prerelease }}" >> $GITHUB_ENV
 
   publish:
     name: Publish
@@ -162,7 +186,11 @@ jobs:
     needs: build
     environment: marketplace
     steps:
-      - name: Download artifacts
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: cli
+      - name: Download extension artifacts
         uses: actions/download-artifact@v2
         with:
           name: vscode_packages
@@ -171,12 +199,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-
-      - name: Update package.json version
-        if: needs.check.outputs.prerelease == 'true'
-        working-directory: editors/vscode
-        run: node ./scripts/updateVersionForPrerelease.js
-        
 
       - name: Publish extension (pre-release)
         run: npx vsce publish --pre-release --packagePath rome_lsp-*.vsix
@@ -198,5 +220,7 @@ jobs:
           tag_name: v${{ needs.build.outputs.version }}
           draft: false
           prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
-          files: rome_lsp-*.vsix
+          files: |
+            rome_lsp-*.vsix
+            rome_cli-*
           fail_on_unmatched_files: true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -5,7 +5,6 @@
 	"description": "Rome LSP VS Code Extension",
 	"version": "0.0.4",
 	"icon": "icon.png",
-	"type": "module",
 	"activationEvents": [
 		"onLanguage:javascript",
 		"onLanguage:typescript"

--- a/editors/vscode/scripts/updateVersionForPrerelease.mjs
+++ b/editors/vscode/scripts/updateVersionForPrerelease.mjs
@@ -27,7 +27,7 @@ readFile(manifestPath, "utf8").then(async (value) => {
     manifest.version = `${currentMajor}.${newMinor}.${newPatch}`;
     try {
         await writeFile(manifestPath, JSON.stringify(manifest, null, "\t"));
-        console.log(manifest.version)
+        console.log('version=' + manifest.version);
     } catch (_e) {
         console.log("Could not write the package.json file at " + manifestPath)
         process.exit(1);


### PR DESCRIPTION
## Summary

This PR adds the CLI to the binaries being built in the `release` workflow besides the LSP. For now this means the CLI and VSCode Extension will be released in lockstep, which should work well enough for an initial release but is probably not how we'll want to version these in the long term.

Additional changes include:
- Changed the LTO mode from `thin` to `fat` and enabled the `strip=symbols` option on rustc to further optimize and trim down the size of the binaries
- Renamed the version update script to `updateVersionForPrerelease.mjs` and remove the `"type": "module"` fields in the manifest of the extension as it was causing issues with VSCode (I also removed the invocation of the script in the `publish` job since it was not being called and thus did not seem to be needed)
