### PR TITLE
docs(website): update pnpm commands

### DIFF
--- a/website/src/_includes/docs/getting-started.md
+++ b/website/src/_includes/docs/getting-started.md
@@ -17,13 +17,12 @@ Rome currently doesn't support other editors than VS Code. [Let us know](https:/
 Install `rome` using your preferred node package manager. We require a minimum Node version of v14.18.
 
 > NOTE: we recommend **not** installing the binary globally, instead please install the binary
-> locally to your project. You can also use `npx`, `pnpx` or `yarn dlx` to run `rome@next`.
-
+> locally to your project. You can also use `npx`, `pnpm dlx` or `yarn dlx` to run `rome@next`.
 
 | Package manager               | Instructions            |
-|-------------------------------|-------------------------|
+| ----------------------------- | ----------------------- |
 | [npm](https://www.npmjs.com/) | `npm i -D rome@next`    |
-| [pnpm](https://pnpm.io/)      | `pnpm i -D rome@next`   |
+| [pnpm](https://pnpm.io/)      | `pnpm add -D rome@next` |
 | [yarn](https://yarnpkg.com/)  | `yarn add -D rome@next` |
 
 If you install the CLI locally, use the [scripts field](https://docs.npmjs.com/cli/v8/using-npm/scripts) of your package.json to run Rome. For instance:
@@ -41,7 +40,7 @@ Then you can run:
 ```bash
 npm run format
 yarn format
-pnpm run format
+pnpm format
 ```
 
 ### Install Rome in your CI pipeline
@@ -52,10 +51,10 @@ Please refer to the [`setup-rome` action documentation](https://github.com/rome/
 
 ```yaml
 steps:
-    - uses: rome/setup-rome@v0.1
-      with:
-        version: latest
-    - run: rome --help
+  - uses: rome/setup-rome@v0.1
+    with:
+      version: latest
+  - run: rome --help
 ```
 
 #### Installation on any other CI
@@ -75,18 +74,16 @@ Where `<OS>` and `<ARCH>` follow the Node.js syntax convention:
 > NOTE: For Windows Subsystem for Linux (WSL), please use `linux` as your OS
 
 |         | `win32`         | `darwin`         | `linux`         |
-|---------|-----------------|------------------|-----------------|
+| ------- | --------------- | ---------------- | --------------- |
 | `arm64` | [`win32-arm64`] | [`darwin-arm64`] | [`linux-arm64`] |
 | `x64`   | [`win32-x64`]   | [`darwin-x64`]   | [`linux-x64`]   |
 
 Please make sure to choose the correct architecture from the [releases page](https://github.com/rome/tools/releases).
 
-
 ## Post-Installation
 
 - check the [formatter section](/formatter#use-the-formatter-with-the-cli) for options and commands;
 - check the options available in the [VS Code extension](/formatter#use-the-formatter-with-the-vscode-extension)
-
 
 [`win32-arm64`]: https://github.com/rome/tools/releases/latest/download/rome-win32-arm64.exe
 [`darwin-arm64`]: https://github.com/rome/tools/releases/latest/download/rome-darwin-arm64


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.m

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
* pnpm deprecated `pnpx` in favor of [`pnpm dlx`](https://pnpm.io/cli/dlx)
* pnpm suggests using [`pnpm add <pkg>`](https://pnpm.io/cli/add) in its docs and does not mention `pnpm i <pkg>` (although it is supported)
* pnpm allows passing through script names like Yarn (`pnpm format` instead of `pnpm run format`)

## Test Plan
n/a