### PR TITLE
feat(vscode): add further options for formatting

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -139,6 +139,8 @@ impl FromStr for IndentStyle {
         match s {
             "tab" => Ok(Self::Tab),
             "space" => Ok(Self::Space(2)),
+            "Tabs" => Ok(Self::Tab),
+            "Spaces" => Ok(Self::Space(2)),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for IndentStyle"),
         }

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -126,6 +126,10 @@ pub enum IndentStyle {
     Space(u8),
 }
 
+impl IndentStyle {
+    pub const DEFAULT_SPACES: u8 = 2;
+}
+
 impl Default for IndentStyle {
     fn default() -> Self {
         Self::Tab
@@ -137,10 +141,8 @@ impl FromStr for IndentStyle {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "tab" => Ok(Self::Tab),
-            "space" => Ok(Self::Space(2)),
-            "Tabs" => Ok(Self::Tab),
-            "Spaces" => Ok(Self::Space(2)),
+            "tab" | "Tabs" => Ok(Self::Tab),
+            "space" | "Spaces" => Ok(Self::Space(IndentStyle::DEFAULT_SPACES)),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for IndentStyle"),
         }

--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -10,6 +10,12 @@ pub const CONFIGURATION_SECTION: &str = "rome";
 pub struct FormatterWorkspaceSettings {
     /// Allows to format code that might contain syntax errors
     pub format_with_syntax_errors: bool,
+    /// The width of a single line, specified by the user
+    pub line_width: u16,
+    /// The indent style, specified by the user
+    pub indent_style: String,
+    /// The number of spaces, specified by the user and applied only when using Spaces
+    pub space_quantity: u8,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -30,10 +30,11 @@ pub(crate) fn to_format_options(
 
     if custom_ident_style != default_options.indent_style {
         // merge settings with the ones provided by the editor
-        if workspace_settings.indent_style == "Spaces" {
+        // We use 2 because that's the default value that we assign to the space
+        if custom_ident_style == IndentStyle::Space(2) {
             default_options.indent_style = IndentStyle::Space(workspace_settings.space_quantity);
-        } else if workspace_settings.indent_style == "Tabs" {
-            default_options.indent_style = IndentStyle::Tab;
+        } else if custom_ident_style == IndentStyle::Tab {
+            default_options.indent_style = custom_ident_style;
         }
         info!(
             "Using user setting indent style: {}",

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -7,7 +7,7 @@ use rome_formatter::{FormatOptions, IndentStyle};
 use rome_js_syntax::{TextRange, TokenAtOffset};
 use rslint_parser::{parse, SourceType};
 use std::str::FromStr;
-use tracing::{info, trace};
+use tracing::info;
 
 /// Utility function that takes formatting options from [LSP](lspower::lsp::FormattingOptions)
 /// and transforms that to [options](rome_formatter::FormatOptions) that the rome formatter can understand

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -10,7 +10,10 @@ use std::str::FromStr;
 use tracing::info;
 
 /// Utility function that takes formatting options from [LSP](lspower::lsp::FormattingOptions)
-/// and transforms that to [options](rome_formatter::FormatOptions) that the rome formatter can understand
+/// and transforms that to [options](rome_formatter::FormatOptions) that the rome formatter can understand.
+///
+/// It also read information from the workspace settings and use their values, which will override
+/// the defaults passed from the client.
 pub(crate) fn to_format_options(
     params: &FormattingOptions,
     workspace_settings: &FormatterWorkspaceSettings,
@@ -30,8 +33,7 @@ pub(crate) fn to_format_options(
 
     if custom_ident_style != default_options.indent_style {
         // merge settings with the ones provided by the editor
-        // We use 2 because that's the default value that we assign to the space
-        if custom_ident_style == IndentStyle::Space(2) {
+        if matches!(custom_ident_style, IndentStyle::Space(_)) {
             default_options.indent_style = IndentStyle::Space(workspace_settings.space_quantity);
         } else if custom_ident_style == IndentStyle::Tab {
             default_options.indent_style = custom_ident_style;

--- a/crates/rome_lsp/src/server.rs
+++ b/crates/rome_lsp/src/server.rs
@@ -105,7 +105,7 @@ impl LanguageServer for LSPServer {
             handlers::formatting::format(FormatParams {
                 text: &doc.text,
                 source_type: doc.get_source_type(),
-                format_options: to_format_options(&params.options),
+                format_options: to_format_options(&params.options, &workspace_settings.formatter),
                 workspace_settings,
                 file_id: doc.file_id(),
             })
@@ -126,7 +126,7 @@ impl LanguageServer for LSPServer {
             handlers::formatting::format_range(FormatRangeParams {
                 text: doc.text.as_ref(),
                 file_id: doc.file_id(),
-                format_options: to_format_options(&params.options),
+                format_options: to_format_options(&params.options, &workspace_settings.formatter),
                 range: params.range,
                 workspace_settings,
                 source_type: doc.get_source_type(),
@@ -148,7 +148,7 @@ impl LanguageServer for LSPServer {
             handlers::formatting::format_on_type(FormatOnTypeParams {
                 text: doc.text.as_ref(),
                 file_id: doc.file_id(),
-                format_options: to_format_options(&params.options),
+                format_options: to_format_options(&params.options, &workspace_settings.formatter),
                 position: params.text_document_position.position,
                 workspace_settings,
                 source_type: doc.get_source_type(),

--- a/crates/rome_playground/package.json
+++ b/crates/rome_playground/package.json
@@ -14,9 +14,9 @@
     "react-tabs": "^3.2.3"
   },
   "devDependencies": {
-		"@tailwindcss/forms": "^0.4.0",
-		"@types/prettier": "^2.4.3",
-		"@types/react": "^17.0.33",
+    "@tailwindcss/forms": "^0.4.0",
+    "@types/prettier": "^2.4.3",
+    "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "@types/react-tabs": "^2.3.4",
     "@vitejs/plugin-react": "^1.0.7",

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "rome",
-	"version": "0.0.4",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -428,9 +428,9 @@
 			"dev": true
 		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"dev": true
 		},
 		"has-unicode": {
@@ -1020,9 +1020,9 @@
 			"dev": true
 		},
 		"vsce": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
-			"integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.7.0.tgz",
+			"integrity": "sha512-CKU34wrQlbKDeJCRBkd1a8iwF9EvNxcYMg9hAUH6AxFGR6Wo2IKWwt3cJIcusHxx6XdjDHWlfAS/fJN30uvVnA==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",
@@ -1048,18 +1048,18 @@
 			}
 		},
 		"vscode-jsonrpc": {
-			"version": "8.0.0-next.6",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.6.tgz",
-			"integrity": "sha512-6Ld3RYjygn5Ih7CkAtcAwiDQC+rakj2O+PnASfNyYv3sLmm44eJpEKzuPUN30Iy2UB09AZg8T6LBKWTJTEJDVw=="
+			"version": "8.0.0-next.7",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.7.tgz",
+			"integrity": "sha512-JX/F31LEsims0dAlOTKFE4E+AJMiJvdRSRViifFJSqSN7EzeYyWlfuDchF7g91oRNPZOIWfibTkDf3/UMsQGzQ=="
 		},
 		"vscode-languageclient": {
-			"version": "8.0.0-next.12",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.0-next.12.tgz",
-			"integrity": "sha512-4+kr1BQcoh+sA5/4XJDJXrQXGQ5Yz/x+WpsVGGzK/TOB7RwQ63ooxG6Ej7i/+aOQM4/QdmcYWmipDtG7vqcOiw==",
+			"version": "8.0.0-next.13",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.0-next.13.tgz",
+			"integrity": "sha512-X4GL8ZhQgTxeLSkGYZKyOjJ80TYauDVH1UmtR++xK4lIIDfWjUFN7oZBuUIlGj0EIY28qDgB180bAaOzKCDJFA==",
 			"requires": {
 				"minimatch": "^3.0.4",
 				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.0-next.14"
+				"vscode-languageserver-protocol": "3.17.0-next.15"
 			},
 			"dependencies": {
 				"semver": {
@@ -1073,18 +1073,18 @@
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.17.0-next.14",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.14.tgz",
-			"integrity": "sha512-iangobY8dL6sFZkOx4OhRPJM9gN0I1caUsOVR+MnPozsqQUtwMXmbIcfaIf0Akp0pd3KhJDPf/tdwRX68QGeeA==",
+			"version": "3.17.0-next.15",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.15.tgz",
+			"integrity": "sha512-73LffxyP/0TRyk3J7bCYt0BuFBzk4Qvo5TqZndOsP+uBDbRV4IT7ebu4M/XoPDSCyZ+jDIxW7if/JbhBznmwBg==",
 			"requires": {
-				"vscode-jsonrpc": "8.0.0-next.6",
-				"vscode-languageserver-types": "3.17.0-next.7"
+				"vscode-jsonrpc": "8.0.0-next.7",
+				"vscode-languageserver-types": "3.17.0-next.8"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.17.0-next.7",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.7.tgz",
-			"integrity": "sha512-KH4zdG1qBXxoso61ChgpeoZYyHGJo8bV7Jv4I+fwQ1Ryy59JAxoZ9GAbhR5TeeafHctLcg6RFvY3m8Jqfu17cg=="
+			"version": "3.17.0-next.8",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.8.tgz",
+			"integrity": "sha512-Mwj+FemiEk4QUUms1GGvXwDC+laJGVFuA4glbMVJTxfXdfOFZaEuyVlLobjccBo+NzD+5oEzzejTX7nWGNajjQ=="
 		},
 		"wide-align": {
 			"version": "1.1.5",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -36,7 +36,7 @@
 				"rome.formatter.formatWithSyntaxErrors": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Allows the formatter to format code that contains syntax errors",
+					"markdownDescription": "**BETA**: allows the formatter to format code that contains syntax errors",
 					"examples": [
 						true,
 						false
@@ -45,7 +45,7 @@
 				"rome.formatter.lineWidth": {
 					"type": "number",
 					"default": 80,
-					"markdownDescription": "The max width of a single line, the code will have to fit in it",
+					"markdownDescription": "**BETA**: the max width of a single line, the code will have to fit in it",
 					"minimum": 40,
 					"maximum": 320
 				},
@@ -54,14 +54,14 @@
 					"enum": ["Tabs", "Spaces"],
 					"default": "Tabs",
 					"markdownEnumDescriptions": [
-						"Applies **tabs** while formatting",
-						"Applies **spaces** while formatting"
+						"**BETA**: applies **tabs** while formatting",
+						"**BETA**: applies **spaces** while formatting"
 					]
 				},
 				"rome.formatter.spaceQuantity": {
 					"type": "number",
 					"default": 2,
-					"markdownDescription": "Applied **only** when choosing **Spaces**, it's the number of spaces applied when printing.",
+					"markdownDescription": "**BETA**: applied **only** when choosing **Spaces**, it's the number of spaces applied when printing.",
 					"minimum": 1,
 					"maximum": 12
 				},

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -42,6 +42,29 @@
 						false
 					]
 				},
+				"rome.formatter.lineWidth": {
+					"type": "number",
+					"default": 80,
+					"markdownDescription": "The max width of a single line, the code will have to fit in it",
+					"minimum": 40,
+					"maximum": 320
+				},
+				"rome.formatter.indentStyle": {
+					"type": "string",
+					"enum": ["Tabs", "Spaces"],
+					"default": "Tabs",
+					"markdownEnumDescriptions": [
+						"Applies **tabs** while formatting",
+						"Applies **spaces** while formatting"
+					]
+				},
+				"rome.formatter.spaceQuantity": {
+					"type": "number",
+					"default": 2,
+					"markdownDescription": "Applied **only** when choosing **Spaces**, it's the number of spaces applied when printing.",
+					"minimum": 1,
+					"maximum": 12
+				},
 				"rome.analysis.enableDiagnostics": {
 					"type": "boolean",
 					"default": false,
@@ -70,12 +93,12 @@
 		"install-extension": "code --install-extension rome_lsp.vsix"
 	},
 	"dependencies": {
-		"vscode-languageclient": "8.0.0-next.12"
+		"vscode-languageclient": "^8.0.0-next.13"
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.9",
 		"@types/vscode": "^1.52.0",
 		"typescript": "^4.5.2",
-		"vsce": "^2.6.7"
+		"vsce": "^2.7.0"
 	}
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR add three more options to the VSCode extension, allowing to customize the formatting experience.

By default, VSCode reads the `.editorconfig` inside the project and it has also its own defaults, but this file doesn't exist or the user wants to use different formatting styles, we should be able to override these defaults.


There's an existing issue where new settings are not applied on the fly. This means, for now, there's need to reload VSCode in order to read the new settings. I will investigate this issue in a different PR.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Manually edited settings and made sure that the formatter uses different line width or indent style

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
