### PR TITLE
refactor(rome_js_formatter): Support arbitrarily deep binary expressions

### DIFF
--- a/crates/rome_analyze/src/analyzers/no_double_equals.rs
+++ b/crates/rome_analyze/src/analyzers/no_double_equals.rs
@@ -13,7 +13,7 @@ pub const ANALYZER: Analyzer = Analyzer {
 fn analyze(ctx: &AnalyzerContext) -> Option<Analysis> {
     ctx.query_nodes::<JsBinaryExpression>()
         .filter_map(|n| {
-            let op = n.operator().ok()?;
+            let op = n.operator_token().ok()?;
 
             if !matches!(op.kind(), EQ2 | NEQ) {
                 return None;

--- a/crates/rome_analyze/src/assists/flip_bin_exp.rs
+++ b/crates/rome_analyze/src/assists/flip_bin_exp.rs
@@ -14,7 +14,7 @@ pub const ASSIST: AssistProvider = AssistProvider {
 fn analyze(ctx: &AssistContext) -> Option<Analysis> {
     let node = ctx.find_node_at_cursor_range::<JsBinaryExpression>()?;
 
-    let op_range = node.operator().ok()?.text_trimmed_range();
+    let op_range = node.operator_token().ok()?.text_trimmed_range();
     if !op_range.contains_range(ctx.cursor_range) {
         return None;
     }

--- a/crates/rome_console/src/diff.rs
+++ b/crates/rome_console/src/diff.rs
@@ -30,7 +30,7 @@ pub enum DiffMode {
     /// 11  9 |   elit,
     ///       | @@ -15,7 +13,5 @@
     /// 14 12 |   eiusmod
-    /// 15 13 |   
+    /// 15 13 |
     /// 16 14 |   incididunt
     /// 17    | - function
     /// 18    | - name(
@@ -154,8 +154,11 @@ impl<'a> Display for Diff<'a> {
                         fmt.write_str(" | ")?;
 
                         let line = change.value().trim_end();
-                        let line_length = line.len().min(MAX_LINE_LENGTH);
-                        let line = &line[..line_length];
+                        let line = line
+                            .char_indices()
+                            .nth(MAX_LINE_LENGTH)
+                            .map(|(byte_index, _)| &line[..byte_index])
+                            .unwrap_or_else(|| &line);
 
                         match change.tag() {
                             ChangeTag::Delete => {

--- a/crates/rome_console/src/diff.rs
+++ b/crates/rome_console/src/diff.rs
@@ -158,7 +158,7 @@ impl<'a> Display for Diff<'a> {
                             .char_indices()
                             .nth(MAX_LINE_LENGTH)
                             .map(|(byte_index, _)| &line[..byte_index])
-                            .unwrap_or_else(|| &line);
+                            .unwrap_or_else(|| line);
 
                         match change.tag() {
                             ChangeTag::Delete => {

--- a/crates/rome_formatter/src/format_element.rs
+++ b/crates/rome_formatter/src/format_element.rs
@@ -1312,7 +1312,7 @@ impl FormatElement {
                     (leading, FormatElement::List(List::new(content)), trailing)
                 } else {
                     // All leading trivia
-                    return (FormatElement::List(list), empty_element(), empty_element());
+                    (FormatElement::List(list), empty_element(), empty_element())
                 }
             }
             FormatElement::HardGroup(group) => {

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -1,11 +1,11 @@
-use crate::utils::format_binary_like_expression;
+use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::{JsAnyExpression, JsBinaryExpression};
+use rome_js_syntax::JsBinaryExpression;
 
 impl ToFormatElement for JsBinaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         format_binary_like_expression(
-            &JsAnyExpression::JsBinaryExpression(self.clone()),
+            JsAnyBinaryLikeExpression::JsBinaryExpression(self.clone()),
             formatter,
         )
     }

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -1,10 +1,10 @@
-use crate::utils::format_binaryish_expression;
+use crate::utils::format_binary_like_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rome_js_syntax::{JsAnyExpression, JsBinaryExpression};
 
 impl ToFormatElement for JsBinaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(
+        format_binary_like_expression(
             &JsAnyExpression::JsBinaryExpression(self.clone()),
             formatter,
         )

--- a/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/binary_expression.rs
@@ -1,10 +1,12 @@
 use crate::utils::format_binaryish_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::JsBinaryExpression;
-use rome_rowan::AstNode;
+use rome_js_syntax::{JsAnyExpression, JsBinaryExpression};
 
 impl ToFormatElement for JsBinaryExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(self.syntax(), formatter)
+        format_binaryish_expression(
+            &JsAnyExpression::JsBinaryExpression(self.clone()),
+            formatter,
+        )
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -1,9 +1,12 @@
-use crate::utils::format_binary_like_expression;
+use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::{JsAnyExpression, JsInExpression};
+use rome_js_syntax::JsInExpression;
 
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binary_like_expression(&JsAnyExpression::JsInExpression(self.clone()), formatter)
+        format_binary_like_expression(
+            JsAnyBinaryLikeExpression::JsInExpression(self.clone()),
+            formatter,
+        )
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -1,9 +1,9 @@
-use crate::utils::format_binaryish_expression;
+use crate::utils::format_binary_like_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rome_js_syntax::{JsAnyExpression, JsInExpression};
 
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(&JsAnyExpression::JsInExpression(self.clone()), formatter)
+        format_binary_like_expression(&JsAnyExpression::JsInExpression(self.clone()), formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/in_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/in_expression.rs
@@ -1,10 +1,9 @@
 use crate::utils::format_binaryish_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::JsInExpression;
-use rome_rowan::AstNode;
+use rome_js_syntax::{JsAnyExpression, JsInExpression};
 
 impl ToFormatElement for JsInExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(self.syntax(), formatter)
+        format_binaryish_expression(&JsAnyExpression::JsInExpression(self.clone()), formatter)
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -1,10 +1,10 @@
-use crate::utils::format_binaryish_expression;
+use crate::utils::format_binary_like_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rome_js_syntax::{JsAnyExpression, JsInstanceofExpression};
 
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(
+        format_binary_like_expression(
             &JsAnyExpression::JsInstanceofExpression(self.clone()),
             formatter,
         )

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -1,11 +1,11 @@
-use crate::utils::format_binary_like_expression;
+use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::{JsAnyExpression, JsInstanceofExpression};
+use rome_js_syntax::JsInstanceofExpression;
 
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         format_binary_like_expression(
-            &JsAnyExpression::JsInstanceofExpression(self.clone()),
+            JsAnyBinaryLikeExpression::JsInstanceofExpression(self.clone()),
             formatter,
         )
     }

--- a/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/instanceof_expression.rs
@@ -1,10 +1,12 @@
 use crate::utils::format_binaryish_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::JsInstanceofExpression;
-use rome_rowan::AstNode;
+use rome_js_syntax::{JsAnyExpression, JsInstanceofExpression};
 
 impl ToFormatElement for JsInstanceofExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(self.syntax(), formatter)
+        format_binaryish_expression(
+            &JsAnyExpression::JsInstanceofExpression(self.clone()),
+            formatter,
+        )
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -1,11 +1,11 @@
-use crate::utils::format_binary_like_expression;
+use crate::utils::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::{JsAnyExpression, JsLogicalExpression};
+use rome_js_syntax::JsLogicalExpression;
 
 impl ToFormatElement for JsLogicalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         format_binary_like_expression(
-            &JsAnyExpression::JsLogicalExpression(self.clone()),
+            JsAnyBinaryLikeExpression::JsLogicalExpression(self.clone()),
             formatter,
         )
     }

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -1,10 +1,10 @@
-use crate::utils::format_binaryish_expression;
+use crate::utils::format_binary_like_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
 use rome_js_syntax::{JsAnyExpression, JsLogicalExpression};
 
 impl ToFormatElement for JsLogicalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(
+        format_binary_like_expression(
             &JsAnyExpression::JsLogicalExpression(self.clone()),
             formatter,
         )

--- a/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/logical_expression.rs
@@ -1,10 +1,12 @@
 use crate::utils::format_binaryish_expression;
 use crate::{FormatElement, FormatResult, Formatter, ToFormatElement};
-use rome_js_syntax::JsLogicalExpression;
-use rome_rowan::AstNode;
+use rome_js_syntax::{JsAnyExpression, JsLogicalExpression};
 
 impl ToFormatElement for JsLogicalExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        format_binaryish_expression(self.syntax(), formatter)
+        format_binaryish_expression(
+            &JsAnyExpression::JsLogicalExpression(self.clone()),
+            formatter,
+        )
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/post_update_expression.rs
@@ -7,11 +7,14 @@ use rome_js_syntax::JsPostUpdateExpressionFields;
 
 impl ToFormatElement for JsPostUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsPostUpdateExpressionFields { operand, operator } = self.as_fields();
+        let JsPostUpdateExpressionFields {
+            operand,
+            operator_token,
+        } = self.as_fields();
 
         Ok(format_elements![
             operand.format(formatter)?,
-            operator.format(formatter)?,
+            operator_token.format(formatter)?,
         ])
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/pre_update_expression.rs
@@ -7,10 +7,13 @@ use rome_js_syntax::JsPreUpdateExpressionFields;
 
 impl ToFormatElement for JsPreUpdateExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
-        let JsPreUpdateExpressionFields { operator, operand } = self.as_fields();
+        let JsPreUpdateExpressionFields {
+            operator_token,
+            operand,
+        } = self.as_fields();
 
         Ok(format_elements![
-            operator.format(formatter)?,
+            operator_token.format(formatter)?,
             operand.format(formatter)?,
         ])
     }

--- a/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/static_member_expression.rs
@@ -11,13 +11,13 @@ impl ToFormatElement for JsStaticMemberExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
         let JsStaticMemberExpressionFields {
             object,
-            operator,
+            operator_token,
             member,
         } = self.as_fields();
 
         Ok(group_elements(format_elements![
             object.format(formatter)?,
-            operator.format(formatter)?,
+            operator_token.format(formatter)?,
             member.format(formatter)?,
         ]))
     }

--- a/crates/rome_js_formatter/src/js/lists/array_element_list.rs
+++ b/crates/rome_js_formatter/src/js/lists/array_element_list.rs
@@ -33,11 +33,11 @@ impl ToFormatElement for JsArrayElementList {
 fn can_print_fill(list: &JsArrayElementList) -> bool {
     use rome_js_syntax::JsAnyArrayElement::*;
     use rome_js_syntax::JsAnyExpression::*;
-    use rome_js_syntax::JsUnaryOperation::*;
+    use rome_js_syntax::JsUnaryOperator::*;
 
     list.iter().all(|item| match item {
         Ok(JsAnyExpression(JsUnaryExpression(expr))) => {
-            match expr.operation() {
+            match expr.operator() {
                 Ok(Plus | Minus | BitwiseNot | LogicalNot) => {}
                 _ => return false,
             }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -422,7 +422,7 @@ a + b * c > 65 + 5;
         });
         assert_eq!(
             result.as_code(),
-            r#"(a + (b * c)) > 65;
+            r#"(a + (b * c)) > (65 + 5);
 "#
         );
     }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -405,11 +405,10 @@ mod test {
     use rome_js_parser::{parse, SourceType};
 
     #[test]
-    #[ignore]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
- const functionName1 = <T,>(arg) => false;
+a + b * c > 65 + 5;
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax.clone());
@@ -423,7 +422,7 @@ mod test {
         });
         assert_eq!(
             result.as_code(),
-            r#"let g = [[], [0, 1], [0, 1]];
+            r#"(a + (b * c)) > 65;
 "#
         );
     }

--- a/crates/rome_js_formatter/src/utils/binarish_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binarish_expression.rs
@@ -647,7 +647,7 @@ impl<'f> FlattenItems<'f> {
         let (formatted, _) =
             format_with_or_without_parenthesis(current_operator, right.syntax(), right_formatted)?;
 
-        let flatten_item = FlattenItem::binarish(
+        let flatten_item = FlattenItem::right(
             previous_operator.format_or_empty(self.formatter)?,
             formatted,
             has_comments.into(),
@@ -673,6 +673,7 @@ impl<'f> FlattenItems<'f> {
             previous_operator,
         } = payload;
 
+        // TODO inline? Rename to non-flattable_expression?
         let (left_item, right_item) = split_binaryish_to_flatten_items(
             &self.formatter,
             SplitToElementParams {
@@ -798,7 +799,7 @@ struct FlattenItem {
 }
 
 impl FlattenItem {
-    fn binarish(
+    fn right(
         operator_element: FormatElement,
         node_element: FormatElement,
         comments: Comments,
@@ -811,7 +812,7 @@ impl FlattenItem {
 
         Self {
             formatted,
-            kind: FlattenItemKind::Binarish,
+            kind: FlattenItemKind::Right,
             comments,
         }
     }
@@ -843,7 +844,7 @@ impl FlattenItem {
 
 #[derive(Debug)]
 enum FlattenItemKind {
-    Binarish,
+    Right,
     /// Used when the right side of a binary/logical expression is another binary/logical.
     /// When we have such cases we
     Group,

--- a/crates/rome_js_formatter/src/utils/binarish_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binarish_expression.rs
@@ -399,10 +399,11 @@ fn can_hard_group(flatten_nodes: &[FlattenItem]) -> bool {
 }
 
 fn is_inside_parenthesis(current_node: &SyntaxNode) -> bool {
-    current_node.parent().map_or(false, |parent| {
-        let kind = parent.kind();
-        matches!(
-            kind,
+    let parent_kind = current_node.parent().map(|parent| parent.kind());
+
+    matches!(
+        parent_kind,
+        Some(
             JsSyntaxKind::JS_IF_STATEMENT
                 | JsSyntaxKind::JS_DO_WHILE_STATEMENT
                 | JsSyntaxKind::JS_WHILE_STATEMENT
@@ -410,7 +411,7 @@ fn is_inside_parenthesis(current_node: &SyntaxNode) -> bool {
                 | JsSyntaxKind::JS_TEMPLATE_ELEMENT
                 | JsSyntaxKind::TS_TEMPLATE_ELEMENT
         )
-    })
+    )
 }
 
 /// This function checks whether the chain of logical/binary expressions **should not** be indented

--- a/crates/rome_js_formatter/src/utils/binarish_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binarish_expression.rs
@@ -490,11 +490,8 @@ impl FlattenItems {
             let head = groups.next().unwrap();
             let rest = join_elements(soft_line_break_or_space(), groups);
 
-            let (head_leading, head, trailing) = head.split_trivia();
-
             format_elements![
-                head_leading,
-                hard_group_elements(format_elements![head, trailing]),
+                hard_group_elements(head),
                 group_elements(soft_line_indent_or_space(rest))
             ]
         };

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -644,6 +644,7 @@ impl Iterator for PostorderIterator {
 
 impl FusedIterator for PostorderIterator {}
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub(crate) enum JsAnyBinaryLikeExpression {
     JsLogicalExpression(JsLogicalExpression),

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -322,8 +322,6 @@ impl FlattenItems {
         formatter: &Formatter,
     ) -> FormatResult<()> {
         let right = binary_like_expression.right()?;
-
-        // Call lazily by storing the right syntax node instead?
         let has_comments = right.syntax().contains_comments();
         let right_formatted = right.format(formatter)?;
 

--- a/crates/rome_js_formatter/src/utils/call_expression.rs
+++ b/crates/rome_js_formatter/src/utils/call_expression.rs
@@ -315,7 +315,7 @@ fn flatten_call_expression(
             let object = static_member.object()?;
             flatten_call_expression(queue, object.syntax().clone(), formatter)?;
             let formatted = vec![
-                static_member.operator().format(formatter)?,
+                static_member.operator_token().format(formatter)?,
                 static_member.member().format(formatter)?,
             ];
             queue.push(FlattenItem::StaticMember(static_member, formatted));

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     empty_element, empty_line, format_elements, hard_group_elements, space_token, token,
     FormatElement, FormatResult, Formatter, Token,
 };
-pub use binarish_expression::format_binary_like_expression;
+pub(crate) use binarish_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use call_expression::format_call_expression;
 pub(crate) use format_conditional::{format_conditional, Conditional};
 use rome_formatter::normalize_newlines;

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     empty_element, empty_line, format_elements, hard_group_elements, space_token, token,
     FormatElement, FormatResult, Formatter, Token,
 };
-pub use binarish_expression::format_binaryish_expression;
+pub use binarish_expression::format_binary_like_expression;
 pub(crate) use call_expression::format_call_expression;
 pub(crate) use format_conditional::{format_conditional, Conditional};
 use rome_formatter::normalize_newlines;

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod array;
-mod binarish_expression;
+mod binary_like_expression;
 mod call_expression;
 mod format_conditional;
 mod simple;
@@ -9,7 +9,7 @@ use crate::{
     empty_element, empty_line, format_elements, hard_group_elements, space_token, token,
     FormatElement, FormatResult, Formatter, Token,
 };
-pub(crate) use binarish_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
+pub(crate) use binary_like_expression::{format_binary_like_expression, JsAnyBinaryLikeExpression};
 pub(crate) use call_expression::format_call_expression;
 pub(crate) use format_conditional::{format_conditional, Conditional};
 use rome_formatter::normalize_newlines;

--- a/crates/rome_js_parser/test_data/inline/err/binary_expressions_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/binary_expressions_err.rast
@@ -20,7 +20,7 @@ JsModule {
                                     value_token: IDENT@4..8 "foo" [] [Whitespace(" ")],
                                 },
                             },
-                            operator: PLUS@8..9 "+" [] [],
+                            operator_token: PLUS@8..9 "+" [] [],
                             right: missing (required),
                         },
                     ],
@@ -36,10 +36,10 @@ JsModule {
                         value_token: IDENT@11..16 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: PLUS@16..18 "+" [] [Whitespace(" ")],
+                operator_token: PLUS@16..18 "+" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
                     left: missing (required),
-                    operator: STAR@18..20 "*" [] [Whitespace(" ")],
+                    operator_token: STAR@18..20 "*" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@20..21 "2" [] [],
                     },
@@ -50,14 +50,14 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsUnaryExpression {
-                    operator: BANG@22..24 "!" [Newline("\n")] [],
+                    operator_token: BANG@22..24 "!" [Newline("\n")] [],
                     argument: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@24..28 "foo" [] [Whitespace(" ")],
                         },
                     },
                 },
-                operator: STAR@28..30 "*" [] [Whitespace(" ")],
+                operator_token: STAR@28..30 "*" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@30..33 "bar" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/exponent_unary_unparenthesized.rast
+++ b/crates/rome_js_parser/test_data/inline/err/exponent_unary_unparenthesized.rast
@@ -6,14 +6,14 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
+                        operator_token: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
                         argument: JsStaticMemberExpression {
                             object: JsIdentifierExpression {
                                 name: JsReferenceIdentifier {
                                     value_token: IDENT@7..8 "a" [] [],
                                 },
                             },
-                            operator: DOT@8..9 "." [] [],
+                            operator_token: DOT@8..9 "." [] [],
                             member: JsName {
                                 value_token: IDENT@9..11 "b" [] [Whitespace(" ")],
                             },
@@ -31,7 +31,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: VOID_KW@16..22 "void" [Newline("\n")] [Whitespace(" ")],
+                        operator_token: VOID_KW@16..22 "void" [Newline("\n")] [Whitespace(" ")],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@22..28 "ident" [] [Whitespace(" ")],
@@ -50,7 +50,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: TYPEOF_KW@33..41 "typeof" [Newline("\n")] [Whitespace(" ")],
+                        operator_token: TYPEOF_KW@33..41 "typeof" [Newline("\n")] [Whitespace(" ")],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@41..47 "ident" [] [Whitespace(" ")],
@@ -69,7 +69,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: MINUS@52..54 "-" [Newline("\n")] [],
+                        operator_token: MINUS@52..54 "-" [Newline("\n")] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@54..56 "3" [] [Whitespace(" ")],
                         },
@@ -86,7 +86,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: PLUS@61..63 "+" [Newline("\n")] [],
+                        operator_token: PLUS@61..63 "+" [Newline("\n")] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@63..65 "3" [] [Whitespace(" ")],
                         },
@@ -103,7 +103,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: TILDE@70..72 "~" [Newline("\n")] [],
+                        operator_token: TILDE@70..72 "~" [Newline("\n")] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@72..74 "3" [] [Whitespace(" ")],
                         },
@@ -120,7 +120,7 @@ JsModule {
             expression: JsUnknownExpression {
                 items: [
                     JsUnaryExpression {
-                        operator: BANG@79..81 "!" [Newline("\n")] [],
+                        operator_token: BANG@79..81 "!" [Newline("\n")] [],
                         argument: JsBooleanLiteralExpression {
                             value_token: TRUE_KW@81..86 "true" [] [Whitespace(" ")],
                         },

--- a/crates/rome_js_parser/test_data/inline/err/for_stmt_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/for_stmt_err.rast
@@ -42,7 +42,7 @@ JsModule {
                             value_token: IDENT@25..27 "i" [] [Whitespace(" ")],
                         },
                     },
-                    operator: L_ANGLE@27..29 "<" [] [Whitespace(" ")],
+                    operator_token: L_ANGLE@27..29 "<" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@29..31 "10" [] [],
                     },
@@ -52,7 +52,7 @@ JsModule {
                     operand: JsIdentifierAssignment {
                         name_token: IDENT@33..34 "i" [] [],
                     },
-                    operator: PLUS2@34..37 "++" [] [Whitespace(" ")],
+                    operator_token: PLUS2@34..37 "++" [] [Whitespace(" ")],
                 },
                 r_paren_token: missing (required),
                 body: JsBlockStatement {
@@ -89,14 +89,14 @@ JsModule {
                         value_token: IDENT@55..57 "i" [] [Whitespace(" ")],
                     },
                 },
-                operator: L_ANGLE@57..59 "<" [] [Whitespace(" ")],
+                operator_token: L_ANGLE@57..59 "<" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@59..61 "10" [] [],
                 },
             },
             second_semi_token: SEMICOLON@61..63 ";" [] [Whitespace(" ")],
             update: JsPreUpdateExpression {
-                operator: PLUS2@63..65 "++" [] [],
+                operator_token: PLUS2@63..65 "++" [] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@65..67 "i" [] [Whitespace(" ")],
                 },
@@ -226,14 +226,14 @@ JsModule {
                             value_token: IDENT@162..164 "i" [] [Whitespace(" ")],
                         },
                     },
-                    operator: L_ANGLE@164..166 "<" [] [Whitespace(" ")],
+                    operator_token: L_ANGLE@164..166 "<" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@166..168 "10" [] [],
                     },
                 },
                 SEMICOLON@168..170 ";" [] [Whitespace(" ")],
                 JsPreUpdateExpression {
-                    operator: PLUS2@170..172 "++" [] [],
+                    operator_token: PLUS2@170..172 "++" [] [],
                     operand: JsIdentifierAssignment {
                         name_token: IDENT@172..173 "i" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/err/function_escaped_async.rast
+++ b/crates/rome_js_parser/test_data/inline/err/function_escaped_async.rast
@@ -4,7 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: VOID_KW@0..5 "void" [] [Whitespace(" ")],
+                operator_token: VOID_KW@0..5 "void" [] [Whitespace(" ")],
                 argument: JsUnknownExpression {
                     items: [
                         ERROR_TOKEN@5..16 "\\u0061sync" [] [Whitespace(" ")],

--- a/crates/rome_js_parser/test_data/inline/err/invalid_method_recover.rast
+++ b/crates/rome_js_parser/test_data/inline/err/invalid_method_recover.rast
@@ -19,7 +19,7 @@ JsModule {
                             left: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@11..13 "1" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@13..15 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@13..15 "+" [] [Whitespace(" ")],
                             right: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@15..16 "1" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/err/js_right_shift_comments.rast
+++ b/crates/rome_js_parser/test_data/inline/err/js_right_shift_comments.rast
@@ -8,10 +8,10 @@ JsModule {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@0..2 "1" [] [Whitespace(" ")],
                     },
-                    operator: SHR@2..21 ">>" [] [Whitespace(" "), Comments("/* a comment */"), Whitespace(" ")],
+                    operator_token: SHR@2..21 ">>" [] [Whitespace(" "), Comments("/* a comment */"), Whitespace(" ")],
                     right: missing (required),
                 },
-                operator: R_ANGLE@21..23 ">" [] [Whitespace(" ")],
+                operator_token: R_ANGLE@21..23 ">" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@23..24 "2" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/err/jsx_child_expression_missing_r_curly.rast
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_child_expression_missing_r_curly.rast
@@ -21,7 +21,7 @@ JsModule {
                                 left: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@8..10 "4" [] [Whitespace(" ")],
                                 },
-                                operator: PLUS@10..12 "+" [] [Whitespace(" ")],
+                                operator_token: PLUS@10..12 "+" [] [Whitespace(" ")],
                                 right: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@12..13 "3" [] [],
                                 },

--- a/crates/rome_js_parser/test_data/inline/err/jsx_children_expression_missing_r_curly.rast
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_children_expression_missing_r_curly.rast
@@ -24,7 +24,7 @@ JsModule {
                                 left: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@11..13 "5" [] [Whitespace(" ")],
                                 },
-                                operator: PLUS@13..15 "+" [] [Whitespace(" ")],
+                                operator_token: PLUS@13..15 "+" [] [Whitespace(" ")],
                                 right: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@15..16 "3" [] [],
                                 },

--- a/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.rast
+++ b/crates/rome_js_parser/test_data/inline/err/jsx_or_type_assertion.rast
@@ -49,12 +49,12 @@ JsModule {
                                                     },
                                                 ],
                                             },
-                                            operator: L_ANGLE@33..34 "<" [] [],
+                                            operator_token: L_ANGLE@33..34 "<" [] [],
                                             right: JsBinaryExpression {
                                                 left: JsRegexLiteralExpression {
                                                     value_token: JS_REGEX_LITERAL@34..42 "/div>; /" [] [],
                                                 },
-                                                operator: SLASH@42..44 "/" [] [Whitespace(" ")],
+                                                operator_token: SLASH@42..44 "/" [] [Whitespace(" ")],
                                                 right: JsIdentifierExpression {
                                                     name: JsReferenceIdentifier {
                                                         value_token: IDENT@44..47 "JSX" [] [],
@@ -126,14 +126,14 @@ JsModule {
                                                         },
                                                     ],
                                                 },
-                                                operator: L_ANGLE@109..110 "<" [] [],
+                                                operator_token: L_ANGLE@109..110 "<" [] [],
                                                 right: JsIdentifierExpression {
                                                     name: JsReferenceIdentifier {
                                                         value_token: IDENT@110..111 "a" [] [],
                                                     },
                                                 },
                                             },
-                                            operator: R_ANGLE@111..112 ">" [] [],
+                                            operator_token: R_ANGLE@111..112 ">" [] [],
                                             right: JsIdentifierExpression {
                                                 name: JsReferenceIdentifier {
                                                     value_token: IDENT@112..113 "d" [] [],
@@ -175,7 +175,7 @@ JsModule {
                                                     },
                                                 ],
                                             },
-                                            operator: L_ANGLE@151..152 "<" [] [],
+                                            operator_token: L_ANGLE@151..152 "<" [] [],
                                             right: JsRegexLiteralExpression {
                                                 value_token: JS_REGEX_LITERAL@152..158 "/div>/" [] [],
                                             },
@@ -212,7 +212,7 @@ JsModule {
                                                     },
                                                 ],
                                             },
-                                            operator: L_ANGLE@258..259 "<" [] [],
+                                            operator_token: L_ANGLE@258..259 "<" [] [],
                                             right: JsRegexLiteralExpression {
                                                 value_token: JS_REGEX_LITERAL@259..268 "/string>/" [] [],
                                             },

--- a/crates/rome_js_parser/test_data/inline/err/logical_expressions_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/logical_expressions_err.rast
@@ -9,10 +9,10 @@ JsModule {
                         value_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
                     },
                 },
-                operator: QUESTION2@4..7 "??" [] [Whitespace(" ")],
+                operator_token: QUESTION2@4..7 "??" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
                     left: missing (required),
-                    operator: STAR@7..9 "*" [] [Whitespace(" ")],
+                    operator_token: STAR@7..9 "*" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@9..10 "2" [] [],
                     },
@@ -23,14 +23,14 @@ JsModule {
         JsExpressionStatement {
             expression: JsLogicalExpression {
                 left: JsUnaryExpression {
-                    operator: BANG@11..13 "!" [Newline("\n")] [],
+                    operator_token: BANG@11..13 "!" [Newline("\n")] [],
                     argument: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@13..17 "foo" [] [Whitespace(" ")],
                         },
                     },
                 },
-                operator: AMP2@17..20 "&&" [] [Whitespace(" ")],
+                operator_token: AMP2@17..20 "&&" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@20..23 "bar" [] [],
@@ -57,7 +57,7 @@ JsModule {
                                     value_token: IDENT@29..33 "foo" [] [Whitespace(" ")],
                                 },
                             },
-                            operator: PIPE2@33..35 "||" [] [],
+                            operator_token: PIPE2@33..35 "||" [] [],
                             right: missing (required),
                         },
                     ],

--- a/crates/rome_js_parser/test_data/inline/err/multiple_default_exports_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/multiple_default_exports_err.rast
@@ -35,7 +35,7 @@ JsModule {
                                     value_token: IDENT@41..43 "a" [] [Whitespace(" ")],
                                 },
                             },
-                            operator: PLUS@43..45 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@43..45 "+" [] [Whitespace(" ")],
                             right: JsIdentifierExpression {
                                 name: JsReferenceIdentifier {
                                     value_token: IDENT@45..46 "b" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/optional_chain_call_without_arguments.rast
+++ b/crates/rome_js_parser/test_data/inline/err/optional_chain_call_without_arguments.rast
@@ -42,12 +42,12 @@ JsModule {
                             value_token: IDENT@23..25 "a" [Newline("\n")] [],
                         },
                     },
-                    operator: DOT@25..26 "." [] [],
+                    operator_token: DOT@25..26 "." [] [],
                     member: JsName {
                         value_token: IDENT@26..30 "test" [] [],
                     },
                 },
-                operator: QUESTIONDOT@30..32 "?." [] [],
+                operator_token: QUESTIONDOT@30..32 "?." [] [],
                 member: missing (required),
             },
             semicolon_token: SEMICOLON@32..33 ";" [] [],
@@ -61,15 +61,15 @@ JsModule {
                                 value_token: IDENT@33..35 "a" [Newline("\n")] [],
                             },
                         },
-                        operator: DOT@35..36 "." [] [],
+                        operator_token: DOT@35..36 "." [] [],
                         member: JsName {
                             value_token: IDENT@36..40 "test" [] [],
                         },
                     },
-                    operator: QUESTIONDOT@40..42 "?." [] [],
+                    operator_token: QUESTIONDOT@40..42 "?." [] [],
                     member: missing (required),
                 },
-                operator: L_ANGLE@42..43 "<" [] [],
+                operator_token: L_ANGLE@42..43 "<" [] [],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@43..45 "ab" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
+++ b/crates/rome_js_parser/test_data/inline/err/paren_or_arrow_expr_invalid_params.rast
@@ -9,7 +9,7 @@ JsModule {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@1..3 "5" [] [Whitespace(" ")],
                     },
-                    operator: PLUS@3..5 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@3..5 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@5..6 "5" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/err/private_name_presence_check_recursive.rast
+++ b/crates/rome_js_parser/test_data/inline/err/private_name_presence_check_recursive.rast
@@ -69,7 +69,7 @@ JsModule {
                                     left: JsNumberLiteralExpression {
                                         value_token: JS_NUMBER_LITERAL@54..60 "5" [Newline("\n"), Whitespace("   ")] [Whitespace(" ")],
                                     },
-                                    operator: PLUS@60..62 "+" [] [Whitespace(" ")],
+                                    operator_token: PLUS@60..62 "+" [] [Whitespace(" ")],
                                     right: JsUnknownExpression {
                                         items: [
                                             HASH@62..63 "#" [] [],
@@ -96,7 +96,7 @@ JsModule {
                                             IDENT@82..87 "prop" [] [Whitespace(" ")],
                                         ],
                                     },
-                                    operator: PLUS@87..89 "+" [] [Whitespace(" ")],
+                                    operator_token: PLUS@87..89 "+" [] [Whitespace(" ")],
                                     right: JsNumberLiteralExpression {
                                         value_token: JS_NUMBER_LITERAL@89..90 "5" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/err/subscripts_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/subscripts_err.rast
@@ -20,7 +20,7 @@ JsModule {
                                 r_paren_token: R_PAREN@4..5 ")" [] [],
                             },
                         },
-                        operator: QUESTIONDOT@5..7 "?." [] [],
+                        operator_token: QUESTIONDOT@5..7 "?." [] [],
                         member: JsName {
                             value_token: IDENT@7..10 "baz" [] [],
                         },
@@ -30,7 +30,7 @@ JsModule {
                     member: missing (required),
                     r_brack_token: R_BRACK@11..12 "]" [] [],
                 },
-                operator: DOT@12..13 "." [] [],
+                operator_token: DOT@12..13 "." [] [],
                 member: missing (required),
             },
             semicolon_token: SEMICOLON@13..14 ";" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/super_expression_err.rast
+++ b/crates/rome_js_parser/test_data/inline/err/super_expression_err.rast
@@ -65,7 +65,7 @@ JsModule {
                                                 SUPER_KW@46..56 "super" [Newline("\n"), Whitespace("    ")] [],
                                             ],
                                         },
-                                        operator: QUESTIONDOT@56..58 "?." [] [],
+                                        operator_token: QUESTIONDOT@56..58 "?." [] [],
                                         member: JsName {
                                             value_token: IDENT@58..62 "test" [] [],
                                         },

--- a/crates/rome_js_parser/test_data/inline/err/template_after_optional_chain.rast
+++ b/crates/rome_js_parser/test_data/inline/err/template_after_optional_chain.rast
@@ -12,12 +12,12 @@ JsModule {
                                     value_token: IDENT@0..3 "obj" [] [],
                                 },
                             },
-                            operator: DOT@3..4 "." [] [],
+                            operator_token: DOT@3..4 "." [] [],
                             member: JsName {
                                 value_token: IDENT@4..7 "val" [] [],
                             },
                         },
-                        operator: QUESTIONDOT@7..9 "?." [] [],
+                        operator_token: QUESTIONDOT@7..9 "?." [] [],
                         member: JsName {
                             value_token: IDENT@9..13 "prop" [] [],
                         },
@@ -43,7 +43,7 @@ JsModule {
                                     value_token: IDENT@23..27 "obj" [Newline("\n")] [],
                                 },
                             },
-                            operator: DOT@27..28 "." [] [],
+                            operator_token: DOT@27..28 "." [] [],
                             member: JsName {
                                 value_token: IDENT@28..31 "val" [] [],
                             },
@@ -78,7 +78,7 @@ JsModule {
                                     value_token: IDENT@49..53 "obj" [Newline("\n")] [],
                                 },
                             },
-                            operator: DOT@53..54 "." [] [],
+                            operator_token: DOT@53..54 "." [] [],
                             member: JsName {
                                 value_token: IDENT@54..58 "func" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/err/type_arguments_incomplete.rast
+++ b/crates/rome_js_parser/test_data/inline/err/type_arguments_incomplete.rast
@@ -10,7 +10,7 @@ JsModule {
                             value_token: IDENT@0..4 "func" [] [],
                         },
                     },
-                    operator: L_ANGLE@4..5 "<" [] [],
+                    operator_token: L_ANGLE@4..5 "<" [] [],
                     right: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@5..6 "T" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/unary_delete.rast
+++ b/crates/rome_js_parser/test_data/inline/err/unary_delete.rast
@@ -25,7 +25,7 @@ JsModule {
                                 value_token: IDENT@21..24 "obj" [] [],
                             },
                         },
-                        operator: DOT@24..25 "." [] [],
+                        operator_token: DOT@24..25 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@25..26 "#" [] [],
                             value_token: IDENT@26..32 "member" [] [],
@@ -54,7 +54,7 @@ JsModule {
                                 r_paren_token: R_PAREN@46..47 ")" [] [],
                             },
                         },
-                        operator: DOT@47..48 "." [] [],
+                        operator_token: DOT@47..48 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@48..49 "#" [] [],
                             value_token: IDENT@49..55 "member" [] [],
@@ -74,7 +74,7 @@ JsModule {
                                 value_token: IDENT@64..67 "obj" [] [],
                             },
                         },
