### PR TITLE
fix(playground): Add `Cloudflare` environment to deploy playground workflow

### DIFF
--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: cloudflare
     name: Deploy
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION

## Summary

Needed because the `CF_API_KEY` secret is in the Cloudflare environment
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
