### PR TITLE
feat(rome_formatter): add instanceof expr and in expr

### DIFF
--- a/crates/rome_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/in_expression.rs
@@ -1,26 +1,9 @@
-use crate::formatter_traits::FormatTokenAndNode;
-
-use crate::{
-    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
-};
-
-use rome_js_syntax::JsInExpression;
-use rome_js_syntax::JsInExpressionFields;
+use crate::utils::format_binaryish_expression;
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rome_js_syntax::{AstNode, JsInExpression};
 
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsInExpressionFields {
-            property,
-            in_token,
-            object,
-        } = self.as_fields();
-
-        Ok(format_elements![
-            property.format(formatter)?,
-            space_token(),
-            in_token.format(formatter)?,
-            space_token(),
-            object.format(formatter)?,
-        ])
+        format_binaryish_expression(self.syntax(), formatter)
     }
 }

--- a/crates/rome_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_formatter/src/js/expressions/instanceof_expression.rs
@@ -1,26 +1,9 @@
-use crate::formatter_traits::FormatTokenAndNode;
-
-use crate::{
-    format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
-};
-
-use rome_js_syntax::JsInstanceofExpression;
-use rome_js_syntax::JsInstanceofExpressionFields;
+use crate::utils::format_binaryish_expression;
+use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
+use rome_js_syntax::{AstNode, JsInstanceofExpression};
 
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsInstanceofExpressionFields {
-            left,
-            instanceof_token,
-            right,
-        } = self.as_fields();
-
-        Ok(format_elements![
-            left.format(formatter)?,
-            space_token(),
-            instanceof_token.format(formatter)?,
-            space_token(),
-            right.format(formatter)?,
-        ])
+        format_binaryish_expression(self.syntax(), formatter)
     }
 }