-                        operator: QUESTIONDOT@67..69 "?." [] [],
+                        operator_token: QUESTIONDOT@67..69 "?." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@69..70 "#" [] [],
                             value_token: IDENT@70..76 "member" [] [],
@@ -95,12 +95,12 @@ JsModule {
                                     value_token: IDENT@85..88 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@88..90 "?." [] [],
+                            operator_token: QUESTIONDOT@88..90 "?." [] [],
                             member: JsName {
                                 value_token: IDENT@90..95 "inner" [] [],
                             },
                         },
-                        operator: DOT@95..96 "." [] [],
+                        operator_token: DOT@95..96 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@96..97 "#" [] [],
                             value_token: IDENT@97..103 "member" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/unary_delete_parenthesized.rast
+++ b/crates/rome_js_parser/test_data/inline/err/unary_delete_parenthesized.rast
@@ -53,7 +53,7 @@ JsModule {
                                         value_token: IDENT@42..45 "obj" [] [],
                                     },
                                 },
-                                operator: DOT@45..46 "." [] [],
+                                operator_token: DOT@45..46 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@46..49 "key" [] [],
                                 },
@@ -83,7 +83,7 @@ JsModule {
                                     value_token: IDENT@67..70 "obj" [] [],
                                 },
                             },
-                            operator: DOT@70..71 "." [] [],
+                            operator_token: DOT@70..71 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@71..72 "#" [] [],
                                 value_token: IDENT@72..78 "member" [] [],
