### PR TITLE
chore(rome_cli): move ending message after diagnostics

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -116,15 +116,6 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
 
     let duration = start.elapsed();
     let count = formatted.load(Ordering::Relaxed);
-    if is_check {
-        session.app.console.message(rome_console::markup! {
-            <Info>"Checked "{count}" files in "{duration}</Info>
-        });
-    } else {
-        session.app.console.message(rome_console::markup! {
-            <Info>"Formatted "{count}" files in "{duration}</Info>
-        });
-    }
 
     let mut has_errors = false;
     let mut file_ids = HashSet::new();
@@ -218,6 +209,15 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
         }
     }
 
+    if is_check {
+        session.app.console.message(rome_console::markup! {
+            <Info>"Checked "{count}" files in "{duration}</Info>
+        });
+    } else {
+        session.app.console.message(rome_console::markup! {
+            <Info>"Formatted "{count}" files in "{duration}</Info>
+        });
+    }
     // Formatting emitted error diagnostics, exit with a non-zero code
     if !has_errors {
         Ok(())


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR moves the ending message for the `format` command after having the diagnostics printed.

Myself and Leo noticed that having the message "Formatted files ..." before the diagnostics wasn't helpful, especially if the number of diagnostics/warning was high.

This PR doesn't handle the "errors where emitted while formatting" message.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing CI. I checked manually that the message shows up after printing diagnostics.


![Screenshot 2022-04-05 at 08 39 12](https://user-images.githubusercontent.com/602478/161703302-5fd03356-d63f-4e24-9740-6d1a38b89c08.png)

