### PR TITLE
chore: Fix playground build

### DIFF
--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "playground",
-  "version": "0.0.0",
-  "scripts": {
-    "start": "vite",
-    "preview": "vite preview",
-		"build": "npm run build:js && npm run build:wasm",
-    "build:js": "tsc && vite build",
+	"name": "playground",
+	"version": "0.0.0",
+	"scripts": {
+		"start": "vite",
+		"preview": "vite preview",
+		"build": "npm run build:wasm && npm run build:js",
+		"build:js": "tsc && vite build",
 		"build:wasm": "wasm-pack build --target web --release",
-    "format": "cargo run -p rome_cli --release -- format ./src"
-  },
-  "dependencies": {
-    "@uiw/react-textarea-code-editor": "^1.4.16",
-    "prettier": "^2.5.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-tabs": "^3.2.3"
-  },
-  "devDependencies": {
-    "@tailwindcss/forms": "^0.4.0",
-    "@types/prettier": "^2.4.3",
-    "@types/react": "^17.0.33",
-    "@types/react-dom": "^17.0.10",
-    "@types/react-tabs": "^2.3.4",
-    "@vitejs/plugin-react": "^1.0.7",
-    "autoprefixer": "^10.4.2",
-    "postcss": "^8.4.6",
-    "tailwindcss": "^3.0.19",
-    "typescript": "^4.4.4",
-    "vite": "^2.7.2"
-  },
-  "engines": {
-    "npm": "^8"
-  }
+		"format": "cargo run -p rome_cli --release -- format ./src"
+	},
+	"dependencies": {
+		"@uiw/react-textarea-code-editor": "^1.4.16",
+		"prettier": "^2.5.1",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"react-tabs": "^3.2.3"
+	},
+	"devDependencies": {
+		"@tailwindcss/forms": "^0.4.0",
+		"@types/prettier": "^2.4.3",
+		"@types/react": "^17.0.33",
+		"@types/react-dom": "^17.0.10",
+		"@types/react-tabs": "^2.3.4",
+		"@vitejs/plugin-react": "^1.0.7",
+		"autoprefixer": "^10.4.2",
+		"postcss": "^8.4.6",
+		"tailwindcss": "^3.0.19",
+		"typescript": "^4.4.4",
+		"vite": "^2.7.2"
+	},
+	"engines": {
+		"npm": "^8"
+	}
 }


### PR DESCRIPTION
The wasm build must run before the JS build or TypeScript will bail out because some dependencies are missing.

## Test

Deleted the `dist` and `pkg` directories, then ran `npm run build`.

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
