### PR TITLE
feat(npm): add a postinstall script to the cli package

### DIFF
--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -2,7 +2,11 @@
     "name": "rome",
     "version": "0.4.0-next",
     "bin": "bin/rome",
+    "scripts": {
+        "postinstall": "node scripts/postinstall.js"
+    },
     "files": [
-        "bin/rome"
+        "bin/rome",
+        "scripts/postinstall.js"
     ]
 }

--- a/npm/rome/scripts/postinstall.js
+++ b/npm/rome/scripts/postinstall.js
@@ -1,0 +1,44 @@
+const { platform, arch } = process;
+
+const PLATFORMS = {
+	win32: {
+		x64: "@rometools/cli-win32-x64/rome.exe",
+		arm64: "@rometools/cli-win32-arm64/rome.exe",
+	},
+	darwin: {
+		x64: "@rometools/cli-darwin-x64/rome",
+		arm64: "@rometools/cli-darwin-arm64/rome",
+	},
+	linux: {
+		x64: "@rometools/cli-linux-x64/rome",
+		arm64: "@rometools/cli-linux-arm64/rome",
+	},
+};
+
+const binName = PLATFORMS?.[platform]?.[arch];
+if (binName) {
+	let binPath;
+	try {
+		binPath = require.resolve(binName);
+	} catch (err) {
+		console.warn(
+			`The Rome CLI postinstall script failed to resolve the binary file "${binName}". ` + "Running Rome from the npm package will probably not work correctly.",
+		);
+	}
+
+	if (binPath) {
+		try {
+			require("fs").chmodSync(binPath, 0o755);
+		} catch (err) {
+			console.warn(
+				"The Rome CLI postinstall script failed to set execution permissions to the native binary. " + "Running Rome from the npm package will probably not work correctly.",
+			);
+		}
+	}
+} else {
+	console.warn(
+		"The Rome CLI package doesn't ship with prebuilt binaries for your platform yet. " +
+			"You can still use the CLI by cloning the rome/tools repo from GitHub, " +
+			"and follow the instructions there to build the CLI for your platform.",
+	);
+}

--- a/npm/rome/scripts/postinstall.js
+++ b/npm/rome/scripts/postinstall.js
@@ -28,7 +28,7 @@ if (binName) {
 
 	if (binPath) {
 		try {
-			require("fs").chmodSync(binPath, 0o755);
+			require("node:fs").chmodSync(binPath, 0o755);
 		} catch (err) {
 			console.warn(
 				"The Rome CLI postinstall script failed to set execution permissions to the native binary. " + "Running Rome from the npm package will probably not work correctly.",


### PR DESCRIPTION
## Summary

Add a `postinstall` script to the `rome` npm package to verify the installation of the native binary, and print a warning to the user immediately if something went wrong.

I decided to only print a warning when something is wrong instead of exiting with an error so that it won't cause an `npm install` on a whole workspace where `rome` is a dependency to fail, in case the user didn't intend to use the Rome CLI anyway.
