### PR TITLE
fix(rome_js_parser): Fix TS Decorator with arrow param parsing

### DIFF
--- a/crates/rome_js_parser/src/parser.rs
+++ b/crates/rome_js_parser/src/parser.rs
@@ -262,12 +262,13 @@ impl<'s> Parser<'s> {
             kind
         };
 
+        let range = self.cur_range();
+        self.push_token(kind, range.end());
+
         if self.skipping {
             self.tokens.skip_as_trivia(context);
         } else {
-            let range = self.cur_range();
             self.tokens.bump(context);
-            self.push_token(kind, range.end());
         }
     }
 

--- a/crates/rome_js_parser/src/syntax/typescript.rs
+++ b/crates/rome_js_parser/src/syntax/typescript.rs
@@ -259,7 +259,11 @@ fn parse_decorator(p: &mut Parser) -> ParsedSyntax {
     if p.at(T![@]) {
         let m = p.start();
         p.bump(T![@]);
-
+        // test ts ts_decorator_call_expression_with_arrow
+        // export class Foo {
+        //  @Decorator((val) => val)
+        //  badField!: number
+        // }
         parse_lhs_expr(p, ExpressionContext::default().and_in_ts_decorator(true))
             .or_add_diagnostic(p, expected_expression);
 

--- a/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.rast
@@ -1,0 +1,72 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExport {
+            export_token: EXPORT_KW@0..7 "export" [] [Whitespace(" ")],
+            export_clause: JsClassDeclaration {
+                abstract_token: missing (optional),
+                class_token: CLASS_KW@7..13 "class" [] [Whitespace(" ")],
+                id: JsIdentifierBinding {
+                    name_token: IDENT@13..17 "Foo" [] [Whitespace(" ")],
+                },
+                type_parameters: missing (optional),
+                extends_clause: missing (optional),
+                implements_clause: missing (optional),
+                l_curly_token: L_CURLY@17..18 "{" [] [],
+                members: JsClassMemberList [
+                    JsPropertyClassMember {
+                        modifiers: JsPropertyModifierList [],
+                        name: JsLiteralMemberName {
+                            value: IDENT@18..54 "badField" [Newline("\n"), Whitespace(" "), Skipped("@"), Skipped("Decorator"), Skipped("("), Skipped("("), Skipped("val"), Skipped(")"), Whitespace(" "), Skipped("=>"), Whitespace(" "), Skipped("val"), Skipped(")"), Newline("\n"), Whitespace(" ")] [],
+                        },
+                        property_annotation: TsDefinitePropertyAnnotation {
+                            excl_token: BANG@54..55 "!" [] [],
+                            type_annotation: TsTypeAnnotation {
+                                colon_token: COLON@55..57 ":" [] [Whitespace(" ")],
+                                ty: TsNumberType {
+                                    number_token: NUMBER_KW@57..63 "number" [] [],
+                                },
+                            },
+                        },
+                        value: missing (optional),
+                        semicolon_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@63..65 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@65..66 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..66
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..65
+    0: JS_EXPORT@0..65
+      0: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
+      1: JS_CLASS_DECLARATION@7..65
+        0: (empty)
+        1: CLASS_KW@7..13 "class" [] [Whitespace(" ")]
+        2: JS_IDENTIFIER_BINDING@13..17
+          0: IDENT@13..17 "Foo" [] [Whitespace(" ")]
+        3: (empty)
+        4: (empty)
+        5: (empty)
+        6: L_CURLY@17..18 "{" [] []
+        7: JS_CLASS_MEMBER_LIST@18..63
+          0: JS_PROPERTY_CLASS_MEMBER@18..63
+            0: JS_PROPERTY_MODIFIER_LIST@18..18
+            1: JS_LITERAL_MEMBER_NAME@18..54
+              0: IDENT@18..54 "badField" [Newline("\n"), Whitespace(" "), Skipped("@"), Skipped("Decorator"), Skipped("("), Skipped("("), Skipped("val"), Skipped(")"), Whitespace(" "), Skipped("=>"), Whitespace(" "), Skipped("val"), Skipped(")"), Newline("\n"), Whitespace(" ")] []
+            2: TS_DEFINITE_PROPERTY_ANNOTATION@54..63
+              0: BANG@54..55 "!" [] []
+              1: TS_TYPE_ANNOTATION@55..63
+                0: COLON@55..57 ":" [] [Whitespace(" ")]
+                1: TS_NUMBER_TYPE@57..63
+                  0: NUMBER_KW@57..63 "number" [] []
+            3: (empty)
+            4: (empty)
+        8: R_CURLY@63..65 "}" [Newline("\n")] []
+  3: EOF@65..66 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_decorator_call_expression_with_arrow.ts
@@ -1,0 +1,4 @@
+export class Foo {
+ @Decorator((val) => val)
+ badField!: number
+}


### PR DESCRIPTION
#2327 changed the parser to not store the last parsed token but instead
retrieve it by getting the kind from the last `Token` event in the parser events.

This didn't play well with skipping tokens because the parser didn't add any tokens to the `events` collection while in `skipping` mode.

This PR changes the `skipping` mode so that it only changes whatever the parser calls `bump` or `skip_as_token_trivia` but the parser will always add it to the `events` collection.

This adds a few unnecessary writes but this should be neglectable because

* Skipping token is rare and even then, often limited to very few tokens
* Moving the `bump` out of the condition may even help with branch prediction.

Fixes #2358

## Tests

Added a new parser test. 

The `conformance/decorators/class/decoratorChecksFunctionBodies.ts` regression is because this test previously failed because of a parser error but it is expected to fail with a type error that our parser doesn't verify. That's why this is regression is OK.