### PR TITLE
fix(rome_lsp): handle changes to workspace settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -498,6 +499,17 @@ name = "futures-core"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1357,6 +1369,7 @@ name = "rome_lsp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "indexmap",
  "lspower",
  "parking_lot 0.12.0",

--- a/crates/rome_lsp/Cargo.toml
+++ b/crates/rome_lsp/Cargo.toml
@@ -22,3 +22,4 @@ tracing = { version = "0.1.31", features = ["max_level_trace", "release_max_leve
 tracing-tree = "0.2.0"
 tracing-subscriber = "0.3.5"
 parking_lot = "0.12.0"
+futures = "0.3"


### PR DESCRIPTION
## Summary

This PR allows the LSP server to register for `workspace/didChangeConfiguration` notifications so that VS Code will send them. There doesn't seem to be a way to register that statically as part of the `initialize` response, so this adds dynamic registration via `client/registerCapability` as part of the `initialized` handler.

VS Code doesn't seem to include changes as part of `DidChangeConfigurationParams` (or `params.initialization_options`) so this always uses a `workspace/configuration` request to update the workspace settings. And it updates diagnostics whenever the value of `analysis.enable_diagnostics` changes.

## Test Plan

Tested manually in VS Code on macOS.