### PR TITLE
fix(rome_formatter): add empty line after interpreter

### DIFF
--- a/crates/rome_formatter/src/utils/mod.rs
+++ b/crates/rome_formatter/src/utils/mod.rs
@@ -6,7 +6,7 @@ mod simple;
 
 use crate::formatter_traits::{FormatOptionalTokenAndNode, FormatTokenAndNode};
 use crate::{
-    empty_element, format_elements, hard_group_elements, hard_line_break, space_token, token,
+    empty_element, empty_line, format_elements, hard_group_elements, space_token, token,
     FormatElement, FormatResult, Formatter, Token,
 };
 pub use binarish_expression::format_binaryish_expression;
@@ -56,7 +56,7 @@ pub(crate) fn format_interpreter(
 ) -> FormatResult<FormatElement> {
     interpreter.format_with_or(
         formatter,
-        |interpreter| format_elements![interpreter, hard_line_break()],
+        |interpreter| format_elements![interpreter, empty_line()],
         empty_element,
     )
 }

--- a/crates/rome_formatter/tests/specs/js/module/interpreter.js
+++ b/crates/rome_formatter/tests/specs/js/module/interpreter.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+console.log(1)
+
+console.log(1)

--- a/crates/rome_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_formatter/tests/specs/js/module/interpreter.js.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
 assertion_line: 198
-expression: script.js
+expression: interpreter.js
 
 ---
 # Input
 #!/usr/bin/env node
-"use strict";
-'use asm'
-var express = require("express")
+console.log(1)
 
+console.log(1)
 =============================
 # Outputs
 ## Output 1
@@ -19,7 +18,7 @@ Line width: 80
 -----
 #!/usr/bin/env node
 
-"use strict";
-"use asm";
-var express = require("express");
+console.log(1);
+
+console.log(1);
 

--- a/crates/rome_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_formatter/tests/specs/js/script/script.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_formatter/tests/spec_test.rs
+assertion_line: 198
 expression: script.js
+
 ---
 # Input
 #!/usr/bin/env node
@@ -16,6 +18,7 @@ Indent style: Tab
 Line width: 80
 -----
 #!/usr/bin/env node
+
 "use strict";
 "use asm";
 var express = require("express");

--- a/crates/rome_formatter/tests/specs/prettier/js/comments/trailing_space.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/comments/trailing_space.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 153
 expression: trailing_space.js
 
 ---
@@ -17,6 +17,7 @@ expression: trailing_space.js
 # Output
 ```js
 #!/there/is-space-here->         
+
 // Do not trim trailing whitespace from this source file!
 
 // There is some space here ->

--- a/crates/rome_formatter/tests/specs/prettier/js/shebang/shebang-newline.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/shebang/shebang-newline.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: shebang-newline.js
 
 ---
@@ -15,6 +15,7 @@ function a() {}
 # Output
 ```js
 #!/usr/bin/env node
+
 function a() {}
 
 ```

--- a/crates/rome_formatter/tests/specs/prettier/js/shebang/shebang.js.snap
+++ b/crates/rome_formatter/tests/specs/prettier/js/shebang/shebang.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: shebang.js
 
 ---
@@ -14,6 +14,7 @@ function a() {}
 # Output
 ```js
 #!/usr/bin/env node
+
 function a() {}
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #2325 

It adds always an empty line after the interpreter.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New test case

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