@@ -116,7 +116,7 @@ JsModule {
                                     r_paren_token: R_PAREN@94..95 ")" [] [],
                                 },
                             },
-                            operator: DOT@95..96 "." [] [],
+                            operator_token: DOT@95..96 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@96..97 "#" [] [],
                                 value_token: IDENT@97..103 "member" [] [],
@@ -140,7 +140,7 @@ JsModule {
                                     value_token: IDENT@114..117 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@117..119 "?." [] [],
+                            operator_token: QUESTIONDOT@117..119 "?." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@119..120 "#" [] [],
                                 value_token: IDENT@120..126 "member" [] [],
@@ -165,12 +165,12 @@ JsModule {
                                         value_token: IDENT@137..140 "obj" [] [],
                                     },
                                 },
-                                operator: QUESTIONDOT@140..142 "?." [] [],
+                                operator_token: QUESTIONDOT@140..142 "?." [] [],
                                 member: JsName {
                                     value_token: IDENT@142..147 "inner" [] [],
                                 },
                             },
-                            operator: DOT@147..148 "." [] [],
+                            operator_token: DOT@147..148 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@148..149 "#" [] [],
                                 value_token: IDENT@149..155 "member" [] [],
@@ -195,7 +195,7 @@ JsModule {
                                         value_token: IDENT@166..169 "obj" [] [],
                                     },
                                 },
-                                operator: DOT@169..170 "." [] [],
+                                operator_token: DOT@169..170 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@170..173 "key" [] [],
                                 },
@@ -207,7 +207,7 @@ JsModule {
                                         value_token: IDENT@175..178 "obj" [] [],
                                     },
                                 },
-                                operator: DOT@178..179 "." [] [],
+                                operator_token: DOT@178..179 "." [] [],
                                 member: JsPrivateName {
                                     hash_token: HASH@179..180 "#" [] [],
                                     value_token: IDENT@180..183 "key" [] [],

--- a/crates/rome_js_parser/test_data/inline/err/unary_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/err/unary_expr.rast
@@ -4,21 +4,21 @@ JsModule {
     items: JsModuleItemList [
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: PLUS2@0..3 "++" [] [Whitespace(" ")],
+                operator_token: PLUS2@0..3 "++" [] [Whitespace(" ")],
                 operand: missing (required),
             },
             semicolon_token: SEMICOLON@3..4 ";" [] [],
         },
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: MINUS2@4..8 "--" [Newline("\n")] [Whitespace(" ")],
+                operator_token: MINUS2@4..8 "--" [Newline("\n")] [Whitespace(" ")],
                 operand: missing (required),
             },
             semicolon_token: SEMICOLON@8..9 ";" [] [],
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: MINUS@9..11 "-" [Newline("\n")] [],
+                operator_token: MINUS@9..11 "-" [Newline("\n")] [],
                 argument: missing (required),
             },
             semicolon_token: SEMICOLON@11..12 ";" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/array_assignment_target_rest.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/array_assignment_target_rest.rast
@@ -159,7 +159,7 @@ JsModule {
                                                     value_token: IDENT@91..94 "any" [] [],
                                                 },
                                             },
-                                            operator: DOT@94..95 "." [] [],
+                                            operator_token: DOT@94..95 "." [] [],
                                             member: JsName {
                                                 value_token: IDENT@95..105 "expression" [] [],
                                             },

--- a/crates/rome_js_parser/test_data/inline/ok/assignment_target.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/assignment_target.rast
@@ -127,7 +127,7 @@ JsModule {
                                             value_token: IDENT@82..84 "a" [Newline("\n")] [],
                                         },
                                     },
-                                    operator: DOT@84..85 "." [] [],
+                                    operator_token: DOT@84..85 "." [] [],
                                     member: JsName {
                                         value_token: IDENT@85..89 "call" [] [],
                                     },
@@ -140,7 +140,7 @@ JsModule {
                                     r_paren_token: R_PAREN@90..91 ")" [] [],
                                 },
                             },
-                            operator: DOT@91..92 "." [] [],
+                            operator_token: DOT@91..92 "." [] [],
                             member: JsName {
                                 value_token: IDENT@92..97 "chain" [] [],
                             },
@@ -170,12 +170,12 @@ JsModule {
         JsExpressionStatement {
             expression: JsBinaryExpression {
                 left: JsPreUpdateExpression {
-                    operator: PLUS2@111..114 "++" [Newline("\n")] [],
+                    operator_token: PLUS2@111..114 "++" [Newline("\n")] [],
                     operand: JsIdentifierAssignment {
                         name_token: IDENT@114..120 "count" [] [Whitespace(" ")],
                     },
                 },
-                operator: EQ3@120..124 "===" [] [Whitespace(" ")],
+                operator_token: EQ3@120..124 "===" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@124..125 "3" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/await_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/await_expression.rast
@@ -63,7 +63,7 @@ JsModule {
                                     r_paren_token: R_PAREN@57..59 ")" [] [Whitespace(" ")],
                                 },
                             },
-                            operator: PLUS@59..61 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@59..61 "+" [] [Whitespace(" ")],
                             right: JsAwaitExpression {
                                 await_token: AWAIT_KW@61..67 "await" [] [Whitespace(" ")],
                                 argument: JsCallExpression {

--- a/crates/rome_js_parser/test_data/inline/ok/binary_expressions.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/binary_expressions.rast
@@ -7,7 +7,7 @@ JsModule {
                 left: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@0..2 "5" [] [Whitespace(" ")],
                 },
-                operator: STAR@2..4 "*" [] [Whitespace(" ")],
+                operator_token: STAR@2..4 "*" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@4..5 "5" [] [],
                 },
@@ -19,12 +19,12 @@ JsModule {
                 left: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@5..8 "6" [Newline("\n")] [Whitespace(" ")],
                 },
-                operator: STAR2@8..11 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@8..11 "**" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@11..13 "6" [] [Whitespace(" ")],
                     },
-                    operator: STAR2@13..16 "**" [] [Whitespace(" ")],
+                    operator_token: STAR2@13..16 "**" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@16..17 "7" [] [],
                     },
@@ -37,13 +37,13 @@ JsModule {
                 left: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@17..20 "1" [Newline("\n")] [Whitespace(" ")],
                 },
-                operator: PLUS@20..22 "+" [] [Whitespace(" ")],
+                operator_token: PLUS@20..22 "+" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
                     left: JsBinaryExpression {
                         left: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@22..24 "2" [] [Whitespace(" ")],
                         },
-                        operator: STAR@24..26 "*" [] [Whitespace(" ")],
+                        operator_token: STAR@24..26 "*" [] [Whitespace(" ")],
                         right: JsCallExpression {
                             callee: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@26..27 "3" [] [],
@@ -57,7 +57,7 @@ JsModule {
                                         left: JsNumberLiteralExpression {
                                             value_token: JS_NUMBER_LITERAL@29..31 "1" [] [Whitespace(" ")],
                                         },
-                                        operator: PLUS@31..33 "+" [] [Whitespace(" ")],
+                                        operator_token: PLUS@31..33 "+" [] [Whitespace(" ")],
                                         right: JsNumberLiteralExpression {
                                             value_token: JS_NUMBER_LITERAL@33..34 "2" [] [],
                                         },
@@ -67,7 +67,7 @@ JsModule {
                             },
                         },
                     },
-                    operator: STAR@36..38 "*" [] [Whitespace(" ")],
+                    operator_token: STAR@36..38 "*" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@38..39 "3" [] [],
                     },
@@ -80,7 +80,7 @@ JsModule {
                 left: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@39..42 "1" [Newline("\n")] [Whitespace(" ")],
                 },
-                operator: SLASH@42..44 "/" [] [Whitespace(" ")],
+                operator_token: SLASH@42..44 "/" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@44..45 "2" [] [],
                 },
@@ -124,7 +124,7 @@ JsModule {
                         value_token: IDENT@76..81 "foo" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: QUESTION2@81..84 "??" [] [Whitespace(" ")],
+                operator_token: QUESTION2@81..84 "??" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@84..87 "bar" [] [],
@@ -140,7 +140,7 @@ JsModule {
                         value_token: IDENT@87..90 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: SHR@90..93 ">>" [] [Whitespace(" ")],
+                operator_token: SHR@90..93 ">>" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@93..94 "b" [] [],
@@ -156,7 +156,7 @@ JsModule {
                         value_token: IDENT@94..97 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: USHR@97..101 ">>>" [] [Whitespace(" ")],
+                operator_token: USHR@97..101 ">>>" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@101..102 "b" [] [],
@@ -172,17 +172,17 @@ JsModule {
                         left: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@102..105 "1" [Newline("\n")] [Whitespace(" ")],
                         },
-                        operator: PLUS@105..107 "+" [] [Whitespace(" ")],
+                        operator_token: PLUS@105..107 "+" [] [Whitespace(" ")],
                         right: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@107..109 "1" [] [Whitespace(" ")],
                         },
                     },
-                    operator: PLUS@109..111 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@109..111 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@111..113 "1" [] [Whitespace(" ")],
                     },
                 },
-                operator: PLUS@113..115 "+" [] [Whitespace(" ")],
+                operator_token: PLUS@113..115 "+" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@115..116 "1" [] [],
                 },
