### PR TITLE
refactor(rome_rowan): Reduce Trivia Memory footprint

### DIFF
--- a/crates/rome_js_syntax/src/lib.rs
+++ b/crates/rome_js_syntax/src/lib.rs
@@ -17,6 +17,7 @@ pub use self::generated::*;
 pub use ast::{AstNode, AstNodeList, AstSeparatedList, AstToken, SyntaxError, SyntaxResult};
 pub use expr_ext::*;
 pub use modifier_ext::*;
+use rome_rowan::api::TriviaPieceKind;
 pub use rome_rowan::{SyntaxText, TextLen, TextRange, TextSize, TokenAtOffset, WalkEvent};
 pub use stmt_ext::*;
 pub use syntax_node::*;
@@ -239,5 +240,23 @@ impl rome_rowan::SyntaxKind for JsSyntaxKind {
     #[inline]
     fn from_raw(raw: RawSyntaxKind) -> Self {
         Self::from(raw.0)
+    }
+}
+
+impl TryFrom<JsSyntaxKind> for TriviaPieceKind {
+    type Error = ();
+
+    fn try_from(value: JsSyntaxKind) -> Result<Self, Self::Error> {
+        if value.is_trivia() {
+            match value {
+                JsSyntaxKind::NEWLINE => Ok(TriviaPieceKind::Newline),
+                JsSyntaxKind::WHITESPACE => Ok(TriviaPieceKind::Whitespace),
+                JsSyntaxKind::COMMENT => Ok(TriviaPieceKind::SingleLineComment),
+                JsSyntaxKind::MULTILINE_COMMENT => Ok(TriviaPieceKind::MultiLineComment),
+                _ => unreachable!("Not Trivia"),
+            }
+        } else {
+            Err(())
+        }
     }
 }

