### PR TITLE
feat(rome_console): create the rome_console and rome_markup crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,7 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.12.0",
  "pico-args",
+ "rome_console",
  "rome_core",
  "rome_diagnostics",
  "rome_formatter",
@@ -1363,9 +1364,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rome_console"
+version = "0.0.0"
+dependencies = [
+ "lazy_static",
+ "rome_diagnostics",
+ "rome_markup",
+]
+
+[[package]]
 name = "rome_core"
 version = "0.0.0"
 dependencies = [
+ "rome_console",
  "rome_fs",
 ]
 
@@ -1465,6 +1476,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
+]
+
+[[package]]
+name = "rome_markup"
+version = "0.0.0"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "globset"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1376,8 @@ dependencies = [
  "lazy_static",
  "rome_diagnostics",
  "rome_markup",
+ "termcolor",
+ "trybuild",
 ]
 
 [[package]]
@@ -1888,6 +1896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +1979,20 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d60539445867cdd9680b2bfe2d0428f1814b7d5c9652f09d8d3eae9d19308db"
+dependencies = [
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -11,6 +11,7 @@ rome_js_parser = { path = "../rome_js_parser" }
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_core = { path = "../rome_core" }
 rome_fs = { path = "../rome_fs" }
+rome_console = { path = "../rome_console" }
 pico-args = "0.4.2"
 tracing = "0.1.31"
 tracing-subscriber = "0.3.6"

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -112,9 +112,15 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
 
     let duration = start.elapsed();
     let count = formatted.load(Ordering::Relaxed);
-    session.app.console.message(rome_console::markup! {
-        <Info>"Formatted {count} files in {duration:?}"</Info>
-    });
+    if is_check {
+        session.app.console.message(rome_console::markup! {
+            <Info>"Checked {count} files in {duration:?}"</Info>
+        });
+    } else {
+        session.app.console.message(rome_console::markup! {
+            <Info>"Formatted {count} files in {duration:?}"</Info>
+        });
+    }
 
     let mut has_errors = false;
     let mut file_ids = HashSet::new();

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -13,8 +13,7 @@ use crossbeam::channel::{unbounded, Sender};
 use rome_core::App;
 use rome_diagnostics::{
     file::{FileId, Files, SimpleFile},
-    termcolor::{ColorChoice, StandardStream},
-    Diagnostic, Emitter,
+    Diagnostic,
 };
 use rome_formatter::{FormatOptions, IndentStyle};
 use rome_fs::{AtomicInterner, PathInterner, RomePath};
@@ -113,7 +112,9 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
 
     let duration = start.elapsed();
     let count = formatted.load(Ordering::Relaxed);
-    println!("Formatted {count} files in {duration:?}");
+    session.app.console.message(rome_console::markup! {
+        <Info>"Formatted {count} files in {duration:?}"</Info>
+    });
 
     let mut has_errors = false;
     let mut file_ids = HashSet::new();
@@ -163,15 +164,8 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
         files.storage.insert(file_id, SimpleFile::new(name, source));
     }
 
