### PR TITLE
refactor: Lexer Diagnostics

### DIFF
--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -596,12 +596,11 @@ mod test {
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-3 + 3 === 7   
+3 + 3 === 7
 "#;
         let syntax = SourceType::ts();
         let tree = parse(src, 0, syntax.clone());
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
-        dbg!(&tree.syntax());
         check_reformat(CheckReformatParams {
             root: &tree.syntax(),
             text: result.as_code(),

--- a/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decimal.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/babel-plugins/decimal.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 144
 expression: decimal.js
 
 ---
@@ -76,23 +76,11 @@ typeof 1m === "decimal128";
 
 # Errors
 ```
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:3:4
-  │
-3 │ 100m;
-  │    ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '100m'
   ┌─ decimal.js:3:1
   │
 3 │ 100m;
   │ ^^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:4:20
-  │
-4 │ 9223372036854775807m;
-  │                    ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '9223372036854775807m'
   ┌─ decimal.js:4:1
@@ -100,23 +88,11 @@ error[SyntaxError]: expected a statement but instead found '9223372036854775807m
 4 │ 9223372036854775807m;
   │ ^^^^^^^^^^^^^^^^^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:5:3
-  │
-5 │ 0.m;
-  │   ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '0.m'
   ┌─ decimal.js:5:1
   │
 5 │ 0.m;
   │ ^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:6:19
-  │
-6 │ 3.1415926535897932m;
-  │                   ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '3.1415926535897932m'
   ┌─ decimal.js:6:1
@@ -124,23 +100,11 @@ error[SyntaxError]: expected a statement but instead found '3.1415926535897932m'
 6 │ 3.1415926535897932m;
   │ ^^^^^^^^^^^^^^^^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:7:8
-  │
-7 │ 100.000m;
-  │        ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '100.000m'
   ┌─ decimal.js:7:1
   │
 7 │ 100.000m;
   │ ^^^^^^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:8:3
-  │
-8 │ .1m;
-  │   ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '.1m'
   ┌─ decimal.js:8:1
@@ -148,23 +112,11 @@ error[SyntaxError]: expected a statement but instead found '.1m'
 8 │ .1m;
   │ ^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:5
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │     ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a property, a shorthand property, a getter, a setter, or a method but instead found '0m'
   ┌─ decimal.js:9:4
   │
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │    ^^ Expected a property, a shorthand property, a getter, a setter, or a method here
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:13
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │             ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a property, a shorthand property, a getter, a setter, or a method but instead found '.1m() {'
   ┌─ decimal.js:9:11
@@ -172,23 +124,11 @@ error[SyntaxError]: expected a property, a shorthand property, a getter, a sette
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │           ^^^^^^^ Expected a property, a shorthand property, a getter, a setter, or a method here
 
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:28
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │                            ^ an identifier cannot appear here
-
 error[SyntaxError]: expected `')'` but instead found `0.2m`
   ┌─ decimal.js:9:25
   │
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │                         ^^^^ unexpected
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:40
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │                                        ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found ', set 3m(_)'
   ┌─ decimal.js:9:33
@@ -196,23 +136,11 @@ error[SyntaxError]: expected a statement but instead found ', set 3m(_)'
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │                                 ^^^^^^^^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:55
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │                                                       ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found ', async 4m()'
   ┌─ decimal.js:9:46
   │
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │                                              ^^^^^^^^^^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-  ┌─ decimal.js:9:66
-  │
-9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
-  │                                                                  ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found ', *.5m()'
   ┌─ decimal.js:9:61
@@ -226,23 +154,11 @@ error[SyntaxError]: expected a statement but instead found '})'
 9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
   │                                                                         ^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:10:3
-   │
-10 │ 1.m;
-   │   ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '1.m'
    ┌─ decimal.js:10:1
    │
 10 │ 1.m;
    │ ^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:11:4
-   │
-11 │ 100m;
-   │    ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '100m'
    ┌─ decimal.js:11:1
@@ -250,23 +166,11 @@ error[SyntaxError]: expected a statement but instead found '100m'
 11 │ 100m;
    │ ^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:12:20
-   │
-12 │ 9223372036854775807m;
-   │                    ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '9223372036854775807m'
    ┌─ decimal.js:12:1
    │
 12 │ 9223372036854775807m;
    │ ^^^^^^^^^^^^^^^^^^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:13:5
-   │
-13 │ 100.m;
-   │     ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '100.m'
    ┌─ decimal.js:13:1
@@ -274,23 +178,11 @@ error[SyntaxError]: expected a statement but instead found '100.m'
 13 │ 100.m;
    │ ^^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:16:4
-   │
-16 │ 2e9m;
-   │    ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '2e9m'
    ┌─ decimal.js:16:1
    │
 16 │ 2e9m;
    │ ^^^^ Expected a statement here
-
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:17:7
-   │
-17 │ 016432m;
-   │       ^ an identifier cannot appear here
 
 error[SyntaxError]: expected a statement but instead found '016432m'
    ┌─ decimal.js:17:1
@@ -298,17 +190,137 @@ error[SyntaxError]: expected a statement but instead found '016432m'
 17 │ 016432m;
    │ ^^^^^^^ Expected a statement here
 
-error: numbers cannot be followed by identifiers directly after
-   ┌─ decimal.js:18:4
-   │
-18 │ 089m;
-   │    ^ an identifier cannot appear here
-
 error[SyntaxError]: expected a statement but instead found '089m'
    ┌─ decimal.js:18:1
    │
 18 │ 089m;
    │ ^^^^ Expected a statement here
+
+error[SyntaxError]: expected a statement but instead found '.1m + .2m === .3m'
+   ┌─ decimal.js:21:1
+   │
+21 │ .1m + .2m === .3m;
+   │ ^^^^^^^^^^^^^^^^^ Expected a statement here
+
+error[SyntaxError]: expected a statement but instead found '2.00m'
+   ┌─ decimal.js:22:1
+   │
+22 │ 2.00m;
+   │ ^^^^^ Expected a statement here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:3:4
+  │
+3 │ 100m;
+  │    ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:4:20
+  │
+4 │ 9223372036854775807m;
+  │                    ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:5:3
+  │
+5 │ 0.m;
+  │   ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:6:19
+  │
+6 │ 3.1415926535897932m;
+  │                   ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:7:8
+  │
+7 │ 100.000m;
+  │        ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:8:3
+  │
+8 │ .1m;
+  │   ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:5
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │     ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:13
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │             ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:28
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │                            ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:40
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │                                        ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:55
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │                                                       ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+  ┌─ decimal.js:9:66
+  │
+9 │ ({ 0m: 0, .1m() {}, get 0.2m(){}, set 3m(_){}, async 4m() {}, *.5m() {} });
+  │                                                                  ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:10:3
+   │
+10 │ 1.m;
+   │   ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:11:4
+   │
+11 │ 100m;
+   │    ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:12:20
+   │
+12 │ 9223372036854775807m;
+   │                    ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:13:5
+   │
+13 │ 100.m;
+   │     ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:16:4
+   │
+16 │ 2e9m;
+   │    ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:17:7
+   │
+17 │ 016432m;
+   │       ^ an identifier cannot appear here
+
+error: numbers cannot be followed by identifiers directly after
+   ┌─ decimal.js:18:4
+   │
+18 │ 089m;
+   │    ^ an identifier cannot appear here
 
 error: numbers cannot be followed by identifiers directly after
    ┌─ decimal.js:21:3
@@ -328,23 +340,11 @@ error: numbers cannot be followed by identifiers directly after
 21 │ .1m + .2m === .3m;
    │                 ^ an identifier cannot appear here
 
-error[SyntaxError]: expected a statement but instead found '.1m + .2m === .3m'
-   ┌─ decimal.js:21:1
-   │
-21 │ .1m + .2m === .3m;
-   │ ^^^^^^^^^^^^^^^^^ Expected a statement here
-
 error: numbers cannot be followed by identifiers directly after
    ┌─ decimal.js:22:5
    │
 22 │ 2.00m;
    │     ^ an identifier cannot appear here
-
-error[SyntaxError]: expected a statement but instead found '2.00m'
-   ┌─ decimal.js:22:1
-   │
-22 │ 2.00m;
-   │ ^^^^^ Expected a statement here
 
 error: numbers cannot be followed by identifiers directly after
    ┌─ decimal.js:23:3

--- a/crates/rome_formatter/tests/specs/prettier/js/do/do.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/do/do.js.snap
@@ -287,6 +287,18 @@ error[SyntaxError]: expected `while` but instead found `;`
 54 │ };
    │  ^ unexpected
 
+error: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
+   ┌─ do.js:31:9
+   │
+31 │         }
+   │         ^
+
+error: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
+   ┌─ do.js:32:7
+   │
+32 │       }
+   │       ^
+
 
 ```
 

--- a/crates/rome_formatter/tests/specs/prettier/js/multiparser-graphql/invalid.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/multiparser-graphql/invalid.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 144
 expression: invalid.js
 
 ---

--- a/crates/rome_formatter/tests/specs/prettier/js/multiparser-invalid/text.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/multiparser-invalid/text.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 144
 expression: text.js
 
 ---
@@ -84,23 +84,11 @@ error: expected hex digits for a unicode code point escape, but encountered an i
 6 │ foo = /* HTML */`\u{prettier}\u{0065}`;
   │                     ^
 
-error[SyntaxError]: Invalid template literal
-  ┌─ text.js:6:18
-  │
-6 │ foo = /* HTML */`\u{prettier}\u{0065}`;
-  │                  ^^^^^^^^^^^^^^^^^^^^
-
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
   ┌─ text.js:7:24
   │
 7 │ foo = /* GraphQL */`\u{prettier}\u{0065}`;
   │                        ^
-
-error[SyntaxError]: Invalid template literal
-  ┌─ text.js:7:21
-  │
-7 │ foo = /* GraphQL */`\u{prettier}\u{0065}`;
-  │                     ^^^^^^^^^^^^^^^^^^^^
 
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:14:21
@@ -108,23 +96,11 @@ error: expected hex digits for a unicode code point escape, but encountered an i
 14 │ foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
    │                     ^
 
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:14:18
-   │
-14 │ foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
-   │                  ^^^^^^^^^^^^
-
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:15:24
    │
 15 │ foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
    │                        ^
-
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:15:21
-   │
-15 │ foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
-   │                     ^^^^^^^^^^^^
 
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:22:42
@@ -132,23 +108,11 @@ error: expected hex digits for a unicode code point escape, but encountered an i
 22 │ foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}`;
    │                                          ^
 
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:22:39
-   │
-22 │ foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}`;
-   │                                       ^^^^^^^^^^^^
-
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:23:45
    │
 23 │ foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}`;
    │                                             ^
-
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:23:42
-   │
-23 │ foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}`;
-   │                                          ^^^^^^^^^^^^
 
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:30:42
@@ -156,23 +120,11 @@ error: expected hex digits for a unicode code point escape, but encountered an i
 30 │ foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
    │                                          ^
 
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:30:39
-   │
-30 │ foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
-   │                                       ^^^^^^^^^^^^
-
 error: expected hex digits for a unicode code point escape, but encountered an invalid character
    ┌─ text.js:31:45
    │
 31 │ foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
    │                                             ^
-
-error[SyntaxError]: Invalid template literal
-   ┌─ text.js:31:42
-   │
-31 │ foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
-   │                                          ^^^^^^^^^^^^
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/numeric-separators/number.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/numeric-separators/number.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 144
 expression: number.js
 
 ---
@@ -30,17 +30,17 @@ error[SyntaxError]: Decimals with leading zeros are not allowed in strict mode.
 3 │ a = 09e1_1;
   │     ^^^^^^
 
-error: unexpected number
-  ┌─ number.js:4:5
-  │
-4 │ a = 09.1_1;
-  │     ^^^
-
 error[SyntaxError]: Decimals with leading zeros are not allowed in strict mode.
   ┌─ number.js:4:5
   │
 4 │ a = 09.1_1;
   │     ^^^^^^
+
+error: unexpected number
+  ┌─ number.js:4:5
+  │
+4 │ a = 09.1_1;
+  │     ^^^
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/record/syntax.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 144
 expression: syntax.js
 
 ---
@@ -35,12 +35,6 @@ expression: syntax.js
 
 # Errors
 ```
-error: expected `!` following a `#`, but found none
-  ┌─ syntax.js:1:1
-  │
-1 │ #{}
-  │ ^
-
 error[SyntaxError]: expected a statement but instead found '#'
   ┌─ syntax.js:1:1
   │
@@ -112,6 +106,12 @@ error[SyntaxError]: expected a statement but instead found ']'
   │
 3 │ #{ a: 1, b: #[2, 3, #{ c: 4 }] }
   │                              ^ Expected a statement here
+
+error: expected `!` following a `#`, but found none
+  ┌─ syntax.js:1:1
+  │
+1 │ #{}
+  │ ^
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/syntax.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/syntax.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 144
 expression: syntax.js
 
 ---
@@ -26,12 +26,6 @@ expression: syntax.js
 
 # Errors
 ```
-error: expected `!` following a `#`, but found none
-  ┌─ syntax.js:1:1
-  │
-1 │ #[]
-  │ ^
-
 error[SyntaxError]: expected a statement but instead found '#[]
 #[1, 2]
 #[1, 2, #'
@@ -47,6 +41,12 @@ error[SyntaxError]: expected a statement but instead found ']'
   │
 3 │ #[1, 2, #{ a: 3 }]
   │                  ^ Expected a statement here
+
+error: expected `!` following a `#`, but found none
+  ┌─ syntax.js:1:1
+  │
+1 │ #[]
+  │ ^
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple-trailing-comma.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/tuple/tuple-trailing-comma.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 83
+assertion_line: 144
 expression: tuple-trailing-comma.js
 
 ---
@@ -18,17 +18,17 @@ expression: tuple-trailing-comma.js
 
 # Errors
 ```
-error: expected `!` following a `#`, but found none
-  ┌─ tuple-trailing-comma.js:1:1
-  │
-1 │ #[1,]
-  │ ^
-
 error[SyntaxError]: expected a statement but instead found '#[1,]'
   ┌─ tuple-trailing-comma.js:1:1
   │
 1 │ #[1,]
   │ ^^^^^ Expected a statement here
+
+error: expected `!` following a `#`, but found none
+  ┌─ tuple-trailing-comma.js:1:1
+  │
+1 │ #[1,]
+  │ ^
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/angular-component-examples/test.component.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/angular-component-examples/test.component.ts.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
+assertion_line: 144
 expression: test.component.ts
+
 ---
 # Input
 ```js
@@ -73,6 +75,12 @@ error[SyntaxError]: Expected a semicolon or an implicit semicolon after a statem
    │  │   An explicit or implicit semicolon is expected here...
    │  ...Which is required to end this statement
 
+error[SyntaxError]: expected `'}'` but instead the file ends
+   ┌─ test.component.ts:18:1
+   │
+18 │ 
+   │ ^ the file ends here
+
 error: unterminated template literal
    ┌─ test.component.ts:13:2
    │  
@@ -84,24 +92,6 @@ error: unterminated template literal
 17 │ │ class     TestComponent {}
 18 │ │ 
    │ └^
-
-error[SyntaxError]: Invalid template literal
-   ┌─ test.component.ts:13:2
-   │  
-13 │   `
-   │ ┌─^
-14 │ │ 
-15 │ │ ]
-16 │ │ })
-17 │ │ class     TestComponent {}
-18 │ │ 
-   │ └^
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-   ┌─ test.component.ts:18:1
-   │
-18 │ 
-   │ ^ the file ends here
 
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/typescript/decorators-ts/angular.ts.snap
+++ b/crates/rome_formatter/tests/specs/prettier/typescript/decorators-ts/angular.ts.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
+assertion_line: 144
 expression: angular.ts
