### PR TITLE
feat(rome_cli): add a user-friendly panic hook to the CLI

### DIFF
--- a/crates/rome_cli/src/bin/rome.rs
+++ b/crates/rome_cli/src/bin/rome.rs
@@ -1,4 +1,4 @@
-use rome_cli::{run_cli, CliSession, Termination};
+use rome_cli::{run_cli, setup_panic_handler, CliSession, Termination};
 
 ///
 /// To run this example, run:
@@ -20,5 +20,6 @@ use rome_cli::{run_cli, CliSession, Termination};
 /// ```
 ///
 fn main() -> Result<(), Termination> {
+    setup_panic_handler();
     run_cli(CliSession::from_env())
 }

--- a/crates/rome_cli/src/lib.rs
+++ b/crates/rome_cli/src/lib.rs
@@ -5,6 +5,9 @@ use rome_core::App;
 
 mod commands;
 mod metrics;
+mod panic;
+
+pub use panic::setup_panic_handler;
 
 /// Global context for an execution of the CLI
 pub struct CliSession {

--- a/crates/rome_cli/src/panic.rs
+++ b/crates/rome_cli/src/panic.rs
@@ -16,10 +16,10 @@ fn panic_handler(info: &PanicInfo) {
     // panic at the same time
     let mut error = String::new();
 
-    writeln!(error, "The Rome CLI encountered an unexpected error").unwrap();
+    writeln!(error, "Rome encountered an unexpected error").unwrap();
     writeln!(error).unwrap();
 
-    writeln!(error, "This is a bug in Rome, not an error in your code, and we would appreciate it if you could report it to https://github.com/rome/tools/ along with the following information to help us fixing the issue:").unwrap();
+    writeln!(error, "This is a bug in Rome, not an error in your code, and we would appreciate it if you could report it to https://github.com/rome/tools/issues/ along with the following information to help us fixing the issue:").unwrap();
     writeln!(error).unwrap();
 
     if let Some(location) = info.location() {

--- a/crates/rome_cli/src/panic.rs
+++ b/crates/rome_cli/src/panic.rs
@@ -1,0 +1,41 @@
+use std::{
+    fmt::Write,
+    panic::{set_hook, PanicInfo},
+    thread,
+};
+
+/// Installs a global panic handler to show a user-friendly error message
+/// in case the CLI panics
+pub fn setup_panic_handler() {
+    set_hook(Box::new(panic_handler))
+}
+
+fn panic_handler(info: &PanicInfo) {
+    // Buffer the error message to a string before printing it to stderr at once
+    // to prevent it from getting mixed with other errors if multiple threads
+    // panic at the same time
+    let mut error = String::new();
+
+    writeln!(error, "The Rome CLI encountered an unexpected error").unwrap();
+    writeln!(error).unwrap();
+
+    writeln!(error, "This is a bug in Rome, not an error in your code, and we would appreciate it if you could report it to https://github.com/rome/tools/ along with the following information to help us fixing the issue:").unwrap();
+    writeln!(error).unwrap();
+
+    if let Some(location) = info.location() {
+        writeln!(error, "Source Location: {location}").unwrap();
+    }
+
+    if let Some(thread) = thread::current().name() {
+        writeln!(error, "Thread Name: {thread}").unwrap();
+    }
+
+    let payload = info.payload();
+    if let Some(msg) = payload.downcast_ref::<&'static str>() {
+        writeln!(error, "Message: {msg}").unwrap();
+    } else if let Some(msg) = payload.downcast_ref::<String>() {
+        writeln!(error, "Message: {msg}").unwrap();
+    }
+
+    eprintln!("{error}");
+}


### PR DESCRIPTION
## Summary

This PR replaces the default Rust panic hook with a custom printing logic for the CLI, directing users towards the GitHub issue tracker in case the CLI panics. The new format for panic errors is:

```text
> rome format --indent-size -1
The Rome CLI encountered an unexpected error

This is a bug in Rome, not an error in your code, and we would appreciate it if you could report it to https://github.com/rome/tools/ along with the following information to help us fixing the issue:

Source Location: crates\rome_cli\src\commands\format.rs:35:10
Thread Name: main
Message: failed to parse indent-size argument: Utf8ArgumentParsingFailed { value: "-1", cause: "invalid digit found in string" }
```

The new panic hook is implemented in the cli library, but is only installed in the cli binary and not the `run_cli` function to avoid overriding it in cargo tests

Currently this error message is going to show up for a number of errors that aren't actually bugs but the CLI using panics as an easy way to bail out of some failures (like parsing command line arguments), I'm working on a second PR besides this one to generalize the use of the `Termination` type for all errors and only panic in case something is seriously wrong