-    {
-        // Only lock stderr once for printing all the diagnostics
-        let out = StandardStream::stderr(ColorChoice::Always);
-        let mut out = out.lock();
-
-        let mut emit = Emitter::new(&files);
-        for diag in diagnostics {
-            emit.emit_with_writer(&diag, &mut out).unwrap();
-        }
+    for diag in diagnostics {
+        session.app.console.diagnostic(&files, &diag);
     }
 
     // Formatting emitted error diagnostics, exit with a non-zero code
@@ -211,9 +205,9 @@ impl Files for PathFiles {
 }
 
 /// Context object shared between directory traversal tasks
-struct FormatCommandOptions<'a> {
+struct FormatCommandOptions<'ctx, 'app> {
     /// Shared instance of [App]
-    app: &'a App,
+    app: &'ctx App<'app>,
     /// Options to use for formatting the discovered files
     options: FormatOptions,
     /// Boolean flag storing whether the command is being run in check mode
@@ -223,12 +217,12 @@ struct FormatCommandOptions<'a> {
     /// File paths interner used by the filesystem traversal
     interner: AtomicInterner,
     /// Shared atomic counter storing the number of formatted files
-    formatted: &'a AtomicUsize,
+    formatted: &'ctx AtomicUsize,
     /// Channel sending diagnostics to the display thread
     diagnostics: Sender<Diagnostic>,
 }
 
-impl<'a> FormatCommandOptions<'a> {
+impl<'ctx, 'app> FormatCommandOptions<'ctx, 'app> {
     /// Increment the formatted files counter
     fn add_formatted(&self) {
         self.formatted.fetch_add(1, Ordering::Relaxed);
@@ -240,7 +234,7 @@ impl<'a> FormatCommandOptions<'a> {
     }
 }
 
-impl<'a> TraversalContext for FormatCommandOptions<'a> {
+impl<'ctx, 'app> TraversalContext for FormatCommandOptions<'ctx, 'app> {
     fn interner(&self) -> &dyn PathInterner {
         &self.interner
     }
@@ -298,12 +292,12 @@ fn handle_file(ctx: &FormatCommandOptions, path: &Path, file_id: FileId) {
     }
 }
 
-struct FormatFileParams<'a> {
-    app: &'a App,
+struct FormatFileParams<'ctx, 'app> {
+    app: &'ctx App<'app>,
     options: FormatOptions,
     is_check: bool,
     ignore_errors: bool,
-    path: &'a Path,
+    path: &'ctx Path,
     file_id: FileId,
 }
 

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -10,14 +10,14 @@ pub use panic::setup_panic_handler;
 pub use termination::Termination;
 
 /// Global context for an execution of the CLI
-pub struct CliSession {
+pub struct CliSession<'app> {
     /// Instance of [App] used by this run of the CLI
-    pub app: App,
+    pub app: App<'app>,
     /// List of command line arguments
     pub args: Arguments,
 }
 
-impl CliSession {
+impl CliSession<'static> {
     pub fn from_env() -> Self {
         Self {
             app: App::from_env(),

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 rome_diagnostics = { path = "../rome_diagnostics" }
 rome_markup = { path = "../rome_markup" }
 lazy_static = "1.4.0"
+termcolor = "1.1.2"
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/crates/rome_console/Cargo.toml
+++ b/crates/rome_console/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "rome_core"
+name = "rome_console"
 version = "0.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rome_fs = { version = "0.0.0", path = "../rome_fs" }
-rome_console = { version = "0.0.0", path = "../rome_console" }
+rome_diagnostics = { path = "../rome_diagnostics" }
+rome_markup = { path = "../rome_markup" }
+lazy_static = "1.4.0"

--- a/crates/rome_console/README.md
+++ b/crates/rome_console/README.md
@@ -1,0 +1,9 @@
+# `rome_console`
+
+The crate contains a general abstraction over printing messages (formatted with markup) and diagnostics to a console.
+
+## Local installation
+
+```toml
+rome_console = { version = "0.0.0", path = "../rome_console" }
+```

--- a/crates/rome_console/README.md
+++ b/crates/rome_console/README.md
@@ -7,3 +7,30 @@ The crate contains a general abstraction over printing messages (formatted with 
 ```toml
 rome_console = { version = "0.0.0", path = "../rome_console" }
 ```
+
+## Usage example
+
+The `Console` trait can be used to print two types of information to the user: messages (in the form of markup) and diagnostics:
+
+```rust
+console.message(markup! {
+    <Info>"Processed "<Emphasis>"{count}"</Emphasis>" files"</Info>
+});
+
+console.diagnostic(
+    &mut files,
+    Diagnostics::error(file_id, code, title),
+);
+```
+
+The following markup elements are supported:
+- `Emphasis`: Print the content in bold text
+- `Dim`: Print the content in dimmed text
+- `Italic`: Print the content in italic text
+- `Underline`: Print the content in underlined text
+- `Error`: Set the text color to red
+- `Success`: Set the text color to green
+- `Warn`: Set the text color to yellow
+- `Info`: Set the text color to blue
+
+*Note*: Markup elements that change the "font" of the printed text (`Emphasis`, `Dim`, `Italic` and `Underline`) are not supported by the native Windows Console API and will instead get printed as ANSI control codes if the current terminal supports it, or will be ignored entirely

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -1,7 +1,7 @@
 use std::panic::RefUnwindSafe;
 
 use rome_diagnostics::{file::Files, Diagnostic, Emitter};
-use termcolor::{ColorChoice, NoColor, StandardStream, StandardStreamLock, WriteColor};
+use termcolor::{ColorChoice, NoColor, StandardStream, WriteColor};
 
 mod markup;
 
@@ -43,24 +43,14 @@ where
 }
 
 /// Type alias of [WriteConsole] printing to the standard output
-pub type EnvConsole = WriteConsole<StandardStreamLock<'static>, StandardStreamLock<'static>>;
+pub type EnvConsole = WriteConsole<StandardStream, StandardStream>;
 
 impl EnvConsole {
     /// Creates an instance of WriteConsole writing to the standard output
-    ///
-    /// This locks the stdout and stderr for the lifetime of the console instance,
-    /// so any attemps to write to the standard output (using println or panic)
-    /// may hang indefinitely if it happens from a different thread (the thread
-    /// owning the WriteConsole could be fine if the lock is reentrant)
     pub fn from_env() -> Self {
-        lazy_static::lazy_static! {
-            static ref STDOUT: StandardStream = StandardStream::stdout(ColorChoice::Always);
-            static ref STDERR: StandardStream = StandardStream::stderr(ColorChoice::Always);
-        }
-
         Self {
-            out: STDOUT.lock(),
-            err: STDERR.lock(),
+            out: StandardStream::stdout(ColorChoice::Always),
+            err: StandardStream::stderr(ColorChoice::Always),
         }
     }
 }

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -1,13 +1,16 @@
 use std::panic::RefUnwindSafe;
 
+use markup::MarkupPrinter;
 use rome_diagnostics::{file::Files, Diagnostic, Emitter};
-use rome_diagnostics::termcolor::{ColorChoice, NoColor, StandardStream, StandardStreamLock, WriteColor};
+use termcolor::{ColorChoice, NoColor, StandardStream, StandardStreamLock, WriteColor};
 
 mod markup;
 
 pub use self::markup::{MarkupElement, MarkupNode};
 pub use rome_markup::markup;
 
+/// Generic abstraction over printing markup and diagnostics to an output,
+/// which can be a terminal, a file, a memory buffer ...
 pub trait Console: Sync + RefUnwindSafe {
     /// Prints a message (formatted using [markup]) to the console
     fn message(&mut self, args: MarkupNode);

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -1,0 +1,96 @@
+use std::panic::RefUnwindSafe;
+
+use rome_diagnostics::{file::Files, Diagnostic, Emitter};
+use rome_diagnostics::termcolor::{ColorChoice, NoColor, StandardStream, StandardStreamLock, WriteColor};
+
+mod markup;
+
+pub use self::markup::{MarkupElement, MarkupNode};
+pub use rome_markup::markup;
+
+pub trait Console: Sync + RefUnwindSafe {
+    /// Prints a message (formatted using [markup]) to the console
+    fn message(&mut self, args: MarkupNode);
+
+    /// Prints a diagnostic to the console using the provided file map to
+    /// display source code
+    fn diagnostic(&mut self, fs: &dyn Files, diag: &Diagnostic);
+}
+
+/// Implementation of [Console] printing messages to a writable stream
+pub struct WriteConsole<O, E> {
+    out: O,
+    err: E,
+}
+
+impl<O, E> Console for WriteConsole<O, E>
+where
+    O: WriteColor + Sync + RefUnwindSafe,
+    E: WriteColor + Sync + RefUnwindSafe,
+{
+    fn message(&mut self, args: MarkupNode) {
+        args.print(&mut MarkupPrinter::new(&mut self.out)).unwrap();
+        writeln!(self.out).unwrap();
+    }
+
+    fn diagnostic(&mut self, fs: &dyn Files, diag: &Diagnostic) {
+        Emitter::new(fs)
+            .emit_with_writer(diag, &mut self.err)
+            .unwrap();
+    }
+}
+
+/// Type alias of [WriteConsole] printing to the standard output
+pub type EnvConsole = WriteConsole<StandardStreamLock<'static>, StandardStreamLock<'static>>;
+
+impl EnvConsole {
+    /// Creates an instance of WriteConsole writing to the standard output
+    ///
+    /// This locks the stdout and stderr for the lifetime of the console instance,
+    /// so any attemps to write to the standard output (using println or panic)
+    /// may hang indefinitely if it happens from a different thread (the thread
+    /// owning the WriteConsole could be fine if the lock is reentrant)
+    pub fn from_env() -> Self {
+        lazy_static::lazy_static! {
+            static ref STDOUT: StandardStream = StandardStream::stdout(ColorChoice::Always);
+            static ref STDERR: StandardStream = StandardStream::stderr(ColorChoice::Always);
+        }
+
+        Self {
+            out: STDOUT.lock(),
+            err: STDERR.lock(),
+        }
+    }
+}
+
+/// Implementation of [Console] storing all printed messages to a memory buffer
+#[derive(Default, Debug)]
+pub struct BufferConsole {
+    pub buffer: Vec<Message>,
+}
+
+/// Individual message entry printed to a [BufferConsole]
+#[derive(Debug)]
+pub enum Message {
+    Message(String),
+    Diagnostic(Diagnostic),
+}
+
+impl Console for BufferConsole {
+    fn message(&mut self, args: MarkupNode) {
+        let mut message = Vec::new();
+
+        {
+            let mut writer = NoColor::new(&mut message);
+            let mut printer = MarkupPrinter::new(&mut writer);
+            args.print(&mut printer).unwrap();
+        }
+
+        let message = String::from_utf8(message).unwrap();
+        self.buffer.push(Message::Message(message));
+    }
+
+    fn diagnostic(&mut self, _: &dyn Files, diag: &Diagnostic) {
+        self.buffer.push(Message::Diagnostic(diag.clone()));
+    }
+}

--- a/crates/rome_console/src/markup.rs
+++ b/crates/rome_console/src/markup.rs
@@ -1,0 +1,182 @@
+use core::fmt;
+use std::io;
+
+use rslint_errors::termcolor::{Color, ColorSpec, WriteColor};
+
+/// Manages the state of an object implementing [WriteColor], tracking the
+/// successive styles being applied to the printer, and restoring the previous
+/// style when the current one goes out of scope
+pub(crate) struct MarkupPrinter<W: WriteColor> {
+    inner: W,
+    colors: Vec<ColorSpec>,
+}
+
+impl<W: WriteColor> MarkupPrinter<W> {
+    pub(crate) fn new(writer: W) -> Self {
+        Self {
+            inner: writer,
+            colors: Vec::new(),
+        }
+    }
+
+    /// Push a new color state to the stack, created from mutating the previous state
+    fn push_color(&mut self, func: impl FnOnce(&mut ColorSpec)) -> io::Result<()> {
+        // Clone the previous state, or create a default ColorSpec if the stack is empty
+        let mut color = match self.colors.last() {
+            Some(color) => color.clone(),
+            None => ColorSpec::new(),
+        };
+
+        func(&mut color);
+        self.inner.set_color(&color)?;
+        self.colors.push(color);
+        Ok(())
+    }
+
+    /// Pop the most recent color state from the stack, restoring the previous state
+    fn pop_color(&mut self) -> io::Result<()> {
+        self.colors.pop();
+        match self.colors.last() {
+            Some(color) => self.inner.set_color(color),
+            None => self.inner.reset(),
+        }
+    }
+}
+
+// MarkupPrinter implements Drop to ensure the color style of the inner printer
+// is properly reset after a printing operation completes
+impl<W: WriteColor> Drop for MarkupPrinter<W> {
+    fn drop(&mut self) {
+        // Any error happing here is ignored since there isn't a good way to
+        // propagate them from `drop`, and panicking here isn't great either
+        self.inner.reset().ok();
+    }
+}
+
+/// Enumeration of all the supported markup elements
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MarkupElement {
+    Emphasis,
+    Dim,
+    Italic,
+    Underline,
+    Error,
+    Success,
+    Warn,
+    Info,
+}
+
+/// Implementation of a single "markup node": can be either a piece of text, or
+/// an element containing zero or more other nodes
+///
+/// Text nodes are formatted lazily by storing an [fmt::Arguments] struct, this
+/// means [MarkupNode] shares the same restriction as the values returned by
+/// [format_args] and can't be stored in a `let` binding for instance
+#[derive(Copy, Clone, Debug)]
+pub enum MarkupNode<'fmt> {
+    Text(fmt::Arguments<'fmt>),
+    Element {
+        kind: MarkupElement,
+        children: &'fmt [MarkupNode<'fmt>],
+    },
+}
+
+impl<'fmt> From<fmt::Arguments<'fmt>> for MarkupNode<'fmt> {
+    fn from(args: fmt::Arguments<'fmt>) -> Self {
+        Self::Text(args)
+    }
+}
+
+impl<'fmt> MarkupNode<'fmt> {
+    /// Print a [MarkupNode] to the provided [MarkupPrinter]
+    pub(crate) fn print(&self, fmt: &mut MarkupPrinter<impl WriteColor>) -> io::Result<()> {
+        match self {
+            // If the node just contains text, print it out directly
+            MarkupNode::Text(text) => write!(fmt.inner, "{}", text),
+
+            // If the node is a MarkupElement, apply the associated style before printing the children
+            MarkupNode::Element { kind, children } => {
+                match kind {
+                    // Text Styles
+                    MarkupElement::Emphasis => {
+                        fmt.push_color(|color| {
+                            color.set_bold(true);
+                        })?;
+                    }
+                    MarkupElement::Dim => {
+                        fmt.push_color(|color| {
+                            color.set_dimmed(true);
+                        })?;
+                    }
+                    MarkupElement::Italic => {
+                        fmt.push_color(|color| {
+                            color.set_italic(true);
+                        })?;
+                    }
+                    MarkupElement::Underline => {
+                        fmt.push_color(|color| {
+                            color.set_underline(true);
+                        })?;
+                    }
+
+                    // Text Colors
+                    MarkupElement::Error => {
+                        fmt.push_color(|color| {
+                            color.set_fg(Some(Color::Red));
+                        })?;
+                    }
+                    MarkupElement::Success => {
+                        fmt.push_color(|color| {
+                            color.set_fg(Some(Color::Green));
+                        })?;
+                    }
+                    MarkupElement::Warn => {
+                        fmt.push_color(|color| {
+                            color.set_fg(Some(Color::Yellow));
+                        })?;
+                    }
+                    MarkupElement::Info => {
+                        fmt.push_color(|color| {
+                            color.set_fg(Some(Color::Blue));
+                        })?;
+                    }
+                }
+
+                // If a child node returns an error while printing, we want to
+                // abort immediately and return the error (like if we had
+                // written `for child in children { child.print(fmt); }`) but
+                // since the console is stateful we need to clean up the style
+                // that was applied above before returning.
+                // This code iterates over the children, aborting if one of
+                // them returns an error but the error is only stored in
+                // `result` to be returned later, so the cleanup code can still
+                // run in-between
+                let mut iter = children.iter();
+                let result = loop {
+                    match iter.next() {
+                        Some(child) => match child.print(fmt) {
+                            Ok(()) => continue,
+                            Err(err) => break Err(err),
+                        },
+                        None => break Ok(()),
+                    }
+                };
+
+                match kind {
+                    MarkupElement::Emphasis
+                    | MarkupElement::Dim
+                    | MarkupElement::Italic
+                    | MarkupElement::Underline
+                    | MarkupElement::Error
+                    | MarkupElement::Success
+                    | MarkupElement::Warn
+                    | MarkupElement::Info => {
+                        fmt.pop_color()?;
+                    }
+                }
+
+                result
+            }
+        }
+    }
+}

--- a/crates/rome_console/src/markup.rs
+++ b/crates/rome_console/src/markup.rs
@@ -3,56 +3,6 @@ use std::io;
 
 use termcolor::{Color, ColorSpec, WriteColor};
 
-/// Manages the state of an object implementing [WriteColor], tracking the
-/// successive styles being applied to the printer, and restoring the previous
-/// style when the current one goes out of scope
-pub(crate) struct MarkupPrinter<W: WriteColor> {
-    inner: W,
-    colors: Vec<ColorSpec>,
-}
-
-impl<W: WriteColor> MarkupPrinter<W> {
-    pub(crate) fn new(writer: W) -> Self {
-        Self {
-            inner: writer,
-            colors: Vec::new(),
-        }
-    }
-
-    /// Push a new color state to the stack, created from mutating the previous state
-    fn push_color(&mut self, func: impl FnOnce(&mut ColorSpec)) -> io::Result<()> {
-        // Clone the previous state, or create a default ColorSpec if the stack is empty
-        let mut color = match self.colors.last() {
-            Some(color) => color.clone(),
-            None => ColorSpec::new(),
-        };
-
-        func(&mut color);
-        self.inner.set_color(&color)?;
-        self.colors.push(color);
-        Ok(())
-    }
-
-    /// Pop the most recent color state from the stack, restoring the previous state
-    fn pop_color(&mut self) -> io::Result<()> {
-        self.colors.pop();
-        match self.colors.last() {
-            Some(color) => self.inner.set_color(color),
-            None => self.inner.reset(),
-        }
-    }
-}
-
-// MarkupPrinter implements Drop to ensure the color style of the inner printer
-// is properly reset after a printing operation completes
-impl<W: WriteColor> Drop for MarkupPrinter<W> {
-    fn drop(&mut self) {
-        // Any error happing here is ignored since there isn't a good way to
-        // propagate them from `drop`, and panicking here isn't great either
-        self.inner.reset().ok();
-    }
-}
-
 /// Enumeration of all the supported markup elements
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MarkupElement {
@@ -67,108 +17,78 @@ pub enum MarkupElement {
 }
 
 impl MarkupElement {
-    fn push_style<W: WriteColor>(&self, fmt: &mut MarkupPrinter<W>) -> io::Result<()> {
+    /// Mutate a [ColorSpec] object in place to apply this element's associated
+    /// style to it
+    fn update_color(&self, color: &mut ColorSpec) {
         match self {
             // Text Styles
-            MarkupElement::Emphasis => fmt.push_color(|color| {
+            MarkupElement::Emphasis => {
                 color.set_bold(true);
-            }),
-            MarkupElement::Dim => fmt.push_color(|color| {
+            }
+            MarkupElement::Dim => {
                 color.set_dimmed(true);
-            }),
-            MarkupElement::Italic => fmt.push_color(|color| {
+            }
+            MarkupElement::Italic => {
                 color.set_italic(true);
-            }),
-            MarkupElement::Underline => fmt.push_color(|color| {
+            }
+            MarkupElement::Underline => {
                 color.set_underline(true);
-            }),
+            }
 
             // Text Colors
-            MarkupElement::Error => fmt.push_color(|color| {
+            MarkupElement::Error => {
                 color.set_fg(Some(Color::Red));
-            }),
-            MarkupElement::Success => fmt.push_color(|color| {
+            }
+            MarkupElement::Success => {
                 color.set_fg(Some(Color::Green));
-            }),
-            MarkupElement::Warn => fmt.push_color(|color| {
+            }
+            MarkupElement::Warn => {
                 color.set_fg(Some(Color::Yellow));
-            }),
-            MarkupElement::Info => fmt.push_color(|color| {
+            }
+            MarkupElement::Info => {
                 color.set_fg(Some(Color::Blue));
-            }),
-        }
-    }
-
-    fn pop_style<W: WriteColor>(&self, fmt: &mut MarkupPrinter<W>) -> io::Result<()> {
-        match self {
-            MarkupElement::Emphasis
-            | MarkupElement::Dim
-            | MarkupElement::Italic
-            | MarkupElement::Underline
-            | MarkupElement::Error
-            | MarkupElement::Success
-            | MarkupElement::Warn
-            | MarkupElement::Info => fmt.pop_color(),
-        }
-    }
-}
-
-/// Implementation of a single "markup node": can be either a piece of text, or
-/// an element containing zero or more other nodes
-///
-/// Text nodes are formatted lazily by storing an [fmt::Arguments] struct, this
-/// means [MarkupNode] shares the same restriction as the values returned by
-/// [format_args] and can't be stored in a `let` binding for instance
-#[derive(Copy, Clone, Debug)]
-pub enum MarkupNode<'fmt> {
-    Text(fmt::Arguments<'fmt>),
-    Element {
-        kind: MarkupElement,
-        children: &'fmt [MarkupNode<'fmt>],
-    },
-}
-
-impl<'fmt> From<fmt::Arguments<'fmt>> for MarkupNode<'fmt> {
-    fn from(args: fmt::Arguments<'fmt>) -> Self {
-        Self::Text(args)
-    }
-}
-
-impl<'fmt> MarkupNode<'fmt> {
-    /// Print a [MarkupNode] to the provided [MarkupPrinter]
-    pub(crate) fn print(&self, fmt: &mut MarkupPrinter<impl WriteColor>) -> io::Result<()> {
-        match self {
-            // If the node just contains text, print it out directly
-            MarkupNode::Text(text) => write!(fmt.inner, "{}", text),
-
-            // If the node is a MarkupElement, apply the associated style before printing the children
-            MarkupNode::Element { kind, children } => {
-                kind.push_style(fmt)?;
-
-                // If a child node returns an error while printing, we want to
-                // abort immediately and return the error (like if we had
-                // written `for child in children { child.print(fmt); }`) but
-                // since the console is stateful we need to clean up the style
-                // that was applied above before returning.
-                // This code iterates over the children, aborting if one of
-                // them returns an error but the error is only stored in
-                // `result` to be returned later, so the cleanup code can still
-                // run in-between
-                let mut iter = children.iter();
-                let result = loop {
-                    match iter.next() {
-                        Some(child) => match child.print(fmt) {
-                            Ok(()) => continue,
-                            Err(err) => break Err(err),
-                        },
-                        None => break Ok(()),
-                    }
-                };
-
-                kind.pop_style(fmt)?;
-
-                result
             }
         }
+    }
+}
+
+/// Implementation of a single "markup node": a piece of text with a number of
+/// associated styles applied to it
+#[derive(Copy, Clone, Debug)]
+pub struct MarkupNode<'fmt> {
+    pub elements: &'fmt [MarkupElement],
+    pub content: fmt::Arguments<'fmt>,
+}
+
+/// Root type returned by the `markup` macro: this is simply a container for a
+/// list of markup nodes
+///
+/// Text nodes are formatted lazily by storing an [fmt::Arguments] struct, this
+/// means [Markup] shares the same restriction as the values returned by
+/// [format_args] and can't be stored in a `let` binding for instance
+pub struct Markup<'fmt>(pub &'fmt [MarkupNode<'fmt>]);
+
+impl<'fmt> Markup<'fmt> {
+    /// Print a [MarkupNode] to the provided [MarkupPrinter]
+    pub(crate) fn print(&self, fmt: &mut impl WriteColor) -> io::Result<()> {
+        for node in self.0 {
+            let mut color = ColorSpec::new();
+            for element in node.elements {
+                element.update_color(&mut color);
+            }
+
+            if let Err(err) = fmt.set_color(&color) {
+                fmt.reset()?;
+                return Err(err);
+            }
+
+            if let Err(err) = write!(fmt, "{}", node.content) {
+                fmt.reset()?;
+                return Err(err);
+            }
+        }
+
+        fmt.reset()?;
+        Ok(())
     }
 }

--- a/crates/rome_console/tests/macro.rs
+++ b/crates/rome_console/tests/macro.rs
@@ -6,7 +6,7 @@ fn test_macro() {
 
     match
     // Due to how MarkupNode is implemented, the result of the markup macro
-    // cannot be stored a binding and must be matched upon immediately
+    // cannot be stored in a binding and must be matched upon immediately
     rome_markup::markup! {
         <Emphasis>"{category} Commands"</Emphasis>
     }
@@ -25,4 +25,10 @@ fn test_macro() {
         }
         markup => panic!("unexpected MarkupNode {markup:?}"),
     }
+}
+
+#[test]
+fn test_macro_errors() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/markup/*.rs");
 }

--- a/crates/rome_console/tests/macro.rs
+++ b/crates/rome_console/tests/macro.rs
@@ -1,0 +1,28 @@
+use rome_console::{MarkupElement, MarkupNode};
+
+#[test]
+fn test_macro() {
+    let category = "test";
+
+    match
+    // Due to how MarkupNode is implemented, the result of the markup macro
+    // cannot be stored a binding and must be matched upon immediately
+    rome_markup::markup! {
+        <Emphasis>"{category} Commands"</Emphasis>
+    }
+    {
+        MarkupNode::Element { kind, children } => {
+            assert_eq!(kind, MarkupElement::Emphasis);
+            assert_eq!(children.len(), 1);
+
+            match children[0] {
+                MarkupNode::Text(args) => {
+                    let args = args.to_string();
+                    assert_eq!(args, format!("{category} Commands"));
+                }
+                markup => panic!("unexpected MarkupNode {markup:?}"),
+            }
+        }
+        markup => panic!("unexpected MarkupNode {markup:?}"),
+    }
+}

--- a/crates/rome_console/tests/macro.rs
+++ b/crates/rome_console/tests/macro.rs
@@ -1,4 +1,4 @@
-use rome_console::{MarkupElement, MarkupNode};
+use rome_console::{Markup, MarkupElement};
 
 #[test]
 fn test_macro() {
@@ -8,22 +8,18 @@ fn test_macro() {
     // Due to how MarkupNode is implemented, the result of the markup macro
     // cannot be stored in a binding and must be matched upon immediately
     rome_markup::markup! {
-        <Emphasis>"{category} Commands"</Emphasis>
+        <Info><Emphasis>"{category}"</Emphasis>" Commands"</Info>
     }
     {
-        MarkupNode::Element { kind, children } => {
-            assert_eq!(kind, MarkupElement::Emphasis);
-            assert_eq!(children.len(), 1);
+        Markup(markup) => {
+            let node_0 = &markup[0];
+            assert_eq!(&node_0.elements, &[MarkupElement::Info, MarkupElement::Emphasis]);
+            assert_eq!(node_0.content.to_string(), category.to_string());
 
-            match children[0] {
-                MarkupNode::Text(args) => {
-                    let args = args.to_string();
-                    assert_eq!(args, format!("{category} Commands"));
-                }
-                markup => panic!("unexpected MarkupNode {markup:?}"),
-            }
+            let node_1 = &markup[1];
+            assert_eq!(&node_1.elements, &[MarkupElement::Info]);
+            assert_eq!(node_1.content.to_string(), " Commands".to_string());
         }
-        markup => panic!("unexpected MarkupNode {markup:?}"),
     }
 }
 

--- a/crates/rome_console/tests/markup/closing_element_mismatch.rs
+++ b/crates/rome_console/tests/markup/closing_element_mismatch.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis></Error>
+    }
+}

--- a/crates/rome_console/tests/markup/closing_element_mismatch.stderr
+++ b/crates/rome_console/tests/markup/closing_element_mismatch.stderr
@@ -1,0 +1,9 @@
+error: closing element mismatch
+
+         = note: found closing element Error
+         = note: expected Emphasis
+
+ --> tests/markup/closing_element_mismatch.rs:3:21
+  |
+3 |         <Emphasis></Error>
+  |                     ^^^^^

--- a/crates/rome_console/tests/markup/closing_element_standalone.rs
+++ b/crates/rome_console/tests/markup/closing_element_standalone.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        </Emphasis>
+    }
+}

--- a/crates/rome_console/tests/markup/closing_element_standalone.stderr
+++ b/crates/rome_console/tests/markup/closing_element_standalone.stderr
@@ -1,0 +1,5 @@
+error: unexpected closing element
+ --> tests/markup/closing_element_standalone.rs:3:11
+  |
+3 |         </Emphasis>
+  |           ^^^^^^^^

--- a/crates/rome_console/tests/markup/element_non_ident_name.rs
+++ b/crates/rome_console/tests/markup/element_non_ident_name.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <"Literal" />
+    }
+}

--- a/crates/rome_console/tests/markup/element_non_ident_name.stderr
+++ b/crates/rome_console/tests/markup/element_non_ident_name.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/element_non_ident_name.rs:3:10
+  |
+3 |         <"Literal" />
+  |          ^^^^^^^^^

--- a/crates/rome_console/tests/markup/invalid_group.rs
+++ b/crates/rome_console/tests/markup/invalid_group.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        {}
+    }
+}

--- a/crates/rome_console/tests/markup/invalid_group.stderr
+++ b/crates/rome_console/tests/markup/invalid_group.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/invalid_group.rs:3:9
+  |
+3 |         {}
+  |         ^^

--- a/crates/rome_console/tests/markup/invalid_literal.rs
+++ b/crates/rome_console/tests/markup/invalid_literal.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        123
+    }
+}

--- a/crates/rome_console/tests/markup/invalid_literal.stderr
+++ b/crates/rome_console/tests/markup/invalid_literal.stderr
@@ -1,0 +1,5 @@
+error: unexpected non-string literal
+ --> tests/markup/invalid_literal.rs:3:9
+  |
+3 |         123
+  |         ^^^

--- a/crates/rome_console/tests/markup/invalid_punct.rs
+++ b/crates/rome_console/tests/markup/invalid_punct.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        !
+    }
+}

--- a/crates/rome_console/tests/markup/invalid_punct.stderr
+++ b/crates/rome_console/tests/markup/invalid_punct.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/invalid_punct.rs:3:9
+  |
+3 |         !
+  |         ^

--- a/crates/rome_console/tests/markup/open_element_improper_close_1.rs
+++ b/crates/rome_console/tests/markup/open_element_improper_close_1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis /<
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_improper_close_1.stderr
+++ b/crates/rome_console/tests/markup/open_element_improper_close_1.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/open_element_improper_close_1.rs:3:20
+  |
+3 |         <Emphasis /<
+  |                    ^

--- a/crates/rome_console/tests/markup/open_element_improper_close_2.rs
+++ b/crates/rome_console/tests/markup/open_element_improper_close_2.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis /"Literal"
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_improper_close_2.stderr
+++ b/crates/rome_console/tests/markup/open_element_improper_close_2.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/open_element_improper_close_2.rs:3:20
+  |
+3 |         <Emphasis /"Literal"
+  |                    ^^^^^^^^^

--- a/crates/rome_console/tests/markup/open_element_props.rs
+++ b/crates/rome_console/tests/markup/open_element_props.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis property />
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_props.stderr
+++ b/crates/rome_console/tests/markup/open_element_props.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+ --> tests/markup/open_element_props.rs:3:19
+  |
+3 |         <Emphasis property />
+  |                   ^^^^^^^^

--- a/crates/rome_console/tests/markup/open_element_unfinished_1.rs
+++ b/crates/rome_console/tests/markup/open_element_unfinished_1.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_unfinished_1.stderr
+++ b/crates/rome_console/tests/markup/open_element_unfinished_1.stderr
@@ -1,0 +1,9 @@
+error: unexpected end of input
+ --> tests/markup/open_element_unfinished_1.rs:2:5
+  |
+2 | /     rome_console::markup! {
+3 | |         <
+4 | |     }
+  | |_____^
+  |
+  = note: this error originates in the macro `rome_console::markup` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rome_console/tests/markup/open_element_unfinished_2.rs
+++ b/crates/rome_console/tests/markup/open_element_unfinished_2.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_unfinished_2.stderr
+++ b/crates/rome_console/tests/markup/open_element_unfinished_2.stderr
@@ -1,0 +1,9 @@
+error: unexpected end of input
+ --> tests/markup/open_element_unfinished_2.rs:2:5
+  |
+2 | /     rome_console::markup! {
+3 | |         <Emphasis
+4 | |     }
+  | |_____^
+  |
+  = note: this error originates in the macro `rome_console::markup` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rome_console/tests/markup/open_element_unfinished_3.rs
+++ b/crates/rome_console/tests/markup/open_element_unfinished_3.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis /
+    }
+}

--- a/crates/rome_console/tests/markup/open_element_unfinished_3.stderr
+++ b/crates/rome_console/tests/markup/open_element_unfinished_3.stderr
@@ -1,0 +1,9 @@
+error: unexpected end of input
+ --> tests/markup/open_element_unfinished_3.rs:2:5
+  |
+2 | /     rome_console::markup! {
+3 | |         <Emphasis /
+4 | |     }
+  | |_____^
+  |
+  = note: this error originates in the macro `rome_console::markup` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/rome_console/tests/markup/unclosed_element.rs
+++ b/crates/rome_console/tests/markup/unclosed_element.rs
@@ -1,0 +1,5 @@
+fn main() {
+    rome_console::markup! {
+        <Emphasis>
+    }
+}

--- a/crates/rome_console/tests/markup/unclosed_element.stderr
+++ b/crates/rome_console/tests/markup/unclosed_element.stderr
@@ -1,0 +1,5 @@
+error: unclosed element
+ --> tests/markup/unclosed_element.rs:3:10
+  |
+3 |         <Emphasis>
+  |          ^^^^^^^^

--- a/crates/rome_formatter/tests/spec_test.rs
+++ b/crates/rome_formatter/tests/spec_test.rs
@@ -1,6 +1,6 @@
 use rome_core::App;
 use rome_formatter::{format, FormatOptions, Formatted, IndentStyle};
-use rome_fs::{MemoryFileSystem, RomePath};
+use rome_fs::RomePath;
 use rome_js_parser::{parse, ModuleKind, SourceType};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -118,7 +118,8 @@ impl SnapshotContent {
 /// * `json/null` -> input: `tests/specs/json/null.json`, expected output: `tests/specs/json/null.json.snap`
 /// * `null` -> input: `tests/specs/null.json`, expected output: `tests/specs/null.json.snap`
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, file_type: &str) {
-    let app = App::with_filesystem(MemoryFileSystem::default());
+    let app = App::from_env();
+
     let file_path = &spec_input_file;
     let spec_input_file = Path::new(spec_input_file);
 

--- a/crates/rome_markup/Cargo.toml
+++ b/crates/rome_markup/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rome_markup"
+version = "0.0.0"
+description = ""
+license = "MIT"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.36"
+quote = "1.0.14"
+proc-macro-error = "1.0.4"

--- a/crates/rome_markup/README.md
+++ b/crates/rome_markup/README.md
@@ -1,0 +1,9 @@
+# `rome_markup`
+
+The crate contains procedural macros to build rome_console markup object with a JSX-like syntax
+
+## Local installation
+
+```toml
+rome_markup = { version = "0.0.0", path = "../rome_markup" }
+```

--- a/crates/rome_markup/README.md
+++ b/crates/rome_markup/README.md
@@ -1,6 +1,9 @@
 # `rome_markup`
 
-The crate contains procedural macros to build rome_console markup object with a JSX-like syntax
+The crate contains procedural macros to build `rome_console` markup object with a JSX-like syntax
+
+The macro cannot be used alone as it generates code that requires supporting types declared in the
+`rome_console` crate, so it's re-exported from there and should be used as `rome_console::markup`
 
 ## Local installation
 

--- a/crates/rome_markup/src/lib.rs
+++ b/crates/rome_markup/src/lib.rs
@@ -1,0 +1,115 @@
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use proc_macro_error::*;
+use quote::quote;
+
+struct StackEntry {
+    ident: Ident,
+    children: Vec<TokenStream>,
+}
+
+#[proc_macro]
+#[proc_macro_error]
+pub fn markup(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mut input = TokenStream::from(input).into_iter().peekable();
+    let mut stack = Vec::new();
+    let mut output = Vec::new();
+
+    while let Some(token) = input.next() {
+        match token {
+            TokenTree::Punct(punct) => match punct.as_char() {
+                '<' => {
+                    let is_closing_element = match input.peek() {
+                        Some(TokenTree::Punct(punct)) if punct.as_char() == '/' => {
+                            // SAFETY: Guarded by above call to peek
+                            input.next().unwrap();
+                            true
+                        }
+                        _ => false,
+                    };
+
+                    let name = match input.next() {
+                        Some(TokenTree::Ident(ident)) => ident,
+                        Some(token) => abort!(token.span(), "unexpected token"),
+                        None => abort_call_site!("unexpected end of input"),
+                    };
+
+                    let is_self_closing = match input.next() {
+                        Some(TokenTree::Punct(punct)) => match punct.as_char() {
+                            '>' => false,
+                            '/' if !is_closing_element => {
+                                match input.next() {
+                                    Some(TokenTree::Punct(punct)) if punct.as_char() == '>' => {}
+                                    Some(token) => abort!(token.span(), "unexpected token"),
+                                    None => abort_call_site!("unexpected end of input"),
+                                }
+                                true
+                            }
+                            _ => abort!(punct.span(), "unexpected token"),
+                        },
+                        Some(token) => abort!(token.span(), "unexpected token"),
+                        None => abort_call_site!("unexpected end of input"),
+                    };
+
+                    if !is_closing_element {
+                        stack.push(StackEntry {
+                            ident: name.clone(),
+                            children: Vec::new(),
+                        });
+                    } else if let Some(top) = stack.last() {
+                        // Only verify the coherence of the top element on the
+                        // stack with a closing element, skip over the check if
+                        // the stack is empty as that error will be handled
+                        // when the top element gets popped off the stack later
+                        let name_str = name.to_string();
+                        let top_str = top.ident.to_string();
+                        if name_str != top_str {
+                            abort!(
+                                name.span(), "closing element mismatch";
+                                close = "found closing element {}", name_str;
+                                open = top.ident.span() => "expected {}", top_str
+                            );
+                        }
+                    }
+
+                    if is_closing_element || is_self_closing {
+                        match stack.pop() {
+                            Some(top) => {
+                                let StackEntry { ident, children } = top;
+                                output.push(quote! {
+                                    rome_console::MarkupNode::Element {
+                                        kind: rome_console::MarkupElement::#ident,
+                                        children: &[ #( #children, )* ],
+                                    }
+                                });
+                            }
+                            None => abort!(name.span(), "unexpected closing element"),
+                        }
+                    }
+                }
+                _ => {
+                    abort!(punct.span(), "unexpected token");
+                }
+            },
+            TokenTree::Literal(literal) => {
+                let output = match stack.last_mut() {
+                    Some(top) => &mut top.children,
+                    None => &mut output,
+                };
+
+                let literal_str = literal.to_string();
+                if literal_str.starts_with('"') {
+                    output.push(quote! { rome_console::MarkupNode::from(format_args!(#literal)) });
+                } else {
+                    abort!(literal.span(), "unexpected non-string literal");
+                }
+            }
+            _ => abort!(token.span(), "unexpected token"),
+        }
+    }
+
+    if let Some(top) = stack.pop() {
+        abort!(top.ident.span(), "unclosed element");
+    }
+
+    output.into_iter().collect::<TokenStream>().into()
+}


### PR DESCRIPTION
## Summary

This PR adds two new crates to the repository, `rome_console` and `rome_markup`

`rome_markup` implements a `markup` procedural macro inspired by the "template tag" of the same name in Rome JS, allowing formatted text to be expressed with a JSX-like syntax:

```rust
rome_console::markup! {
    <Info>"Formatted {count} files in {duration:?}"</Info>
}
```

`rome_console` implements the runtime-part of the markup (the actual structures being generated by the `macro` macro), as well as a `Console` trait used by the CLI to manage printing its output. This trait has two implementations: `WriteConsole` prints to any stream implementing `termcolor::WriteColor` (and has an `EnvConsole` type alias that prints to stdout / stderr), and `BufferConsole` simply stores all messages / diagnostics to an in-memory buffer (and is generally aimed at writing tests for the CLI)

## Test Plan

- Due to how the crates are structured, the test for `rome_markup` live in the `rome_console` crate (there's just a single test case for now, to verify it works)
- The test for the formatting CLI now verifies the command actually prints a line to the console, but does not verify the actual output since I'm not entirely certain how we would want to check it (`insta` snapshots ?)