@@ -195,28 +195,28 @@ JsModule {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@116..119 "5" [Newline("\n")] [Whitespace(" ")],
                     },
-                    operator: PLUS@119..121 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@119..121 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@121..123 "6" [] [Whitespace(" ")],
                     },
                 },
-                operator: MINUS@123..125 "-" [] [Whitespace(" ")],
+                operator_token: MINUS@123..125 "-" [] [Whitespace(" ")],
                 right: JsBinaryExpression {
                     left: JsBinaryExpression {
                         left: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@125..127 "1" [] [Whitespace(" ")],
                         },
-                        operator: STAR@127..129 "*" [] [Whitespace(" ")],
+                        operator_token: STAR@127..129 "*" [] [Whitespace(" ")],
                         right: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@129..131 "2" [] [Whitespace(" ")],
                         },
                     },
-                    operator: SLASH@131..133 "/" [] [Whitespace(" ")],
+                    operator_token: SLASH@131..133 "/" [] [Whitespace(" ")],
                     right: JsBinaryExpression {
                         left: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@133..135 "1" [] [Whitespace(" ")],
                         },
-                        operator: STAR2@135..138 "**" [] [Whitespace(" ")],
+                        operator_token: STAR2@135..138 "**" [] [Whitespace(" ")],
                         right: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@138..139 "6" [] [],
                         },
@@ -270,7 +270,7 @@ JsModule {
                                     left: JsBooleanLiteralExpression {
                                         value_token: TRUE_KW@169..174 "true" [] [Whitespace(" ")],
                                     },
-                                    operator: AMP2@174..177 "&&" [] [Whitespace(" ")],
+                                    operator_token: AMP2@174..177 "&&" [] [Whitespace(" ")],
                                     right: JsInExpression {
                                         property: JsPrivateName {
                                             hash_token: HASH@177..178 "#" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/class_declaration.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/class_declaration.rast
@@ -51,7 +51,7 @@ JsModule {
                             value_token: IDENT@56..59 "foo" [] [],
                         },
                     },
-                    operator: DOT@59..60 "." [] [],
+                    operator_token: DOT@59..60 "." [] [],
                     member: JsName {
                         value_token: IDENT@60..64 "bar" [] [Whitespace(" ")],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/computed_member_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/computed_member_expression.rast
@@ -33,7 +33,7 @@ JsModule {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@13..15 "5" [] [Whitespace(" ")],
                     },
-                    operator: PLUS@15..17 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@15..17 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@17..18 "5" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/directives.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/directives.rast
@@ -115,7 +115,7 @@ JsScript {
                                     object: JsStringLiteralExpression {
                                         value_token: JS_STRING_LITERAL@180..195 "\"use strict\"" [Newline("\n"), Whitespace("  ")] [],
                                     },
-                                    operator: DOT@195..201 "." [Newline("\n"), Whitespace("    ")] [],
+                                    operator_token: DOT@195..201 "." [Newline("\n"), Whitespace("    ")] [],
                                     member: JsName {
                                         value_token: IDENT@201..207 "length" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/ok/do_while_statement.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/do_while_statement.rast
@@ -12,7 +12,7 @@ JsModule {
                                 value_token: IDENT@3..10 "console" [] [],
                             },
                         },
-                        operator: DOT@10..11 "." [] [],
+                        operator_token: DOT@10..11 "." [] [],
                         member: JsName {
                             value_token: IDENT@11..14 "log" [] [],
                         },
@@ -52,7 +52,7 @@ JsModule {
                                         value_token: IDENT@40..50 "console" [Newline("\n"), Whitespace("  ")] [],
                                     },
                                 },
-                                operator: DOT@50..51 "." [] [],
+                                operator_token: DOT@50..51 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@51..54 "log" [] [],
                                 },
@@ -121,7 +121,7 @@ JsModule {
                                             value_token: IDENT@104..106 "a" [] [Whitespace(" ")],
                                         },
                                     },
-                                    operator: PLUS@106..108 "+" [] [Whitespace(" ")],
+                                    operator_token: PLUS@106..108 "+" [] [Whitespace(" ")],
                                     right: JsNumberLiteralExpression {
                                         value_token: JS_NUMBER_LITERAL@108..109 "1" [] [],
                                     },
@@ -140,7 +140,7 @@ JsModule {
                             value_token: IDENT@118..120 "a" [] [Whitespace(" ")],
                         },
                     },
-                    operator: L_ANGLE@120..122 "<" [] [Whitespace(" ")],
+                    operator_token: L_ANGLE@120..122 "<" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@122..123 "5" [] [],
                     },
@@ -156,7 +156,7 @@ JsModule {
                         value_token: IDENT@132..134 "a" [] [Whitespace(" ")],
                     },
                 },
-                operator: L_ANGLE@134..136 "<" [] [Whitespace(" ")],
+                operator_token: L_ANGLE@134..136 "<" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@136..139 "100" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/exponent_unary_parenthesized.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/exponent_unary_parenthesized.rast
@@ -7,14 +7,14 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@0..1 "(" [] [],
                     expression: JsUnaryExpression {
-                        operator: DELETE_KW@1..8 "delete" [] [Whitespace(" ")],
+                        operator_token: DELETE_KW@1..8 "delete" [] [Whitespace(" ")],
                         argument: JsStaticMemberExpression {
                             object: JsIdentifierExpression {
                                 name: JsReferenceIdentifier {
                                     value_token: IDENT@8..9 "a" [] [],
                                 },
                             },
-                            operator: DOT@9..10 "." [] [],
+                            operator_token: DOT@9..10 "." [] [],
                             member: JsName {
                                 value_token: IDENT@10..11 "b" [] [],
                             },
@@ -22,7 +22,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@11..13 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@13..16 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@13..16 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@16..17 "2" [] [],
                 },
@@ -34,7 +34,7 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@18..20 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: VOID_KW@20..25 "void" [] [Whitespace(" ")],
+                        operator_token: VOID_KW@20..25 "void" [] [Whitespace(" ")],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@25..30 "ident" [] [],
@@ -43,7 +43,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@30..32 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@32..35 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@32..35 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@35..36 "2" [] [],
                 },
@@ -55,7 +55,7 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@37..39 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: TYPEOF_KW@39..46 "typeof" [] [Whitespace(" ")],
+                        operator_token: TYPEOF_KW@39..46 "typeof" [] [Whitespace(" ")],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@46..51 "ident" [] [],
@@ -64,7 +64,7 @@ JsModule {
                     },
                     r_paren_token: R_PAREN@51..53 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@53..56 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@53..56 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@56..57 "2" [] [],
                 },
@@ -76,14 +76,14 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@58..60 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: MINUS@60..61 "-" [] [],
+                        operator_token: MINUS@60..61 "-" [] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@61..62 "3" [] [],
                         },
                     },
                     r_paren_token: R_PAREN@62..64 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@64..67 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@64..67 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@67..68 "2" [] [],
                 },
@@ -95,14 +95,14 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@69..71 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: PLUS@71..72 "+" [] [],
+                        operator_token: PLUS@71..72 "+" [] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@72..73 "3" [] [],
                         },
                     },
                     r_paren_token: R_PAREN@73..75 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@75..78 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@75..78 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@78..79 "2" [] [],
                 },
@@ -114,14 +114,14 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@80..82 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: TILDE@82..83 "~" [] [],
+                        operator_token: TILDE@82..83 "~" [] [],
                         argument: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@83..84 "3" [] [],
                         },
                     },
                     r_paren_token: R_PAREN@84..86 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@86..89 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@86..89 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@89..90 "2" [] [],
                 },
@@ -133,14 +133,14 @@ JsModule {
                 left: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@91..93 "(" [Newline("\n")] [],
                     expression: JsUnaryExpression {
-                        operator: BANG@93..94 "!" [] [],
+                        operator_token: BANG@93..94 "!" [] [],
                         argument: JsBooleanLiteralExpression {
                             value_token: TRUE_KW@94..98 "true" [] [],
                         },
                     },
                     r_paren_token: R_PAREN@98..100 ")" [] [Whitespace(" ")],
                 },
-                operator: STAR2@100..103 "**" [] [Whitespace(" ")],
+                operator_token: STAR2@100..103 "**" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@103..104 "2" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/for_stmt.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/for_stmt.rast
@@ -29,7 +29,7 @@ JsModule {
                         value_token: IDENT@16..18 "i" [] [Whitespace(" ")],
                     },
                 },
-                operator: L_ANGLE@18..20 "<" [] [Whitespace(" ")],
+                operator_token: L_ANGLE@18..20 "<" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@20..22 "10" [] [],
                 },
@@ -39,7 +39,7 @@ JsModule {
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@24..25 "i" [] [],
                 },
-                operator: PLUS2@25..27 "++" [] [],
+                operator_token: PLUS2@25..27 "++" [] [],
             },
             r_paren_token: R_PAREN@27..29 ")" [] [Whitespace(" ")],
             body: JsBlockStatement {
@@ -192,7 +192,7 @@ JsModule {
                         value_token: IDENT@141..143 "i" [] [Whitespace(" ")],
                     },
                 },
-                operator: L_ANGLE@143..145 "<" [] [Whitespace(" ")],
+                operator_token: L_ANGLE@143..145 "<" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@145..146 "j" [] [],
@@ -201,7 +201,7 @@ JsModule {
             },
             second_semi_token: SEMICOLON@146..148 ";" [] [Whitespace(" ")],
             update: JsPreUpdateExpression {
-                operator: PLUS2@148..150 "++" [] [],
+                operator_token: PLUS2@148..150 "++" [] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@150..151 "j" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/getter_class_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/getter_class_member.rast
@@ -90,7 +90,7 @@ JsModule {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@95..99 "\"a\"" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@99..101 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@99..101 "+" [] [Whitespace(" ")],
                             right: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@101..104 "\"b\"" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/getter_object_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/getter_object_member.rast
@@ -74,7 +74,7 @@ JsModule {
                                                 left: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@91..95 "\"a\"" [] [Whitespace(" ")],
                                                 },
-                                                operator: PLUS@95..97 "+" [] [Whitespace(" ")],
+                                                operator_token: PLUS@95..97 "+" [] [Whitespace(" ")],
                                                 right: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@97..100 "\"b\"" [] [],
                                                 },
@@ -94,7 +94,7 @@ JsModule {
                                                         left: JsStringLiteralExpression {
                                                             value_token: JS_STRING_LITERAL@117..121 "\"a\"" [] [Whitespace(" ")],
                                                         },
-                                                        operator: PLUS@121..123 "+" [] [Whitespace(" ")],
+                                                        operator_token: PLUS@121..123 "+" [] [Whitespace(" ")],
                                                         right: JsStringLiteralExpression {
                                                             value_token: JS_STRING_LITERAL@123..126 "\"b\"" [] [],
                                                         },

--- a/crates/rome_js_parser/test_data/inline/ok/js_unary_expressions.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/js_unary_expressions.rast
@@ -4,7 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
+                operator_token: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
@@ -23,7 +23,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: VOID_KW@17..23 "void" [Newline("\n")] [Whitespace(" ")],
+                operator_token: VOID_KW@17..23 "void" [Newline("\n")] [Whitespace(" ")],
                 argument: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@23..24 "a" [] [],
@@ -34,7 +34,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: TYPEOF_KW@25..33 "typeof" [Newline("\n")] [Whitespace(" ")],
+                operator_token: TYPEOF_KW@25..33 "typeof" [Newline("\n")] [Whitespace(" ")],
                 argument: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@33..34 "a" [] [],
@@ -45,7 +45,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: PLUS@35..37 "+" [Newline("\n")] [],
+                operator_token: PLUS@35..37 "+" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@37..38 "1" [] [],
                 },
@@ -54,7 +54,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: MINUS@39..41 "-" [Newline("\n")] [],
+                operator_token: MINUS@39..41 "-" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@41..42 "1" [] [],
                 },
@@ -63,7 +63,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: TILDE@43..45 "~" [Newline("\n")] [],
+                operator_token: TILDE@43..45 "~" [Newline("\n")] [],
                 argument: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@45..46 "1" [] [],
                 },
@@ -72,7 +72,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: BANG@47..49 "!" [Newline("\n")] [],
+                operator_token: BANG@47..49 "!" [Newline("\n")] [],
                 argument: JsBooleanLiteralExpression {
                     value_token: TRUE_KW@49..53 "true" [] [],
                 },
@@ -83,16 +83,16 @@ JsModule {
             expression: JsBinaryExpression {
                 left: JsBinaryExpression {
                     left: JsUnaryExpression {
-                        operator: MINUS@54..56 "-" [Newline("\n")] [],
+                        operator_token: MINUS@54..56 "-" [Newline("\n")] [],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@56..58 "a" [] [Whitespace(" ")],
                             },
                         },
                     },
-                    operator: PLUS@58..60 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@58..60 "+" [] [Whitespace(" ")],
                     right: JsUnaryExpression {
-                        operator: MINUS@60..61 "-" [] [],
+                        operator_token: MINUS@60..61 "-" [] [],
                         argument: JsIdentifierExpression {
                             name: JsReferenceIdentifier {
                                 value_token: IDENT@61..63 "b" [] [Whitespace(" ")],
@@ -100,9 +100,9 @@ JsModule {
                         },
                     },
                 },
-                operator: PLUS@63..65 "+" [] [Whitespace(" ")],
+                operator_token: PLUS@63..65 "+" [] [Whitespace(" ")],
                 right: JsUnaryExpression {
-                    operator: PLUS@65..66 "+" [] [],
+                    operator_token: PLUS@65..66 "+" [] [],
                     argument: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@66..67 "a" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/jsx_children_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/jsx_children_expression.rast
@@ -213,7 +213,7 @@ JsModule {
                                                 value_token: IDENT@144..151 "console" [] [],
                                             },
                                         },
-                                        operator: DOT@151..152 "." [] [],
+                                        operator_token: DOT@151..152 "." [] [],
                                         member: JsName {
                                             value_token: IDENT@152..155 "log" [] [],
                                         },
@@ -275,7 +275,7 @@ JsModule {
                                 left: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@185..187 "1" [] [Whitespace(" ")],
                                 },
-                                operator: PLUS@187..189 "+" [] [Whitespace(" ")],
+                                operator_token: PLUS@187..189 "+" [] [Whitespace(" ")],
                                 right: JsNumberLiteralExpression {
                                     value_token: JS_NUMBER_LITERAL@189..190 "1" [] [],
                                 },
@@ -483,7 +483,7 @@ JsModule {
                                         value_token: IDENT@323..325 "a" [] [Whitespace(" ")],
                                     },
                                 },
-                                operator: AMP2@325..328 "&&" [] [Whitespace(" ")],
+                                operator_token: AMP2@325..328 "&&" [] [Whitespace(" ")],
                                 right: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@328..329 "b" [] [],
@@ -550,7 +550,7 @@ JsModule {
                                 operand: JsIdentifierAssignment {
                                     name_token: IDENT@361..362 "a" [] [],
                                 },
-                                operator: PLUS2@362..364 "++" [] [],
+                                operator_token: PLUS2@362..364 "++" [] [],
                             },
                             r_curly_token: R_CURLY@364..365 "}" [] [],
                         },
@@ -560,7 +560,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@368..369 "{" [] [],
                             expression: JsPreUpdateExpression {
-                                operator: PLUS2@369..371 "++" [] [],
+                                operator_token: PLUS2@369..371 "++" [] [],
                                 operand: JsIdentifierAssignment {
                                     name_token: IDENT@371..372 "a" [] [],
                                 },
@@ -598,7 +598,7 @@ JsModule {
                                         value_token: IDENT@385..386 "a" [] [],
                                     },
                                 },
-                                operator: DOT@386..387 "." [] [],
+                                operator_token: DOT@386..387 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@387..388 "b" [] [],
                                 },
