### PR TITLE
feat(rome_formatter): less allocation when concat elements

### DIFF
--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -250,7 +250,7 @@ where
 {
     let mut elements = elements.into_iter();
 
-    let mut size_hint = if let (_, Some(upper_bound)) = elements.size_hint() {
+    let size_hint = if let (_, Some(upper_bound)) = elements.size_hint() {
         upper_bound
     } else {
         0


### PR DESCRIPTION
When we concat elements, we create a list and flat items in it. Sometimes the first item is actually a list. Sometimes a big list, actually. In this case, we hijack this list instead of creating a new one and avoid moving all elements.

Another advantage is that we can use ```size_hint``` better.

On ```rsuite``` case, when formatting 600 files this hijacking happened more than 120K times and the biggest list had 150 items.
On our benchmark:

jquery: +38K times, +800 items;
threejs: +170K times; +3000 items;

Maybe we want a "lazy list" like rope? But a linked list of vecs.