--- a/crates/rome_formatter/src/utils/binarish_expression.rs
+++ b/crates/rome_formatter/src/utils/binarish_expression.rs
@@ -5,10 +5,11 @@ use crate::{
     soft_line_break_or_space, space_token, token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
-use rome_js_syntax::{AstNode, JsSyntaxKind, SyntaxNode, SyntaxNodeExt, SyntaxToken};
 use rome_js_syntax::{
-    JsAnyExpression, JsBinaryExpression, JsBinaryExpressionFields, JsBinaryOperation,
-    JsLogicalExpression, JsLogicalExpressionFields, JsLogicalOperation,
+    AstNode, JsAnyExpression, JsAnyInProperty, JsBinaryExpression, JsBinaryExpressionFields,
+    JsBinaryOperation, JsInExpression, JsInExpressionFields, JsInstanceofExpression,
+    JsInstanceofExpressionFields, JsLogicalExpression, JsLogicalExpressionFields,
+    JsLogicalOperation, JsSyntaxKind, SyntaxNode, SyntaxNodeExt, SyntaxToken,
 };
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -101,7 +102,7 @@ pub fn format_binaryish_expression(
     syntax_node: &SyntaxNode,
     formatter: &Formatter,
 ) -> FormatResult<FormatElement> {
-    let mut flatten_nodes = FlattenItems::new(syntax_node.clone());
+    let mut flatten_nodes = FlattenItems::new(syntax_node.clone(), formatter);
 
     flatten_expressions(&mut flatten_nodes, syntax_node.clone(), formatter, None)?;
     flatten_nodes.into_format_element()
@@ -115,137 +116,130 @@ fn flatten_expressions(
     formatter: &Formatter,
     previous_operator: Option<SyntaxToken>,
 ) -> FormatResult<()> {
-    match syntax_node.kind() {
-        JsSyntaxKind::JS_BINARY_EXPRESSION => {
-            let binary_expression = JsBinaryExpression::cast(syntax_node).unwrap();
-            let JsBinaryExpressionFields {
+    if let Some(binary_expression) = JsBinaryExpression::cast(syntax_node.clone()) {
+        let JsBinaryExpressionFields {
+            left,
+            right,
+            operator,
+        } = binary_expression.as_fields();
+        let right = right?;
+        let operator = operator?;
+        let left = left?;
+        let should_flatten = should_flatten_binary_expression(&binary_expression)?;
+
+        let current_operator = Operation::Binary(binary_expression.operator_kind()?);
+        flatten_items.make_flatten_item_from_binaryish_expression(
+            MakeFlattenItemPayload {
                 left,
                 right,
                 operator,
-            } = binary_expression.as_fields();
-            let right = right?;
-            let operator = operator?;
-            let left = left?;
-            let has_comments =
-                right.syntax().contains_comments() || operator.has_trailing_comments();
+                previous_operator,
+                current_operator,
+                should_flatten,
+            },
+            |formatted, has_comments| {
+                FlattenItem::Binary(binary_expression, formatted, has_comments)
+            },
+        )?;
+    } else if let Some(logical_expression) = JsLogicalExpression::cast(syntax_node.clone()) {
+        let JsLogicalExpressionFields {
+            left,
+            right,
+            operator,
+        } = logical_expression.as_fields();
+        let right = right?;
+        let operator = operator?;
+        let left = left?;
 
-            // In order to flatten the expression, we have to check if the left node
-            // is a binary expression with the same operator.
-            // If the two operators are not the same, we stop the flattening.
-            let current_operator = Operation::Binary(binary_expression.operator_kind()?);
-            if should_flatten_binary_expression(&binary_expression)? {
-                flatten_expressions(
-                    flatten_items,
-                    left.syntax().clone(),
-                    formatter,
-                    Some(operator),
-                )?;
-                let (formatted, _) = format_with_or_without_parenthesis(
-                    current_operator,
-                    right.clone(),
-                    right.format(formatter)?,
-                )?;
-                flatten_items.items.push(FlattenItem::Binary(
-                    binary_expression,
-                    FlattenItemFormatted {
-                        node_element: formatted,
-                        operator_element: previous_operator.format_or_empty(formatter)?,
-                    },
-                    has_comments.into(),
-                ))
-            } else {
-                let (left_item, right_item) =
-                    split_binaryish_to_flatten_items(SplitToElementParams {
-                        formatter,
-                        left,
-                        previous_operator,
-                        right,
-                        operator,
-                        current_operator,
-                    })?;
-                flatten_items.items.push(left_item);
-                flatten_items.items.push(right_item);
-            };
-        }
-        JsSyntaxKind::JS_LOGICAL_EXPRESSION => {
-            let logical_expression = JsLogicalExpression::cast(syntax_node).unwrap();
-
-            let JsLogicalExpressionFields {
+        let current_operator = Operation::Logical(logical_expression.operator_kind()?);
+        let should_flatten = should_flatten_logical_expression(&logical_expression)?;
+        flatten_items.make_flatten_item_from_binaryish_expression(
+            MakeFlattenItemPayload {
                 left,
                 right,
                 operator,
-            } = logical_expression.as_fields();
-            let right = right?;
-            let operator = operator?;
-            let left = left?;
-            let has_comments =
-                right.syntax().contains_comments() || operator.has_trailing_comments();
+                previous_operator,
+                current_operator,
+                should_flatten,
+            },
+            |formatted, has_comments| {
+                FlattenItem::Logical(logical_expression, formatted, has_comments)
+            },
+        )?;
+    } else if let Some(instanceof_expression) = JsInstanceofExpression::cast(syntax_node.clone()) {
+        let JsInstanceofExpressionFields {
+            left,
+            right,
+            instanceof_token,
+        } = instanceof_expression.as_fields();
+        let right = right?;
+        let operator = instanceof_token?;
+        let left = left?;
 
-            // In order to flatten the expression, we have to check if the left node
-            // is a binary expression with the same operator.
-            // If the two operators are not the same, we stop the flattening.
-            let current_operator = Operation::Logical(logical_expression.operator_kind()?);
-            if should_flatten_logical_expression(&logical_expression)? {
-                flatten_expressions(
-                    flatten_items,
-                    left.syntax().clone(),
-                    formatter,
-                    Some(operator),
-                )?;
+        let current_operator = Operation::Instanceof;
+        let should_flatten = should_flatten_instanceof_expression(&instanceof_expression)?;
+        flatten_items.make_flatten_item_from_binaryish_expression(
+            MakeFlattenItemPayload {
+                left,
+                right,
+                operator,
+                previous_operator,
+                current_operator,
+                should_flatten,
+            },
+            |formatted, has_comments| {
+                FlattenItem::Instanceof(instanceof_expression, formatted, has_comments)
+            },
+        )?;
+    } else if let Some(in_expression) = JsInExpression::cast(syntax_node.clone()) {
+        let JsInExpressionFields {
+            property,
+            in_token,
+            object,
+        } = in_expression.as_fields();
+        let left = property?;
+        let operator = in_token?;
+        let right = object?;
 
-                let (formatted, _) = format_with_or_without_parenthesis(
-                    current_operator,
-                    right.clone(),
-                    right.format(formatter)?,
-                )?;
-                flatten_items.items.push(FlattenItem::Logical(
-                    logical_expression,
-                    FlattenItemFormatted {
-                        node_element: formatted,
-                        operator_element: previous_operator.format_or_empty(formatter)?,
-                    },
-                    has_comments.into(),
-                ));
-            } else {
-                let (left_item, right_item) =
-                    split_binaryish_to_flatten_items(SplitToElementParams {
-                        formatter,
-                        left,
-                        previous_operator,
-                        right,
-                        operator,
-                        current_operator,
-                    })?;
-                flatten_items.items.push(left_item);
-                flatten_items.items.push(right_item);
-            }
-        }
-        _ => {
-            let (formatted, has_comments) = if let Some(previous_operator) = previous_operator {
-                let formatted = format_elements![
-                    syntax_node.to_format_element(formatter)?,
-                    space_token(),
-                    previous_operator.format(formatter)?
-                ];
-                (
-                    formatted,
-                    previous_operator.has_leading_comments()
-                        || previous_operator.has_trailing_comments(),
-                )
-            } else {
-                (
-                    syntax_node.to_format_element(formatter)?,
-                    syntax_node.contains_comments(),
-                )
-            };
+        let current_operator = Operation::In;
+        let should_flatten = should_flatten_in_expression(&in_expression)?;
 
-            flatten_items.items.push(FlattenItem::Node(
-                syntax_node,
+        flatten_items.make_flatten_item_from_binaryish_expression(
+            MakeFlattenItemPayload {
+                left,
+                right,
+                operator,
+                previous_operator,
+                current_operator,
+                should_flatten,
+            },
+            |formatted, has_comments| FlattenItem::In(in_expression, formatted, has_comments),
+        )?;
+    } else {
+        let (formatted, has_comments) = if let Some(previous_operator) = previous_operator {
+            let formatted = format_elements![
+                syntax_node.to_format_element(formatter)?,
+                space_token(),
+                previous_operator.format(formatter)?
+            ];
+            (
                 formatted,
-                has_comments.into(),
-            ));
-        }
-    }
+                previous_operator.has_leading_comments()
+                    || previous_operator.has_trailing_comments(),
+            )
+        } else {
+            (
+                syntax_node.to_format_element(formatter)?,
+                syntax_node.contains_comments(),
+            )
+        };
+
+        flatten_items.items.push(FlattenItem::Node(
+            syntax_node,
+            formatted,
+            has_comments.into(),
+        ));
+    };
 
     Ok(())
 }
@@ -300,22 +294,46 @@ fn should_flatten_logical_expression(node: &JsLogicalExpression) -> FormatResult
     Ok(should_flatten)
 }
 
+/// The `JsInstanceofExpression` should be flatten if its left hand side is also a `JsInstanceofExpression`
+fn should_flatten_instanceof_expression(node: &JsInstanceofExpression) -> FormatResult<bool> {
+    let JsInstanceofExpressionFields { left, .. } = node.as_fields();
+
+    Ok(matches!(left?, JsAnyExpression::JsInstanceofExpression(_)))
+}
+
+/// The `JsInExpression` should be flatten if its left hand side is also a `JsInExpression`
+fn should_flatten_in_expression(node: &JsInExpression) -> FormatResult<bool> {
+    let JsInExpressionFields { property, .. } = node.as_fields();
+
+    Ok(matches!(
+        property?,
+        JsAnyInProperty::JsAnyExpression(JsAnyExpression::JsInExpression(_))
+    ))
+}
+
+/// Small wrapper to identify the operation of an expression and deduce their precedence
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum Operation {
     Logical(JsLogicalOperation),
     Binary(JsBinaryOperation),
+    Instanceof,
+    In,
 }
 
 /// Parameters needed for [split_node_to_flatten_items].
 ///
 /// Check the documentation of  [split_node_to_flatten_items] for a better explanation of the payload
-struct SplitToElementParams<'a> {
+struct SplitToElementParams<
+    'a,
+    Left: AstNode + ToFormatElement + Clone,
+    Right: AstNode + ToFormatElement + Clone,
+> {
     /// Current instance of the formatter
     formatter: &'a Formatter,
     /// The left property of the current binaryish expression
-    left: JsAnyExpression,
+    left: Left,
     /// The right property of the current binaryish expression
-    right: JsAnyExpression,
+    right: Right,
     /// The token of the operator of the current binaryish expression
     operator: SyntaxToken,
     /// The  token of the operator of the previous binaryish expression, if it exists
@@ -345,9 +363,13 @@ struct SplitToElementParams<'a> {
 /// `[ `left`, `&&` ]` and `[ `right`, `&&` ]`.
 ///
 /// Doing so will us to correctly maintain the formatting of the whole algorithm.
-fn split_binaryish_to_flatten_items(
-    params: SplitToElementParams,
-) -> FormatResult<(FlattenItem, FlattenItem)> {
+fn split_binaryish_to_flatten_items<Left, Right>(
+    params: SplitToElementParams<Left, Right>,
+) -> FormatResult<(FlattenItem, FlattenItem)>
+where
+    Left: AstNode + ToFormatElement + Clone,
+    Right: AstNode + ToFormatElement + Clone,
+{
     let SplitToElementParams {
         formatter,
         left,
@@ -578,17 +600,95 @@ fn should_indent_if_parent_inlines(current_node: &SyntaxNode) -> bool {
 }
 
 #[derive(Debug)]
-struct FlattenItems {
+struct FlattenItems<'f> {
     pub current_node: SyntaxNode,
     pub items: Vec<FlattenItem>,
+    pub formatter: &'f Formatter,
 }
 
-impl FlattenItems {
-    pub fn new(current_node: SyntaxNode) -> Self {
+struct MakeFlattenItemPayload<
+    Node: AstNode + ToFormatElement + Clone,
+    Right: AstNode + ToFormatElement + Clone,
+> {
+    /// Left hand side of the expression
+    left: Node,
+    /// The operator of the expression
+    operator: SyntaxToken,
+    /// Right hand side of the expression
+    right: Right,
+    // In order to flatten the expression, we have to check if the left node has the same operator
+    // of the parent node.
+    // If the two operators are not the same, we stop the flattening.
+    should_flatten: bool,
+    /// The operation that belongs to the current node
+    current_operator: Operation,
+    previous_operator: Option<SyntaxToken>,
+}
+
+impl<'f> FlattenItems<'f> {
+    pub fn new(current_node: SyntaxNode, formatter: &'f Formatter) -> Self {
         Self {
             current_node,
             items: Vec::new(),
+            formatter,
         }
+    }
+
+    /// Generic function that used to create a [FlattenItem] out of a binaryish expression:
+    ///
+    /// Nodes that fit the requirements are:
+    /// - `JsLogicalExpression`
+    /// - `JsBinaryExpression`
+    /// - `JsInstanceofExpression`
+    /// - `JsInExpression`
+    pub fn make_flatten_item_from_binaryish_expression<MakeItem, Left, Right>(
+        &mut self,
+        payload: MakeFlattenItemPayload<Left, Right>,
+        make_item: MakeItem,
+    ) -> FormatResult<()>
+    where
+        MakeItem: FnOnce(FlattenItemFormatted, WithComments) -> FlattenItem,
+        Left: AstNode + ToFormatElement + Clone,
+        Right: AstNode + ToFormatElement + Clone,
+    {
+        let MakeFlattenItemPayload {
+            left,
+            right,
+            operator,
+            should_flatten,
+            current_operator,
+            previous_operator,
+        } = payload;
+
+        let has_comments = right.syntax().contains_comments() || operator.has_trailing_comments();
+
+        if should_flatten {
+            flatten_expressions(self, left.syntax().clone(), self.formatter, Some(operator))?;
+            let (formatted, _) = format_with_or_without_parenthesis(
+                current_operator,
+                right.clone(),
+                right.format(self.formatter)?,
+            )?;
+            let flatten_item_formatted = FlattenItemFormatted {
+                node_element: formatted,
+                operator_element: previous_operator.format_or_empty(self.formatter)?,
+            };
+            let flatten_item = make_item(flatten_item_formatted, has_comments.into());
+            self.items.push(flatten_item);
+        } else {
+            let (left_item, right_item) = split_binaryish_to_flatten_items(SplitToElementParams {
+                formatter: self.formatter,
+                left,
+                previous_operator,
+                right,
+                operator,
+                current_operator,
+            })?;
+            self.items.push(left_item);
+            self.items.push(right_item);
+        };
+
+        Ok(())
     }
 
     pub fn into_format_element(self) -> FormatResult<FormatElement> {
@@ -714,8 +814,8 @@ impl From<bool> for WithComments {
 impl Debug for WithComments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WithComments::True => write!(f, "has comments"),
-            WithComments::False => write!(f, "no comments"),
+            WithComments::True => write!(f, "Has comments"),
+            WithComments::False => write!(f, "No comments"),
         }
     }
 }
@@ -724,7 +824,8 @@ impl Debug for WithComments {
 enum FlattenItem {
     Binary(JsBinaryExpression, FlattenItemFormatted, WithComments),
     Logical(JsLogicalExpression, FlattenItemFormatted, WithComments),
-
+    Instanceof(JsInstanceofExpression, FlattenItemFormatted, WithComments),
+    In(JsInExpression, FlattenItemFormatted, WithComments),
     /// Used when the right side of a binary/logical expression is another binary/logical.
     /// When we have such cases we
     Group(FormatElement, WithComments),
@@ -738,6 +839,8 @@ impl FlattenItem {
         match self {
             FlattenItem::Binary(_, _, w_c) => w_c.into(),
             FlattenItem::Logical(_, _, w_c) => w_c.into(),
+            FlattenItem::Instanceof(_, _, w_c) => w_c.into(),
+            FlattenItem::In(_, _, w_c) => w_c.into(),
             FlattenItem::Node(_, _, w_c) => w_c.into(),
             FlattenItem::Group(_, w_c) => w_c.into(),
         }
@@ -750,30 +853,36 @@ impl Debug for FlattenItem {
             FlattenItem::Logical(_, formatted, has_comments) => {
                 write!(
                     f,
-                    "LogicalExpression: {:?} - {:?}\nHas comments: {:?}",
+                    "LogicalExpression: {:?} - {:?}\n{:?}",
                     formatted.node_element, formatted.operator_element, has_comments
                 )
             }
             FlattenItem::Binary(_, formatted, has_comments) => {
                 write!(
                     f,
-                    "BinaryExpression: {:?} - {:?}\nHas comments: {:?}",
+                    "BinaryExpression: {:?} - {:?}\n{:?}",
+                    formatted.node_element, formatted.operator_element, has_comments
+                )
+            }
+            FlattenItem::Instanceof(_, formatted, has_comments) => {
+                write!(
+                    f,
+                    "InstanceofExpression: {:?} - {:?}\n{:?}",
+                    formatted.node_element, formatted.operator_element, has_comments
+                )
+            }
+            FlattenItem::In(_, formatted, has_comments) => {
+                write!(
+                    f,
+                    "InExpression: {:?} - {:?}\n{:?}",
                     formatted.node_element, formatted.operator_element, has_comments
                 )
             }
             FlattenItem::Node(_, formatted, has_comments) => {
-                write!(
-                    f,
-                    "Any other node: {:?}\nHas comments: {:?}",
-                    formatted, has_comments
-                )
+                write!(f, "Any other node: {:?}\n{:?}", formatted, has_comments)
             }
             FlattenItem::Group(formatted, has_comments) => {
-                write!(
-                    f,
-                    "Right group: {:?}\nHas comments: {:?}",
-                    formatted, has_comments
-                )
+                write!(f, "Right group: {:?}\n{:?}", formatted, has_comments)
             }
         }
     }
@@ -784,6 +893,8 @@ impl From<FlattenItem> for FormatElement {
         match item {
             FlattenItem::Binary(_, formatted, _) => formatted.into(),
             FlattenItem::Logical(_, formatted, _) => formatted.into(),
+            FlattenItem::Instanceof(_, formatted, _) => formatted.into(),
+            FlattenItem::In(_, formatted, _) => formatted.into(),
             FlattenItem::Node(_, element, _) => element,
             FlattenItem::Group(element, _) => element,
         }

--- a/crates/rome_formatter/tests/specs/js/module/expression/binaryish_expression.js
+++ b/crates/rome_formatter/tests/specs/js/module/expression/binaryish_expression.js
@@ -1,0 +1,1 @@
+2 > 4 + 4 * 24 % 3 << 23 instanceof Number in data || a in status instanceof String + 15 && foo && bar && lorem instanceof String;

--- a/crates/rome_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 197
+expression: binaryish_expression.js
+
+---
+# Input
+2 > 4 + 4 * 24 % 3 << 23 instanceof Number in data || a in status instanceof String + 15 && foo && bar && lorem instanceof String;
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+-----
+((2 > (4 + (4 * 24 % 3) << 23) instanceof Number) in data) || (
+	((a in status) instanceof String + 15) &&
+		foo &&
+		bar &&
+		(lorem instanceof String)
+);
+

--- a/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js
+++ b/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js
@@ -106,3 +106,7 @@ foo && bar || baz;
 a instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean;
 
 a in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName;
+
+
+veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo instanceof String && veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Number || veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Boolean
+

--- a/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js
+++ b/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js
@@ -102,3 +102,7 @@ let foo = one && two || three && four || five && six;
 // Implicitly parenthesized && and || requires parens
 foo && bar || baz;
 
+
+a instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean;
+
+a in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName;

--- a/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -113,6 +113,11 @@ foo && bar || baz;
 a instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean;
 
 a in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName;
+
+
+veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo instanceof String && veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Number || veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Boolean
+
+
 =============================
 # Outputs
 ## Output 1
@@ -302,4 +307,12 @@ a in
 	LongClassName in
 	LongClassName in
 	LongClassName;
+
+(
+	(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo instanceof String) && (
+		veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Number
+	)
+) || (
+	veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar instanceof Boolean
+);
 

--- a/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -110,6 +110,9 @@ let foo = one && two || three && four || five && six;
 foo && bar || baz;
 
 
+a instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean instanceof Number instanceof String instanceof Boolean;
+
+a in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName in LongClassName;
 =============================
 # Outputs
 ## Output 1
@@ -277,4 +280,26 @@ let foo = (one && two) || (three && four) || (five && six);
 
 // Implicitly parenthesized && and || requires parens
 (foo && bar) || baz;
+
+a instanceof
+	Number instanceof
+	String instanceof
+	Boolean instanceof
+	Number instanceof
+	String instanceof
+	Boolean instanceof
+	Number instanceof
+	String instanceof
+	Boolean;
+
+a in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName in
+	LongClassName;
 

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/private-fields-in-in.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/private-fields-in-in.js.snap
@@ -109,7 +109,7 @@ class C3 {
   get #getter() {}
 
   static isC(obj) {
-    return #brand in obj && #method in obj && #getter in obj;
+    return (#brand in obj) && (#method in obj) && (#getter in obj);
   }
 }
 // Invalid https://github.com/tc39/proposal-private-fields-in-in#try-statement

--- a/crates/rome_formatter/tests/specs/prettier/js/binary-expressions/test.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/binary-expressions/test.js.snap
@@ -73,7 +73,7 @@ const x10 = longVariable > longint && longVariable === (
 );
 
 foo(
-  obj.property * new Class() && obj instanceof Class && longVariable ? number + 5 : false,
+  obj.property * new Class() && (obj instanceof Class) && longVariable ? number + 5 : false,
 );
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/in/arrow-function.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/in/arrow-function.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 144
 expression: arrow-function.js
 
 ---
@@ -14,7 +14,7 @@ const y = () => [] in x
 
 # Output
 ```js
-const x = () => [].includes(true) || "ontouchend" in document;
+const x = () => [].includes(true) || ("ontouchend" in document);
 
 const y = () => [] in x;
 

--- a/crates/rome_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -206,7 +206,7 @@ d3.select("body").selectAll("p").data([1, 2, 3]).enter().style("color", "white")
 
 Object
   .keys(props)
-  .filter((key) => key in own === false)
+  .filter((key) => (key in own) === false)
   .reduce(
     (a, key) => {
       a[key] = props[key];

--- a/crates/rome_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/private-fields-in-in/basic.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 144
 expression: basic.ts
 
 ---
@@ -36,7 +36,7 @@ class Person {
     return (
       other &&
         typeof other === "object" &&
-        #name in other && // <- this is new!
+        (#name in other) && // <- this is new!
         this.#name === other.#name
     );
   }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds `JsInstanceofExpression` and `JsInExpression` to be considered inside the formatting of binaryish expressions.

I took the opportunity to also refactor and generalize a bit the implementation of some parts of the code.

The formatted result of the new tests is a bit strange, also because it's highly impossible to have some code like this, but it's completely inline with the whole algorithm.

Also Prettier formats them at the same way.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