@@ -615,7 +615,7 @@ JsModule {
                                     object: JsSuperExpression {
                                         super_token: SUPER_KW@393..398 "super" [] [],
                                     },
-                                    operator: DOT@398..399 "." [] [],
+                                    operator_token: DOT@398..399 "." [] [],
                                     member: JsName {
                                         value_token: IDENT@399..400 "a" [] [],
                                     },
@@ -646,14 +646,14 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@415..416 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: DELETE_KW@416..423 "delete" [] [Whitespace(" ")],
+                                operator_token: DELETE_KW@416..423 "delete" [] [Whitespace(" ")],
                                 argument: JsStaticMemberExpression {
                                     object: JsIdentifierExpression {
                                         name: JsReferenceIdentifier {
                                             value_token: IDENT@423..424 "a" [] [],
                                         },
                                     },
-                                    operator: DOT@424..425 "." [] [],
+                                    operator_token: DOT@424..425 "." [] [],
                                     member: JsName {
                                         value_token: IDENT@425..426 "a" [] [],
                                     },
@@ -667,7 +667,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@430..431 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: VOID_KW@431..436 "void" [] [Whitespace(" ")],
+                                operator_token: VOID_KW@431..436 "void" [] [Whitespace(" ")],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@436..437 "a" [] [],
@@ -682,7 +682,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@441..442 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: TYPEOF_KW@442..449 "typeof" [] [Whitespace(" ")],
+                                operator_token: TYPEOF_KW@442..449 "typeof" [] [Whitespace(" ")],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@449..450 "a" [] [],
@@ -697,7 +697,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@454..455 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: PLUS@455..456 "+" [] [],
+                                operator_token: PLUS@455..456 "+" [] [],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@456..457 "a" [] [],
@@ -712,7 +712,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@461..462 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: MINUS@462..463 "-" [] [],
+                                operator_token: MINUS@462..463 "-" [] [],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@463..464 "a" [] [],
@@ -727,7 +727,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@468..469 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: BANG@469..470 "!" [] [],
+                                operator_token: BANG@469..470 "!" [] [],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@470..471 "a" [] [],
@@ -742,7 +742,7 @@ JsModule {
                         JsxExpressionChild {
                             l_curly_token: L_CURLY@475..476 "{" [] [],
                             expression: JsUnaryExpression {
-                                operator: TILDE@476..477 "~" [] [],
+                                operator_token: TILDE@476..477 "~" [] [],
                                 argument: JsIdentifierExpression {
                                     name: JsReferenceIdentifier {
                                         value_token: IDENT@477..478 "a" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/jsx_primary_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/jsx_primary_expression.rast
@@ -40,7 +40,7 @@ JsModule {
                                         },
                                     },
                                 },
-                                operator: DOT@25..26 "." [] [],
+                                operator_token: DOT@25..26 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@26..27 "c" [] [],
                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/logical_expressions.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/logical_expressions.rast
@@ -9,7 +9,7 @@ JsModule {
                         value_token: IDENT@0..4 "foo" [] [Whitespace(" ")],
                     },
                 },
-                operator: QUESTION2@4..7 "??" [] [Whitespace(" ")],
+                operator_token: QUESTION2@4..7 "??" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@7..10 "bar" [] [],
@@ -25,7 +25,7 @@ JsModule {
                         value_token: IDENT@10..13 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: PIPE2@13..16 "||" [] [Whitespace(" ")],
+                operator_token: PIPE2@13..16 "||" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@16..17 "b" [] [],
@@ -41,7 +41,7 @@ JsModule {
                         value_token: IDENT@17..20 "a" [Newline("\n")] [Whitespace(" ")],
                     },
                 },
-                operator: AMP2@20..23 "&&" [] [Whitespace(" ")],
+                operator_token: AMP2@20..23 "&&" [] [Whitespace(" ")],
                 right: JsIdentifierExpression {
                     name: JsReferenceIdentifier {
                         value_token: IDENT@23..24 "b" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/method_class_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/method_class_member.rast
@@ -133,7 +133,7 @@ JsModule {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@128..134 "\"foo\"" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@134..136 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@134..136 "+" [] [Whitespace(" ")],
                             right: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@136..141 "\"bar\"" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/new_exprs.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/new_exprs.rast
@@ -100,7 +100,7 @@ JsModule {
                             left: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@71..73 "6" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@73..75 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@73..75 "+" [] [Whitespace(" ")],
                             right: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@75..76 "6" [] [],
                             },
@@ -122,7 +122,7 @@ JsModule {
                                 },
                                 r_brack_token: R_BRACK@85..87 "]" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@87..89 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@87..89 "+" [] [Whitespace(" ")],
                             right: JsBinaryExpression {
                                 left: JsParenthesizedExpression {
                                     l_paren_token: L_PAREN@89..90 "(" [] [],
@@ -154,14 +154,14 @@ JsModule {
                                     },
                                     r_paren_token: R_PAREN@101..103 ")" [] [Whitespace(" ")],
                                 },
-                                operator: STAR@103..105 "*" [] [Whitespace(" ")],
+                                operator_token: STAR@103..105 "*" [] [Whitespace(" ")],
                                 right: JsStaticMemberExpression {
                                     object: JsIdentifierExpression {
                                         name: JsReferenceIdentifier {
                                             value_token: IDENT@105..108 "foo" [] [],
                                         },
                                     },
-                                    operator: QUESTIONDOT@108..110 "?." [] [],
+                                    operator_token: QUESTIONDOT@108..110 "?." [] [],
                                     member: JsName {
                                         value_token: IDENT@110..113 "bar" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/ok/object_expr_method.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/object_expr_method.rast
@@ -94,7 +94,7 @@ JsModule {
                                                 left: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@46..52 "\"foo\"" [] [Whitespace(" ")],
                                                 },
-                                                operator: PLUS@52..54 "+" [] [Whitespace(" ")],
+                                                operator_token: PLUS@52..54 "+" [] [Whitespace(" ")],
                                                 right: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@54..59 "\"bar\"" [] [],
                                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/object_member_name.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/object_member_name.rast
@@ -35,7 +35,7 @@ JsModule {
                                                 left: JsNumberLiteralExpression {
                                                     value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
                                                 },
-                                                operator: PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                operator_token: PLUS@24..26 "+" [] [Whitespace(" ")],
                                                 right: JsNumberLiteralExpression {
                                                     value_token: JS_NUMBER_LITERAL@26..27 "6" [] [],
                                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/object_prop_name.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/object_prop_name.rast
@@ -35,7 +35,7 @@ JsModule {
                                                 left: JsNumberLiteralExpression {
                                                     value_token: JS_NUMBER_LITERAL@22..24 "6" [] [Whitespace(" ")],
                                                 },
-                                                operator: PLUS@24..26 "+" [] [Whitespace(" ")],
+                                                operator_token: PLUS@24..26 "+" [] [Whitespace(" ")],
                                                 right: JsNumberLiteralExpression {
                                                     value_token: JS_NUMBER_LITERAL@26..27 "6" [] [],
                                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/paren_or_arrow_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/paren_or_arrow_expr.rast
@@ -50,7 +50,7 @@ JsModule {
                     left: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@21..23 "5" [] [Whitespace(" ")],
                     },
-                    operator: PLUS@23..25 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@23..25 "+" [] [Whitespace(" ")],
                     right: JsNumberLiteralExpression {
                         value_token: JS_NUMBER_LITERAL@25..26 "5" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/post_update_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/post_update_expr.rast
@@ -7,7 +7,7 @@ JsModule {
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@0..3 "foo" [] [],
                 },
-                operator: PLUS2@3..5 "++" [] [],
+                operator_token: PLUS2@3..5 "++" [] [],
             },
             semicolon_token: missing (optional),
         },
@@ -16,7 +16,7 @@ JsModule {
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@5..9 "foo" [Newline("\n")] [],
                 },
-                operator: MINUS2@9..11 "--" [] [],
+                operator_token: MINUS2@9..11 "--" [] [],
             },
             semicolon_token: missing (optional),
         },

--- a/crates/rome_js_parser/test_data/inline/ok/postfix_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/postfix_expr.rast
@@ -7,7 +7,7 @@ JsModule {
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@0..3 "foo" [] [],
                 },
-                operator: PLUS2@3..5 "++" [] [],
+                operator_token: PLUS2@3..5 "++" [] [],
             },
             semicolon_token: missing (optional),
         },
@@ -16,7 +16,7 @@ JsModule {
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@5..9 "foo" [Newline("\n")] [],
                 },
-                operator: MINUS2@9..11 "--" [] [],
+                operator_token: MINUS2@9..11 "--" [] [],
             },
             semicolon_token: missing (optional),
         },

--- a/crates/rome_js_parser/test_data/inline/ok/pre_update_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/pre_update_expr.rast
@@ -4,7 +4,7 @@ JsModule {
     items: JsModuleItemList [
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: PLUS2@0..2 "++" [] [],
+                operator_token: PLUS2@0..2 "++" [] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@2..5 "foo" [] [],
                 },
@@ -13,7 +13,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsPreUpdateExpression {
-                operator: MINUS2@5..8 "--" [Newline("\n")] [],
+                operator_token: MINUS2@5..8 "--" [Newline("\n")] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@8..11 "foo" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/property_assignment_target.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/property_assignment_target.rast
@@ -80,7 +80,7 @@ JsModule {
                                                     value_token: IDENT@30..31 "y" [] [],
                                                 },
                                             },
-                                            operator: DOT@31..32 "." [] [],
+                                            operator_token: DOT@31..32 "." [] [],
                                             member: JsName {
                                                 value_token: IDENT@32..36 "test" [] [],
                                             },

--- a/crates/rome_js_parser/test_data/inline/ok/property_class_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/property_class_member.rast
@@ -71,7 +71,7 @@ JsModule {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@76..80 "\"a\"" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@80..82 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@80..82 "+" [] [Whitespace(" ")],
                             right: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@82..85 "\"b\"" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/rest_property_assignment_target.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/rest_property_assignment_target.rast
@@ -159,7 +159,7 @@ JsModule {
                                                     value_token: IDENT@91..94 "any" [] [],
                                                 },
                                             },
-                                            operator: DOT@94..95 "." [] [],
+                                            operator_token: DOT@94..95 "." [] [],
                                             member: JsName {
                                                 value_token: IDENT@95..105 "expression" [] [],
                                             },

--- a/crates/rome_js_parser/test_data/inline/ok/setter_class_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/setter_class_member.rast
@@ -118,7 +118,7 @@ JsModule {
                             left: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@99..103 "\"a\"" [] [Whitespace(" ")],
                             },
-                            operator: PLUS@103..105 "+" [] [Whitespace(" ")],
+                            operator_token: PLUS@103..105 "+" [] [Whitespace(" ")],
                             right: JsStringLiteralExpression {
                                 value_token: JS_STRING_LITERAL@105..108 "\"b\"" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/setter_object_member.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/setter_object_member.rast
@@ -70,7 +70,7 @@ JsModule {
                                                 left: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@62..66 "\"a\"" [] [Whitespace(" ")],
                                                 },
-                                                operator: PLUS@66..68 "+" [] [Whitespace(" ")],
+                                                operator_token: PLUS@66..68 "+" [] [Whitespace(" ")],
                                                 right: JsStringLiteralExpression {
                                                     value_token: JS_STRING_LITERAL@68..71 "\"b\"" [] [],
                                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/static_member_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/static_member_expression.rast
@@ -9,7 +9,7 @@ JsModule {
                         value_token: IDENT@0..3 "foo" [] [],
                     },
                 },
-                operator: DOT@3..4 "." [] [],
+                operator_token: DOT@3..4 "." [] [],
                 member: JsName {
                     value_token: IDENT@4..7 "bar" [] [],
                 },
@@ -23,7 +23,7 @@ JsModule {
                         value_token: IDENT@7..11 "foo" [Newline("\n")] [],
                     },
                 },
-                operator: DOT@11..12 "." [] [],
+                operator_token: DOT@11..12 "." [] [],
                 member: JsName {
                     value_token: IDENT@12..17 "await" [] [],
                 },
@@ -37,7 +37,7 @@ JsModule {
                         value_token: IDENT@17..21 "foo" [Newline("\n")] [],
                     },
                 },
-                operator: DOT@21..22 "." [] [],
+                operator_token: DOT@21..22 "." [] [],
                 member: JsName {
                     value_token: IDENT@22..27 "yield" [] [],
                 },
@@ -51,7 +51,7 @@ JsModule {
                         value_token: IDENT@27..31 "foo" [Newline("\n")] [],
                     },
                 },
-                operator: DOT@31..32 "." [] [],
+                operator_token: DOT@31..32 "." [] [],
                 member: JsName {
                     value_token: IDENT@32..35 "for" [] [],
                 },
@@ -65,7 +65,7 @@ JsModule {
                         value_token: IDENT@35..39 "foo" [Newline("\n")] [],
                     },
                 },
-                operator: QUESTIONDOT@39..41 "?." [] [],
+                operator_token: QUESTIONDOT@39..41 "?." [] [],
                 member: JsName {
                     value_token: IDENT@41..44 "for" [] [],
                 },
@@ -79,7 +79,7 @@ JsModule {
                         value_token: IDENT@44..48 "foo" [Newline("\n")] [],
                     },
                 },
-                operator: QUESTIONDOT@48..50 "?." [] [],
+                operator_token: QUESTIONDOT@48..50 "?." [] [],
                 member: JsName {
                     value_token: IDENT@50..53 "bar" [] [],
                 },
@@ -140,7 +140,7 @@ JsModule {
                                     object: JsThisExpression {
                                         this_token: THIS_KW@89..98 "this" [Newline("\n"), Whitespace("    ")] [],
                                     },
-                                    operator: DOT@98..99 "." [] [],
+                                    operator_token: DOT@98..99 "." [] [],
                                     member: JsPrivateName {
                                         hash_token: HASH@99..100 "#" [] [],
                                         value_token: IDENT@100..103 "bar" [] [],
@@ -153,7 +153,7 @@ JsModule {
                                     object: JsThisExpression {
                                         this_token: THIS_KW@104..113 "this" [Newline("\n"), Whitespace("    ")] [],
                                     },
-                                    operator: QUESTIONDOT@113..115 "?." [] [],
+                                    operator_token: QUESTIONDOT@113..115 "?." [] [],
                                     member: JsPrivateName {
                                         hash_token: HASH@115..116 "#" [] [],
                                         value_token: IDENT@116..119 "bar" [] [],
@@ -168,7 +168,7 @@ JsModule {
                                             value_token: IDENT@120..130 "other" [Newline("\n"), Whitespace("    ")] [],
                                         },
                                     },
-                                    operator: DOT@130..131 "." [] [],
+                                    operator_token: DOT@130..131 "." [] [],
                                     member: JsPrivateName {
                                         hash_token: HASH@131..132 "#" [] [],
                                         value_token: IDENT@132..135 "bar" [] [],
@@ -183,7 +183,7 @@ JsModule {
                                             value_token: IDENT@136..146 "other" [Newline("\n"), Whitespace("    ")] [],
                                         },
                                     },
-                                    operator: QUESTIONDOT@146..148 "?." [] [],
+                                    operator_token: QUESTIONDOT@146..148 "?." [] [],
                                     member: JsPrivateName {
                                         hash_token: HASH@148..149 "#" [] [],
                                         value_token: IDENT@149..152 "bar" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/super_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/super_expression.rast
@@ -79,7 +79,7 @@ JsModule {
                                         object: JsSuperExpression {
                                             super_token: SUPER_KW@68..78 "super" [Newline("\n"), Whitespace("    ")] [],
                                         },
-                                        operator: DOT@78..79 "." [] [],
+                                        operator_token: DOT@78..79 "." [] [],
                                         member: JsName {
                                             value_token: IDENT@79..83 "test" [] [],
                                         },

--- a/crates/rome_js_parser/test_data/inline/ok/this_expr.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/this_expr.rast
@@ -13,7 +13,7 @@ JsModule {
                 object: JsThisExpression {
                     this_token: THIS_KW@4..9 "this" [Newline("\n")] [],
                 },
-                operator: DOT@9..10 "." [] [],
+                operator_token: DOT@9..10 "." [] [],
                 member: JsName {
                     value_token: IDENT@10..13 "foo" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_abstract_classes.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_abstract_classes.rast
@@ -124,7 +124,7 @@ JsModule {
                                                 value_token: IDENT@145..152 "console" [] [],
                                             },
                                         },
-                                        operator: DOT@152..153 "." [] [],
+                                        operator_token: DOT@152..153 "." [] [],
                                         member: JsName {
                                             value_token: IDENT@153..156 "log" [] [],
                                         },
@@ -138,7 +138,7 @@ JsModule {
                                                 object: JsThisExpression {
                                                     this_token: THIS_KW@157..161 "this" [] [],
                                                 },
-                                                operator: DOT@161..162 "." [] [],
+                                                operator_token: DOT@161..162 "." [] [],
                                                 member: JsName {
                                                     value_token: IDENT@162..166 "name" [] [],
                                                 },
@@ -176,7 +176,7 @@ JsModule {
                                     object: JsThisExpression {
                                         this_token: THIS_KW@205..209 "this" [] [],
                                     },
-                                    operator: DOT@209..210 "." [] [],
+                                    operator_token: DOT@209..210 "." [] [],
                                     member: JsName {
                                         value_token: IDENT@210..214 "name" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_as_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_as_expression.rast
@@ -142,7 +142,7 @@ JsModule {
                                                 type_arguments: missing (optional),
                                             },
                                         },
-                                        operator: PLUS@131..133 "+" [] [Whitespace(" ")],
+                                        operator_token: PLUS@131..133 "+" [] [Whitespace(" ")],
                                         right: JsNumberLiteralExpression {
                                             value_token: JS_NUMBER_LITERAL@133..135 "3" [] [Whitespace(" ")],
                                         },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_call_expr_with_type_arguments.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_call_expr_with_type_arguments.rast
@@ -128,7 +128,7 @@ JsModule {
                                 },
                                 r_paren_token: R_PAREN@51..52 ")" [] [],
                             },
-                            operator: DOT@52..53 "." [] [],
+                            operator_token: DOT@52..53 "." [] [],
                             member: JsName {
                                 value_token: IDENT@53..54 "a" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_identifier.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_identifier.rast
@@ -106,12 +106,12 @@ JsModule {
                         left: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@94..96 "4" [] [Whitespace(" ")],
                         },
-                        operator: PLUS@96..98 "+" [] [Whitespace(" ")],
+                        operator_token: PLUS@96..98 "+" [] [Whitespace(" ")],
                         right: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@98..100 "3" [] [Whitespace(" ")],
                         },
                     },
-                    operator: PLUS@100..102 "+" [] [Whitespace(" ")],
+                    operator_token: PLUS@100..102 "+" [] [Whitespace(" ")],
                     right: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@102..103 "a" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_qualified_name.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_export_assignment_qualified_name.rast
@@ -52,7 +52,7 @@ JsModule {
                             value_token: IDENT@40..41 "a" [] [],
                         },
                     },
-                    operator: DOT@41..42 "." [] [],
+                    operator_token: DOT@41..42 "." [] [],
                     member: JsName {
                         value_token: IDENT@42..43 "b" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_global_variable.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_global_variable.rast
@@ -33,7 +33,7 @@ JsModule {
                             value_token: IDENT@46..54 "console" [Newline("\n")] [],
                         },
                     },
-                    operator: DOT@54..55 "." [] [],
+                    operator_token: DOT@54..55 "." [] [],
                     member: JsName {
                         value_token: IDENT@55..58 "log" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_non_null_assertion_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_non_null_assertion_expression.rast
@@ -97,12 +97,12 @@ JsModule {
                                 value_token: IDENT@49..52 "a" [Newline("\n"), Whitespace("\t")] [],
                             },
                         },
-                        operator: DOT@52..53 "." [] [],
+                        operator_token: DOT@52..53 "." [] [],
                         member: JsName {
                             value_token: IDENT@53..54 "b" [] [],
                         },
                     },
-                    operator: DOT@54..55 "." [] [],
+                    operator_token: DOT@54..55 "." [] [],
                     member: JsName {
                         value_token: IDENT@55..56 "c" [] [],
                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_return_type_annotation.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_return_type_annotation.rast
@@ -187,14 +187,14 @@ JsModule {
                                                     return_token: RETURN_KW@128..135 "return" [] [Whitespace(" ")],
                                                     argument: JsBinaryExpression {
                                                         left: JsUnaryExpression {
-                                                            operator: TYPEOF_KW@135..142 "typeof" [] [Whitespace(" ")],
+                                                            operator_token: TYPEOF_KW@135..142 "typeof" [] [Whitespace(" ")],
                                                             argument: JsIdentifierExpression {
                                                                 name: JsReferenceIdentifier {
                                                                     value_token: IDENT@142..144 "x" [] [Whitespace(" ")],
                                                                 },
                                                             },
                                                         },
-                                                        operator: EQ3@144..148 "===" [] [Whitespace(" ")],
+                                                        operator_token: EQ3@144..148 "===" [] [Whitespace(" ")],
                                                         right: JsStringLiteralExpression {
                                                             value_token: JS_STRING_LITERAL@148..157 "\"string\"" [] [Whitespace(" ")],
                                                         },
@@ -268,14 +268,14 @@ JsModule {
                                 return_token: RETURN_KW@194..201 "return" [] [Whitespace(" ")],
                                 argument: JsBinaryExpression {
                                     left: JsUnaryExpression {
-                                        operator: TYPEOF_KW@201..208 "typeof" [] [Whitespace(" ")],
+                                        operator_token: TYPEOF_KW@201..208 "typeof" [] [Whitespace(" ")],
                                         argument: JsIdentifierExpression {
                                             name: JsReferenceIdentifier {
                                                 value_token: IDENT@208..210 "x" [] [Whitespace(" ")],
                                             },
                                         },
                                     },
-                                    operator: EQ3@210..214 "===" [] [Whitespace(" ")],
+                                    operator_token: EQ3@210..214 "===" [] [Whitespace(" ")],
                                     right: JsStringLiteralExpression {
                                         value_token: JS_STRING_LITERAL@214..222 "\"string\"" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_tagged_template_literal.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_tagged_template_literal.rast
@@ -73,7 +73,7 @@ JsModule {
                     ],
                     r_tick_token: BACKTICK@32..33 "`" [] [],
                 },
-                operator: DOT@33..34 "." [] [],
+                operator_token: DOT@33..34 "." [] [],
                 member: JsName {
                     value_token: IDENT@34..41 "_string" [] [],
                 },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_this_type.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_this_type.rast
@@ -82,12 +82,12 @@ JsModule {
                                 return_token: RETURN_KW@87..103 "return" [Newline("\n"), Whitespace("        ")] [Whitespace(" ")],
                                 argument: JsBinaryExpression {
                                     left: JsUnaryExpression {
-                                        operator: TYPEOF_KW@103..110 "typeof" [] [Whitespace(" ")],
+                                        operator_token: TYPEOF_KW@103..110 "typeof" [] [Whitespace(" ")],
                                         argument: JsThisExpression {
                                             this_token: THIS_KW@110..115 "this" [] [Whitespace(" ")],
                                         },
                                     },
-                                    operator: EQ3@115..119 "===" [] [Whitespace(" ")],
+                                    operator_token: EQ3@115..119 "===" [] [Whitespace(" ")],
                                     right: JsStringLiteralExpression {
                                         value_token: JS_STRING_LITERAL@119..127 "\"string\"" [] [],
                                     },

--- a/crates/rome_js_parser/test_data/inline/ok/ts_type_variable_annotation.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_type_variable_annotation.rast
@@ -60,7 +60,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: BANG@48..50 "!" [Newline("\n")] [],
+                operator_token: BANG@48..50 "!" [Newline("\n")] [],
                 argument: JsFunctionExpression {
                     async_token: missing (optional),
                     function_token: FUNCTION_KW@50..59 "function" [] [Whitespace(" ")],

--- a/crates/rome_js_parser/test_data/inline/ok/type_arguments_like_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/type_arguments_like_expression.rast
@@ -14,12 +14,12 @@ JsModule {
                             },
                             r_paren_token: R_PAREN@3..4 ")" [] [],
                         },
-                        operator: L_ANGLE@4..5 "<" [] [],
+                        operator_token: L_ANGLE@4..5 "<" [] [],
                         right: JsNumberLiteralExpression {
                             value_token: JS_NUMBER_LITERAL@5..6 "5" [] [],
                         },
                     },
-                    operator: R_ANGLE@6..7 ">" [] [],
+                    operator_token: R_ANGLE@6..7 ">" [] [],
                     right: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@7..8 "(" [] [],
                         expression: JsNumberLiteralExpression {

--- a/crates/rome_js_parser/test_data/inline/ok/type_arguments_no_recovery.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/type_arguments_no_recovery.rast
@@ -29,14 +29,14 @@ JsModule {
                         value_token: IDENT@17..19 "i" [] [Whitespace(" ")],
                     },
                 },
-                operator: L_ANGLE@19..21 "<" [] [Whitespace(" ")],
+                operator_token: L_ANGLE@19..21 "<" [] [Whitespace(" ")],
                 right: JsNumberLiteralExpression {
                     value_token: JS_NUMBER_LITERAL@21..22 "3" [] [],
                 },
             },
             second_semi_token: SEMICOLON@22..24 ";" [] [Whitespace(" ")],
             update: JsPreUpdateExpression {
-                operator: PLUS2@24..26 "++" [] [],
+                operator_token: PLUS2@24..26 "++" [] [],
                 operand: JsIdentifierAssignment {
                     name_token: IDENT@26..27 "i" [] [],
                 },
@@ -53,7 +53,7 @@ JsModule {
                                         value_token: IDENT@30..41 "verify" [Newline("\n"), Whitespace("    ")] [],
                                     },
                                 },
-                                operator: DOT@41..42 "." [] [],
+                                operator_token: DOT@41..42 "." [] [],
                                 member: JsName {
                                     value_token: IDENT@42..53 "completions" [] [],
                                 },
@@ -84,7 +84,7 @@ JsModule {
                                                                         value_token: IDENT@75..77 "i" [] [Whitespace(" ")],
                                                                     },
                                                                 },
-                                                                operator: PLUS@77..79 "+" [] [Whitespace(" ")],
+                                                                operator_token: PLUS@77..79 "+" [] [Whitespace(" ")],
                                                                 right: JsNumberLiteralExpression {
                                                                     value_token: JS_NUMBER_LITERAL@79..80 "1" [] [],
                                                                 },
@@ -130,7 +130,7 @@ JsModule {
                                                                                         value_token: IDENT@145..149 "test" [] [],
                                                                                     },
                                                                                 },
-                                                                                operator: DOT@149..150 "." [] [],
+                                                                                operator_token: DOT@149..150 "." [] [],
                                                                                 member: JsName {
                                                                                     value_token: IDENT@150..156 "ranges" [] [],
                                                                                 },
@@ -183,7 +183,7 @@ JsModule {
                                                                                         value_token: IDENT@209..213 "test" [] [],
                                                                                     },
                                                                                 },
-                                                                                operator: DOT@213..214 "." [] [],
+                                                                                operator_token: DOT@213..214 "." [] [],
                                                                                 member: JsName {
                                                                                     value_token: IDENT@214..220 "ranges" [] [],
                                                                                 },

--- a/crates/rome_js_parser/test_data/inline/ok/typescript_enum.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/typescript_enum.rast
@@ -75,7 +75,7 @@ JsModule {
                                     value_token: IDENT@55..57 "A" [] [Whitespace(" ")],
                                 },
                             },
-                            operator: STAR@57..59 "*" [] [Whitespace(" ")],
+                            operator_token: STAR@57..59 "*" [] [Whitespace(" ")],
                             right: JsNumberLiteralExpression {
                                 value_token: JS_NUMBER_LITERAL@59..60 "2" [] [],
                             },

--- a/crates/rome_js_parser/test_data/inline/ok/unary_delete.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/unary_delete.rast
@@ -4,14 +4,14 @@ JsModule {
     items: JsModuleItemList [
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
+                operator_token: DELETE_KW@0..7 "delete" [] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
                             value_token: IDENT@7..10 "obj" [] [],
                         },
                     },
-                    operator: DOT@10..11 "." [] [],
+                    operator_token: DOT@10..11 "." [] [],
                     member: JsName {
                         value_token: IDENT@11..14 "key" [] [],
                     },
@@ -21,7 +21,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@15..23 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@15..23 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@23..24 "(" [] [],
@@ -32,7 +32,7 @@ JsModule {
                         },
                         r_paren_token: R_PAREN@27..28 ")" [] [],
                     },
-                    operator: DOT@28..29 "." [] [],
+                    operator_token: DOT@28..29 "." [] [],
                     member: JsName {
                         value_token: IDENT@29..32 "key" [] [],
                     },
@@ -42,7 +42,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@33..41 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@33..41 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsIdentifierExpression {
@@ -50,13 +50,13 @@ JsModule {
                                 value_token: IDENT@41..44 "obj" [] [],
                             },
                         },
-                        operator: DOT@44..45 "." [] [],
+                        operator_token: DOT@44..45 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@45..46 "#" [] [],
                             value_token: IDENT@46..52 "member" [] [],
                         },
                     },
-                    operator: DOT@52..53 "." [] [],
+                    operator_token: DOT@52..53 "." [] [],
                     member: JsName {
                         value_token: IDENT@53..56 "key" [] [],
                     },
@@ -66,7 +66,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@57..65 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@57..65 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@65..66 "(" [] [],
@@ -76,7 +76,7 @@ JsModule {
                                     value_token: IDENT@66..69 "obj" [] [],
                                 },
                             },
-                            operator: DOT@69..70 "." [] [],
+                            operator_token: DOT@69..70 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@70..71 "#" [] [],
                                 value_token: IDENT@71..77 "member" [] [],
@@ -84,7 +84,7 @@ JsModule {
                         },
                         r_paren_token: R_PAREN@77..78 ")" [] [],
                     },
-                    operator: DOT@78..79 "." [] [],
+                    operator_token: DOT@78..79 "." [] [],
                     member: JsName {
                         value_token: IDENT@79..82 "key" [] [],
                     },
@@ -94,7 +94,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@83..91 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@83..91 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsCallExpression {
@@ -111,13 +111,13 @@ JsModule {
                                 r_paren_token: R_PAREN@96..97 ")" [] [],
                             },
                         },
-                        operator: DOT@97..98 "." [] [],
+                        operator_token: DOT@97..98 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@98..99 "#" [] [],
                             value_token: IDENT@99..105 "member" [] [],
                         },
                     },
-                    operator: DOT@105..106 "." [] [],
+                    operator_token: DOT@105..106 "." [] [],
                     member: JsName {
                         value_token: IDENT@106..109 "key" [] [],
                     },
@@ -127,7 +127,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@110..118 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@110..118 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@118..119 "(" [] [],
@@ -146,7 +146,7 @@ JsModule {
                                     r_paren_token: R_PAREN@124..125 ")" [] [],
                                 },
                             },
-                            operator: DOT@125..126 "." [] [],
+                            operator_token: DOT@125..126 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@126..127 "#" [] [],
                                 value_token: IDENT@127..133 "member" [] [],
@@ -154,7 +154,7 @@ JsModule {
                         },
                         r_paren_token: R_PAREN@133..134 ")" [] [],
                     },
