### PR TITLE
fix(rome_js_parser: JSX `>=` parsing

### DIFF
--- a/crates/rome_js_parser/src/syntax/jsx/mod.rs
+++ b/crates/rome_js_parser/src/syntax/jsx/mod.rs
@@ -42,6 +42,10 @@ use super::typescript::parse_ts_type_arguments;
 //     let d = <div>a</div>/; // ambigous: JSX or "type assertion a less than regex /div>/". Probably JSX.
 //     let d = <string>a</string>/;
 // }
+
+// test jsx jsx_equal_content
+// <span></span>;
+// <span>=</span>;
 pub(crate) fn parse_jsx_tag_expression(p: &mut Parser) -> ParsedSyntax {
     if !p.at(T![<]) {
         return Absent;
@@ -491,7 +495,7 @@ impl ParseNodeList for JsxAttributeList {
         parsed_element.or_recover(
             p,
             &ParseRecovery::new(
-                JsSyntaxKind::JS_UNKNOWN_MEMBER,
+                JsSyntaxKind::JS_UNKNOWN,
                 token_set![T![/], T![>], T![<], T!['{'], T!['}'], T![...], T![ident]],
             ),
             jsx_expected_attribute,

--- a/crates/rome_js_parser/test_data/inline/err/jsx_closing_element_mismatch.rast
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_closing_element_mismatch.rast
@@ -114,7 +114,7 @@ JsModule {
                                                     L_ANGLE@60..61 "<" [] [],
                                                     JsUnknown {
                                                         items: [
-                                                            JsUnknownMember {
+                                                            JsUnknown {
                                                                 items: [
                                                                     JS_NUMBER_LITERAL@61..62 "5" [] [],
                                                                 ],
@@ -235,7 +235,7 @@ JsModule {
               0: JS_UNKNOWN@60..63
                 0: L_ANGLE@60..61 "<" [] []
                 1: JS_UNKNOWN@61..62
-                  0: JS_UNKNOWN_MEMBER@61..62
+                  0: JS_UNKNOWN@61..62
                     0: JS_NUMBER_LITERAL@61..62 "5" [] []
                 2: R_ANGLE@62..63 ">" [] []
               1: JSX_CHILD_LIST@63..63

--- a/crates/rome_js_parser/test_data/inline/ok/jsx_equal_content.jsx
+++ b/crates/rome_js_parser/test_data/inline/ok/jsx_equal_content.jsx
@@ -1,0 +1,2 @@
+<span></span>;
+<span>=</span>;

--- a/crates/rome_js_parser/test_data/inline/ok/jsx_equal_content.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/jsx_equal_content.rast
@@ -1,0 +1,105 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsxTagExpression {
+                tag: JsxElement {
+                    opening_element: JsxOpeningElement {
+                        l_angle_token: L_ANGLE@0..1 "<" [] [],
+                        name: JsxName {
+                            value_token: JSX_IDENT@1..5 "span" [] [],
+                        },
+                        type_arguments: missing (optional),
+                        attributes: JsxAttributeList [],
+                        r_angle_token: R_ANGLE@5..6 ">" [] [],
+                    },
+                    children: JsxChildList [],
+                    closing_element: JsxClosingElement {
+                        l_angle_token: L_ANGLE@6..7 "<" [] [],
+                        slash_token: SLASH@7..8 "/" [] [],
+                        name: JsxName {
+                            value_token: JSX_IDENT@8..12 "span" [] [],
+                        },
+                        r_angle_token: R_ANGLE@12..13 ">" [] [],
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@13..14 ";" [] [],
+        },
+        JsExpressionStatement {
+            expression: JsxTagExpression {
+                tag: JsxElement {
+                    opening_element: JsxOpeningElement {
+                        l_angle_token: L_ANGLE@14..16 "<" [Newline("\n")] [],
+                        name: JsxName {
+                            value_token: JSX_IDENT@16..20 "span" [] [],
+                        },
+                        type_arguments: missing (optional),
+                        attributes: JsxAttributeList [],
+                        r_angle_token: R_ANGLE@20..21 ">" [] [],
+                    },
+                    children: JsxChildList [
+                        JsxText {
+                            value_token: JSX_TEXT_LITERAL@21..22 "=" [] [],
+                        },
+                    ],
+                    closing_element: JsxClosingElement {
+                        l_angle_token: L_ANGLE@22..23 "<" [] [],
+                        slash_token: SLASH@23..24 "/" [] [],
+                        name: JsxName {
+                            value_token: JSX_IDENT@24..28 "span" [] [],
+                        },
+                        r_angle_token: R_ANGLE@28..29 ">" [] [],
+                    },
+                },
+            },
+            semicolon_token: SEMICOLON@29..30 ";" [] [],
+        },
+    ],
+    eof_token: EOF@30..31 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..31
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..30
+    0: JS_EXPRESSION_STATEMENT@0..14
+      0: JSX_TAG_EXPRESSION@0..13
+        0: JSX_ELEMENT@0..13
+          0: JSX_OPENING_ELEMENT@0..6
+            0: L_ANGLE@0..1 "<" [] []
+            1: JSX_NAME@1..5
+              0: JSX_IDENT@1..5 "span" [] []
+            2: (empty)
+            3: JSX_ATTRIBUTE_LIST@5..5
+            4: R_ANGLE@5..6 ">" [] []
+          1: JSX_CHILD_LIST@6..6
+          2: JSX_CLOSING_ELEMENT@6..13
+            0: L_ANGLE@6..7 "<" [] []
+            1: SLASH@7..8 "/" [] []
+            2: JSX_NAME@8..12
+              0: JSX_IDENT@8..12 "span" [] []
+            3: R_ANGLE@12..13 ">" [] []
+      1: SEMICOLON@13..14 ";" [] []
+    1: JS_EXPRESSION_STATEMENT@14..30
+      0: JSX_TAG_EXPRESSION@14..29
+        0: JSX_ELEMENT@14..29
+          0: JSX_OPENING_ELEMENT@14..21
+            0: L_ANGLE@14..16 "<" [Newline("\n")] []
+            1: JSX_NAME@16..20
+              0: JSX_IDENT@16..20 "span" [] []
+            2: (empty)
+            3: JSX_ATTRIBUTE_LIST@20..20
+            4: R_ANGLE@20..21 ">" [] []
+          1: JSX_CHILD_LIST@21..22
+            0: JSX_TEXT@21..22
+              0: JSX_TEXT_LITERAL@21..22 "=" [] []
+          2: JSX_CLOSING_ELEMENT@22..29
+            0: L_ANGLE@22..23 "<" [] []
+            1: SLASH@23..24 "/" [] []
+            2: JSX_NAME@24..28
+              0: JSX_IDENT@24..28 "span" [] []
+            3: R_ANGLE@28..29 ">" [] []
+      1: SEMICOLON@29..30 ";" [] []
+  3: EOF@30..31 "" [Newline("\n")] []


### PR DESCRIPTION
## Summary

The parser failed to parse `<span>=</span>` because the lexer lexed `>=` as a single token rather than a `>` and a `=` token.

This PR changes the lexer to always lex `>=` (and `>>=` and `>>>=` as single tokens and only lex them as binary operators when called with `ReLex::BinaryOperator`.

Part of #2310

## Test Plan

Added a new test verifying that `>=` works correctly
