### PR TITLE
chore(coverage): Sort test suite names before comparing results

### DIFF
--- a/xtask/coverage/src/compare.rs
+++ b/xtask/coverage/src/compare.rs
@@ -47,7 +47,13 @@ pub fn coverage_compare(
         );
     }
 
-    let base_results = read_test_results(base_result_dir.as_path(), "base");
+    let mut base_results = read_test_results(base_result_dir.as_path(), "base")
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    // Sort suite names to get a stable result in CI comments
+    base_results.sort_unstable_by(|(suite_a, _), (suite_b, _)| suite_a.cmp(suite_b));
+
     let mut new_results = read_test_results(new_result_dir.as_path(), "new");
 
     for (suite, base) in base_results.into_iter() {


### PR DESCRIPTION
## Summary
Sort the coverage results by test suite name to ensure the suites don't get reordered when the comment gets updated.