+
 ---
 # Input
 ```js
@@ -52,6 +54,12 @@ error[SyntaxError]: expected a type but instead found '/'
 3 │   template: `<button>{{label}}</button>`
   │                                ^ Expected a type here
 
+error[SyntaxError]: expected `'}'` but instead the file ends
+  ┌─ angular.ts:9:1
+  │
+9 │ 
+  │ ^ the file ends here
+
 error: unterminated regex literal
   ┌─ angular.ts:3:41
   │
@@ -72,25 +80,6 @@ error: unterminated template literal
 8 │ │ }
 9 │ │ 
   │ └^
-
-error[SyntaxError]: Invalid template literal
-  ┌─ angular.ts:3:41
-  │  
-3 │     template: `<button>{{label}}</button>`
-  │ ┌────────────────────────────────────────^
-4 │ │ })
-5 │ │ export class HeroButtonComponent {
-6 │ │   @Output() change = new EventEmitter<any>();
-7 │ │   @Input() label: string;
-8 │ │ }
-9 │ │ 
-  │ └^
-
-error[SyntaxError]: expected `'}'` but instead the file ends
-  ┌─ angular.ts:9:1
-  │
-9 │ 
-  │ ^ the file ends here
 
 
 ```

--- a/crates/rslint_lexer/src/errors.rs
+++ b/crates/rslint_lexer/src/errors.rs
@@ -4,8 +4,7 @@ pub fn invalid_digits_after_unicode_escape_sequence(
     file_id: FileId,
     start: usize,
     end: usize,
-) -> Box<Diagnostic> {
-    let err = Diagnostic::error(file_id, "", "invalid digits after unicode escape sequence")
-        .primary(start..end, "expected valid unicode escape sequence");
-    Box::new(err)
+) -> Diagnostic {
+    Diagnostic::error(file_id, "", "invalid digits after unicode escape sequence")
+        .primary(start..end, "expected valid unicode escape sequence")
 }

