### PR TITLE
docs: add diff and migration against other formatters

### DIFF
--- a/website/src/_includes/docs/formatter.md
+++ b/website/src/_includes/docs/formatter.md
@@ -135,5 +135,77 @@ const expr = [
 
 As you can see the first array, which has a suppression comment, is left untouched! 
 
+### Differences with Prettier/dprint
+
+Rome formatter uses a CST to implement its algorithms - as supposed to Prettier or dprint, which use an 
+AST -, which means that it has to deal with a different set of problems e.g. comments and how to place them.
+
+As you might know, comments can appear almost everywhere inside a program, which can make the implementation
+of a formatter more difficult.
+
+In a CST, comments are attached to tokens, so it's possible to extract this information when inspecting
+a single node. 
+
+Considering these assumptions, the Rome team had to create some heuristics and concepts in order to 
+**consistently format comments inside a program**.
+
+#### Comments with hard groups
+
+A **hard group** is a concept that the Rome team created when formatting certain parts of the code. The 
+idea of a hard group is that tokens that belong to this group can't be broken on multiple lines and, they can't
+contain comments. 
+
+We apply this concept, for example, to JavaScript functions and JavaScript classes. A function has a "head" and a "body":
+- the head is where we define the name of the function and its signature (its parameters, return type, etc.);
+- the body is where we define the implementation of the function, usually - but not only - inside a block `{}`;
+
+Our formatter marks a function head as a hard group, while the body is a normal group. This means that all 
+the comments inside the head are "pushed out" and moved outside it, making the formatting **always consistent**.
+
+Here's an example against Prettier/dprint, we place comments inside the head of a function:
+
+```js
+function // something
+ a(b, c)  {
+  let a = "f";
+}
+
+function a(b, c) // something 
+{
+    let a = "f";
+}
+```
+
+This how Rome and Prettier format this code:
+```js
+// Rome
+function a(b, c) {
+	// something
+	let a = "f";
+}
+
+function a(b, c) {
+    // something
+    let a = "f";
+}
+
+
+// Prettier/dprint
+function // something
+a(b, c) {
+    let a = "f";
+}
+function a(b, c) {
+    // something
+    let a = "f";
+}
+```
+
+Please check our [playground] and its result
+
+
+
+- [playground]: https://play.rome.tools/?lineWidth=80&indentStyle=tab&indentWidth=2&typescript=true&jsx=false#ZnVuY3Rpb24gLy8gc29tZXRoaW5nCiBhKGIsIGMpICB7CiAgbGV0IGEgPSAiZiI7Cn0KCmZ1bmN0aW9uIGEoYiwgYykgLy8gc29tZXRoaW5nIAp7CiAgICBsZXQgYSA9ICJmIjsKfQ==
+
 
 [command palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette

--- a/website/src/_includes/docs/formatter.md
+++ b/website/src/_includes/docs/formatter.md
@@ -1,7 +1,6 @@
 ## Formatter
 
-You can use the Rome formatter via our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=rome.rome)
-or by downloading our CLI directly from our  [release page](https://github.com/rome/tools/releases).
+You can use the Rome formatter via our [VS Code extension] or by downloading our CLI directly from our [release page].
 
 > WARNING: both the CLI and the VS Code extension are packaged with separated binaries, which means that if you don't 
 > use our default options, you will have to make sure to **pass them to both the extension AND the CLI**.
@@ -149,17 +148,15 @@ a single node.
 Considering these assumptions, the Rome team had to create some heuristics and concepts in order to 
 **consistently format comments inside a program**.
 
-#### Comments with hard groups
+#### Comments
 
-A **hard group** is a concept that the Rome team created when formatting certain parts of the code. The 
-idea of a hard group is that tokens that belong to this group can't be broken on multiple lines and, they can't
-contain comments. 
+The placements of some comments might be different, for example in JavaScript functions and JavaScript classes. 
 
-We apply this concept, for example, to JavaScript functions and JavaScript classes. A function has a "head" and a "body":
+A function has a "head" and a "body":
 - the head is where we define the name of the function and its signature (its parameters, return type, etc.);
 - the body is where we define the implementation of the function, usually - but not only - inside a block `{}`;
 
-Our formatter marks a function head as a hard group, while the body is a normal group. This means that all 
+Our formatter marks a function head as a [hard group](#hard-groups), while the body is a normal [group](#groups). This means that all 
 the comments inside the head are "pushed out" and moved outside it, making the formatting **always consistent**.
 
 Here's an example against Prettier/dprint, we place comments inside the head of a function:
@@ -220,8 +217,21 @@ Then, you are free to change the reason of the suppression that you want.
 Run Rome formatter and make sure that **the code that was ignored is still the same**.
 
 
+### Formatter internals
 
+If you are interested in the internals of our formatter, the following section will explain some of them.
+
+### Groups
+
+...description will arrive soon.
+
+### Hard groups
+
+...description will arrive soon.
+
+
+[VS Code extension]: https://marketplace.visualstudio.com/items?itemName=rome.rome
+[release page]: https://github.com/rome/tools/releases
 [playground]: https://play.rome.tools/?lineWidth=80&indentStyle=tab&indentWidth=2&typescript=true&jsx=false#ZnVuY3Rpb24gLy8gc29tZXRoaW5nCiBhKGIsIGMpICB7CiAgbGV0IGEgPSAiZiI7Cn0KCmZ1bmN0aW9uIGEoYiwgYykgLy8gc29tZXRoaW5nIAp7CiAgICBsZXQgYSA9ICJmIjsKfQ==
-
 
 [command palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette

--- a/website/src/_includes/docs/formatter.md
+++ b/website/src/_includes/docs/formatter.md
@@ -156,7 +156,7 @@ A function has a "head" and a "body":
 - the head is where we define the name of the function and its signature (its parameters, return type, etc.);
 - the body is where we define the implementation of the function, usually - but not only - inside a block `{}`;
 
-Our formatter marks a function head as a [hard group](#hard-groups), while the body is a normal [group](#groups). This means that all 
+Our formatter marks a function head as a hard group, while the body is a normal group. This means that all 
 the comments inside the head are "pushed out" and moved outside it, making the formatting **always consistent**.
 
 Here's an example against Prettier/dprint, we place comments inside the head of a function:
@@ -217,21 +217,7 @@ Then, you are free to change the reason of the suppression that you want.
 Run Rome formatter and make sure that **the code that was ignored is still the same**.
 
 
-### Formatter internals
-
-If you are interested in the internals of our formatter, the following section will explain some of them.
-
-### Groups
-
-...description will arrive soon.
-
-### Hard groups
-
-...description will arrive soon.
-
-
 [VS Code extension]: https://marketplace.visualstudio.com/items?itemName=rome.rome
 [release page]: https://github.com/rome/tools/releases
 [playground]: https://play.rome.tools/?lineWidth=80&indentStyle=tab&indentWidth=2&typescript=true&jsx=false#ZnVuY3Rpb24gLy8gc29tZXRoaW5nCiBhKGIsIGMpICB7CiAgbGV0IGEgPSAiZiI7Cn0KCmZ1bmN0aW9uIGEoYiwgYykgLy8gc29tZXRoaW5nIAp7CiAgICBsZXQgYSA9ICJmIjsKfQ==
-
 [command palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette

--- a/website/src/_includes/docs/formatter.md
+++ b/website/src/_includes/docs/formatter.md
@@ -203,9 +203,25 @@ function a(b, c) {
 
 Please check our [playground] and its result
 
+#### Migrate from other formatters
+
+Rome doesn't support a lot of options like other web formatters, which means that particular styles 
+won't be available to all developers.
+
+To migrate from suppression comments of the old formatter, it's recommended to run a global search and replace against the code
+base and replace the formatting comment with:
+
+```block
+// rome-ignore format: migration from <name_of_former_formatter>
+```
+
+Then, you are free to change the reason of the suppression that you want.
+
+Run Rome formatter and make sure that **the code that was ignored is still the same**.
 
 
-- [playground]: https://play.rome.tools/?lineWidth=80&indentStyle=tab&indentWidth=2&typescript=true&jsx=false#ZnVuY3Rpb24gLy8gc29tZXRoaW5nCiBhKGIsIGMpICB7CiAgbGV0IGEgPSAiZiI7Cn0KCmZ1bmN0aW9uIGEoYiwgYykgLy8gc29tZXRoaW5nIAp7CiAgICBsZXQgYSA9ICJmIjsKfQ==
+
+[playground]: https://play.rome.tools/?lineWidth=80&indentStyle=tab&indentWidth=2&typescript=true&jsx=false#ZnVuY3Rpb24gLy8gc29tZXRoaW5nCiBhKGIsIGMpICB7CiAgbGV0IGEgPSAiZiI7Cn0KCmZ1bmN0aW9uIGEoYiwgYykgLy8gc29tZXRoaW5nIAp7CiAgICBsZXQgYSA9ICJmIjsKfQ==
 
 
 [command palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds two sections to how and why our formatter is different from the others, and how to migrate from them. 

I added a section around comments, which - I believe - is the most important one. It's where we deal things differently because of one CST works and we managed to find a way to consistently print comments.


The migration strategy should be simple enough.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Check the cloudflare pages

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