-                    operator: DOT@134..135 "." [] [],
+                    operator_token: DOT@134..135 "." [] [],
                     member: JsName {
                         value_token: IDENT@135..138 "key" [] [],
                     },
@@ -164,7 +164,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@139..147 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@139..147 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsIdentifierExpression {
@@ -172,13 +172,13 @@ JsModule {
                                 value_token: IDENT@147..150 "obj" [] [],
                             },
                         },
-                        operator: QUESTIONDOT@150..152 "?." [] [],
+                        operator_token: QUESTIONDOT@150..152 "?." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@152..153 "#" [] [],
                             value_token: IDENT@153..159 "member" [] [],
                         },
                     },
-                    operator: DOT@159..160 "." [] [],
+                    operator_token: DOT@159..160 "." [] [],
                     member: JsName {
                         value_token: IDENT@160..163 "key" [] [],
                     },
@@ -188,7 +188,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@164..172 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@164..172 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@172..173 "(" [] [],
@@ -198,7 +198,7 @@ JsModule {
                                     value_token: IDENT@173..176 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@176..178 "?." [] [],
+                            operator_token: QUESTIONDOT@176..178 "?." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@178..179 "#" [] [],
                                 value_token: IDENT@179..185 "member" [] [],
@@ -206,7 +206,7 @@ JsModule {
                         },
                         r_paren_token: R_PAREN@185..186 ")" [] [],
                     },