--- a/crates/rslint_lexer/src/tests.rs
+++ b/crates/rslint_lexer/src/tests.rs
@@ -18,9 +18,9 @@ macro_rules! assert_lex {
         let mut tok_idx = TextSize::default();
 
         let mut new_str = String::with_capacity($src.len());
-        let mut tokens = Vec::new();
+        let mut tokens = vec![];
 
-        while lexer.next_token(LexContext::default()).kind != EOF {
+        while lexer.next_token(LexContext::default()) != EOF {
             tokens.push((lexer.current(), lexer.current_range()));
         }
 
@@ -75,7 +75,7 @@ fn losslessness(string: String) -> bool {
         let mut lexer = Lexer::from_str(&cloned, 0);
         let mut tokens = vec![];
 
-        while lexer.next_token(LexContext::default()).kind != EOF {
+        while lexer.next_token(LexContext::default()) != EOF {
             tokens.push(lexer.current_range());
         }
 
@@ -1358,6 +1358,6 @@ fn keywords() {
             lexed_range.len()
         );
 
-        assert_eq!(lexer.next_token(LexContext::default()).kind, EOF);
+        assert_eq!(lexer.next_token(LexContext::default()), EOF);
     }
 }

--- a/crates/rslint_parser/test_data/inline/err/literals.rast
+++ b/crates/rslint_parser/test_data/inline/err/literals.rast
@@ -138,6 +138,22 @@ error[SyntaxError]: Decimals with leading zeros are not allowed in strict mode.
   │                   ^^^^
 
 --
+error[SyntaxError]: "0"-prefixed octal literals are deprecated; use the "0o" prefix instead.
+  ┌─ literals.js:2:11
+  │
+2 │ 01n, 0_0, 01.2 // lexer errors
+  │           ^^^^
+
+--
+error[SyntaxError]: expected a statement but instead found '"test
+continues" // unterminated string literal'
+  ┌─ literals.js:3:1
+  │  
+3 │ ┌ "test
+4 │ │ continues" // unterminated string literal
+  │ └─────────────────────────────────────────^ Expected a statement here
+
+--
 error: Octal literals are not allowed for BigInts.
   ┌─ literals.js:2:1
   │
@@ -159,13 +175,6 @@ error: unexpected number
   │           ^^^
 
 --
-error[SyntaxError]: "0"-prefixed octal literals are deprecated; use the "0o" prefix instead.
-  ┌─ literals.js:2:11
-  │
-2 │ 01n, 0_0, 01.2 // lexer errors
-  │           ^^^^
-
---
 error: unterminated string literal
   ┌─ literals.js:3:1
   │  
@@ -184,15 +193,6 @@ error: unterminated string literal
   │ ┌─────────────────────────────────────────'
 5 │ │ 
   │ └' line breaks here
-
---
-error[SyntaxError]: expected a statement but instead found '"test
-continues" // unterminated string literal'
-  ┌─ literals.js:3:1
-  │  
-3 │ ┌ "test
-4 │ │ continues" // unterminated string literal
-  │ └─────────────────────────────────────────^ Expected a statement here
 
 --
 00, 012, 08, 091, 0789 // parser errors

--- a/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rslint_parser/test_data/inline/err/subscripts_err.rast
@@ -36,20 +36,20 @@ JsModule {
             semicolon_token: SEMICOLON@13..14 ";" [] [],
         },
         JsExpressionStatement {
-            expression: JsUnknownExpression {
-                items: [
-                    JsIdentifierExpression {
-                        name: JsReferenceIdentifier {
-                            value_token: IDENT@14..18 "BAR" [Newline("\n")] [],
-                        },
+            expression: JsTemplate {
+                tag: JsIdentifierExpression {
+                    name: JsReferenceIdentifier {
+                        value_token: IDENT@14..18 "BAR" [Newline("\n")] [],
                     },
-                    BACKTICK@18..19 "`" [] [],
-                    JsUnknown {
-                        items: [
-                            ERROR_TOKEN@19..21 "b\n" [] [],
-                        ],
+                },
+                type_arguments: missing (optional),
+                l_tick_token: BACKTICK@18..19 "`" [] [],
+                elements: JsTemplateElementList [
+                    JsTemplateChunkElement {
+                        template_chunk_token: TEMPLATE_CHUNK@19..21 "b\n" [] [],
                     },
                 ],
+                r_tick_token: missing (required),
             },
             semicolon_token: missing (optional),
         },
@@ -86,13 +86,16 @@ JsModule {
         2: (empty)
       1: SEMICOLON@13..14 ";" [] []
     1: JS_EXPRESSION_STATEMENT@14..21
-      0: JS_UNKNOWN_EXPRESSION@14..21
+      0: JS_TEMPLATE@14..21
         0: JS_IDENTIFIER_EXPRESSION@14..18
           0: JS_REFERENCE_IDENTIFIER@14..18
             0: IDENT@14..18 "BAR" [Newline("\n")] []
-        1: BACKTICK@18..19 "`" [] []
-        2: JS_UNKNOWN@19..21
-          0: ERROR_TOKEN@19..21 "b\n" [] []
+        1: (empty)
+        2: BACKTICK@18..19 "`" [] []
+        3: JS_TEMPLATE_ELEMENT_LIST@19..21
+          0: JS_TEMPLATE_CHUNK_ELEMENT@19..21
+            0: TEMPLATE_CHUNK@19..21 "b\n" [] []
+        4: (empty)
       1: (empty)
   3: EOF@21..21 "" [] []
 --
@@ -111,15 +114,6 @@ error[SyntaxError]: expected an identifier but instead found ';'
 
 --
 error: unterminated template literal
-  ┌─ subscripts_err.js:2:5
-  │  
-2 │   BAR`b
-  │ ┌─────^
-3 │ │ 
-  │ └^
-
---
-error[SyntaxError]: Invalid template literal
   ┌─ subscripts_err.js:2:5
   │  
 2 │   BAR`b

--- a/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
+++ b/crates/rslint_parser/test_data/inline/err/template_literal_unterminated.rast
@@ -13,24 +13,25 @@ JsModule {
                         variable_annotation: missing (optional),
                         initializer: JsInitializerClause {
                             eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
-                            expression: JsUnknownExpression {
-                                items: [
-                                    BACKTICK@8..9 "`" [] [],
-                                    JsUnknown {
-                                        items: [
-                                            JsTemplateElement {
-                                                dollar_curly_token: DOLLAR_CURLY@9..11 "${" [] [],
-                                                expression: JsIdentifierExpression {
-                                                    name: JsReferenceIdentifier {
-                                                        value_token: IDENT@11..14 "foo" [] [],
-                                                    },
-                                                },
-                                                r_curly_token: R_CURLY@14..15 "}" [] [],
+                            expression: JsTemplate {
+                                tag: missing (optional),
+                                type_arguments: missing (optional),
+                                l_tick_token: BACKTICK@8..9 "`" [] [],
+                                elements: JsTemplateElementList [
+                                    JsTemplateElement {
+                                        dollar_curly_token: DOLLAR_CURLY@9..11 "${" [] [],
+                                        expression: JsIdentifierExpression {
+                                            name: JsReferenceIdentifier {
+                                                value_token: IDENT@11..14 "foo" [] [],
                                             },
-                                            ERROR_TOKEN@15..20 " bar\n" [] [],
-                                        ],
+                                        },
+                                        r_curly_token: R_CURLY@14..15 "}" [] [],
+                                    },
+                                    JsTemplateChunkElement {
+                                        template_chunk_token: TEMPLATE_CHUNK@15..20 " bar\n" [] [],
                                     },
                                 ],
+                                r_tick_token: missing (required),
                             },
                         },
                     },
@@ -56,29 +57,24 @@ JsModule {
             1: (empty)
             2: JS_INITIALIZER_CLAUSE@6..20
               0: EQ@6..8 "=" [] [Whitespace(" ")]
-              1: JS_UNKNOWN_EXPRESSION@8..20
-                0: BACKTICK@8..9 "`" [] []
-                1: JS_UNKNOWN@9..20
+              1: JS_TEMPLATE@8..20
+                0: (empty)
+                1: (empty)
+                2: BACKTICK@8..9 "`" [] []
+                3: JS_TEMPLATE_ELEMENT_LIST@9..20
                   0: JS_TEMPLATE_ELEMENT@9..15
                     0: DOLLAR_CURLY@9..11 "${" [] []
                     1: JS_IDENTIFIER_EXPRESSION@11..14
                       0: JS_REFERENCE_IDENTIFIER@11..14
                         0: IDENT@11..14 "foo" [] []
                     2: R_CURLY@14..15 "}" [] []
-                  1: ERROR_TOKEN@15..20 " bar\n" [] []
+                  1: JS_TEMPLATE_CHUNK_ELEMENT@15..20
+                    0: TEMPLATE_CHUNK@15..20 " bar\n" [] []
+                4: (empty)
       1: (empty)
   3: EOF@20..20 "" [] []
 --
 error: unterminated template literal
-  ┌─ template_literal_unterminated.js:1:16
-  │  
-1 │   let a = `${foo} bar
-  │ ┌────────────────^
-2 │ │ 
-  │ └^
-
---
-error[SyntaxError]: Invalid template literal
   ┌─ template_literal_unterminated.js:1:16
   │  
 1 │   let a = `${foo} bar


### PR DESCRIPTION
## Summary
This PR changes the lexer to store the diagnostics instead of returning them when calling `next_token`. The main motivation is to improve performance:

```
group                                    PR                                    main
-----                                    ----                                    ----
parser/checker.ts                        1.00     81.6±2.90ms    31.8 MB/sec    1.04     84.5±2.68ms    30.8 MB/sec
parser/compiler.js                       1.00     49.5±1.98ms    21.2 MB/sec    1.04     51.7±2.29ms    20.3 MB/sec
parser/d3.min.js                         1.00     31.5±1.15ms     8.3 MB/sec    1.03     32.5±1.03ms     8.1 MB/sec
parser/dojo.js                           1.00      2.6±0.06ms    26.1 MB/sec    1.02      2.7±0.04ms    25.5 MB/sec
parser/ios.d.ts                          1.00     76.8±3.38ms    24.3 MB/sec    1.03     79.4±3.46ms    23.5 MB/sec
parser/jquery.min.js                     1.00      9.0±0.37ms     9.2 MB/sec    1.03      9.3±0.37ms     8.9 MB/sec
parser/math.js                           1.00     60.2±2.41ms    10.8 MB/sec    1.04     62.8±2.47ms    10.3 MB/sec
parser/parser.ts                         1.00  1760.4±36.83µs    26.2 MB/sec    1.03  1821.6±35.04µs    25.3 MB/sec
parser/pixi.min.js                       1.00     38.4±1.82ms    11.4 MB/sec    1.03     39.5±1.55ms    11.1 MB/sec
parser/react-dom.production.min.js       1.00     11.7±0.40ms     9.8 MB/sec    1.03     12.1±0.44ms     9.5 MB/sec
parser/react.production.min.js           1.00   567.7±10.37µs    10.8 MB/sec    1.02    579.7±8.56µs    10.6 MB/sec
parser/router.ts                         1.00  1470.8±28.50µs    41.2 MB/sec    1.04  1522.4±56.46µs    39.8 MB/sec
parser/tex-chtml-full.js                 1.00     80.8±3.26ms    11.3 MB/sec    1.04     84.0±3.00ms    10.9 MB/sec
parser/three.min.js                      1.00     43.3±1.80ms    13.6 MB/sec    1.03     44.5±1.63ms    13.2 MB/sec
parser/typescript.js                     1.00    347.4±8.53ms    27.3 MB/sec    1.01    351.5±7.53ms    27.0 MB/sec
parser/vue.global.prod.js                1.00     14.3±0.56ms     8.4 MB/sec    1.03     14.7±0.49ms     8.2 MB/sec
```

The downside of this is that the lexer diagnostics are now no longer in order with the diagnostics produced by the parser. We can implement a merging of the vecs by going through them in order if that's something we care about.

## Test Plan

`cargo test`
