### PR TITLE
refactor(rome_formatter): use `prelude` terminology

### DIFF
--- a/crates/rome_formatter/src/formatter_traits.rs
+++ b/crates/rome_formatter/src/formatter_traits.rs
@@ -7,6 +7,9 @@ use crate::{
 use rome_js_syntax::{AstNode, SyntaxResult, SyntaxToken};
 
 /// Utility trait used to simplify the formatting of optional tokens
+///
+/// In order to take advantage of all the functions, you only need to implement the [FormatOptionalTokenAndNode::format_with_or]
+/// function.
 pub trait FormatOptionalTokenAndNode {
     /// This function tries to format an optional [token](rome_js_syntax::SyntaxToken) or [node](rome_js_syntax::AstNode).
     /// If the token doesn't exist, an [empty token](FormatElement::Empty) is created
@@ -16,7 +19,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::formatter_traits::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
     ///
     /// let formatter = Formatter::default();
     /// let token: Option<SyntaxToken> = None;
@@ -37,7 +40,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element, space_token, format_elements, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::formatter_traits::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let formatter = Formatter::default();
@@ -79,7 +82,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::formatter_traits::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
     ///
     /// let formatter = Formatter::default();
     /// let empty_token: Option<SyntaxToken> = None;
@@ -107,7 +110,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element, space_token, format_elements, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::formatter_traits::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let formatter = Formatter::default();
@@ -153,7 +156,7 @@ pub trait FormatTokenAndNode {
     ///
     /// ```
     /// use rome_formatter::{Formatter, token, space_token};
-    /// use rome_formatter::formatter_traits::FormatTokenAndNode;
+    /// use rome_formatter::prelude::FormatTokenAndNode;
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let mut builder = SyntaxTreeBuilder::new();
@@ -185,7 +188,7 @@ pub trait FormatTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, token, format_elements, space_token};
     /// use rome_js_syntax::{SyntaxNode, SyntaxTreeBuilder, JsSyntaxKind};
-    /// use rome_formatter::formatter_traits::FormatTokenAndNode;
+    /// use rome_formatter::prelude::FormatTokenAndNode;
     ///
     /// let mut builder = SyntaxTreeBuilder::new();
     /// builder.start_node(JsSyntaxKind::JS_STRING_LITERAL_EXPRESSION);
@@ -213,6 +216,10 @@ pub trait FormatTokenAndNode {
 
 /// Utility trait to convert [crate::FormatElement] to [FormatResult]
 pub trait IntoFormatResult {
+    /// Consumes a [crate::FormatElement] to return a [FormatResult::FormatElement]
+    ///
+    /// This function in important when working with closures and the rest of the traits
+    /// that belong to this module.
     fn into_format_result(self) -> FormatResult<FormatElement>;
 }
 

--- a/crates/rome_formatter/src/formatter_traits.rs
+++ b/crates/rome_formatter/src/formatter_traits.rs
@@ -19,7 +19,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::*;
     ///
     /// let formatter = Formatter::default();
     /// let token: Option<SyntaxToken> = None;
@@ -40,7 +40,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element, space_token, format_elements, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::*;
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let formatter = Formatter::default();
@@ -82,7 +82,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::*;
     ///
     /// let formatter = Formatter::default();
     /// let empty_token: Option<SyntaxToken> = None;
@@ -110,7 +110,7 @@ pub trait FormatOptionalTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, empty_element, space_token, format_elements, token};
     /// use rome_js_syntax::{SyntaxToken};
-    /// use rome_formatter::prelude::{FormatOptionalTokenAndNode};
+    /// use rome_formatter::prelude::*;
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let formatter = Formatter::default();
@@ -156,7 +156,7 @@ pub trait FormatTokenAndNode {
     ///
     /// ```
     /// use rome_formatter::{Formatter, token, space_token};
-    /// use rome_formatter::prelude::FormatTokenAndNode;
+    /// use rome_formatter::prelude::*;
     /// use rome_js_syntax::{SyntaxTreeBuilder, JsSyntaxKind};
     ///
     /// let mut builder = SyntaxTreeBuilder::new();
@@ -188,7 +188,7 @@ pub trait FormatTokenAndNode {
     /// ```
     /// use rome_formatter::{Formatter, token, format_elements, space_token};
     /// use rome_js_syntax::{SyntaxNode, SyntaxTreeBuilder, JsSyntaxKind};
-    /// use rome_formatter::prelude::FormatTokenAndNode;
+    /// use rome_formatter::prelude::*;
     ///
     /// let mut builder = SyntaxTreeBuilder::new();
     /// builder.start_node(JsSyntaxKind::JS_STRING_LITERAL_EXPRESSION);

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -51,21 +51,14 @@ mod cst;
 mod format_element;
 mod format_elements;
 mod formatter;
-pub mod formatter_traits;
+mod formatter_traits;
 mod intersperse;
 mod js;
 mod jsx;
+pub mod prelude;
 mod printer;
 mod ts;
 mod utils;
-
-pub use formatter::Formatter;
-use rome_js_syntax::{SyntaxError, SyntaxNode};
-use rome_rowan::TextRange;
-use rome_rowan::TextSize;
-use rome_rowan::TokenAtOffset;
-use std::fmt::Display;
-
 pub use format_element::{
     block_indent, comment, concat_elements, empty_element, empty_line, fill_elements,
     group_elements, hard_group_elements, hard_line_break, if_group_breaks,
@@ -73,8 +66,14 @@ pub use format_element::{
     soft_block_indent, soft_line_break, soft_line_break_or_space, soft_line_indent_or_space,
     space_token, token, FormatElement, Token,
 };
+pub use formatter::Formatter;
 pub use printer::Printer;
 pub use printer::PrinterOptions;
+use rome_js_syntax::{SyntaxError, SyntaxNode};
+use rome_rowan::TextRange;
+use rome_rowan::TextSize;
+use rome_rowan::TokenAtOffset;
+use std::fmt::Display;
 use std::str::FromStr;
 use thiserror::Error;
 

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -1,0 +1,6 @@
+//! This module provides important and useful traits to help to format tokens and nodes
+//! when implementing the [crate::ToFormatElement] trait.
+
+pub use crate::formatter_traits::{
+    FormatOptionalTokenAndNode, FormatTokenAndNode, IntoFormatResult,
+};

--- a/crates/rome_formatter/src/prelude.rs
+++ b/crates/rome_formatter/src/prelude.rs
@@ -2,5 +2,5 @@
 //! when implementing the [crate::ToFormatElement] trait.
 
 pub use crate::formatter_traits::{
-    FormatOptionalTokenAndNode, FormatTokenAndNode, IntoFormatResult,
+    FormatOptionalTokenAndNode as _, FormatTokenAndNode as _, IntoFormatResult as _,
 };


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR uses the `prelude`  terminology to expose our traits. Now `formatter_prelude` only contains these traits.
The implementation has been moved inside `formatter.rs`. I could not find a better way to have these implementations. If you have a better idea, it's very welcome!

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
