### PR TITLE
chore: add banner to rome classic CLI

### DIFF
--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -499,7 +499,7 @@ export default class Parser<T> {
 	public async init(): Promise<T> {
 		const flagsConsumer = this.getFlagsConsumer();
 		const {flags} = flagsConsumer;
-
+		writeBanner(this.reporter);
 		// Show help for --version
 		const version = this.opts.version;
 		if (version !== undefined) {
@@ -596,6 +596,7 @@ export default class Parser<T> {
 			) {
 				this.opts.onRunHiddenCommand(this.reporter);
 			}
+
 			await definedCommand.command.callback(definedCommand.flags);
 		}
 
@@ -1314,4 +1315,19 @@ export class ParserInterface<T> {
 	public command(opts: AnyCommandOptions) {
 		this.parser.addCommand(opts);
 	}
+}
+
+function writeBanner(reporter: Reporter) {
+	reporter.hr(markup`Please read carefully`);
+	reporter.indentSync(() => {
+		reporter.warn(markup`This is rome classic and the project is archived.`);
+		reporter.br();
+		reporter.warn(
+			markup`The project is now <underline><hyperlink target="https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust">written in Rust</hyperlink></underline>.`,
+		);
+		reporter.br();
+		reporter.info(
+			markup`Please update the project to use to <emphasis>rome@next</emphasis>.`,
+		);
+	});
 }

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -1327,7 +1327,12 @@ function writeBanner(reporter: Reporter) {
 		);
 		reporter.br();
 		reporter.info(
-			markup`Please update the project to use to <emphasis>rome@next</emphasis>.`,
+			markup`Please update the project to the <emphasis>next</emphasis> tag.`,
 		);
+		reporter.br();
+		reporter.info(
+			markup`Please visit the official website for details on how to install the correct version: <underline><hyperlink target="https://rome.tools/#getting-started">https://rome.tools/#getting-started</hyperlink></underline>.`,
+		);
+		reporter.br();
 	});
 }

--- a/internal/cli-flags/Parser.ts
+++ b/internal/cli-flags/Parser.ts
@@ -313,16 +313,8 @@ export default class Parser<T> {
 					target: ConsumeSourceLocationRequestTarget,
 				) => {
 					return serializeCLIFlags(
-						{
-							...this.getSerializeOptions(),
-							defaultFlags,
-							flags,
-						},
-						{
-							type: "flag",
-							key: String(keys[0]),
-							target,
-						},
+						{...this.getSerializeOptions(), defaultFlags, flags},
+						{type: "flag", key: String(keys[0]), target},
 					);
 				},
 			},
@@ -505,9 +497,7 @@ export default class Parser<T> {
 		if (version !== undefined) {
 			const shouldDisplayVersion = flags.get(
 				"version",
-				{
-					description: markup`Show the version`,
-				},
+				{description: markup`Show the version`},
 			).required(false).asBoolean();
 			if (shouldDisplayVersion) {
 				this.reporter.log(version);
@@ -519,10 +509,7 @@ export default class Parser<T> {
 		// `--write-shell-completions <SHELL>` writes the commands to a file
 		const writeShellCompletions: undefined | SupportedCompletionShells = flags.get(
 			"writeShellCompletions",
-			{
-				description: markup`Write shell completion commands`,
-				inputName: "shell",
-			},
+			{description: markup`Write shell completion commands`, inputName: "shell"},
 		).asStringSetOrVoid(["fish", "bash", "zsh"]);
 		if (writeShellCompletions !== undefined) {
 			await this.writeShellCompletions(
@@ -546,10 +533,7 @@ export default class Parser<T> {
 		// Show help for --help
 		const shouldShowHelp = flags.get(
 			"help",
-			{
-				description: markup`Show this help screen`,
-				alternateName: "h",
-			},
+			{description: markup`Show this help screen`, alternateName: "h"},
 		).required(false).asBoolean();
 
 		let definedCommand: undefined | DefinedCommand;
@@ -678,7 +662,10 @@ export default class Parser<T> {
 			optionOutput.push({
 				argName,
 				arg: joinMarkup(
-					highlightShell({input: argCol, isShorthand: !!metadata.alternateName}),
+					highlightShell({
+						input: argCol,
+						isShorthand: !!metadata.alternateName,
+					}),
 					markup` `,
 				),
 				description: descCol,
@@ -1200,10 +1187,7 @@ export default class Parser<T> {
 
 				const selected = await this.reporter.select(
 					markup`Unknown command <emphasis>${commandName}</emphasis>. Found matching commands`,
-					{
-						radio: true,
-						options,
-					},
+					{radio: true, options},
 				);
 
 				const args = Array.from(selected)[0].split(" ");
@@ -1318,21 +1302,18 @@ export class ParserInterface<T> {
 }
 
 function writeBanner(reporter: Reporter) {
-	reporter.hr(markup`Please read carefully`);
-	reporter.indentSync(() => {
-		reporter.warn(markup`This is rome classic and the project is archived.`);
-		reporter.br();
-		reporter.warn(
-			markup`The project is now <underline><hyperlink target="https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust">written in Rust</hyperlink></underline>.`,
-		);
-		reporter.br();
-		reporter.info(
-			markup`Please update the project to the <emphasis>next</emphasis> tag.`,
-		);
-		reporter.br();
-		reporter.info(
-			markup`Please visit the official website for details on how to install the correct version: <underline><hyperlink target="https://rome.tools/#getting-started">https://rome.tools/#getting-started</hyperlink></underline>.`,
-		);
-		reporter.br();
-	});
+	reporter.warn(markup`This is rome classic and the project is archived.`);
+	reporter.br();
+	reporter.warn(
+		markup`The project is now <underline><hyperlink target="https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust">written in Rust</hyperlink></underline>.`,
+	);
+	reporter.br();
+	reporter.info(
+		markup`Install <emphasis>rome@next</emphasis> if you want to use the new blazing fast rust rewrite of Rome.`,
+	);
+	reporter.br();
+	reporter.info(
+		markup`Please visit the official website for details on how to install the correct version: <underline><hyperlink target="https://rome.tools/#getting-started">https://rome.tools/#getting-started</hyperlink></underline>.`,
+	);
+	reporter.br();
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a small banner to the **Rome classic**. The banner is displayed every time the CLI is run, regardless of arguments and commands.

This is the look and feel:

![Screenshot 2022-03-29 at 14 35 07](https://user-images.githubusercontent.com/602478/160623520-453a9009-d40f-4334-954c-2f553e184a62.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

None

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