--- a/crates/rome_js_syntax/src/modifier_ext.rs
+++ b/crates/rome_js_syntax/src/modifier_ext.rs
@@ -5,7 +5,6 @@ use crate::{
 
 /// Helpful data structure to make the order modifiers predictable inside the formatter
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
-#[repr(u8)]
 pub enum Modifiers {
     // modifiers must be sorted by precedence.
     Accessibility,

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -30,7 +30,7 @@ pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Ha
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub enum TriviaPieceKind {
-    /// A newline character
+    /// A line break (`\n`, `\r`, `\r\n`, ...)
     Newline,
     /// Any whitespace character
     Whitespace,
@@ -65,18 +65,22 @@ pub struct TriviaPiece {
 }
 
 impl TriviaPiece {
+    /// Creates a new whitespace trivia piece with the given length
     pub fn whitespace<L: Into<TextSize>>(len: L) -> TriviaPiece {
         Self::new(TriviaPieceKind::Whitespace, len)
     }
 
+    /// Creates a new newline trivia piece with the given text length
     pub fn newline<L: Into<TextSize>>(len: L) -> TriviaPiece {
         Self::new(TriviaPieceKind::Newline, len)
     }
 
+    /// Creates a new comment trivia piece that does not contain any line breaks
     pub fn single_line_comment<L: Into<TextSize>>(len: L) -> TriviaPiece {
         Self::new(TriviaPieceKind::SingleLineComment, len)
     }
 
+    /// Creates a new comment trivia piece that contains at least one line breaks
     pub fn multi_line_comment<L: Into<TextSize>>(len: L) -> TriviaPiece {
         Self::new(TriviaPieceKind::MultiLineComment, len)
     }
@@ -88,11 +92,12 @@ impl TriviaPiece {
         }
     }
 
-    #[inline]
+    /// Returns the trivia's length
     pub fn text_len(&self) -> TextSize {
         self.length
     }
 
+    /// Returns the trivia's kind
     pub fn kind(&self) -> TriviaPieceKind {
         self.kind
     }
@@ -144,10 +149,7 @@ impl<L: Language> SyntaxTriviaPieceComments<L> {
     }
 
     pub fn has_newline(&self) -> bool {
-        match self.0.trivia.kind {
-            TriviaPieceKind::MultiLineComment => true,
-            _ => false,
-        }
+        self.0.trivia.kind.is_multiline_comment()
     }
 }
 
@@ -265,7 +267,7 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     /// assert!(pieces[0].is_newline())
     /// ```
     pub fn is_newline(&self) -> bool {
-        matches!(self.trivia.kind, TriviaPieceKind::Newline)
+        self.trivia.kind.is_newline()
     }
 
     /// Returns true if this trivia piece is a [SyntaxTriviaPieceWhitespace].
@@ -286,7 +288,7 @@ impl<L: Language> SyntaxTriviaPiece<L> {
     /// assert!(pieces[1].is_whitespace())
     /// ```
     pub fn is_whitespace(&self) -> bool {
-        matches!(self.trivia.kind, TriviaPieceKind::Whitespace)
+        self.trivia.kind.is_whitespace()
     }
 
     /// Returns true if this trivia piece is a [SyntaxTriviaPieceComments].

--- a/crates/rome_rowan/src/api.rs
+++ b/crates/rome_rowan/src/api.rs
@@ -66,22 +66,25 @@ pub struct TriviaPiece {
 
 impl TriviaPiece {
     /// Creates a new whitespace trivia piece with the given length
-    pub fn whitespace<L: Into<TextSize>>(len: L) -> TriviaPiece {
+    pub fn whitespace<L: Into<TextSize>>(len: L) -> Self {
         Self::new(TriviaPieceKind::Whitespace, len)
     }
 
     /// Creates a new newline trivia piece with the given text length
-    pub fn newline<L: Into<TextSize>>(len: L) -> TriviaPiece {
+    pub fn newline<L: Into<TextSize>>(len: L) -> Self {
         Self::new(TriviaPieceKind::Newline, len)
     }
 
-    /// Creates a new comment trivia piece that does not contain any line breaks
-    pub fn single_line_comment<L: Into<TextSize>>(len: L) -> TriviaPiece {
+    /// Creates a new comment trivia piece that does not contain any line breaks.
+    /// For example, JavaScript's `//` comments are guaranteed to not spawn multiple lines. However,
+    /// this can also be a `/* ... */` comment if it doesn't contain any line break characters.
+    pub fn single_line_comment<L: Into<TextSize>>(len: L) -> Self {
         Self::new(TriviaPieceKind::SingleLineComment, len)
     }
 
-    /// Creates a new comment trivia piece that contains at least one line breaks
-    pub fn multi_line_comment<L: Into<TextSize>>(len: L) -> TriviaPiece {
+    /// Creates a new comment trivia piece that contains at least one line breaks.
+    /// For example, a JavaScript `/* ... */` comment that spawns at least two lines (contains at least one line break character).
+    pub fn multi_line_comment<L: Into<TextSize>>(len: L) -> Self {
         Self::new(TriviaPieceKind::MultiLineComment, len)
     }
 

--- a/crates/rome_rowan/src/arc.rs
+++ b/crates/rome_rowan/src/arc.rs
@@ -255,6 +255,11 @@ impl<H, T> HeaderSlice<H, [T]> {
     pub(crate) fn slice(&self) -> &[T] {
         &self.slice
     }
+
+    /// Returns the number of items
+    pub(crate) fn len(&self) -> usize {
+        self.length
+    }
 }
 
 impl<H, T> Deref for HeaderSlice<H, [T; 0]> {

--- a/crates/rome_rowan/src/cursor.rs
+++ b/crates/rome_rowan/src/cursor.rs
@@ -568,7 +568,7 @@ impl Iterator for SyntaxTriviaPiecesIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         let trivia = self.raw.get_piece(self.next_index)?;
-        let piece = (self.next_offset, trivia);
+        let piece = (self.next_offset, *trivia);
 
         self.next_index += 1;
         self.next_offset += trivia.text_len();
@@ -593,7 +593,7 @@ impl DoubleEndedIterator for SyntaxTriviaPiecesIterator {
         let trivia = self.raw.get_piece(self.end_index)?;
         self.end_offset -= trivia.text_len();
 
-        Some((self.end_offset, trivia))
+        Some((self.end_offset, *trivia))
     }
 }
 
@@ -641,7 +641,7 @@ impl SyntaxTrivia {
 
     /// Gets index-th trivia piece when the token associated with this trivia was created.
     /// See [SyntaxTriviaPiece].
-    pub(crate) fn get_piece(&self, index: usize) -> Option<TriviaPiece> {
+    pub(crate) fn get_piece(&self, index: usize) -> Option<&TriviaPiece> {
         let green_token = self.token.green();
         if self.is_leading {
             green_token.leading_trivia().get_piece(index)

--- a/crates/rome_rowan/src/green.rs
+++ b/crates/rome_rowan/src/green.rs
@@ -2,6 +2,7 @@ mod element;
 mod node;
 mod node_cache;
 mod token;
+mod trivia;
 
 pub(crate) use self::{
     element::{GreenElement, GreenElementRef},
@@ -19,6 +20,7 @@ pub struct RawSyntaxKind(pub u16);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::green::trivia::GreenTrivia;
 
     #[test]
     fn assert_send_sync() {
@@ -34,6 +36,7 @@ mod tests {
 
         assert_eq!(8, size_of::<GreenNode>());
         assert_eq!(8, size_of::<GreenToken>());
+        assert_eq!(8, size_of::<GreenTrivia>());
         assert_eq!(16, size_of::<GreenElement>());
     }
 }

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -257,14 +257,14 @@ mod tests {
         let t1 = GreenToken::with_trivia(
             kind,
             text,
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::whitespace(TextSize::from(1)),
+            GreenTokenTrivia::whitespace(TextSize::from(1)),
         );
         let t2 = GreenToken::with_trivia(
             kind,
             text,
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::whitespace(1),
+            GreenTokenTrivia::whitespace(1),
         );
 
         assert_eq!(token_hash(&t1), token_hash(&t2));
@@ -275,8 +275,8 @@ mod tests {
         let t4 = GreenToken::with_trivia(
             kind,
             "\tlet ",
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
-            GreenTokenTrivia::Whitespace(TextSize::from(1)),
+            GreenTokenTrivia::whitespace(1),
+            GreenTokenTrivia::whitespace(1),
         );
         assert_ne!(token_hash(&t1), token_hash(&t4));
     }

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -1,8 +1,9 @@
 use hashbrown::hash_map::{RawEntryMut, RawOccupiedEntryMut, RawVacantEntryMut};
 use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
+use text_size::TextSize;
 
-use crate::api::TriviaPiece;
+use crate::api::{TriviaPiece, TriviaPieceKind};
 use crate::green::Slot;
 use crate::{
     green::GreenElementRef, GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken,
@@ -10,7 +11,7 @@ use crate::{
 };
 
 use super::element::GreenElement;
-use super::token::GreenTokenTrivia;
+use super::trivia::GreenTrivia;
 
 type HashMap<K, V> = hashbrown::HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
@@ -58,6 +59,7 @@ struct CachedNode {
 pub struct NodeCache {
     nodes: HashMap<CachedNode, ()>,
     tokens: HashMap<CachedToken, ()>,
+    trivia: TriviaCache,
 }
 
 fn token_hash_of(kind: RawSyntaxKind, text: &str) -> u64 {
@@ -166,8 +168,8 @@ impl NodeCache {
         let token = match entry {
             RawEntryMut::Occupied(entry) => entry.key().0.clone(),
             RawEntryMut::Vacant(entry) => {
-                let leading = GreenTokenTrivia::from(leading);
-                let trailing = GreenTokenTrivia::from(trailing);
+                let leading = self.trivia.get(leading);
+                let trailing = self.trivia.get(trailing);
 
                 let token = GreenToken::with_trivia(kind, text, leading, trailing);
                 entry
@@ -243,10 +245,88 @@ impl<'a> VacantNodeEntry<'a> {
     }
 }
 
+/// A cached [GreenTrivia].
+/// Deliberately doesn't implement `Hash` to make sure all
+/// usages go through the custom `FxHasher`.
+#[derive(Debug)]
+struct CachedTrivia(GreenTrivia);
+
+#[derive(Debug)]
+struct TriviaCache {
+    /// Generic cache for trivia
+    cache: HashMap<CachedTrivia, ()>,
+
+    /// Cached empty trivia. Almost every program has empty trivia attached to at least one token.
+    /// Even empty text files where the empty trivia is attached to the EOF token.
+    empty: GreenTrivia,
+
+    /// Cached single whitespace trivia.
+    whitespace: GreenTrivia,
+}
+
+impl Default for TriviaCache {
+    fn default() -> Self {
+        Self {
+            cache: Default::default(),
+            empty: GreenTrivia::new([]),
+            whitespace: GreenTrivia::new([TriviaPiece::whitespace(1)]),
+        }
+    }
+}
+
+impl TriviaCache {
+    /// Tries to retrieve a [GreenTrivia] with the given pieces from the cache or creates a new one and caches
+    /// it for further calls.
+    fn get(&mut self, pieces: &[TriviaPiece]) -> GreenTrivia {
+        match pieces {
+            [] => self.empty.clone(),
+            [TriviaPiece {
+                kind: TriviaPieceKind::Whitespace,
+                length,
+            }] if *length == TextSize::from(1) => self.whitespace.clone(),
+
+            _ => {
+                let hash = Self::trivia_hash_of(pieces);
+
+                let entry = self
+                    .cache
+                    .raw_entry_mut()
+                    .from_hash(hash, |trivia| trivia.0.pieces() == pieces);
+
+                match entry {
+                    RawEntryMut::Occupied(entry) => entry.key().0.clone(),
+                    RawEntryMut::Vacant(entry) => {
+                        let trivia = GreenTrivia::new(pieces.iter().copied());
+                        entry.insert_with_hasher(
+                            hash,
+                            CachedTrivia(trivia.clone()),
+                            (),
+                            |cached| Self::trivia_hash_of(cached.0.pieces()),
+                        );
+                        trivia
+                    }
+                }
+            }
+        }
+    }
+
+    fn trivia_hash_of(pieces: &[TriviaPiece]) -> u64 {
+        let mut h = FxHasher::default();
+
+        pieces.len().hash(&mut h);
+
+        for piece in pieces {
+            piece.hash(&mut h);
+        }
+
+        h.finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::green::node_cache::token_hash;
-    use crate::green::token::GreenTokenTrivia;
+    use crate::green::trivia::GreenTrivia;
     use crate::{GreenToken, RawSyntaxKind};
     use text_size::TextSize;
 
@@ -257,14 +337,14 @@ mod tests {
         let t1 = GreenToken::with_trivia(
             kind,
             text,
-            GreenTokenTrivia::whitespace(TextSize::from(1)),
-            GreenTokenTrivia::whitespace(TextSize::from(1)),
+            GreenTrivia::whitespace(TextSize::from(1)),
+            GreenTrivia::whitespace(TextSize::from(1)),
         );
         let t2 = GreenToken::with_trivia(
             kind,
             text,
-            GreenTokenTrivia::whitespace(1),
-            GreenTokenTrivia::whitespace(1),
+            GreenTrivia::whitespace(1),
+            GreenTrivia::whitespace(1),
         );
 
         assert_eq!(token_hash(&t1), token_hash(&t2));
@@ -275,8 +355,8 @@ mod tests {
         let t4 = GreenToken::with_trivia(
             kind,
             "\tlet ",
-            GreenTokenTrivia::whitespace(1),
-            GreenTokenTrivia::whitespace(1),
+            GreenTrivia::whitespace(1),
+            GreenTrivia::whitespace(1),
         );
         assert_ne!(token_hash(&t1), token_hash(&t4));
     }

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -256,10 +256,6 @@ struct TriviaCache {
     /// Generic cache for trivia
     cache: HashMap<CachedTrivia, ()>,
 
-    /// Cached empty trivia. Almost every program has empty trivia attached to at least one token.
-    /// Even empty text files where the empty trivia is attached to the EOF token.
-    empty: GreenTrivia,
-
     /// Cached single whitespace trivia.
     whitespace: GreenTrivia,
 }
@@ -268,7 +264,6 @@ impl Default for TriviaCache {
     fn default() -> Self {
         Self {
             cache: Default::default(),
-            empty: GreenTrivia::new([]),
             whitespace: GreenTrivia::new([TriviaPiece::whitespace(1)]),
         }
     }
@@ -279,7 +274,7 @@ impl TriviaCache {
     /// it for further calls.
     fn get(&mut self, pieces: &[TriviaPiece]) -> GreenTrivia {
         match pieces {
-            [] => self.empty.clone(),
+            [] => GreenTrivia::empty(),
             [TriviaPiece {
                 kind: TriviaPieceKind::Whitespace,
                 length,

--- a/crates/rome_rowan/src/green/trivia.rs
+++ b/crates/rome_rowan/src/green/trivia.rs
@@ -101,10 +101,8 @@ impl GreenTrivia {
 
     /// Returns the pieces of the trivia
     pub fn pieces(&self) -> &[TriviaPiece] {
-        static EMPTY: [TriviaPiece; 0] = [];
-
         match &self.ptr {
-            None => &EMPTY,
+            None => &[],
             Some(ptr) => ptr.slice(),
         }
     }

--- a/crates/rome_rowan/src/green/trivia.rs
+++ b/crates/rome_rowan/src/green/trivia.rs
@@ -1,8 +1,8 @@
 use crate::arc::{HeaderSlice, ThinArc};
 use crate::TriviaPiece;
 use countme::Count;
+use std::fmt;
 use std::fmt::Formatter;
-use std::{fmt, mem};
 use text_size::TextSize;
 
 #[derive(PartialEq, Eq, Hash)]
@@ -10,7 +10,6 @@ pub(crate) struct GreenTriviaHead {
     _c: Count<GreenTrivia>,
 }
 
-type Repr = HeaderSlice<GreenTriviaHead, [TriviaPiece]>;
 type ReprThin = HeaderSlice<GreenTriviaHead, [TriviaPiece; 0]>;
 
 #[repr(transparent)]
@@ -94,30 +93,19 @@ impl GreenTrivia {
 
     /// Returns the pieces count
     pub fn len(&self) -> usize {
-        self.pieces().len()
+        match &self.ptr {
+            None => 0,
+            Some(ptr) => ptr.len(),
+        }
     }
 
     /// Returns the pieces of the trivia
     pub fn pieces(&self) -> &[TriviaPiece] {
         static EMPTY: [TriviaPiece; 0] = [];
 
-        match self.data() {
-            None => &EMPTY,
-            Some(data) => data.pieces(),
-        }
-    }
-
-    fn data(&self) -> Option<&GreenTriviaData> {
         match &self.ptr {
-            None => None,
-            Some(ptr) => {
-                let repr: &Repr = ptr;
-                let data = unsafe {
-                    let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
-                    mem::transmute::<&ReprThin, &GreenTriviaData>(repr)
-                };
-                Some(data)
-            }
+            None => &EMPTY,
+            Some(ptr) => ptr.slice(),
         }
     }
 

--- a/crates/rslint_parser/src/lossless_tree_sink.rs
+++ b/crates/rslint_parser/src/lossless_tree_sink.rs
@@ -1,4 +1,4 @@
-use crate::token_source::{Trivia, TriviaKind};
+use crate::token_source::Trivia;
 use crate::{ParseDiagnostic, TreeSink};
 use rome_js_syntax::{JsSyntaxKind, SyntaxNode, SyntaxTreeBuilder, TextRange, TextSize};
 use rome_rowan::TriviaPiece;
@@ -107,14 +107,8 @@ impl<'a> LosslessTreeSink<'a> {
 
             self.text_pos += trivia.len();
 
-            let current_trivia = match trivia.kind() {
-                TriviaKind::Newline => TriviaPiece::Newline(trivia.len()),
-                TriviaKind::Whitespace => TriviaPiece::Whitespace(trivia.len()),
-                TriviaKind::Comment => TriviaPiece::Comments(trivia.len(), false),
-                TriviaKind::MultilineComment => TriviaPiece::Comments(trivia.len(), true),
-            };
-
-            self.trivia_pieces.push(current_trivia);
+            let trivia_piece = TriviaPiece::new(trivia.kind(), trivia.len());
+            self.trivia_pieces.push(trivia_piece);
             count += 1;
         }
 

--- a/crates/rslint_parser/src/syntax/function.rs
+++ b/crates/rslint_parser/src/syntax/function.rs
@@ -382,8 +382,7 @@ pub(crate) fn parse_ts_type_annotation_or_error(p: &mut Parser) -> ParsedSyntax 
 }
 
 /// Tells [is_at_async_function] if it needs to check line breaks
-#[derive(PartialEq)]
-#[repr(u8)]
+#[derive(PartialEq, Eq)]
 pub(crate) enum LineBreak {
     // check line breaks
     DoCheck,

--- a/crates/rslint_parser/src/syntax/stmt.rs
+++ b/crates/rslint_parser/src/syntax/stmt.rs
@@ -1035,7 +1035,6 @@ pub(super) fn parse_variable_declaration(
 }
 
 /// What's the parent node of the variable declaration
-#[repr(u8)]
 #[derive(Clone, Debug, Copy, Eq, PartialEq)]
 pub(super) enum VariableDeclarationParent {
     /// Declaration inside a `for...of` or `for...in` or `for (;;)` loop

--- a/crates/rslint_parser/src/syntax/util.rs
+++ b/crates/rslint_parser/src/syntax/util.rs
@@ -5,7 +5,6 @@ use rome_js_syntax::{JsSyntaxKind, T};
 /// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table
 #[allow(dead_code)]
 #[derive(Debug, Eq, Ord, PartialOrd, PartialEq, Copy, Clone)]
-#[repr(u8)]
 pub(crate) enum OperatorPrecedence {
     Comma = 0,
     Yield = 1,


### PR DESCRIPTION
## Summary

This PR reduces the memory footprint for storing trivia by:

* Caching and re-using trivia across tokens
* Reducing the size of `GreenTrivia` from `16` to `8` bytes which, in turn, reduces the size of `GreenTokenData` from 36 bytes to 20 bytes. That means, we save 16 bytes for every allocated token. 
* Reducing the size for a "many" trivia from: 32 (8 byte pointer + tag, 16 byte vec + trivia) to 16 bytes (8 byte pointer, 8 byte len + trivia)

Downside:

* This now requires a heap allocation for trivia containing a single piece which is, for example, very common for whitespace. This comes with a slight memory increase because of the heap metadata but that is amortized by caching the trivia across multiple tokens. 

Related discussion #1809

## What has changed since the initial implementation?

The optimization for storing a single trivia inline with the token has become less effective since we decided to have two different trivia for 'newlines' and 'whitespace' (space, tabs). Splitting the trivia had the consequence that now any indented token at the beginning of a line requires a heap allocated `Vec` to store the leading line break + the indent spaces. 


## Test Plan

Performance is neutral. 

`cargo bench_parser`

```
group                                    green2                                 main
-----                                    ------                                 ----
parser/checker.ts                        1.01     84.4±1.66ms    30.8 MB/sec    1.00     83.6±1.29ms    31.1 MB/sec
parser/compiler.js                       1.00     50.8±1.52ms    20.6 MB/sec    1.01     51.1±1.16ms    20.5 MB/sec
parser/d3.min.js                         1.00     32.5±0.54ms     8.1 MB/sec    1.00     32.4±0.47ms     8.1 MB/sec
parser/dojo.js                           1.00      2.6±0.04ms    26.0 MB/sec    1.01      2.7±0.06ms    25.7 MB/sec
parser/ios.d.ts                          1.00     78.1±1.45ms    23.9 MB/sec    1.01     78.9±1.36ms    23.6 MB/sec
parser/jquery.min.js                     1.01      9.3±0.13ms     8.9 MB/sec    1.00      9.3±0.13ms     8.9 MB/sec
parser/math.js                           1.00     62.0±1.37ms    10.4 MB/sec    1.12     69.6±3.44ms     9.3 MB/sec
parser/parser.ts                         1.00  1761.2±36.09µs    26.2 MB/sec    1.06  1870.9±156.93µs    24.7 MB/sec
parser/pixi.min.js                       1.00     39.5±0.66ms    11.1 MB/sec    1.00     39.5±0.74ms    11.1 MB/sec
parser/react-dom.production.min.js       1.00     12.0±0.17ms     9.6 MB/sec    1.01     12.2±0.14ms     9.5 MB/sec
parser/react.production.min.js           1.00   578.1±10.38µs    10.6 MB/sec    1.00    579.5±8.05µs    10.6 MB/sec
parser/router.ts                         1.00  1480.2±33.52µs    41.0 MB/sec    1.01  1500.2±27.17µs    40.4 MB/sec
parser/tex-chtml-full.js                 1.01     84.1±1.74ms    10.8 MB/sec    1.00     83.5±1.34ms    10.9 MB/sec
parser/three.min.js                      1.01     44.6±0.70ms    13.2 MB/sec    1.00     44.4±0.83ms    13.2 MB/sec
parser/typescript.js                     1.00    344.9±5.11ms    27.5 MB/sec    1.03    357.0±8.25ms    26.6 MB/sec
parser/vue.global.prod.js                1.00     14.7±0.19ms     8.2 MB/sec    1.00     14.7±0.21ms     8.2 MB/sec
```

Memory consumption: 

* `pixi`: Minified file. Only contains whitespace trivia. From 7.74MB to 7.66MB (~1%). Memory reduction comes from the reduced token size. 

* `checker`: Huge source file, unmodified: Contains whitespace, new lines, and comments: From 16.86MB to 16.50 MB (~2%)
