### PR TITLE
chore: Upgrade to Rust 1.59.0

### DIFF
--- a/crates/rome_analyze/src/signals.rs
+++ b/crates/rome_analyze/src/signals.rs
@@ -156,13 +156,12 @@ pub struct Analysis {
 impl Analysis {
     pub fn into_actions(self) -> impl Iterator<Item = Action> {
         self.signals
-            .into_iter()
             // TODO: There must be a better way to do this.
-            .map(|s| match s {
+            .into_iter()
+            .flat_map(|s| match s {
                 Signal::Action(a) => vec![a].into_iter(),
                 Signal::Diagnostic(d) => d.actions.into_iter(),
             })
-            .flatten()
     }
 
     pub fn into_diagnostics(self) -> impl Iterator<Item = AnalyzeDiagnostic> {

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -149,7 +149,7 @@ pub(crate) fn format(mut session: CliSession) {
         }
 
         let name = path.display().to_string();
-        let source = fs::read_to_string(path).ok().unwrap_or_else(String::new);
+        let source = fs::read_to_string(path).ok().unwrap_or_default();
 
         files.storage.insert(file_id, SimpleFile::new(name, source));
     }

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -29,12 +29,11 @@ pub struct PrinterOptions {
 
 impl From<FormatOptions> for PrinterOptions {
     fn from(options: FormatOptions) -> Self {
-        let indent_string: String;
         let tab_width = 2;
 
-        match options.indent_style {
-            IndentStyle::Tab => indent_string = String::from("\t"),
-            IndentStyle::Space(width) => indent_string = " ".repeat(width as usize),
+        let indent_string = match options.indent_style {
+            IndentStyle::Tab => String::from("\t"),
+            IndentStyle::Space(width) => " ".repeat(width as usize),
         };
 
         PrinterOptions {

--- a/crates/rome_js_syntax/src/numbers.rs
+++ b/crates/rome_js_syntax/src/numbers.rs
@@ -6,10 +6,10 @@ pub use num_bigint::BigInt;
 
 fn split_into_radix_and_number(num: &str) -> (u32, String) {
     match num.get(0..2) {
-        Some("0x") | Some("0X") => (16, num.get(2..).unwrap().replace("_", "")),
-        Some("0b") | Some("0B") => (2, num.get(2..).unwrap().replace("_", "")),
-        Some("0o") | Some("0O") => (8, num.get(2..).unwrap().replace("_", "")),
-        _ => (10, num.replace("_", "")),
+        Some("0x") | Some("0X") => (16, num.get(2..).unwrap().replace('_', "")),
+        Some("0b") | Some("0B") => (2, num.get(2..).unwrap().replace('_', "")),
+        Some("0o") | Some("0O") => (8, num.get(2..).unwrap().replace('_', "")),
+        _ => (10, num.replace('_', "")),
     }
 }
 

--- a/crates/rslint_errors/src/emit.rs
+++ b/crates/rslint_errors/src/emit.rs
@@ -46,8 +46,7 @@ impl<'a> codespan::files::Files<'a> for EmitterFiles<'_> {
             EmitterFileId::Virtual(id) => self
                 .virtual_files
                 .get(&id)
-                .map(|x| x.source(id))
-                .flatten()
+                .and_then(|x| x.source(id))
                 .ok_or(Error::FileMissing),
         }
     }
@@ -65,8 +64,7 @@ impl<'a> codespan::files::Files<'a> for EmitterFiles<'_> {
             EmitterFileId::Virtual(id) => self
                 .virtual_files
                 .get(&id)
-                .map(|x| x.line_index(id, byte_index))
-                .flatten()
+                .and_then(|x| x.line_index(id, byte_index))
                 .ok_or(Error::IndexTooLarge {
                     given: byte_index,
                     max: usize::MAX,
@@ -87,8 +85,7 @@ impl<'a> codespan::files::Files<'a> for EmitterFiles<'_> {
             EmitterFileId::Virtual(id) => self
                 .virtual_files
                 .get(&id)
-                .map(|x| x.line_range(id, line_index))
-                .flatten()
+                .and_then(|x| x.line_range(id, line_index))
                 .ok_or(Error::IndexTooLarge {
                     given: line_index,
                     max: usize::MAX,

--- a/crates/rslint_parser/src/tests.rs
+++ b/crates/rslint_parser/src/tests.rs
@@ -69,7 +69,7 @@ fn try_parse(path: &str, text: &str) -> Parse<JsAnyRoot> {
 
         parse
     });
-    assert!(!res.is_err(), "Trying to parse `{}` panicked", path);
+    assert!(res.is_ok(), "Trying to parse `{}` panicked", path);
     res.unwrap()
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.58.0"
+channel = "1.59.0"

--- a/xtask/coverage/src/runner.rs
+++ b/xtask/coverage/src/runner.rs
@@ -295,8 +295,8 @@ fn load_tests(suite: &dyn TestSuite, context: &mut TestRunContext) -> TestSuiteI
             }
 
             if let Some(filter) = &context.filter {
-                let normalized_path = path.to_string_lossy().replace("\\", "/");
-                let normalized_query = filter.replace("\\", "/");
+                let normalized_path = path.to_string_lossy().replace('\\', "/");
+                let normalized_query = filter.replace('\\', "/");
                 normalized_path.contains(&normalized_query)
             } else {
                 true


### PR DESCRIPTION
## Summary

Upgrades toolchain to Rust 1.59 and fixes any new clippy errors.

## Test Plan

`cargo test`