### PR TITLE
chore: fix benchmark actions

### DIFF
--- a/.github/workflows/bench_formatter.yml
+++ b/.github/workflows/bench_formatter.yml
@@ -5,37 +5,32 @@ name: Formatter Benchmark
 
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
 
 env:
   RUST_LOG: info
-  RUST_BACKTRACE: 1
 
 jobs:
   bench:
     name: Bench
     if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench_formatter')
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
+      - name: Get PR SHA
+        id: sha
+        uses: actions/github-script@v4
+        with:
+          result-encoding: string
+          script: |
+            const response = await github.request(context.payload.issue.pull_request.url);
+            return response.data.head.sha;
+
       - name: Checkout PR Branch
         uses: actions/checkout@v2
         with:
           submodules: false
-
-      - name: Support longpaths
-        run: git config core.longpaths true
-
-      - name: Checkout PR Branch
-        uses: actions/checkout@v2
-
-      - name: Fetch Main Branch
-        run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main
+          ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
         run: rustup show

--- a/.github/workflows/bench_parser.yml
+++ b/.github/workflows/bench_parser.yml
@@ -9,33 +9,27 @@ on:
 
 env:
   RUST_LOG: info
-  RUST_BACKTRACE: 1
 
 jobs:
   bench:
     name: Bench
     if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench_parser')
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-       os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
+      - name: Get PR SHA
+        id: sha
+        uses: actions/github-script@v4
+        with:
+          result-encoding: string
+          script: |
+            const response = await github.request(context.payload.issue.pull_request.url);
+            return response.data.head.sha;
       - name: Checkout PR Branch
         uses: actions/checkout@v2
         with:
           submodules: false
-
-      - name: Support longpaths
-        run: git config core.longpaths true
-        
-      - name: Checkout PR Branch
-        uses: actions/checkout@v2
-
-      - name: Fetch Main Branch
-        run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin main
+          ref: ${{ steps.sha.outputs.result }}
 
       - name: Install toolchain
         run: rustup show


### PR DESCRIPTION

## Summary

Our benchmarks always compared `main` vs `main` because the `issue_comment` action doesn't set `GITHUB_REF` and the github checkout action then checks out the default branch.

This PR adds a small script that retrieves the PR ref from the PR. It also removes a few unnecessary steps (no need for submodules)

## Test Plan

I tried testing with `act` but faced plenty of issues. Let's test in prod
