### PR TITLE
feature(playground): Deploy every commit to subdomain

### DIFF
--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -4,8 +4,11 @@ name: Deploy Playground
 
 on:
   workflow_dispatch:
-  push:
-
+  pull_request:
+    paths:
+      - "website/playground"
+    branches:
+      - main
 
 
 jobs:

--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: cloudflare
+    environment: aws
     name: Deploy
     steps:
       - uses: actions/checkout@master
@@ -24,9 +24,12 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.3.0
       - run: npm run build --prefix website/playground
       - name: Publish
-        uses: cloudflare/wrangler-action@1.3.0
-        with:
-          apiToken: ${{ secrets.CF_API_KEY }}
-          workingDirectory: 'website/playground'
-          environment: 'production'
+        uses: jakejarvis/s3-sync-action@master
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'website/playground/dist'      # optional: defaults to entire repository
+          DEST_DIR: $GITHUB_SHA
+
 

--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -34,4 +34,36 @@ jobs:
           SOURCE_DIR: 'website/playground/dist'      # optional: defaults to entire repository
           DEST_DIR: $GITHUB_SHA
 
+      - name: Get the PR number
+        if: github.event_name == 'pull_request'
+        id: pr-number
+        uses: kkak10/pr-number-action@v1.3
+
+      - name: Find Previous Comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v1.3.0
+        id: previous-comment
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body-includes: Playground link
+
+      - name: Update existing comment
+        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.previous-comment.outputs.comment-id }}
+          body: |
+            [Playground link](http://play.rome.tools.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA/index.html)
+          edit-mode: replace
+
+      - name: Write a new comment
+        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        continue-on-error: true
+        with:
+          issue-number: ${{ steps.pr-number.outputs.pr }}
+          body: |
+            [Playground link](http://play.rome.tools.s3-website-us-east-1.amazonaws.com/$GITHUB_SHA/index.html)
+
 

--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -20,7 +20,8 @@ jobs:
           node-version: '14'
       - run: npm install --prefix website/playground
       - uses: jetli/wasm-pack-action@v0.3.0
-      - run: npm run build --prefix website/playground
+      - run: wasm-pack build website/playground --target web --release
+      - run: npm run build --prefix website/playground -- --base=/$GITHUB_SHA/
       - name: Publish
         uses: jakejarvis/s3-sync-action@master
         env:

--- a/.github/workflows/deploy_playground_on_main.yml
+++ b/.github/workflows/deploy_playground_on_main.yml
@@ -1,10 +1,12 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Deploy Playground
+name: Deploy Playground on Main
 
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
 
 
 
@@ -18,16 +20,15 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - run: npm install --prefix website/playground
+      - run: npm install --prefix crates/rome_playground
       - uses: jetli/wasm-pack-action@v0.3.0
-      - run: npm run build --prefix website/playground
+      - run: wasm-pack build crates/rome_playground --target web --release
+      - run: npm run build --prefix crates/rome_playground
       - name: Publish
         uses: jakejarvis/s3-sync-action@master
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: 'website/playground/dist'      # optional: defaults to entire repository
-          DEST_DIR: $GITHUB_SHA
-
+          SOURCE_DIR: 'crates/rome_playground/dist'      # optional: defaults to entire repository
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

It can be annoying to play around with people's changes to the formatter. By deploying on every commit and storing in a subdomain, we can try out people's changes to the formatter in the playground.

The only issue I could see is that too many commits can clog up the actions pipeline.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
