### PR TITLE
refactor(rome_rowan): change the internal representation of green trivia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1454,7 @@ dependencies = [
 name = "rome_rowan"
 version = "0.0.0"
 dependencies = [
+ "bitfield",
  "countme",
  "hashbrown",
  "memoffset",

--- a/crates/rome_rowan/Cargo.toml
+++ b/crates/rome_rowan/Cargo.toml
@@ -15,6 +15,7 @@ hashbrown = { version = "0.11.2", features = [
 text-size = "1.1.0"
 memoffset = "0.6.5"
 countme = "3.0.0"
+bitfield = "0.13.2"
 
 serde = { version = "1.0.133", optional = true, default-features = false }
 

--- a/crates/rome_rowan/src/green/node_cache.rs
+++ b/crates/rome_rowan/src/green/node_cache.rs
@@ -260,10 +260,10 @@ impl TriviaCache {
     /// Tries to retrieve a [GreenTrivia] with the given pieces from the cache or creates a new one and caches
     /// it for further calls.
     fn get(&mut self, pieces: &[TriviaPiece]) -> GreenTrivia {
-        // Bypass the cache if there is one or less piece in the trivia (it can
-        // be stored directly inside the GreenTrivia)
-        if pieces.len() < 2 {
-            return GreenTrivia::new(pieces.first().copied());
+        // Bypass the cache if there is two or less pieces in the trivia (it
+        // can be stored directly inside the GreenTrivia)
+        if pieces.len() <= 2 {
+            return GreenTrivia::new(pieces.iter().copied());
         }
 
         let hash = Self::trivia_hash_of(pieces);

--- a/crates/rome_rowan/src/green/token.rs
+++ b/crates/rome_rowan/src/green/token.rs
@@ -163,7 +163,7 @@ impl GreenToken {
     #[inline]
     #[cfg(test)]
     pub fn new(kind: RawSyntaxKind, text: &str) -> GreenToken {
-        let leading = GreenTrivia::empty();
+        let leading = GreenTrivia::new(None);
         let trailing = leading.clone();
 
         Self::with_trivia(kind, text, leading, trailing)
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn empty_text_len() {
-        assert_eq!(TextSize::from(0), GreenTrivia::empty().text_len());
+        assert_eq!(TextSize::from(0), GreenTrivia::new(None).text_len());
     }
 
     #[quickcheck]

--- a/crates/rome_rowan/src/green/trivia.rs
+++ b/crates/rome_rowan/src/green/trivia.rs
@@ -145,6 +145,12 @@ impl GreenTrivia {
         I::IntoIter: ExactSizeIterator,
     {
         let mut items = pieces.into_iter();
+        if items.len() == 0 {
+            return GreenTrivia {
+                inner: GreenTriviaRepr { bits: 0 },
+            };
+        }
+
         if items.len() == 1 {
             // SAFETY: Unwrap guarded by above call to len
             let item = GreenTriviaRepr {
@@ -185,13 +191,6 @@ impl GreenTrivia {
         }
 
         GreenTrivia { inner: data }
-    }
-
-    /// Creates an empty trivia
-    pub fn empty() -> Self {
-        GreenTrivia {
-            inner: GreenTriviaRepr { bits: 0 },
-        }
     }
 
     /// Returns the total length of all pieces

--- a/crates/rome_rowan/src/green/trivia.rs
+++ b/crates/rome_rowan/src/green/trivia.rs
@@ -3,6 +3,9 @@ use crate::TriviaPiece;
 use countme::Count;
 use std::fmt;
 use std::fmt::Formatter;
+use std::hash::Hash;
+use std::mem::ManuallyDrop;
+use std::slice;
 use text_size::TextSize;
 
 #[derive(PartialEq, Eq, Hash)]
@@ -42,6 +45,43 @@ impl fmt::Debug for GreenTriviaData {
     }
 }
 
+type TriviaPtr = ThinArc<GreenTriviaHead, TriviaPiece>;
+
+/// Internal memory layout of GreenTrivia
+///
+/// A [GreenTrivia] is represented in memory as a 64-bits integer that is either:
+/// - If the value is 0, this is an empty trivia
+/// - If the least significant bit of the value is 1, its interpreted as a single
+/// [TriviaPiece] stored inline in the [GreenTrivia]
+/// - Otherwise the value is interpreted as a [TriviaPtr], that is a [ThinArc]
+/// pointing to the actual slice of [TriviaPiece]
+///
+/// This encoding relies on the following invariants:
+/// - The pointer contained in a [ThinArc] is `NonNull`, meaning a valid
+/// [ThinArc] will never contain a value where all the bits are zeroes
+/// - The data pointed to by a [ThinArc] contains an `AtomicUsize` and is thus
+/// aligned to a pointer-sized boundary (8 bytes on 64 bits architectures).
+/// This means the three least-significant bits of a valid [ThinArc] will
+/// always be zero
+/// - [TriviaPiece] and all the type it contains are using "forced
+/// representations" ([TriviaPiece] itself is `repr(C)`, `TriviaPieceKind` is a
+/// `repr(u8)` enum with manually specified discriminants, and `TextSize` is a
+/// `repr(transparent)` newtype struct wrapping a `u32`): this allows this type
+/// to have a stable memory layout that can be relied upon, an specifically to
+/// uphold the invariant that the least-significant bit of a valid [TriviaPiece]
+/// is alway set to one
+/// - The target platform must be using little-endian byte order for the [TriviaPiece]
+/// struct to be laid out correctly. This invariant is weaker than the previous ones
+/// as it could be lifted by using a slightly different different logic depending on
+/// the target platform endianness, but since Rome doesn't support any big-endian
+/// platform for now the code is just set to fail compiling on those
+#[cfg(target_endian = "little")]
+union GreenTriviaRepr {
+    bits: u64,
+    inline: TriviaPiece,
+    ptr: ManuallyDrop<TriviaPtr>,
+}
+
 /// List of trivia. Used to store either the leading or trailing trivia of a token.
 /// The identity of a trivia is defined by the kinds and lengths of its items but not by
 /// the texts of an individual piece. That means, that `\r` and `\n` can both be represented
@@ -49,10 +89,46 @@ impl fmt::Debug for GreenTriviaData {
 /// This is safe because the text is stored on the token to which the trivia belongs and
 /// `a\n` and `a\r` never resolve to the same tokens. Thus, they only share the trivia but are
 /// otherwise two different tokens.
-#[derive(Eq, PartialEq, Hash, Clone)]
 #[repr(transparent)]
 pub(crate) struct GreenTrivia {
-    ptr: Option<ThinArc<GreenTriviaHead, TriviaPiece>>,
+    inner: GreenTriviaRepr,
+}
+
+impl Eq for GreenTrivia {}
+
+impl PartialEq for GreenTrivia {
+    fn eq(&self, other: &Self) -> bool {
+        self.pieces() == other.pieces()
+    }
+}
+
+impl Hash for GreenTrivia {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pieces().hash(state);
+    }
+}
+
+impl Clone for GreenTrivia {
+    fn clone(&self) -> Self {
+        // SAFETY: This reads the content of `inner` as plain bits first,
+        // and either copies those directly or call clone on the contained
+        // ThinArc if the content is determined to be a pointer
+        unsafe {
+            if self.inner.bits == 0 || (self.inner.bits & 1) == 1 {
+                GreenTrivia {
+                    inner: GreenTriviaRepr {
+                        bits: self.inner.bits,
+                    },
+                }
+            } else {
+                GreenTrivia {
+                    inner: GreenTriviaRepr {
+                        ptr: self.inner.ptr.clone(),
+                    },
+                }
+            }
+        }
+    }
 }
 
 impl fmt::Debug for GreenTrivia {
@@ -68,15 +144,54 @@ impl GreenTrivia {
         I: IntoIterator<Item = TriviaPiece>,
         I::IntoIter: ExactSizeIterator,
     {
-        let data =
-            ThinArc::from_header_and_iter(GreenTriviaHead { _c: Count::new() }, pieces.into_iter());
+        let mut items = pieces.into_iter();
+        if items.len() == 1 {
+            // SAFETY: Unwrap guarded by above call to len
+            let item = GreenTriviaRepr {
+                inline: items.next().unwrap(),
+            };
 
-        GreenTrivia { ptr: Some(data) }
+            // SAFETY: This turns a TriviaPiece into a u64, this is safe since
+            // that struct only stores plain integers and enums
+            unsafe {
+                debug_assert_eq!(
+                    item.bits & 1,
+                    1,
+                    "unexpected bit pattern for TriviaPiece: {:0>64b}",
+                    item.bits,
+                );
+            }
+
+            return GreenTrivia { inner: item };
+        }
+
+        let data = GreenTriviaRepr {
+            ptr: ManuallyDrop::new(ThinArc::from_header_and_iter(
+                GreenTriviaHead { _c: Count::new() },
+                items,
+            )),
+        };
+
+        // SAFETY: this turns a ThinArc into a u64, this is safe since ThinArc
+        // in turn only contains a NonNull that get reinterpreted as a
+        // pointer-sized unsigned integer
+        unsafe {
+            debug_assert_eq!(
+                data.bits & 1,
+                0,
+                "unexpected bit pattern for ThinArc: {:0>64b}",
+                data.bits,
+            );
+        }
+
+        GreenTrivia { inner: data }
     }
 
     /// Creates an empty trivia
     pub fn empty() -> Self {
-        GreenTrivia { ptr: None }
+        GreenTrivia {
+            inner: GreenTriviaRepr { bits: 0 },
+        }
     }
 
     /// Returns the total length of all pieces
@@ -93,23 +208,58 @@ impl GreenTrivia {
 
     /// Returns the pieces count
     pub fn len(&self) -> usize {
-        match &self.ptr {
-            None => 0,
-            Some(ptr) => ptr.len(),
+        // SAFETY: This reads the content of inner as bits, and use it to
+        // detect whether the content is empty, an inline trivia piece or a
+        // pointer
+        unsafe {
+            if self.inner.bits == 0 {
+                return 0;
+            }
+
+            if (self.inner.bits & 1) == 1 {
+                return 1;
+            }
+
+            self.inner.ptr.len()
         }
     }
 
     /// Returns the pieces of the trivia
     pub fn pieces(&self) -> &[TriviaPiece] {
-        match &self.ptr {
-            None => &[],
-            Some(ptr) => ptr.slice(),
+        // SAFETY: This reads the content of inner as bits, and use it to
+        // detect whether the content is empty, an inline trivia piece or a
+        // pointer
+        unsafe {
+            if self.inner.bits == 0 {
+                return &[];
+            }
+
+            if (self.inner.bits & 1) == 1 {
+                return slice::from_ref(&self.inner.inline);
+            }
+
+            self.inner.ptr.slice()
         }
     }
 
     /// Returns the piece at the given index.
     pub fn get_piece(&self, index: usize) -> Option<&TriviaPiece> {
         self.pieces().get(index)
+    }
+}
+
+impl Drop for GreenTrivia {
+    fn drop(&mut self) {
+        // SAFETY: This reads the content of inner as bits, and manually calls
+        // the implementation of Drop for ThinArc if the content is determined
+        // to be a pointer
+        unsafe {
+            if self.inner.bits == 0 || (self.inner.bits & 1) == 1 {
+                return;
+            }
+
+            ManuallyDrop::drop(&mut self.inner.ptr);
+        }
     }
 }
 
@@ -141,5 +291,36 @@ mod tests {
     fn sizes() {
         assert_eq!(0, std::mem::size_of::<GreenTriviaHead>());
         assert_eq!(8, std::mem::size_of::<GreenTrivia>());
+    }
+
+    #[test]
+    fn trivia_piece_layout() {
+        assert_eq!(
+            std::mem::size_of::<u64>(),
+            std::mem::size_of::<TriviaPiece>()
+        );
+
+        let piece = TriviaPiece {
+            kind: TriviaPieceKind::Newline,
+            length: TextSize::from(0),
+        };
+
+        let ptr = &piece as *const TriviaPiece as *const u8;
+        let kind = &piece.kind as *const TriviaPieceKind as *const u8;
+        let length = &piece.length as *const TextSize as *const u8;
+
+        let kind_offset = unsafe { kind.offset_from(ptr) };
+        let length_offset = unsafe { length.offset_from(ptr) };
+
+        assert_eq!(kind_offset, 0);
+        assert_eq!(length_offset, 4);
+
+        let bits: u64 = unsafe { std::mem::transmute(piece) };
+        assert_eq!(
+            bits & 1,
+            1,
+            "unexpected bit pattern for TriviaPiece: {:0>64b}",
+            bits,
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR modifies how `GreenTrivia` are represented in memory, specifically allowing for single-piece trivias to be stored inline in a tagged pointer instead of allocating a trivia piece in the cache
