### PR TITLE
refactor(rome_js_parser): Streamline parser events

### DIFF
--- a/crates/rome_js_parser/src/lib.rs
+++ b/crates/rome_js_parser/src/lib.rs
@@ -100,7 +100,7 @@ use std::path::Path;
 /// An abstraction for syntax tree implementations
 pub trait TreeSink {
     /// Adds new token to the current branch.
-    fn token(&mut self, kind: JsSyntaxKind, length: TextSize);
+    fn token(&mut self, kind: JsSyntaxKind, end: TextSize);
 
     /// Start new branch and make it current.
     fn start_node(&mut self, kind: JsSyntaxKind);

--- a/crates/rome_js_parser/src/lossless_tree_sink.rs
+++ b/crates/rome_js_parser/src/lossless_tree_sink.rs
@@ -21,8 +21,8 @@ pub struct LosslessTreeSink<'a> {
 }
 
 impl<'a> TreeSink for LosslessTreeSink<'a> {
-    fn token(&mut self, kind: JsSyntaxKind, length: TextSize) {
-        self.do_token(kind, length);
+    fn token(&mut self, kind: JsSyntaxKind, end: TextSize) {
+        self.do_token(kind, end);
     }
 
     fn start_node(&mut self, kind: JsSyntaxKind) {
@@ -34,7 +34,7 @@ impl<'a> TreeSink for LosslessTreeSink<'a> {
         self.parents_count -= 1;
 
         if self.parents_count == 0 && self.needs_eof {
-            self.do_token(JsSyntaxKind::EOF, TextSize::default());
+            self.do_token(JsSyntaxKind::EOF, TextSize::from(self.text.len() as u32));
         }
 
         self.inner.finish_node();
@@ -69,7 +69,7 @@ impl<'a> LosslessTreeSink<'a> {
     }
 
     #[inline]
-    fn do_token(&mut self, kind: JsSyntaxKind, length: TextSize) {
+    fn do_token(&mut self, kind: JsSyntaxKind, token_end: TextSize) {
         if kind == JsSyntaxKind::EOF {
             self.needs_eof = false;
         }
@@ -80,7 +80,7 @@ impl<'a> LosslessTreeSink<'a> {
         self.eat_trivia(false);
         let trailing_start = self.trivia_pieces.len();
 
-        self.text_pos += length;
+        self.text_pos = token_end;
 
         // Everything until the next linebreak (but not including it)
         // will be the trailing trivia...

--- a/crates/rome_js_parser/src/syntax/class.rs
+++ b/crates/rome_js_parser/src/syntax/class.rs
@@ -958,10 +958,7 @@ fn parse_property_class_member_body(
 fn expect_member_semi(p: &mut Parser, member_marker: &Marker, name: &str) {
     if !optional_semi(p) {
         // Gets the start of the member
-        let end = p
-            .last_range()
-            .map(|r| r.end())
-            .unwrap_or_else(|| p.cur_range().start());
+        let end = p.last_end().unwrap_or_else(|| p.cur_range().start());
 
         let err = p
             .err_builder(&format!(

--- a/crates/rome_js_parser/src/syntax/function.rs
+++ b/crates/rome_js_parser/src/syntax/function.rs
@@ -186,9 +186,11 @@ fn parse_function(p: &mut Parser, m: Marker, kind: FunctionKind) -> CompletedMar
     }
 
     p.expect(T![function]);
-    let generator_range = if p.eat(T![*]) {
+    let generator_range = if p.at(T![*]) {
+        let range = p.cur_range();
+        p.bump(T![*]);
         flags |= SignatureFlags::GENERATOR;
-        p.last_range()
+        Some(range)
     } else {
         None
     };

--- a/crates/rome_js_parser/src/syntax/module.rs
+++ b/crates/rome_js_parser/src/syntax/module.rs
@@ -237,10 +237,7 @@ fn parse_import_default_or_named_clause_rest(
             parse_named_import(p).or_add_diagnostic(p, expected_named_import);
 
             if is_typed {
-                let end = p
-                    .last_range()
-                    .map(|r| r.end())
-                    .unwrap_or_else(|| p.cur_range().start());
+                let end = p.last_end().unwrap_or_else(|| p.cur_range().start());
 
                 // test_err ts ts_typed_default_import_with_named
                 // import type A, { B, C } from './a';


### PR DESCRIPTION
Reduce the size of a single parser event from 16 bytes to 8 bytes each by:

* Using a `NonZeroU32` for the forward parent. The forward parent can never be 0 because it stores the offset from the current event to the start of the "forwarded" parent.
* Store the `start` of a node in the `CompletedMarker` (can't be computed because of forward parents)
* Remove `end` from the `Finish` event and instead retrieve the last token of the node when queried (mainly to produce diagnostics).
* Only store the end offset for each Token instead of the full range. The end offset is sufficient to reconstruct the length in the tree sink.

This reduces the memory consumption during the parse phase significantly:

* `jquery`:
  * Current Bytes: 4.12 MB -> 2.12 MB
  * Max Bytes: 5.82 MB -> 3.82 MB
  * Total Bytes: 8.45 MB -> 4.37 MB
* `tex-chtml-full`
  * Current bytes: 33.11 MB -> 17.11 MB
  * Max bytes: 46 MB -> 30 MB
  * Total bytes: 67.78 -> 34.92 MB

It also reduces the max bytes required during the tree sink phase.

The changes do improve parse times but not as much as I did hope for:

```
group                                    event                                  main
-----                                    -----                                  ----
parser/checker.ts                        1.00     63.6±1.84ms    40.9 MB/sec    1.00     63.8±0.45ms    40.8 MB/sec
parser/compiler.js                       1.00     36.3±0.77ms    28.9 MB/sec    1.03     37.5±0.38ms    27.9 MB/sec
parser/d3.min.js                         1.00     24.3±0.25ms    10.8 MB/sec    1.03     25.1±2.39ms    10.4 MB/sec
parser/dojo.js                           1.00      2.2±0.00ms    30.9 MB/sec    1.03      2.3±0.02ms    30.0 MB/sec
parser/ios.d.ts                          1.00     52.7±0.55ms    35.4 MB/sec    1.19     62.6±0.58ms    29.8 MB/sec
parser/jquery.min.js                     1.00      6.6±0.13ms    12.6 MB/sec    1.05      6.9±0.26ms    12.0 MB/sec
parser/math.js                           1.00     45.4±0.90ms    14.3 MB/sec    1.02     46.3±0.59ms    14.0 MB/sec
parser/parser.ts                         1.00  1525.9±16.73µs    31.7 MB/sec    1.02  1556.6±21.54µs    31.0 MB/sec
parser/pixi.min.js                       1.00     28.9±0.67ms    15.2 MB/sec    1.01     29.3±0.14ms    15.0 MB/sec
parser/react-dom.production.min.js       1.00      9.0±0.01ms    12.7 MB/sec    1.02      9.2±0.05ms    12.5 MB/sec
parser/react.production.min.js           1.00    466.9±1.03µs    13.2 MB/sec    1.03    481.5±3.49µs    12.8 MB/sec
parser/router.ts                         1.00   1186.9±8.65µs    50.4 MB/sec    1.03  1222.2±10.20µs    48.9 MB/sec
parser/tex-chtml-full.js                 1.00     60.5±0.68ms    15.1 MB/sec    1.10     66.4±1.53ms    13.7 MB/sec
parser/three.min.js                      1.00     32.1±0.24ms    18.3 MB/sec    1.03     33.0±0.43ms    17.8 MB/sec
parser/typescript.js                     1.00    279.9±4.87ms    33.9 MB/sec    1.04    292.2±2.93ms    32.5 MB/sec
parser/vue.global.prod.js                1.00     11.4±0.34ms    10.6 MB/sec    1.01     11.5±0.03ms    10.5 MB/sec
```

## Tests

`cargo test`