-                    operator: DOT@186..187 "." [] [],
+                    operator_token: DOT@186..187 "." [] [],
                     member: JsName {
                         value_token: IDENT@187..190 "key" [] [],
                     },
@@ -216,7 +216,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@191..199 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@191..199 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsStaticMemberExpression {
@@ -225,18 +225,18 @@ JsModule {
                                     value_token: IDENT@199..202 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@202..204 "?." [] [],
+                            operator_token: QUESTIONDOT@202..204 "?." [] [],
                             member: JsName {
                                 value_token: IDENT@204..209 "inner" [] [],
                             },
                         },
-                        operator: DOT@209..210 "." [] [],
+                        operator_token: DOT@209..210 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@210..211 "#" [] [],
                             value_token: IDENT@211..217 "member" [] [],
                         },
                     },
-                    operator: DOT@217..218 "." [] [],
+                    operator_token: DOT@217..218 "." [] [],
                     member: JsName {
                         value_token: IDENT@218..221 "key" [] [],
                     },
@@ -246,7 +246,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@222..230 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@222..230 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsStaticMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@230..231 "(" [] [],
@@ -257,12 +257,12 @@ JsModule {
                                         value_token: IDENT@231..234 "obj" [] [],
                                     },
                                 },
-                                operator: QUESTIONDOT@234..236 "?." [] [],
+                                operator_token: QUESTIONDOT@234..236 "?." [] [],
                                 member: JsName {
                                     value_token: IDENT@236..241 "inner" [] [],
                                 },
                             },
-                            operator: DOT@241..242 "." [] [],
+                            operator_token: DOT@241..242 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@242..243 "#" [] [],
                                 value_token: IDENT@243..249 "member" [] [],
@@ -270,7 +270,7 @@ JsModule {
                         },
                         r_paren_token: R_PAREN@249..250 ")" [] [],
                     },
-                    operator: DOT@250..251 "." [] [],
+                    operator_token: DOT@250..251 "." [] [],
                     member: JsName {
                         value_token: IDENT@251..254 "key" [] [],
                     },
@@ -280,7 +280,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@255..263 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@255..263 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsIdentifierExpression {
                         name: JsReferenceIdentifier {
@@ -301,7 +301,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@272..280 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@272..280 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@280..281 "(" [] [],
@@ -326,7 +326,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@291..299 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@291..299 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsIdentifierExpression {
@@ -334,7 +334,7 @@ JsModule {
                                 value_token: IDENT@299..302 "obj" [] [],
                             },
                         },
-                        operator: DOT@302..303 "." [] [],
+                        operator_token: DOT@302..303 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@303..304 "#" [] [],
                             value_token: IDENT@304..310 "member" [] [],
@@ -354,7 +354,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@316..324 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@316..324 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@324..325 "(" [] [],
@@ -364,7 +364,7 @@ JsModule {
                                     value_token: IDENT@325..328 "obj" [] [],
                                 },
                             },
-                            operator: DOT@328..329 "." [] [],
+                            operator_token: DOT@328..329 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@329..330 "#" [] [],
                                 value_token: IDENT@330..336 "member" [] [],
@@ -386,7 +386,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@343..351 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@343..351 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsCallExpression {
@@ -403,7 +403,7 @@ JsModule {
                                 r_paren_token: R_PAREN@356..357 ")" [] [],
                             },
                         },
-                        operator: DOT@357..358 "." [] [],
+                        operator_token: DOT@357..358 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@358..359 "#" [] [],
                             value_token: IDENT@359..365 "member" [] [],
@@ -423,7 +423,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@371..379 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@371..379 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@379..380 "(" [] [],
@@ -442,7 +442,7 @@ JsModule {
                                     r_paren_token: R_PAREN@385..386 ")" [] [],
                                 },
                             },
-                            operator: DOT@386..387 "." [] [],
+                            operator_token: DOT@386..387 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@387..388 "#" [] [],
                                 value_token: IDENT@388..394 "member" [] [],
@@ -464,7 +464,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@401..409 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@401..409 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsIdentifierExpression {
@@ -472,7 +472,7 @@ JsModule {
                                 value_token: IDENT@409..412 "obj" [] [],
                             },
                         },
-                        operator: QUESTIONDOT@412..414 "?." [] [],
+                        operator_token: QUESTIONDOT@412..414 "?." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@414..415 "#" [] [],
                             value_token: IDENT@415..421 "member" [] [],
