### PR TITLE
fix(rslint_parser): Don't panic for `import` in expression position

### DIFF
--- a/crates/rslint_parser/src/syntax/expr.rs
+++ b/crates/rslint_parser/src/syntax/expr.rs
@@ -1142,7 +1142,10 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
         T!['('] => parse_parenthesized_expression(p, context).unwrap(),
         T!['['] => parse_array_expr(p).unwrap(),
         T!['{'] if context.is_object_expression_allowed() => parse_object_expression(p).unwrap(),
-        T![import] => {
+
+        // test_err import_keyword_in_expression_position
+        // let a = import;
+        T![import] if matches!(p.nth(1), T![.] | T!['(']) => {
             let m = p.start();
             p.bump_any();
 
@@ -1173,7 +1176,7 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
                     p.error(err);
                     m.complete(p, JS_UNKNOWN)
                 }
-            } else if p.at(T!['(']) {
+            } else {
                 // test import_call
                 // import("foo")
                 // import("foo", { assert: { type: 'json' } })
@@ -1232,8 +1235,6 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
                 p.expect(T![')']);
                 args.complete(p, JS_CALL_ARGUMENTS);
                 m.complete(p, JS_IMPORT_CALL_EXPRESSION)
-            } else {
-                return Absent;
             }
         }
         T![new] => parse_new_expr(p, context).unwrap(),

--- a/crates/rslint_parser/test_data/inline/err/import_keyword_in_expression_position.js
+++ b/crates/rslint_parser/test_data/inline/err/import_keyword_in_expression_position.js
@@ -1,0 +1,1 @@
+let a = import;

--- a/crates/rslint_parser/test_data/inline/err/import_keyword_in_expression_position.rast
+++ b/crates/rslint_parser/test_data/inline/err/import_keyword_in_expression_position.rast
@@ -1,0 +1,68 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsVariableStatement {
+            declaration: JsVariableDeclaration {
+                kind: LET_KW@0..4 "let" [] [Whitespace(" ")],
+                declarators: JsVariableDeclaratorList [
+                    JsVariableDeclarator {
+                        id: JsIdentifierBinding {
+                            name_token: IDENT@4..6 "a" [] [Whitespace(" ")],
+                        },
+                        variable_annotation: missing (optional),
+                        initializer: JsInitializerClause {
+                            eq_token: EQ@6..8 "=" [] [Whitespace(" ")],
+                            expression: missing (required),
+                        },
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+        JsImport {
+            import_token: IMPORT_KW@8..14 "import" [] [],
+            import_clause: missing (required),
+            semicolon_token: SEMICOLON@14..15 ";" [] [],
+        },
+    ],
+    eof_token: EOF@15..16 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..16
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..15
+    0: JS_VARIABLE_STATEMENT@0..8
+      0: JS_VARIABLE_DECLARATION@0..8
+        0: LET_KW@0..4 "let" [] [Whitespace(" ")]
+        1: JS_VARIABLE_DECLARATOR_LIST@4..8
+          0: JS_VARIABLE_DECLARATOR@4..8
+            0: JS_IDENTIFIER_BINDING@4..6
+              0: IDENT@4..6 "a" [] [Whitespace(" ")]
+            1: (empty)
+            2: JS_INITIALIZER_CLAUSE@6..8
+              0: EQ@6..8 "=" [] [Whitespace(" ")]
+              1: (empty)
+      1: (empty)
+    1: JS_IMPORT@8..15
+      0: IMPORT_KW@8..14 "import" [] []
+      1: (empty)
+      2: SEMICOLON@14..15 ";" [] []
+  3: EOF@15..16 "" [Newline("\n")] []
+--
+error[SyntaxError]: expected an expression, or an assignment but instead found 'import'
+  ┌─ import_keyword_in_expression_position.js:1:9
+  │
+1 │ let a = import;
+  │         ^^^^^^ Expected an expression, or an assignment here
+
+--
+error[SyntaxError]: expected a default import, a namespace import, or a named import but instead found ';'
+  ┌─ import_keyword_in_expression_position.js:1:15
+  │
+1 │ let a = import;
+  │               ^ Expected a default import, a namespace import, or a named import here
+
+--
+let a = import;


### PR DESCRIPTION


## Summary

Fix a panic in the parser if `import` appears in an expression position, for example: `let a = import`.

## Test Plan

Added a new parser test
