### PR TITLE
feat(rome_cli): CLI Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.12.0",
  "pico-args",
+ "rayon",
  "rome_console",
  "rome_core",
  "rome_diagnostics",

--- a/crates/rome_cli/Cargo.toml
+++ b/crates/rome_cli/Cargo.toml
@@ -20,3 +20,4 @@ lazy_static = "1.4.0"
 hdrhistogram = { version = "7.5.0", default-features = false }
 crossbeam = "0.8.1"
 thiserror = "1.0.30"
+rayon = "1.5.1"

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -56,6 +56,18 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
         None => {}
     }
 
+    let line_width = session
+        .args
+        .opt_value_from_str("--line-width")
+        .map_err(|source| Termination::ParseError {
+            argument: "--line-width",
+            source,
+        })?;
+
+    if let Some(line_width) = line_width {
+        options.line_width = line_width;
+    }
+
     let is_check = session.args.contains("--ci");
     let ignore_errors = session.args.contains("--skip-errors");
 

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -18,6 +18,7 @@ USAGE:
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
 OPTIONS:
+    --write                     Write the output of the formatter to the files instead of printing the diff to the console
     --ci                        Enable CI mode, lock files and exit with an error if the formatter would modify them
     --skip-errors               Skip over files containing syntax errors instead of returning an error
     --indent-style <tabs|space> Determine whether the formatter should use tabs or spaces for indentation (default: tabs)

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -26,7 +26,7 @@ OPTIONS:
 
 pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {
     match command {
-        None => {
+        Some("help") | None => {
             print!("{MAIN}");
             Ok(())
         }

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -22,6 +22,7 @@ OPTIONS:
     --skip-errors               Skip over files containing syntax errors instead of returning an error
     --indent-style <tabs|space> Determine whether the formatter should use tabs or spaces for indentation (default: tabs)
     --indent-size <number>      If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
+    --line-width <number>       Determine how many characters the formatter is allowed to print in a single line (default: 80)
 ";
 
 pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {

--- a/crates/rome_cli/src/termination.rs
+++ b/crates/rome_cli/src/termination.rs
@@ -42,6 +42,10 @@ pub enum Termination {
     #[error("empty arguments")]
     EmptyArguments,
 
+    /// Returned when a subcommand is called with an unsupported combination of arguments
+    #[error("incompatible arguments '{0}' and '{1}'")]
+    IncompatibleArguments(&'static str, &'static str),
+
     /// Returned by the formatter when error diagnostics were emitted in CI mode
     #[error("errors where emitted while formatting")]
     FormattingError,

--- a/crates/rome_cli/src/termination.rs
+++ b/crates/rome_cli/src/termination.rs
@@ -38,6 +38,10 @@ pub enum Termination {
     )]
     MissingArgument { argument: &'static str },
 
+    /// Returned when a subcommand is called without any arguments
+    #[error("empty arguments")]
+    EmptyArguments,
+
     /// Returned by the formatter when error diagnostics were emitted in CI mode
     #[error("errors where emitted while formatting")]
     FormattingError,

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -140,7 +140,7 @@ fn test_missing_argument() {
             DynRef::Owned(Box::new(MemoryFileSystem::default())),
             DynRef::Owned(Box::new(BufferConsole::default())),
         ),
-        args: Arguments::from_vec(vec![OsString::from("format")]),
+        args: Arguments::from_vec(vec![OsString::from("format"), OsString::from("--ci")]),
     });
 
     match result {
@@ -173,6 +173,22 @@ fn test_formatting_error() {
 
     match result {
         Err(Termination::FormattingError) => {}
+        _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
+    }
+}
+
+#[test]
+fn test_empty_arguments() {
+    let result = run_cli(CliSession {
+        app: App::with_filesystem_and_console(
+            DynRef::Owned(Box::new(MemoryFileSystem::default())),
+            DynRef::Owned(Box::new(BufferConsole::default())),
+        ),
+        args: Arguments::from_vec(vec![OsString::from("format")]),
+    });
+
+    match result {
+        Err(Termination::EmptyArguments) => {}
         _ => panic!("run_cli returned {result:?} for a failed CI check, expected an error"),
     }
 }

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -112,6 +112,27 @@ fn test_indent_size_parse_errors() {
 }
 
 #[test]
+fn test_line_width_parse_errors() {
+    let result = run_cli(CliSession {
+        app: App::with_filesystem_and_console(
+            DynRef::Owned(Box::new(MemoryFileSystem::default())),
+            DynRef::Owned(Box::new(BufferConsole::default())),
+        ),
+        args: Arguments::from_vec(vec![
+            OsString::from("format"),
+            OsString::from("--line-width"),
+            OsString::from("-1"),
+            OsString::from("file.js"),
+        ]),
+    });
+
+    match result {
+        Err(Termination::ParseError { argument, .. }) => assert_eq!(argument, "--line-width"),
+        _ => panic!("run_cli returned {result:?} for an invalid argument value, expected an error"),
+    }
+}
+
+#[test]
 fn test_unexpected_argument() {
     let result = run_cli(CliSession {
         app: App::with_filesystem_and_console(

--- a/crates/rome_cli/tests/main.rs
+++ b/crates/rome_cli/tests/main.rs
@@ -233,7 +233,7 @@ fn test_line_width_parse_errors_overflow() {
         args: Arguments::from_vec(vec![
             OsString::from("format"),
             OsString::from("--line-width"),
-            OsString::from("65537"),
+            OsString::from("321"),
             OsString::from("file.js"),
         ]),
     });

--- a/crates/rome_console/src/lib.rs
+++ b/crates/rome_console/src/lib.rs
@@ -25,7 +25,7 @@ pub enum LogLevel {
 
 /// Generic abstraction over printing markup and diagnostics to an output,
 /// which can be a terminal, a file, a memory buffer ...
-pub trait Console: Sync + RefUnwindSafe {
+pub trait Console: Send + Sync + RefUnwindSafe {
     /// Prints a message (formatted using [markup]) to the console
     fn print(&mut self, level: LogLevel, args: Markup);
 }

--- a/crates/rome_core/src/lib.rs
+++ b/crates/rome_core/src/lib.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 pub mod file_handlers;
 
 /// Features available for each language
-struct Features {
+pub struct Features {
     js: JsFileHandler,
     json: JsonFileHandler,
     unknown: UnknownFileHandler,
@@ -19,7 +19,7 @@ struct Features {
 pub struct App<'app> {
     pub fs: DynRef<'app, dyn FileSystem>,
     /// features available throughout the application
-    features: Features,
+    pub features: Features,
     pub console: DynRef<'app, dyn Console>,
 }
 
@@ -84,7 +84,7 @@ impl<'app> App<'app> {
     }
 
     /// Return a [Language] from a string
-    pub fn get_language<L: Into<Language>>(&self, file_extension: L) -> Language {
+    pub fn get_language<L: Into<Language>>(file_extension: L) -> Language {
         file_extension.into()
     }
 
@@ -107,16 +107,18 @@ impl<'app> App<'app> {
     pub fn get_unknown_features(&self) -> &UnknownFileHandler {
         &self.features.unknown
     }
+}
 
+impl Features {
     /// Checks if the current file can be formatted
     pub fn can_format(&self, rome_path: &RomePath) -> bool {
         rome_path.extension().map_or(false, |extension| {
-            let language = self.get_language(extension);
+            let language = App::get_language(extension);
 
             match language {
-                Language::JavaScript => self.features.js.capabilities().format,
-                Language::Json => self.features.json.capabilities().format,
-                Language::Unknown => self.features.unknown.capabilities().format,
+                Language::JavaScript => self.js.capabilities().format,
+                Language::Json => self.json.capabilities().format,
+                Language::Unknown => self.unknown.capabilities().format,
             }
         })
     }
@@ -124,12 +126,12 @@ impl<'app> App<'app> {
     /// Checks if the current file can be analyzed for linting rules
     pub fn can_lint(&self, rome_path: &RomePath) -> bool {
         rome_path.extension().map_or(false, |extension| {
-            let language = self.get_language(extension);
+            let language = App::get_language(extension);
 
             match language {
-                Language::JavaScript => self.features.js.capabilities().lint,
-                Language::Json => self.features.json.capabilities().lint,
-                Language::Unknown => self.features.unknown.capabilities().lint,
+                Language::JavaScript => self.js.capabilities().lint,
+                Language::Json => self.json.capabilities().lint,
+                Language::Unknown => self.unknown.capabilities().lint,
             }
         })
     }

--- a/crates/rome_diagnostics/src/lib.rs
+++ b/crates/rome_diagnostics/src/lib.rs
@@ -10,7 +10,7 @@ mod formatters;
 mod suggestion;
 
 pub use diagnostic::{Diagnostic, SubDiagnostic};
-pub use emit::Emitter;
+pub use emit::{DiagnosticHeader, Emitter};
 pub use file::Span;
 pub use formatters::*;
 pub use suggestion::*;

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -39,7 +39,7 @@ pub fn empty_element() -> FormatElement {
 ///
 /// Soft line breaks are emitted if the enclosing `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break, FormatOptions};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break, FormatOptions, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a long word,"),
@@ -48,7 +48,7 @@ pub fn empty_element() -> FormatElement {
 /// ]);
 ///
 /// let options = FormatOptions {
-///  line_width: 10,
+///  line_width: LineWidth::try_from(10).unwrap(),
 ///  ..FormatOptions::default()
 /// };
 ///
@@ -123,7 +123,7 @@ pub const fn empty_line() -> FormatElement {
 ///
 /// The printer breaks the lines if the enclosing `Group` doesn't fit on a single line:
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("a long word,"),
@@ -132,7 +132,7 @@ pub const fn empty_line() -> FormatElement {
 /// ]);
 ///
 /// let options = FormatOptions {
-///  line_width: 10,
+///  line_width: LineWidth::try_from(10).unwrap(),
 ///  ..FormatOptions::default()
 /// };
 ///
@@ -428,7 +428,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't fit on a single line
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -441,7 +441,7 @@ pub fn block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ]);
 ///
 /// let options = FormatOptions {
-///  line_width: 10,
+///  line_width: LineWidth::try_from(10).unwrap(),
 ///  ..FormatOptions::default()
 /// };
 ///
@@ -494,7 +494,7 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// fit on a single line. Otherwise, just inserts a space.
 ///
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_indent_or_space, FormatOptions, soft_block_indent, space_token, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("name"),
@@ -510,7 +510,7 @@ pub fn soft_block_indent<T: Into<FormatElement>>(content: T) -> FormatElement {
 /// ]);
 ///
 /// let options = FormatOptions {
-///  line_width: 10,
+///  line_width: LineWidth::try_from(10).unwrap(),
 ///  ..FormatOptions::default()
 /// };
 ///
@@ -583,7 +583,7 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 ///
 /// The printer breaks the `Group` over multiple lines if its content doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -598,7 +598,7 @@ pub fn soft_line_indent_or_space<T: Into<FormatElement>>(content: T) -> FormatEl
 /// ]);
 ///
 /// let options = FormatOptions {
-///   line_width: 20,
+///   line_width: LineWidth::try_from(20).unwrap(),
 ///   ..FormatOptions::default()
 /// };
 ///
@@ -681,7 +681,7 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///
 /// Prints the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_breaks, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -696,7 +696,7 @@ pub fn hard_group_elements<T: Into<FormatElement>>(content: T) -> FormatElement 
 ///   token("]"),
 /// ]);
 ///
-/// let options = FormatOptions { line_width: 20, ..FormatOptions::default() };
+/// let options = FormatOptions { line_width: LineWidth::try_from(20).unwrap(), ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
 ///   format_element(&elements, options).as_code()
@@ -744,7 +744,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///
 /// Omits the trailing comma for the last array element if the `Group` doesn't fit on a single line
 /// ```
-/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line};
+/// use rome_formatter::{group_elements, format_element, format_elements, token, soft_line_break_or_space, FormatOptions, soft_block_indent, if_group_fits_on_single_line, LineWidth};
 ///
 /// let elements = group_elements(format_elements![
 ///   token("["),
@@ -759,7 +759,7 @@ pub fn if_group_breaks<T: Into<FormatElement>>(content: T) -> FormatElement {
 ///   token("]"),
 /// ]);
 ///
-/// let options = FormatOptions { line_width: 20, ..FormatOptions::default() };
+/// let options = FormatOptions { line_width: LineWidth::try_from(20).unwrap(), ..FormatOptions::default() };
 /// assert_eq!(
 ///   "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3\n]",
 ///   format_element(&elements, options).as_code()

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -63,6 +63,9 @@ impl Display for IndentStyle {
 pub struct LineWidth(u16);
 
 impl LineWidth {
+    /// Maximum allowed value for a valid [LineWidth]
+    pub const MAX: u16 = 320;
+
     /// Return the numeric value for this [LineWidth]
     pub fn value(&self) -> u16 {
         self.0
@@ -108,7 +111,7 @@ impl TryFrom<u16> for LineWidth {
     type Error = LineWidthFromIntError;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        if value > 0 && value <= 320 {
+        if value > 0 && value <= Self::MAX {
             Ok(Self(value))
         } else {
             Err(LineWidthFromIntError(value))

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -3,7 +3,7 @@ use crate::format_element::{
 };
 use crate::intersperse::Intersperse;
 use crate::{
-    hard_line_break, space_token, FormatElement, FormatOptions, Formatted, IndentStyle,
+    hard_line_break, space_token, FormatElement, FormatOptions, Formatted, IndentStyle, LineWidth,
     SourceMarker, TextRange,
 };
 use rome_rowan::TextSize;
@@ -16,7 +16,7 @@ pub struct PrinterOptions {
     pub tab_width: u8,
 
     /// What's the max width of a line. Defaults to 80
-    pub print_width: u16,
+    pub print_width: LineWidth,
 
     /// The type of line ending to apply to the printed input
     pub line_ending: LineEnding,
@@ -75,7 +75,7 @@ impl Default for PrinterOptions {
     fn default() -> Self {
         PrinterOptions {
             tab_width: 2,
-            print_width: 80,
+            print_width: LineWidth::default(),
             indent_string: String::from("\t"),
             line_ending: LineEnding::LineFeed,
         }
@@ -326,7 +326,7 @@ impl<'a> Printer<'a> {
                 self.print_element(queue, element, args);
 
                 // If the line is too long, break the group
-                if self.state.line_width > self.options.print_width as usize {
+                if self.state.line_width > self.options.print_width.value().into() {
                     return Err(LineBreakRequiredError);
                 }
 
@@ -417,7 +417,7 @@ impl<'a> Printer<'a> {
 
             self.print_all(queue, item, args.clone());
 
-            if self.state.line_width > self.options.print_width.into() {
+            if self.state.line_width > self.options.print_width.value().into() {
                 if let Some(snapshot) = snapshot.take() {
                     self.state.restore(snapshot);
 
@@ -645,7 +645,7 @@ mod tests {
     use crate::{
         block_indent, empty_line, format_elements, group_elements, hard_line_break,
         if_group_breaks, soft_block_indent, soft_line_break, soft_line_break_or_space, token,
-        FormatElement, Formatted,
+        FormatElement, Formatted, LineWidth,
     };
 
     /// Prints the given element with the default printer options
@@ -771,7 +771,7 @@ two lines`,
         let printer = Printer::new(PrinterOptions {
             indent_string: String::from("\t"),
             tab_width: 4,
-            print_width: 19,
+            print_width: LineWidth::try_from(19).unwrap(),
             ..PrinterOptions::default()
         });
 

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -130,7 +130,7 @@ pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, fi
     );
 
     let mut rome_path = RomePath::new(file_path);
-    if app.can_format(&rome_path) {
+    if app.features.can_format(&rome_path) {
         let mut snapshot_content = SnapshotContent::default();
         let buffer = rome_path.get_buffer_from_file();
         let mut source_type: SourceType = rome_path.as_path().try_into().unwrap();

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,4 +1,5 @@
 use rome_core::App;
+use rome_formatter::LineWidth;
 use rome_fs::RomePath;
 use rome_js_formatter::{format, FormatOptions, Formatted, IndentStyle};
 use rome_js_parser::{parse, ModuleKind, SourceType};
@@ -43,7 +44,10 @@ impl From<SerializableFormatOptions> for FormatOptions {
             indent_style: test
                 .indent_style
                 .map_or_else(|| IndentStyle::Tab, |value| value.into()),
-            line_width: test.line_width.unwrap_or(80),
+            line_width: test
+                .line_width
+                .and_then(|width| LineWidth::try_from(width).ok())
+                .unwrap_or_default(),
         }
     }
 }

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -45,11 +45,12 @@ pub(crate) fn to_format_options(
     }
 
     // apply the new line width only if they are different
-    if default_options.line_width != workspace_settings.line_width {
-        default_options.line_width = workspace_settings.line_width;
+    let custom_line_width = workspace_settings.line_width.try_into().unwrap_or_default();
+    if default_options.line_width != custom_line_width {
+        default_options.line_width = custom_line_width;
         info!(
             "Using user setting line width: {}",
-            default_options.line_width
+            default_options.line_width.value()
         );
     }
 

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -110,7 +110,7 @@ pub fn run(
 
     let options = FormatOptions {
         indent_style,
-        line_width,
+        line_width: line_width.try_into().unwrap_or_default(),
     };
 
     let cst = format!("{:#?}", syntax);


### PR DESCRIPTION
## Summary

I batched together a few QoL improvements to the CLI:
- Show the help for a subcommand when it's called with no other arguments (`rome format`), but still exit with an error
- Expose the line width formatting option through the `--line-width` CLI arguments
- Add a `--dry-run` mode to the CLI to print the diff to the console instead of writing the formatting result to the file (similar to how CI mode works, except the diff isn't reported as an error)
- Reworked how messages are printed to the console: they are now being handled by a dedicated thread in parallel to the formatting process instead of being buffered and flushed once the traversal is complete
- Add a `LineWidth` wrapper type for the `line_width` formatter setting to validate the value is within an acceptable range (`1..=320`)

## Test Plan

I've added a few additional tests for the CLI verifying the new arguments are properly handled and validated
