### PR TITLE
feat(rome_cli): refactor the Termination type into a proper error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ dependencies = [
  "rome_formatter",
  "rome_fs",
  "rome_js_parser",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -18,3 +18,4 @@ parking_lot = "0.12.0"
 lazy_static = "1.4.0"
 hdrhistogram = { version = "7.5.0", default-features = false }
 crossbeam = "0.8.1"
+thiserror = "1.0.30"

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -1,3 +1,5 @@
+use crate::Termination;
+
 const MAIN: &str = concat!(
     "Rome v",
     env!("CARGO_PKG_VERSION"),
@@ -22,17 +24,19 @@ OPTIONS:
     --indent-size <number>      If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
 ";
 
-pub(crate) fn help(command: Option<&str>) {
+pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {
     match command {
         None => {
-            print!("{MAIN}")
+            print!("{MAIN}");
+            Ok(())
         }
         Some("format") => {
-            print!("{FORMAT}")
+            print!("{FORMAT}");
+            Ok(())
         }
 
-        Some(cmd) => {
-            panic!("cannot print help for unknown command {cmd:?}")
-        }
+        Some(cmd) => Err(Termination::UnknownCommandHelp {
+            command: cmd.into(),
+        }),
     }
 }

--- a/crates/rome_cli/src/termination.rs
+++ b/crates/rome_cli/src/termination.rs
@@ -1,0 +1,61 @@
+use std::{
+    env::current_exe,
+    ffi::OsString,
+    fmt::{self, Debug, Formatter},
+};
+use thiserror::Error;
+
+/// Error message returned by the CLI when it aborts with an error
+#[derive(Error)]
+pub enum Termination {
+    /// Returned by the CLI when it is called with a subcommand it doesn't know
+    #[error("unknown command '{command}'")]
+    UnknownCommand { command: String },
+
+    /// Return by the help command when it is called with a subcommand it doesn't know
+    #[error("cannot print help for unknown command '{command}'")]
+    UnknownCommandHelp { command: String },
+
+    /// Returned when the value of a command line argument could not be parsed
+    #[error("failed to parse argument '{argument}': {source}")]
+    ParseError {
+        argument: &'static str,
+        #[source]
+        source: pico_args::Error,
+    },
+
+    /// Returned when the CLI is passed a command line argument it doesn't know
+    #[error(
+        "unrecognized option {argument:?}. Type '{} format --help' for more information.",
+        command_name()
+    )]
+    UnexpectedArgument { argument: OsString },
+
+    /// Returned when the CLI when a required argument is not present in the command line
+    #[error(
+        "missing argument '{argument}'. Type '{} format --help' for more information.",
+        command_name()
+    )]
+    MissingArgument { argument: &'static str },
+
+    /// Returned by the formatter when error diagnostics were emitted in CI mode
+    #[error("errors where emitted while formatting")]
+    FormattingError,
+}
+
+fn command_name() -> String {
+    current_exe()
+        .ok()
+        .and_then(|path| Some(path.file_name()?.to_str()?.to_string()))
+        .unwrap_or_else(|| String::from("rome"))
+}
+
+// Termination implements Debug by redirecting to Display instead of deriving
+// a "canonical" debug implementation as it it is returned as a Result in the
+// main function and gets printed by the standard library, which uses Debug but
+// we want to show the actuall error message to the user in case of an error
+impl Debug for Termination {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "{}", self)
+    }
+}

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -18,7 +18,7 @@ fn test_format_cli() {
         args: Arguments::from_vec(vec![OsString::from("format"), file_path.as_os_str().into()]),
     });
 
-    assert_eq!(result, Ok(()));
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 
     let mut file = fs
         .open(file_path)


### PR DESCRIPTION
## Summary

This PR turns the `Termination` struct in the CLI into an enum using `thiserror` to actually define all the possible errors that can happen in a normal run of the CLI. All the errors resulting from incorrect inputs or configuration from the user are now handled properly instead of panicking, and are checked as part of the integration tests as well.

## Test Plan

New test cases have been added to exercise all the paths that can lead to the different error variants being emitted by the CLI