### PR TITLE
fix(rome_formatter): Don't remove parenthesis from member assignments

### DIFF
--- a/crates/rome_formatter/src/utils/mod.rs
+++ b/crates/rome_formatter/src/utils/mod.rs
@@ -561,8 +561,8 @@ impl FormatPrecedence {
             | JsSyntaxKind::JS_TEMPLATE
             | JsSyntaxKind::JS_SPREAD
             | JsSyntaxKind::JS_STATIC_MEMBER_EXPRESSION
-            | JsSyntaxKind::JS_CALL_EXPRESSION
             | JsSyntaxKind::JS_STATIC_MEMBER_ASSIGNMENT
+            | JsSyntaxKind::JS_CALL_EXPRESSION
             | JsSyntaxKind::JS_NEW_EXPRESSION
             | JsSyntaxKind::JS_CONDITIONAL_EXPRESSION
             | JsSyntaxKind::JS_EXTENDS_CLAUSE
@@ -572,7 +572,8 @@ impl FormatPrecedence {
             | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
             | JsSyntaxKind::JS_EXPRESSION_STATEMENT
             | JsSyntaxKind::JS_RETURN_STATEMENT
-            | JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION => FormatPrecedence::High,
+            | JsSyntaxKind::JS_COMPUTED_MEMBER_EXPRESSION
+            | JsSyntaxKind::JS_COMPUTED_MEMBER_ASSIGNMENT => FormatPrecedence::High,
 
             _ => FormatPrecedence::None,
         })

--- a/crates/rome_formatter/tests/specs/js/module/assignment/assignment.js
+++ b/crates/rome_formatter/tests/specs/js/module/assignment/assignment.js
@@ -20,4 +20,7 @@ a[ b ]  =  c[ d ]
 ;[a, b = "b", ...c] = d
 ;[fooooooooooooooooooooooooooooooooooooooooooooooooo, barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr, bazzzzzzzzzzzzzzzzzzzzzzzzzz] = d
 ;({a,b=c,d:e,f:g=h,...j} = x)
-;({aaaaaaaaaa,bbbbbbbbbb=cccccccccc,dddddddddd:eeeeeeeeee,ffffffffff:gggggggggg=hhhhhhhhhh,...jjjjjjjjjj} = x)
+;({aaaaaaaaaa,bbbbbbbbbb=cccccccccc,dddddddddd:eeeeeeeeee,ffffffffff:gggggggggg=hhhhhhhhhh,...jjjjjjjjjj} = x);
+
+(s||(s=Object.create(null)))[i]=!0;
+(s||(s=Object.create(null))).test=!0;

--- a/crates/rome_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: assignment.js
-
 ---
 # Input
 a  =    b
@@ -27,7 +25,10 @@ a[ b ]  =  c[ d ]
 ;[a, b = "b", ...c] = d
 ;[fooooooooooooooooooooooooooooooooooooooooooooooooo, barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr, bazzzzzzzzzzzzzzzzzzzzzzzzzz] = d
 ;({a,b=c,d:e,f:g=h,...j} = x)
-;({aaaaaaaaaa,bbbbbbbbbb=cccccccccc,dddddddddd:eeeeeeeeee,ffffffffff:gggggggggg=hhhhhhhhhh,...jjjjjjjjjj} = x)
+;({aaaaaaaaaa,bbbbbbbbbb=cccccccccc,dddddddddd:eeeeeeeeee,ffffffffff:gggggggggg=hhhhhhhhhh,...jjjjjjjjjj} = x);
+
+(s||(s=Object.create(null)))[i]=!0;
+(s||(s=Object.create(null))).test=!0;
 
 =============================
 # Outputs
@@ -71,4 +72,7 @@ a[b] = c[d];
 		...jjjjjjjjjj
 	} = x
 );
+
+(s || (s = Object.create(null)))[i] = !0;
+(s || (s = Object.create(null))).test = !0;
 


### PR DESCRIPTION
## Summary

I played around with our formatter and noticed that formatting the benchmark test files twice results in the following parse errors:

```
error[SyntaxError]: Invalid assignment to `s || (s = Object.create(null))[i]`
     ┌─ vue.global.prod.js:4372:44
     │
4372 │                             this._props[i] = Z(this._props[i]), s || (s = Object.create(null))[i] =
     │                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This expression cannot be assigned to
```

The issue is that the formatter removes the parenthesis around the `object` of a static or computed member assignment.

This PR ensures that parenthesis around removed from the left-hand sie of a member assignment which is in line with what the formatter does for expressions.

## Test Plan

Added a new formatter test. 

Running the formatter over the benchmark libs no longer yields a parsing error on the second time.

```
❯ time rome format *.js *.ts
Formatted 16 files in 1.44378446s

________________________________________________________
Executed in    1.49 secs    fish           external
   usr time    3.88 secs  366.00 micros    3.88 secs
   sys time    0.72 secs    0.00 micros    0.72 secs


rome/target on  HEAD (8419495) [!?] via  v16.13.1 
❯ time rome format *.js *.ts
Formatted 16 files in 1.419161996s

________________________________________________________
Executed in    1.45 secs    fish           external
   usr time    3.85 secs  239.00 micros    3.85 secs
   sys time    0.67 secs  164.00 micros    0.67 secs
```