@@ -492,7 +492,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@427..435 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@427..435 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@435..436 "(" [] [],
@@ -502,7 +502,7 @@ JsModule {
                                     value_token: IDENT@436..439 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@439..441 "?." [] [],
+                            operator_token: QUESTIONDOT@439..441 "?." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@441..442 "#" [] [],
                                 value_token: IDENT@442..448 "member" [] [],
@@ -524,7 +524,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@455..463 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@455..463 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsStaticMemberExpression {
                         object: JsStaticMemberExpression {
@@ -533,12 +533,12 @@ JsModule {
                                     value_token: IDENT@463..466 "obj" [] [],
                                 },
                             },
-                            operator: QUESTIONDOT@466..468 "?." [] [],
+                            operator_token: QUESTIONDOT@466..468 "?." [] [],
                             member: JsName {
                                 value_token: IDENT@468..473 "inner" [] [],
                             },
                         },
-                        operator: DOT@473..474 "." [] [],
+                        operator_token: DOT@473..474 "." [] [],
                         member: JsPrivateName {
                             hash_token: HASH@474..475 "#" [] [],
                             value_token: IDENT@475..481 "member" [] [],
@@ -558,7 +558,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@487..495 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@487..495 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsComputedMemberExpression {
                     object: JsParenthesizedExpression {
                         l_paren_token: L_PAREN@495..496 "(" [] [],
@@ -569,12 +569,12 @@ JsModule {
                                         value_token: IDENT@496..499 "obj" [] [],
                                     },
                                 },
-                                operator: QUESTIONDOT@499..501 "?." [] [],
+                                operator_token: QUESTIONDOT@499..501 "?." [] [],
                                 member: JsName {
                                     value_token: IDENT@501..506 "inner" [] [],
                                 },
                             },
-                            operator: DOT@506..507 "." [] [],
+                            operator_token: DOT@506..507 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@507..508 "#" [] [],
                                 value_token: IDENT@508..514 "member" [] [],
@@ -596,7 +596,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@521..529 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@521..529 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@529..530 "(" [] [],
                     expression: JsSequenceExpression {
@@ -606,7 +606,7 @@ JsModule {
                                     value_token: IDENT@530..533 "obj" [] [],
                                 },
                             },
-                            operator: DOT@533..534 "." [] [],
+                            operator_token: DOT@533..534 "." [] [],
                             member: JsPrivateName {
                                 hash_token: HASH@534..535 "#" [] [],
                                 value_token: IDENT@535..538 "key" [] [],
@@ -619,7 +619,7 @@ JsModule {
                                     value_token: IDENT@540..543 "obj" [] [],
                                 },
                             },
-                            operator: DOT@543..544 "." [] [],
+                            operator_token: DOT@543..544 "." [] [],
                             member: JsName {
                                 value_token: IDENT@544..547 "key" [] [],
                             },
@@ -632,7 +632,7 @@ JsModule {
         },
         JsExpressionStatement {
             expression: JsUnaryExpression {
-                operator: DELETE_KW@549..557 "delete" [Newline("\n")] [Whitespace(" ")],
+                operator_token: DELETE_KW@549..557 "delete" [Newline("\n")] [Whitespace(" ")],
                 argument: JsParenthesizedExpression {
                     l_paren_token: L_PAREN@557..558 "(" [] [],
                     expression: JsInExpression {

--- a/crates/rome_js_parser/test_data/inline/ok/unary_delete_nested.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/unary_delete_nested.rast
@@ -49,7 +49,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@45..52 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@45..52 "delete" [] [Whitespace(" ")],
                                     argument: JsCallExpression {
                                         callee: JsIdentifierExpression {
                                             name: JsReferenceIdentifier {
@@ -65,7 +65,7 @@ JsModule {
                                                     object: JsThisExpression {
                                                         this_token: THIS_KW@57..61 "this" [] [],
                                                     },
-                                                    operator: DOT@61..62 "." [] [],
+                                                    operator_token: DOT@61..62 "." [] [],
                                                     member: JsPrivateName {
                                                         hash_token: HASH@62..63 "#" [] [],
                                                         value_token: IDENT@63..69 "member" [] [],
@@ -132,7 +132,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@120..127 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@120..127 "delete" [] [Whitespace(" ")],
                                     argument: JsArrayExpression {
                                         l_brack_token: L_BRACK@127..128 "[" [] [],
                                         elements: JsArrayElementList [
@@ -140,7 +140,7 @@ JsModule {
                                                 object: JsThisExpression {
                                                     this_token: THIS_KW@128..132 "this" [] [],
                                                 },
-                                                operator: DOT@132..133 "." [] [],
+                                                operator_token: DOT@132..133 "." [] [],
                                                 member: JsPrivateName {
                                                     hash_token: HASH@133..134 "#" [] [],
                                                     value_token: IDENT@134..140 "member" [] [],
@@ -206,7 +206,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@191..198 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@191..198 "delete" [] [Whitespace(" ")],
                                     argument: JsObjectExpression {
                                         l_curly_token: L_CURLY@198..200 "{" [] [Whitespace(" ")],
                                         members: JsObjectMemberList [
@@ -219,7 +219,7 @@ JsModule {
                                                     object: JsThisExpression {
                                                         this_token: THIS_KW@205..209 "this" [] [],
                                                     },
-                                                    operator: DOT@209..210 "." [] [],
+                                                    operator_token: DOT@209..210 "." [] [],
                                                     member: JsPrivateName {
                                                         hash_token: HASH@210..211 "#" [] [],
                                                         value_token: IDENT@211..218 "member" [] [Whitespace(" ")],
@@ -286,7 +286,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@269..276 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@269..276 "delete" [] [Whitespace(" ")],
                                     argument: JsParenthesizedExpression {
                                         l_paren_token: L_PAREN@276..277 "(" [] [],
                                         expression: JsArrowFunctionExpression {
@@ -308,7 +308,7 @@ JsModule {
                                                             object: JsThisExpression {
                                                                 this_token: THIS_KW@285..289 "this" [] [],
                                                             },
-                                                            operator: DOT@289..290 "." [] [],
+                                                            operator_token: DOT@289..290 "." [] [],
                                                             member: JsPrivateName {
                                                                 hash_token: HASH@290..291 "#" [] [],
                                                                 value_token: IDENT@291..297 "member" [] [],
@@ -379,7 +379,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@351..358 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@351..358 "delete" [] [Whitespace(" ")],
                                     argument: JsParenthesizedExpression {
                                         l_paren_token: L_PAREN@358..359 "(" [] [],
                                         expression: JsArrowFunctionExpression {
@@ -399,7 +399,7 @@ JsModule {
                                                             object: JsThisExpression {
                                                                 this_token: THIS_KW@370..374 "this" [] [],
                                                             },
-                                                            operator: DOT@374..375 "." [] [],
+                                                            operator_token: DOT@374..375 "." [] [],
                                                             member: JsPrivateName {
                                                                 hash_token: HASH@375..376 "#" [] [],
                                                                 value_token: IDENT@376..382 "member" [] [],
@@ -470,7 +470,7 @@ JsModule {
                         statements: JsStatementList [
                             JsExpressionStatement {
                                 expression: JsUnaryExpression {
-                                    operator: DELETE_KW@436..443 "delete" [] [Whitespace(" ")],
+                                    operator_token: DELETE_KW@436..443 "delete" [] [Whitespace(" ")],
                                     argument: JsParenthesizedExpression {
                                         l_paren_token: L_PAREN@443..444 "(" [] [],
                                         expression: JsArrowFunctionExpression {
@@ -492,7 +492,7 @@ JsModule {
                                                             object: JsThisExpression {
                                                                 this_token: THIS_KW@458..462 "this" [] [],
                                                             },
-                                                            operator: DOT@462..463 "." [] [],
+                                                            operator_token: DOT@462..463 "." [] [],
                                                             member: JsPrivateName {
                                                                 hash_token: HASH@463..464 "#" [] [],
                                                                 value_token: IDENT@464..470 "member" [] [],

--- a/crates/rome_js_parser/test_data/inline/ok/with_statement.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/with_statement.rast
@@ -58,7 +58,7 @@ JsScript {
                                                     value_token: IDENT@41..53 "console" [Newline("\n"), Whitespace("    ")] [],
                                                 },
                                             },
-                                            operator: DOT@53..54 "." [] [],
+                                            operator_token: DOT@53..54 "." [] [],
                                             member: JsName {
                                                 value_token: IDENT@54..57 "log" [] [],
                                             },

--- a/crates/rome_js_syntax/src/expr_ext.rs
+++ b/crates/rome_js_syntax/src/expr_ext.rs
@@ -77,7 +77,7 @@ impl JsLiteralMemberName {
 ///
 /// The variants are ordered based on their precedence
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum JsBinaryOperation {
+pub enum JsBinaryOperator {
     /// `<`
     LessThan,
     /// `>`
@@ -120,45 +120,45 @@ pub enum JsBinaryOperation {
     BitwiseXor,
 }
 
-impl JsBinaryOperation {
+impl JsBinaryOperator {
     pub fn is_bit_wise_operator(&self) -> bool {
         matches!(
             self,
-            JsBinaryOperation::LeftShift
-                | JsBinaryOperation::RightShift
-                | JsBinaryOperation::UnsignedRightShift
-                | JsBinaryOperation::BitwiseAnd
-                | JsBinaryOperation::BitwiseOr
-                | JsBinaryOperation::BitwiseXor
+            JsBinaryOperator::LeftShift
+                | JsBinaryOperator::RightShift
+                | JsBinaryOperator::UnsignedRightShift
+                | JsBinaryOperator::BitwiseAnd
+                | JsBinaryOperator::BitwiseOr
+                | JsBinaryOperator::BitwiseXor
         )
     }
 
     pub fn is_plus_or_minus_operator(&self) -> bool {
-        matches!(self, JsBinaryOperation::Plus | JsBinaryOperation::Minus)
+        matches!(self, JsBinaryOperator::Plus | JsBinaryOperator::Minus)
     }
 
     pub fn is_times_or_div_operator(&self) -> bool {
         matches!(
             self,
-            JsBinaryOperation::Divide | JsBinaryOperation::Times | JsBinaryOperation::Remainder
+            JsBinaryOperator::Divide | JsBinaryOperator::Times | JsBinaryOperator::Remainder
         )
     }
 
     pub fn is_exponent_operator(&self) -> bool {
-        matches!(self, JsBinaryOperation::Exponent)
+        matches!(self, JsBinaryOperator::Exponent)
     }
 
     pub fn is_comparison_operator(&self) -> bool {
         matches!(
             self,
-            JsBinaryOperation::LessThan
-                | JsBinaryOperation::GreaterThan
-                | JsBinaryOperation::LessThanOrEqual
-                | JsBinaryOperation::GreaterThanOrEqual
-                | JsBinaryOperation::Equality
-                | JsBinaryOperation::StrictEquality
-                | JsBinaryOperation::Inequality
-                | JsBinaryOperation::StrictInequality
+            JsBinaryOperator::LessThan
+                | JsBinaryOperator::GreaterThan
+                | JsBinaryOperator::LessThanOrEqual
+                | JsBinaryOperator::GreaterThanOrEqual
+                | JsBinaryOperator::Equality
+                | JsBinaryOperator::StrictEquality
+                | JsBinaryOperator::Inequality
+                | JsBinaryOperator::StrictInequality
         )
     }
 
@@ -187,28 +187,28 @@ impl JsBinaryOperation {
 }
 
 impl JsBinaryExpression {
-    pub fn operator_kind(&self) -> SyntaxResult<JsBinaryOperation> {
-        let kind = match self.operator()?.kind() {
-            T![<] => JsBinaryOperation::LessThan,
-            T![>] => JsBinaryOperation::GreaterThan,
-            T![<=] => JsBinaryOperation::LessThanOrEqual,
-            T![>=] => JsBinaryOperation::GreaterThanOrEqual,
-            T![==] => JsBinaryOperation::Equality,
-            T![===] => JsBinaryOperation::StrictEquality,
-            T![!=] => JsBinaryOperation::Inequality,
-            T![!==] => JsBinaryOperation::StrictInequality,
-            T![+] => JsBinaryOperation::Plus,
-            T![-] => JsBinaryOperation::Minus,
-            T![*] => JsBinaryOperation::Times,
-            T![/] => JsBinaryOperation::Divide,
-            T![%] => JsBinaryOperation::Remainder,
-            T![**] => JsBinaryOperation::Exponent,
-            T![<<] => JsBinaryOperation::LeftShift,
-            T![>>] => JsBinaryOperation::RightShift,
-            T![>>>] => JsBinaryOperation::UnsignedRightShift,
-            T![&] => JsBinaryOperation::BitwiseAnd,
-            T![|] => JsBinaryOperation::BitwiseOr,
-            T![^] => JsBinaryOperation::BitwiseXor,
+    pub fn operator(&self) -> SyntaxResult<JsBinaryOperator> {
+        let kind = match self.operator_token()?.kind() {
+            T![<] => JsBinaryOperator::LessThan,
+            T![>] => JsBinaryOperator::GreaterThan,
+            T![<=] => JsBinaryOperator::LessThanOrEqual,
+            T![>=] => JsBinaryOperator::GreaterThanOrEqual,
+            T![==] => JsBinaryOperator::Equality,
+            T![===] => JsBinaryOperator::StrictEquality,
+            T![!=] => JsBinaryOperator::Inequality,
+            T![!==] => JsBinaryOperator::StrictInequality,
+            T![+] => JsBinaryOperator::Plus,
+            T![-] => JsBinaryOperator::Minus,
+            T![*] => JsBinaryOperator::Times,
+            T![/] => JsBinaryOperator::Divide,
+            T![%] => JsBinaryOperator::Remainder,
+            T![**] => JsBinaryOperator::Exponent,
+            T![<<] => JsBinaryOperator::LeftShift,
+            T![>>] => JsBinaryOperator::RightShift,
+            T![>>>] => JsBinaryOperator::UnsignedRightShift,
+            T![&] => JsBinaryOperator::BitwiseAnd,
+            T![|] => JsBinaryOperator::BitwiseOr,
+            T![^] => JsBinaryOperator::BitwiseXor,
             _ => unreachable!(),
         };
 
@@ -217,14 +217,14 @@ impl JsBinaryExpression {
     /// Whether this is a comparison operation, such as `>`, `<`, `==`, `!=`, `===`, etc.
     pub fn is_comparison_operator(&self) -> bool {
         matches!(
-            self.operator().map(|t| t.kind()),
+            self.operator_token().map(|t| t.kind()),
             Ok(T![>] | T![<] | T![>=] | T![<=] | T![==] | T![===] | T![!=] | T![!==])
         )
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub enum JsLogicalOperation {
+pub enum JsLogicalOperator {
     /// `??`
     NullishCoalescing,
     /// `||`
@@ -234,11 +234,11 @@ pub enum JsLogicalOperation {
 }
 
 impl JsLogicalExpression {
-    pub fn operator_kind(&self) -> SyntaxResult<JsLogicalOperation> {
-        let kind = match self.operator()?.kind() {
-            T![&&] => JsLogicalOperation::LogicalAnd,
-            T![||] => JsLogicalOperation::LogicalOr,
-            T![??] => JsLogicalOperation::NullishCoalescing,
+    pub fn operator(&self) -> SyntaxResult<JsLogicalOperator> {
+        let kind = match self.operator_token()?.kind() {
+            T![&&] => JsLogicalOperator::LogicalAnd,
+            T![||] => JsLogicalOperator::LogicalOr,
+            T![??] => JsLogicalOperator::NullishCoalescing,
             _ => unreachable!(),
         };
 
@@ -253,7 +253,7 @@ impl JsArrayHole {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum JsUnaryOperation {
+pub enum JsUnaryOperator {
     /// `delete`
     Delete,
     /// `void`
@@ -271,24 +271,24 @@ pub enum JsUnaryOperation {
 }
 
 impl JsUnaryExpression {
-    pub fn operation(&self) -> SyntaxResult<JsUnaryOperation> {
-        let operator = self.operator()?;
+    pub fn operator(&self) -> SyntaxResult<JsUnaryOperator> {
+        let operator = self.operator_token()?;
 
         Ok(match operator.kind() {
-            T![+] => JsUnaryOperation::Plus,
-            T![-] => JsUnaryOperation::Minus,
-            T![~] => JsUnaryOperation::BitwiseNot,
-            T![!] => JsUnaryOperation::LogicalNot,
-            T![typeof] => JsUnaryOperation::Typeof,
-            T![void] => JsUnaryOperation::Void,
-            T![delete] => JsUnaryOperation::Delete,
+            T![+] => JsUnaryOperator::Plus,
+            T![-] => JsUnaryOperator::Minus,
+            T![~] => JsUnaryOperator::BitwiseNot,
+            T![!] => JsUnaryOperator::LogicalNot,
+            T![typeof] => JsUnaryOperator::Typeof,
+            T![void] => JsUnaryOperator::Void,
+            T![delete] => JsUnaryOperator::Delete,
             _ => unreachable!(),
         })
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum JsPreUpdateOperation {
+pub enum JsPreUpdateOperator {
     /// `++`
     Increment,
     /// `--`
@@ -296,12 +296,12 @@ pub enum JsPreUpdateOperation {
 }
 
 impl JsPreUpdateExpression {
-    pub fn operation(&self) -> SyntaxResult<JsPreUpdateOperation> {
-        let operator = self.operator()?;
+    pub fn operator(&self) -> SyntaxResult<JsPreUpdateOperator> {
+        let operator = self.operator_token()?;
 
         Ok(match operator.kind() {
-            T![++] => JsPreUpdateOperation::Increment,
-            T![--] => JsPreUpdateOperation::Decrement,
+            T![++] => JsPreUpdateOperator::Increment,
+            T![--] => JsPreUpdateOperator::Decrement,
             _ => unreachable!(),
         })
     }

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -404,14 +404,14 @@ impl JsBinaryExpression {
     pub fn as_fields(&self) -> JsBinaryExpressionFields {
         JsBinaryExpressionFields {
             left: self.left(),
-            operator: self.operator(),
+            operator_token: self.operator_token(),
             right: self.right(),
         }
     }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
     pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
@@ -420,7 +420,7 @@ impl JsBinaryExpression {
 }
 pub struct JsBinaryExpressionFields {
     pub left: SyntaxResult<JsAnyExpression>,
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
     pub right: SyntaxResult<JsAnyExpression>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -2985,14 +2985,14 @@ impl JsLogicalExpression {
     pub fn as_fields(&self) -> JsLogicalExpressionFields {
         JsLogicalExpressionFields {
             left: self.left(),
-            operator: self.operator(),
+            operator_token: self.operator_token(),
             right: self.right(),
         }
     }
     pub fn left(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
     pub fn right(&self) -> SyntaxResult<JsAnyExpression> {
@@ -3001,7 +3001,7 @@ impl JsLogicalExpression {
 }
 pub struct JsLogicalExpressionFields {
     pub left: SyntaxResult<JsAnyExpression>,
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
     pub right: SyntaxResult<JsAnyExpression>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -3780,19 +3780,19 @@ impl JsPostUpdateExpression {
     pub fn as_fields(&self) -> JsPostUpdateExpressionFields {
         JsPostUpdateExpressionFields {
             operand: self.operand(),
-            operator: self.operator(),
+            operator_token: self.operator_token(),
         }
     }
     pub fn operand(&self) -> SyntaxResult<JsAnyAssignment> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
 }
 pub struct JsPostUpdateExpressionFields {
     pub operand: SyntaxResult<JsAnyAssignment>,
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsPreUpdateExpression {
@@ -3808,11 +3808,11 @@ impl JsPreUpdateExpression {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_fields(&self) -> JsPreUpdateExpressionFields {
         JsPreUpdateExpressionFields {
-            operator: self.operator(),
+            operator_token: self.operator_token(),
             operand: self.operand(),
         }
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
     pub fn operand(&self) -> SyntaxResult<JsAnyAssignment> {
@@ -3820,7 +3820,7 @@ impl JsPreUpdateExpression {
     }
 }
 pub struct JsPreUpdateExpressionFields {
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
     pub operand: SyntaxResult<JsAnyAssignment>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -4395,21 +4395,21 @@ impl JsStaticMemberExpression {
     pub fn as_fields(&self) -> JsStaticMemberExpressionFields {
         JsStaticMemberExpressionFields {
             object: self.object(),
-            operator: self.operator(),
+            operator_token: self.operator_token(),
             member: self.member(),
         }
     }
     pub fn object(&self) -> SyntaxResult<JsAnyExpression> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 1usize)
     }
     pub fn member(&self) -> SyntaxResult<JsAnyName> { support::required_node(&self.syntax, 2usize) }
 }
 pub struct JsStaticMemberExpressionFields {
     pub object: SyntaxResult<JsAnyExpression>,
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
     pub member: SyntaxResult<JsAnyName>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -4773,11 +4773,11 @@ impl JsUnaryExpression {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn as_fields(&self) -> JsUnaryExpressionFields {
         JsUnaryExpressionFields {
-            operator: self.operator(),
+            operator_token: self.operator_token(),
             argument: self.argument(),
         }
     }
-    pub fn operator(&self) -> SyntaxResult<SyntaxToken> {
+    pub fn operator_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 0usize)
     }
     pub fn argument(&self) -> SyntaxResult<JsAnyExpression> {
@@ -4785,7 +4785,7 @@ impl JsUnaryExpression {
     }
 }
 pub struct JsUnaryExpressionFields {
-    pub operator: SyntaxResult<SyntaxToken>,
+    pub operator_token: SyntaxResult<SyntaxToken>,
     pub argument: SyntaxResult<JsAnyExpression>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -10037,7 +10037,10 @@ impl std::fmt::Debug for JsBinaryExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsBinaryExpression")
             .field("left", &support::DebugSyntaxResult(self.left()))
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .field("right", &support::DebugSyntaxResult(self.right()))
             .finish()
     }
@@ -12414,7 +12417,10 @@ impl std::fmt::Debug for JsLogicalExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsLogicalExpression")
             .field("left", &support::DebugSyntaxResult(self.left()))
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .field("right", &support::DebugSyntaxResult(self.right()))
             .finish()
     }
@@ -13148,7 +13154,10 @@ impl std::fmt::Debug for JsPostUpdateExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsPostUpdateExpression")
             .field("operand", &support::DebugSyntaxResult(self.operand()))
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .finish()
     }
 }
@@ -13172,7 +13181,10 @@ impl AstNode<Language> for JsPreUpdateExpression {
 impl std::fmt::Debug for JsPreUpdateExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsPreUpdateExpression")
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .field("operand", &support::DebugSyntaxResult(self.operand()))
             .finish()
     }
@@ -13704,7 +13716,10 @@ impl std::fmt::Debug for JsStaticMemberExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsStaticMemberExpression")
             .field("object", &support::DebugSyntaxResult(self.object()))
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .field("member", &support::DebugSyntaxResult(self.member()))
             .finish()
     }
@@ -14072,7 +14087,10 @@ impl AstNode<Language> for JsUnaryExpression {
 impl std::fmt::Debug for JsUnaryExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("JsUnaryExpression")
-            .field("operator", &support::DebugSyntaxResult(self.operator()))
+            .field(
+                "operator_token",
+                &support::DebugSyntaxResult(self.operator_token()),
+            )
             .field("argument", &support::DebugSyntaxResult(self.argument()))
             .finish()
     }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -453,7 +453,7 @@ JsIdentifierExpression = name: JsReferenceIdentifier
 // a.#b
 JsStaticMemberExpression =
 	object: JsAnyExpression
-	operator: ('.' | '?.')
+	operator_token: ('.' | '?.')
 	member: JsAnyName
 
 // a[b]
@@ -466,7 +466,7 @@ JsComputedMemberExpression =
 
 JsBinaryExpression =
     left: JsAnyExpression
-    operator: (
+    operator_token: (
     	'<' | '>' | '<=' | '>=' | '==' | '===' | '!=' | '!=='
     	| '+' | '-' | '*' | '/' | '%' | '**' | '<<' | '>>' | '>>>'
     	| '&' | '|' | '^'
@@ -489,21 +489,21 @@ JsAnyInProperty =
 
 JsLogicalExpression =
 	left: JsAnyExpression
-	operator: ('??' | '||' | '&&')
+	operator_token: ('??' | '||' | '&&')
 	right: JsAnyExpression
 
 // unary expression
 JsUnaryExpression =
-  operator: ('delete' | 'void' | 'typeof' | '+' | '-' | '~' | '!')
+  operator_token: ('delete' | 'void' | 'typeof' | '+' | '-' | '~' | '!')
   argument: JsAnyExpression
 
 JsPreUpdateExpression =
-    operator: ('++' | '--')
+    operator_token: ('++' | '--')
     operand: JsAnyAssignment
 
 JsPostUpdateExpression =
     operand: JsAnyAssignment
-    operator: ('++' | '--')
+    operator_token: ('++' | '--')
 
 
 ///////////////


### PR DESCRIPTION
## Summary

`format_binarish` used to use recursion to format the binary expressions. While this led to somewhat simpler code it had the downside that it stack overflowed for binary expressions with deep left subtrees. 

This PR rewrites the implementation to use an `Iterator` instead that visits the left-hand sides of binary-like-expressions in post order (first visiting the deepest left-hand side, then traversing upwards). 

This PR further fixes a unicode issue in the diff printing logic and renames `operator` to `operator_token` for a consistent naming.

## Test Plan

`cargo test`

Running the formatter on all test repositories (t262, TypeScript...) no longer fails with a stack overflow. There still seems to be some issue that rome enters an infinite loop. I need to look into this separately.
