### PR TITLE
chore(ci): enable changelog generation and bump the version numbers for the extension and CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,3 +236,4 @@ jobs:
             rome_lsp-*.vsix
             rome-*
           fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
 	"publisher": "rome",
 	"displayName": "Rome",
 	"description": "Rome LSP VS Code Extension",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"icon": "icon.png",
 	"activationEvents": [
 		"onLanguage:javascript",
@@ -112,7 +112,6 @@
 			}
 		}
 	},
-
 	"categories": [
 		"Formatters"
 	],

--- a/npm/rome/package.json
+++ b/npm/rome/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rome",
-    "version": "0.4.0-next",
+    "version": "0.4.1-next",
     "bin": "bin/rome",
     "scripts": {
         "postinstall": "node scripts/postinstall.js"


### PR DESCRIPTION
## Summary

Enable the `generate_release_notes` option of the `action-gh-release` action to use GitHub's auto-generated changelog as a release note text. This also bumps the version numbers of the npm package and VSCode extension to trigger a new release when this PR gets merged to main.
