### PR TITLE
feature(rome_js_formatter): Add support for printing single quotes

### DIFF
--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -23,7 +23,7 @@ use rome_diagnostics::{
 };
 use rome_fs::{AtomicInterner, FileSystem, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
-use rome_js_formatter::{FormatOptions, IndentStyle, QuoteStyle};
+use rome_js_formatter::{FormatOptions, IndentStyle};
 use rome_js_parser::{parse, SourceType};
 
 use crate::{CliSession, Termination};
@@ -66,14 +66,8 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
             source,
         })?;
 
-    match quote_style {
-        Some(QuoteStyle::Double) => {
-            options.quote_style = QuoteStyle::Double;
-        }
-        Some(QuoteStyle::Single) => {
-            options.quote_style = QuoteStyle::Single;
-        }
-        None => {}
+    if let Some(quote_style) = quote_style {
+        options.quote_style = quote_style;
     }
 
     let line_width = session

--- a/crates/rome_cli/src/commands/format.rs
+++ b/crates/rome_cli/src/commands/format.rs
@@ -23,7 +23,7 @@ use rome_diagnostics::{
 };
 use rome_fs::{AtomicInterner, FileSystem, PathInterner, RomePath};
 use rome_fs::{TraversalContext, TraversalScope};
-use rome_js_formatter::{FormatOptions, IndentStyle};
+use rome_js_formatter::{FormatOptions, IndentStyle, QuoteStyle};
 use rome_js_parser::{parse, SourceType};
 
 use crate::{CliSession, Termination};
@@ -40,7 +40,7 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
             source,
         })?;
 
-    let style = session
+    let indent_style = session
         .args
         .opt_value_from_str("--indent-style")
         .map_err(|source| Termination::ParseError {
@@ -48,12 +48,30 @@ pub(crate) fn format(mut session: CliSession) -> Result<(), Termination> {
             source,
         })?;
 
-    match style {
+    match indent_style {
         Some(IndentStyle::Tab) => {
             options.indent_style = IndentStyle::Tab;
         }
         Some(IndentStyle::Space(default_size)) => {
             options.indent_style = IndentStyle::Space(size.unwrap_or(default_size));
+        }
+        None => {}
+    }
+
+    let quote_style = session
+        .args
+        .opt_value_from_str("--quote-style")
+        .map_err(|source| Termination::ParseError {
+            argument: "--quote-style",
+            source,
+        })?;
+
+    match quote_style {
+        Some(QuoteStyle::Double) => {
+            options.quote_style = QuoteStyle::Double;
+        }
+        Some(QuoteStyle::Single) => {
+            options.quote_style = QuoteStyle::Single;
         }
         None => {}
     }

--- a/crates/rome_cli/src/commands/help.rs
+++ b/crates/rome_cli/src/commands/help.rs
@@ -18,12 +18,13 @@ USAGE:
     INPUTS can be one or more filesystem path, each pointing to a single file or an entire directory to be searched recursively for supported files
 
 OPTIONS:
-    --write                     Write the output of the formatter to the files instead of printing the diff to the console
-    --ci                        Enable CI mode, lock files and exit with an error if the formatter would modify them
-    --skip-errors               Skip over files containing syntax errors instead of returning an error
-    --indent-style <tabs|space> Determine whether the formatter should use tabs or spaces for indentation (default: tabs)
-    --indent-size <number>      If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
-    --line-width <number>       Determine how many characters the formatter is allowed to print in a single line (default: 80)
+    --write                       Write the output of the formatter to the files instead of printing the diff to the console
+    --ci                          Enable CI mode, lock files and exit with an error if the formatter would modify them
+    --skip-errors                 Skip over files containing syntax errors instead of returning an error
+    --indent-style <tabs|space>   Determine whether the formatter should use tabs or spaces for indentation (default: tabs)
+    --indent-size <number>        If the indentation style is set to spaces, determine how many spaces should be used for indentation (default: 2)
+    --line-width <number>         Determine how many characters the formatter is allowed to print in a single line (default: 80)
+    --quote-style <single|double> Determine whether the formatter should use single or double quotes for strings (default: double)
 ";
 
 pub(crate) fn help(command: Option<&str>) -> Result<(), Termination> {

--- a/crates/rome_formatter/src/lib.rs
+++ b/crates/rome_formatter/src/lib.rs
@@ -125,13 +125,50 @@ impl From<LineWidth> for u16 {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum QuoteStyle {
+    Double,
+    Single,
+}
+
+impl Default for QuoteStyle {
+    fn default() -> Self {
+        Self::Double
+    }
+}
+
+impl FromStr for QuoteStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "double" | "Double" => Ok(Self::Double),
+            "single" | "Single" => Ok(Self::Single),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Value not supported for QuoteStyle"),
+        }
+    }
+}
+
+impl Display for QuoteStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QuoteStyle::Double => write!(f, "Double Quotes"),
+            QuoteStyle::Single => write!(f, "Single Quotes"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FormatOptions {
-    /// The indent style
+    /// The indent style.
     pub indent_style: IndentStyle,
 
-    /// What's the max width of a line. Defaults to 80
+    /// What's the max width of a line. Defaults to 80.
     pub line_width: LineWidth,
+
+    // The style for quotes. Defaults to double.
+    pub quote_style: QuoteStyle,
 }
 
 impl FormatOptions {
@@ -147,6 +184,7 @@ impl Display for FormatOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Indent style: {}", self.indent_style)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
+        writeln!(f, "Quote style: {}", self.quote_style)?;
         Ok(())
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -20,7 +20,7 @@ pub use rome_formatter::{
     if_group_breaks, if_group_fits_on_single_line, indent, join_elements, join_elements_hard_line,
     join_elements_soft_line, join_elements_with, line_suffix, soft_block_indent, soft_line_break,
     soft_line_break_or_space, soft_line_indent_or_space, space_token, token, FormatElement,
-    FormatOptions, Formatted, IndentStyle, Token, Verbatim, LINE_TERMINATORS,
+    FormatOptions, Formatted, IndentStyle, QuoteStyle, Token, Verbatim, LINE_TERMINATORS,
 };
 use rome_js_syntax::JsSyntaxNode;
 use rome_rowan::TextSize;

--- a/crates/rome_js_formatter/tests/spec_test.rs
+++ b/crates/rome_js_formatter/tests/spec_test.rs
@@ -1,7 +1,7 @@
 use rome_core::App;
 use rome_formatter::LineWidth;
 use rome_fs::RomePath;
-use rome_js_formatter::{format, FormatOptions, Formatted, IndentStyle};
+use rome_js_formatter::{format, FormatOptions, Formatted, IndentStyle, QuoteStyle};
 use rome_js_parser::{parse, ModuleKind, SourceType};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -29,13 +29,31 @@ impl From<SerializableIndentStyle> for IndentStyle {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize, Serialize)]
+pub enum SerializableQuoteStyle {
+    Double,
+    Single,
+}
+
+impl From<SerializableQuoteStyle> for QuoteStyle {
+    fn from(test: SerializableQuoteStyle) -> Self {
+        match test {
+            SerializableQuoteStyle::Double => QuoteStyle::Double,
+            SerializableQuoteStyle::Single => QuoteStyle::Single,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub struct SerializableFormatOptions {
-    /// The indent style
+    /// The indent style.
     pub indent_style: Option<SerializableIndentStyle>,
 
-    /// What's the max width of a line. Defaults to 80
+    /// What's the max width of a line. Defaults to 80.
     pub line_width: Option<u16>,
+
+    // The style for quotes. Defaults to double.
+    pub quote_style: Option<SerializableQuoteStyle>,
 }
 
 impl From<SerializableFormatOptions> for FormatOptions {
@@ -48,6 +66,9 @@ impl From<SerializableFormatOptions> for FormatOptions {
                 .line_width
                 .and_then(|width| LineWidth::try_from(width).ok())
                 .unwrap_or_default(),
+            quote_style: test
+                .quote_style
+                .map_or_else(|| QuoteStyle::Double, |value| value.into()),
         }
     }
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: array_nested.js
-
 ---
 # Input
 let a = [[]];
@@ -53,6 +51,7 @@ let o1 = [{ a, b }, { a, b, c }];
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = [[]];
 let b = [[], []];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: binding_pattern.js
-
 ---
 # Input
 let [a,b]=c;
@@ -15,6 +13,7 @@ let [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,...cccccccccc
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let [a, b] = c;
 let [d, ...e] = c;

--- a/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: empty_lines.js
-
 ---
 # Input
 let a = [
@@ -24,6 +22,7 @@ let a = [
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = [
 	1,

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: spaces.js
-
 ---
 # Input
 let a = [,];
@@ -17,6 +15,7 @@ let e = [2,2,1,3];
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = [,];
 let b = [, ,];

--- a/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: spread.js
-
 ---
 # Input
 let a = [...a, ...b,];
@@ -17,6 +15,7 @@ let a = [...baaaaaaaaaaaaaaaaaaaaaaaaaaaaa,...bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,...
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = [...a, ...b];
 let b = [...a, ...b];

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: arrow_function.js
-
 ---
 # Input
 () => {}
@@ -18,6 +16,7 @@ async () => {}
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 () => {};
 async () => {};

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: arrow_nested.js
-
 ---
 # Input
 Seq(typeDef.interface.groups).forEach(group =>
@@ -39,6 +37,7 @@ runtimeAgent.getProperties(
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 Seq(typeDef.interface.groups).forEach(
 	(group) =>

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: call.js
-
 ---
 # Input
 const testResults = results.testResults.map(testResult =>
@@ -56,6 +54,7 @@ romise.then(result => result.veryLongVariable.veryLongPropertyName > someOtherVa
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 const testResults = results.testResults.map(
 	(testResult) => formatResult(testResult, formatter, reporter),

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: currying.js
-
 ---
 # Input
 const fn = b => c => d => {
@@ -29,6 +27,7 @@ const middleware = options => (req, res, next) => {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 const fn = (b) => (c) => (d) => {
 	return 3;

--- a/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: params.js
-
 ---
 # Input
 fooooooooooooooooooooooooooooooooooooooooooooooooooo(action => next =>
@@ -333,6 +331,7 @@ foo(
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 fooooooooooooooooooooooooooooooooooooooooooooooooooo(
 	(action) => (next) => dispatch(action),

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: array-assignment-holes.js
-
 ---
 # Input
 let a, b;
@@ -14,6 +12,7 @@ let a, b;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a, b;
 [a, /*empty*/ ,] = b;

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -36,6 +36,7 @@ a[ b ]  =  c[ d ]
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 a = b;
 a += b;

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: array-binding-holes.js
-
 ---
 # Input
 function foo([foo, /* not used */, /* not used */]) {
@@ -13,6 +11,7 @@ function foo([foo, /* not used */, /* not used */]) {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function foo([foo, /* not used */ , /* not used */ ]) {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: array_binding.js
-
 ---
 # Input
 [a="b"]=c
@@ -15,6 +13,7 @@ let [aaaaaaaaaaaaaaaaaaaa=bbbbbbbbbbbbbbbbbbbb,cccccccccccccccccccc=dddddddddddd
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 [a = "b"] = c;
 let [a = "b"] = c;

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: identifier_binding.js
-
 ---
 # Input
 let x = y
@@ -15,6 +13,7 @@ let abcde = "very long value that will cause a line break", fghij = "this should
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let x = y;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: object_binding.js
-
 ---
 # Input
 let {a}=b
@@ -16,6 +14,7 @@ let {aaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbb=cccccccccccccccccccc,dddddddddddd
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let { a } = b;
 let { d, b: c } = d;

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: class.js
-
 ---
 # Input
 class Foo extends Boar {
@@ -69,6 +67,7 @@ x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbb
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class Foo extends Boar {
 	static {

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: class_comments.js
-
 ---
 # Input
 class A extends B { // leading comment
@@ -18,6 +16,7 @@ class A extends B { // leading comment
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class A extends B {
 	// leading comment

--- a/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: private_method.js
-
 ---
 # Input
 class Foo {
@@ -28,6 +26,7 @@ class Foo {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class Foo {
 	a = 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: comments.js
-
 ---
 # Input
 // import {
@@ -68,6 +66,7 @@ function name(very, long, list, of_parameters, to, insert, a_break, in_the, para
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 // import {
 //     func, // trailing comma removal

--- a/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: class_clause.js
-
 ---
 # Input
 // another comment
@@ -21,6 +19,7 @@ B {}
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 // another comment
 export class A {

--- a/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: expression_clause.js
-
 ---
 # Input
 export default (1 - 43);
@@ -12,6 +10,7 @@ export default (1 - 43);
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export default 1 - 43;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: from_clause.js
-
 ---
 # Input
 export * from "hey"
@@ -16,6 +14,7 @@ export * as something_bad_will_happen from "something_bad_might_not_happen" asse
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export * from "hey";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: function_clause.js
-
 ---
 # Input
 export function f() {
@@ -20,6 +18,7 @@ export default function ff() {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export function f() {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: named_clause.js
-
 ---
 # Input
 export {
@@ -18,6 +16,7 @@ export {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export {
 	// the boo api

--- a/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: named_from_clause.js
-
 ---
 # Input
 export {a,
@@ -20,6 +18,7 @@ export {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export { a, b as c } from "fancy" assert { type: "json" };
 

--- a/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: variable_declaration.js
-
 ---
 # Input
 export let a, d, c;
@@ -14,6 +12,7 @@ export const foofoofoofoofoofoofoo = "ahah", barbarbarbarbarbarbar = {}, loremlo
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export let a, d, c;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: binary_expression.js
-
 ---
 # Input
 a  +   b
@@ -39,6 +37,7 @@ a + b * c > 65 + 5;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 a + b;
 a < b;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: binaryish_expression.js
-
 ---
 # Input
 2 > 4 + 4 * 24 % 3 << 23 instanceof Number in data || a in status instanceof String + 15 && foo && bar && lorem instanceof String;
@@ -12,6 +10,7 @@ expression: binaryish_expression.js
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 ((2 > (4 + (4 * 24 % 3) << 23) instanceof Number) in data) || (
 	((a in status) instanceof String + 15) &&

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: conditional_expression.js
-
 ---
 # Input
 a  ?  b  :  c
@@ -21,6 +19,7 @@ somethingThatsAReallyLongPropName ? somethingThatsAReallyLongPropName : somethin
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 a ? b : c;
 d ? (e + f) : (g + h);

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: import_meta_expression.js
-
 ---
 # Input
 console.log(import.meta);
@@ -15,6 +13,7 @@ import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherR
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 console.log(import.meta);
 import.meta.field =
@@ -24,6 +23,7 @@ import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherR
 -----
 Indent style: Spaces, size: 4
 Line width: 120
+Quote style: Double Quotes
 -----
 console.log(import.meta);
 import.meta.field =

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: literal_expression.js
-
 ---
 # Input
 "a"
@@ -18,6 +16,7 @@ null
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 "a";
 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: logical_expression.js
-
 ---
 # Input
 x ?? y;
@@ -124,6 +122,7 @@ veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo instanceof String && ver
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 x ?? y;
 x || y;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: new_expression.js
-
 ---
 # Input
 new a()
@@ -15,6 +13,7 @@ new c(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,cccccccccccc
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 new a();
 new b(x);

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: post_update_expression.js
-
 ---
 # Input
 y++
@@ -16,6 +14,7 @@ x = y--
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 y++;
 y--;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: pre_update_expression.js
-
 ---
 # Input
 ++y
@@ -16,6 +14,7 @@ x = --y
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 ++y;
 --y;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: sequence_expression.js
-
 ---
 # Input
 a,b
@@ -13,6 +11,7 @@ a,b
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 a, b;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: static_member_expression.js
-
 ---
 # Input
 a.b
@@ -24,6 +22,7 @@ something()[1]()[3]().items.item.what_else[3]().something().something().then().c
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 a.b;
 a?.b;

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: this_expression.js
-
 ---
 # Input
 this
@@ -13,6 +11,7 @@ this
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 this;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: unary_expression.js
-
 ---
 # Input
 delete  a.a
@@ -26,6 +24,7 @@ x = !aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 delete a.a;
 void b;

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: function.js
-
 ---
 # Input
 function foo() {
@@ -44,6 +42,7 @@ function directives() {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function foo() {}
 async function foo(a) {

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: function_args.js
-
 ---
 # Input
 function foo(someotherlongvariableshould1, someotherlongvariableshould2, someotherlongvariableshould3, someotherlongvariableshould4, someotherlongvariableshould5, someotherlongvariableshould6 = foooooooooooo, ...someotherlongvariableshould7) {
@@ -14,6 +12,7 @@ function foo(someotherlongvariableshould1, someotherlongvariableshould2, someoth
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function foo(
 	someotherlongvariableshould1,

--- a/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: function_comments.js
-
 ---
 # Input
 function a() { // trailing comment
@@ -28,6 +26,7 @@ function c( //some comment
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function a() {
 	// trailing comment

--- a/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: ident.js
-
 ---
 # Input
 x
@@ -13,6 +11,7 @@ x
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 x;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: bare_import.js
-
 ---
 # Input
 import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_";
@@ -31,6 +29,7 @@ import "very_long_import_very_long_import_very" assert {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_";
 import "very_long_import_very_long_import_very_long_import_very_long_import_very_long_import_very_long" assert {

--- a/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: default_import.js
-
 ---
 # Input
 import hey from "hey"
@@ -23,6 +21,7 @@ import a, * as b from "foo"
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import hey from "hey";
 import hey from "hey";

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: import_call.js
-
 ---
 # Input
 import(x)
@@ -15,6 +13,7 @@ import(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import(x);
 import("x");

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: import_specifiers.js
-
 ---
 # Input
 import { hey } from "hey"
@@ -28,6 +26,7 @@ import loooooooooooooooooooong7, { loooooooooooooooooooong8, loooooooooooooooooo
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import { hey } from "hey";
 import { hey } from "hey";

--- a/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: namespace_import.js
-
 ---
 # Input
 import * as all from "all"
@@ -12,6 +10,7 @@ import * as all from "all"
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import * as all from "all";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 198
 expression: interpreter.js
-
 ---
 # Input
 #!/usr/bin/env node
@@ -15,6 +13,7 @@ console.log(1)
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: block_stmt_err.js
-
 ---
 # Input
 {
@@ -22,6 +20,7 @@ let recovered     = "no"
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: if_stmt_err.js
-
 ---
 # Input
 function test() {
@@ -28,6 +26,7 @@ if (false) {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function test() {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -88,6 +88,7 @@ const object = {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 "directive";
 // comment

--- a/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: number.js
-
 ---
 # Input
 1.23e4
@@ -14,6 +12,7 @@ expression: number.js
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 1.23e4;
 1000e3; // FIXME handle number with scientific notation #1294

--- a/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: computed_member.js
-
 ---
 # Input
 const foo = {};
@@ -20,6 +18,7 @@ c?.[ d ]
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 const foo = {};
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: getter_setter.js
-
 ---
 # Input
 let a = {
@@ -18,6 +16,7 @@ let b = {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = { get foo() {} };
 let b = { set foo(a) {} };

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: object.js
-
 ---
 # Input
 let a = {
@@ -33,6 +31,7 @@ let a = {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = {
 	...spread,

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: object_comments.js
-
 ---
 # Input
 let a = { // leading comment
@@ -15,6 +13,7 @@ let a = { // leading comment
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a = {
 	// leading comment

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: property_key.js
-
 ---
 # Input
 const foo = {
@@ -20,6 +18,7 @@ const foo = {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 const foo = {
 	"foo-bar": true,

--- a/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: parentheses.js
-
 ---
 # Input
 (foo++)?.();
@@ -35,6 +33,7 @@ const a = () => ({}?.() && a);
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 (foo++)?.();
 async () => {

--- a/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/script.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 198
 expression: script.js
-
 ---
 # Input
 #!/usr/bin/env node
@@ -16,6 +14,7 @@ var express = require("express")
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: do_while.js
-
 ---
 # Input
 do {
@@ -23,6 +21,7 @@ while (something)
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 do {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: for_in.js
-
 ---
 # Input
 for (a in b) {}
@@ -18,6 +16,7 @@ for (a in b) { // trailing
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 for (a in b) {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: for_loop.js
-
 ---
 # Input
 for (;  ;) {
@@ -29,6 +27,7 @@ for(let aVeryLongVariableNameToEnforceLineBreaks = 0; aVeryLongVariableNameToEnf
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 for (;;) {
 	let x = 10;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 159
 expression: for_of.js
-
 ---
 # Input
 for (a of b) {}
@@ -20,6 +18,7 @@ for await ( const a of b ) {}
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 for (a of b) {}
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: if_chain.js
-
 ---
 # Input
 if(1)1;else if(2)2;else 3;
@@ -15,6 +13,7 @@ if(very_long_condition_1) very_long_statement_1(); else if (very_long_condition_
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 if (1) {
 	1;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: if_else.js
-
 ---
 # Input
 if (Math.random() > 0.5) {
@@ -71,6 +69,7 @@ if (true) that(); else;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 if (Math.random() > 0.5) {
 	console.log(1);

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: return.js
-
 ---
 # Input
 function f1() {
@@ -18,6 +16,7 @@ function f2() {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function f1() {
 	return 1;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: statement.js
-
 ---
 # Input
 ;
@@ -14,6 +12,7 @@ debugger
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 debugger;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: switch.js
-
 ---
 # Input
 switch (key) {
@@ -27,6 +25,7 @@ switch (key) {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 switch (key) {
 	case value: // comment

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: throw.js
-
 ---
 # Input
 throw "Something";
@@ -15,6 +13,7 @@ throw false
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 throw "Something";
 

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: try_catch_finally.js
-
 ---
 # Input
 try {
@@ -38,6 +36,7 @@ try {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 try {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: while_loop.js
-
 ---
 # Input
 while (true) { var foo = 4 }
@@ -38,6 +36,7 @@ tour: while (true) {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 while (true) {
 	var foo = 4;

--- a/crates/rome_js_formatter/tests/specs/js/module/string/options.json
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/options.json
@@ -1,0 +1,7 @@
+{
+	"cases": [
+		{
+			"quote_style": "Single"
+		}
+	]
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/string/string.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/string.js
@@ -1,0 +1,45 @@
+import hey from "hey"
+import hey from "hey";
+import "x" assert { type: "json" }
+import "foo" assert { "type": "json" };
+import foo from "foo.json" assert { type: "json" };
+import foo from "foo.json" assert {
+
+    type:
+        "json" };
+import foo2 from "foo.json" assert { "type": "json", type: "html", "type": "js" };
+import a, * as b from "foo"
+
+const foo = {};
+
+foo["bar"] = true;
+foo["foo-bar"] = true;
+foo.bar["bar"]["lorem_ispsum"].foo["lorem-ipsum"] = true;
+
+a[ b ]
+c?.[ d ]
+
+let a = { // leading comment
+  "type": "bar"
+  // trailing comment
+}
+
+class Foo extends Boar {
+	static { // some comment
+		this.a = "test";
+	}
+
+	method() {
+		return "ipsum";
+	}
+
+	static staticMethod() {
+		return "bar"
+	}
+}
+
+export * from "hey"
+
+export * as something_bad_will_happen from "something_bad_might_not_happen"
+
+export * as something_bad_will_happen from "something_bad_might_not_happen" assert { "type": "json", "type2": "json3"}

--- a/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/string/string.js.snap
@@ -1,0 +1,167 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+expression: string.js
+---
+# Input
+import hey from "hey"
+import hey from "hey";
+import "x" assert { type: "json" }
+import "foo" assert { "type": "json" };
+import foo from "foo.json" assert { type: "json" };
+import foo from "foo.json" assert {
+
+    type:
+        "json" };
+import foo2 from "foo.json" assert { "type": "json", type: "html", "type": "js" };
+import a, * as b from "foo"
+
+const foo = {};
+
+foo["bar"] = true;
+foo["foo-bar"] = true;
+foo.bar["bar"]["lorem_ispsum"].foo["lorem-ipsum"] = true;
+
+a[ b ]
+c?.[ d ]
+
+let a = { // leading comment
+  "type": "bar"
+  // trailing comment
+}
+
+class Foo extends Boar {
+	static { // some comment
+		this.a = "test";
+	}
+
+	method() {
+		return "ipsum";
+	}
+
+	static staticMethod() {
+		return "bar"
+	}
+}
+
+export * from "hey"
+
+export * as something_bad_will_happen from "something_bad_might_not_happen"
+
+export * as something_bad_will_happen from "something_bad_might_not_happen" assert { "type": "json", "type2": "json3"}
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+import hey from "hey";
+import hey from "hey";
+import "x" assert { type: "json" };
+import "foo" assert { "type": "json" };
+import foo from "foo.json" assert { type: "json" };
+import foo from "foo.json" assert { type: "json" };
+import foo2 from "foo.json" assert {
+	"type": "json",
+	type: "html",
+	"type": "js",
+};
+import a, * as b from "foo";
+
+const foo = {};
+
+foo["bar"] = true;
+foo["foo-bar"] = true;
+foo.bar["bar"]["lorem_ispsum"].foo["lorem-ipsum"] = true;
+
+a[b];
+c?.[d];
+
+let a = {
+	// leading comment
+	"type": "bar",
+	// trailing comment
+};
+
+class Foo extends Boar {
+	static {
+		// some comment
+		this.a = "test";
+	}
+
+	method() {
+		return "ipsum";
+	}
+
+	static staticMethod() {
+		return "bar";
+	}
+}
+
+export * from "hey";
+
+export * as something_bad_will_happen from "something_bad_might_not_happen";
+
+export * as something_bad_will_happen from "something_bad_might_not_happen" assert {
+	"type": "json",
+	"type2": "json3",
+};
+## Output 2
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Single Quotes
+-----
+import hey from 'hey';
+import hey from 'hey';
+import 'x' assert { type: 'json' };
+import 'foo' assert { 'type': 'json' };
+import foo from 'foo.json' assert { type: 'json' };
+import foo from 'foo.json' assert { type: 'json' };
+import foo2 from 'foo.json' assert {
+	'type': 'json',
+	type: "html",
+	"type": "js",
+};
+import a, * as b from 'foo';
+
+const foo = {};
+
+foo['bar'] = true;
+foo['foo-bar'] = true;
+foo.bar['bar']['lorem_ispsum'].foo['lorem-ipsum'] = true;
+
+a[b];
+c?.[d];
+
+let a = {
+	// leading comment
+	'type': 'bar',
+	// trailing comment
+};
+
+class Foo extends Boar {
+	static {
+		// some comment
+		this.a = 'test';
+	}
+
+	method() {
+		return 'ipsum';
+	}
+
+	static staticMethod() {
+		return 'bar';
+	}
+}
+
+export * from 'hey';
+
+export * as something_bad_will_happen from 'something_bad_might_not_happen';
+
+export * as something_bad_will_happen from 'something_bad_might_not_happen' assert {
+	'type': 'json',
+	'type2': 'json3',
+};
+

--- a/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: suppression.js
-
 ---
 # Input
 // rome-ignore format: the following if should print inline
@@ -40,6 +38,7 @@ function () {}
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 // rome-ignore format: the following if should print inline
 if(true) statement();

--- a/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: template.js
-
 ---
 # Input
 `something`;
@@ -56,6 +54,7 @@ ExampleStory.getFragment('story')}
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 `something`;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/with.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: with.js
-
 ---
 # Input
 with (   b)
@@ -17,6 +15,7 @@ with (   b)
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 with (   b)
 

--- a/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/script.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 198
 expression: script.js
-
 ---
 # Input
 #!/usr/bin/env node
@@ -16,6 +14,7 @@ var express = require("express")
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 #!/usr/bin/env node
 

--- a/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/script/with.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 157
 expression: with.js
-
 ---
 # Input
 with (   b)
@@ -17,6 +15,7 @@ with (   b)
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 with (b) {
 	5;

--- a/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/rome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: smoke.jsx
-
 ---
 # Input
 "foo";
@@ -12,6 +10,7 @@ expression: smoke.jsx
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 "foo";
 

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: as_assignment.ts
-
 ---
 # Input
 let binding;
@@ -17,6 +15,7 @@ let binding;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let binding;
 

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: type_assertion_assignment.ts
-
 ---
 # Input
 let x;
@@ -26,6 +24,7 @@ for (<boolean> x of []) {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let x;
 

--- a/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: definite_variable.ts
-
 ---
 # Input
 let definiteVariable!: TypeName;
@@ -13,6 +11,7 @@ let definiteVariable!: TypeName;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let definiteVariable!: TypeName;
 

--- a/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: constructor_parameter.ts
-
 ---
 # Input
 class B {
@@ -47,6 +45,7 @@ class C {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class B {
 	constructor(private a: string) {}

--- a/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: implements_clause.ts
-
 ---
 # Input
 class ClassName implements Interface { }
@@ -14,6 +12,7 @@ class LongClassName implements Interface1, Interface2, Interface3, Interface4, I
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class ClassName implements Interface {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: class.ts
-
 ---
 # Input
 
@@ -71,6 +69,7 @@ abstract class Test1 {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 class Test {
 	name: string;

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: declare_function.ts
-
 ---
 # Input
 declare function
@@ -15,6 +13,7 @@ declare function looooooooooooooooooooooooooooong_naaaaaame<FirstType, SecondTyp
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 declare function test(): Promise<string>;
 

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: global_declaration.ts
-
 ---
 # Input
 declare module "./test"
@@ -18,6 +16,7 @@ declare module "./test"
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 declare module "./test" {
 	global {

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: interface.ts
-
 ---
 # Input
 interface A {}
@@ -33,6 +31,7 @@ interface D extends B<string, symbol>, F<string, symbol> {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 interface A {}
 interface B extends A /** comment **/ { something: string }

--- a/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: decoartors.ts
-
 ---
 # Input
 @sealed
@@ -58,6 +56,7 @@ class Test2 {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 @sealed
 class Test {

--- a/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: as_expression.ts
-
 ---
 # Input
 
@@ -15,6 +13,7 @@ let b =
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a: any;
 let b = a as string;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: non_null_expression.ts
-
 ---
 # Input
 let a: any;
@@ -13,6 +11,7 @@ let  b  =   a   !;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let a: any;
 let b = a!;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: type_assertion_expression.ts
-
 ---
 # Input
 let x = <
@@ -18,6 +16,7 @@ var d = <Error>
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 let x = <const>"hello";
 let y = <string>x;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 173
 expression: type_expression.ts
-
 ---
 # Input
 import * as assert from "assert";
@@ -116,6 +114,7 @@ type Type01 = 0 extends
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import * as assert from "assert";
 

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: type_member.ts
-
 ---
 # Input
 type A =
@@ -58,6 +56,7 @@ type K = { set     something( something_with_long_name: string ) }
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type A = { [a: string]: number };
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: export_clause.ts
-
 ---
 # Input
 export  type   A  =   string;
@@ -30,6 +28,7 @@ export  declare  class   E {  }
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 export type A = string;
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -13,6 +13,7 @@ import name2 = require('other_source')
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 import name = require("module_source");
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: module_declaration.ts
-
 ---
 # Input
 module singleName { }
@@ -16,6 +14,7 @@ module qualified.name { }
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 module singleName {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: qualified_module_name.ts
-
 ---
 # Input
 module a . b . c { }
@@ -13,6 +11,7 @@ module a . b . c { }
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 module a.b.c {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: parameters.ts
-
 ---
 # Input
 function a(
@@ -14,6 +12,7 @@ function a(
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 function a(this: string) {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: parenthesis.ts
-
 ---
 # Input
 const a = (c && b) as boolean;
@@ -14,6 +12,7 @@ const a = !(c && b) as boolean;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 const a = (c && b) as boolean;
 const a = <any>(c && b) as boolean;

--- a/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 163
 expression: enum_statement.ts
-
 ---
 # Input
 enum    A   {}
@@ -24,6 +22,7 @@ const enum C {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 enum A {}
 enum B {

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: suppressions.ts
-
 ---
 # Input
 
@@ -18,6 +16,7 @@ interface Suppressions {
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 interface Suppressions {
 	// rome-ignore format: test

--- a/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: conditional.ts
-
 ---
 # Input
 type test = string;
@@ -28,6 +26,7 @@ type T4 = test extends string
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type test = string;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -16,6 +16,7 @@ type QualifiedImportType = typeof import('source').Qualified<TypeParams>;
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type ImportType1 = typeof import("source");
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: intersection_type.ts
-
 ---
 # Input
 type ShortIntersection =
@@ -18,6 +16,7 @@ type LongIntersection = A & B & C & D & E & F & G & H & I & J & K & L & M & N & 
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type ShortIntersection = A & B;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 168
 expression: qualified_name.ts
-
 ---
 # Input
 type QualifiedType = A  .  B . C
@@ -12,6 +10,7 @@ type QualifiedType = A  .  B . C
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type QualifiedType = A.B.C;
 

--- a/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -13,6 +13,7 @@ type TemplateType = `
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type TemplateType = `
     text

--- a/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: union_type.ts
-
 ---
 # Input
 type ShortUnion =
@@ -25,6 +23,7 @@ trailing type */
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 type ShortUnion = A | B;
 

--- a/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
-assertion_line: 197
 expression: smoke.tsx
-
 ---
 # Input
 "foo"
@@ -12,6 +10,7 @@ expression: smoke.tsx
 -----
 Indent style: Tab
 Line width: 80
+Quote style: Double Quotes
 -----
 "foo";
 

--- a/crates/rome_lsp/src/config.rs
+++ b/crates/rome_lsp/src/config.rs
@@ -14,6 +14,8 @@ pub struct FormatterWorkspaceSettings {
     pub line_width: u16,
     /// The indent style, specified by the user
     pub indent_style: String,
+    /// The quote style, specified by the user
+    pub quote_style: String,
     /// The number of spaces, specified by the user and applied only when using Spaces
     pub space_quantity: u8,
 }

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -44,10 +44,10 @@ pub(crate) fn to_format_options(
         );
     }
 
-    let custom_ident_style =
+    let custom_quote_style =
         QuoteStyle::from_str(workspace_settings.quote_style.as_str()).unwrap_or(QuoteStyle::Double);
-    if custom_ident_style != default_options.quote_style {
-        default_options.quote_style = custom_ident_style;
+    if custom_quote_style != default_options.quote_style {
+        default_options.quote_style = custom_quote_style;
         info!(
             "Using user setting quote style: {}",
             default_options.quote_style

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -3,7 +3,7 @@ use crate::line_index::{self, LineCol};
 use anyhow::{bail, Result};
 use lspower::lsp::*;
 use rome_analyze::FileId;
-use rome_js_formatter::{FormatOptions, IndentStyle};
+use rome_js_formatter::{FormatOptions, IndentStyle, QuoteStyle};
 use rome_js_parser::{parse, SourceType};
 use rome_js_syntax::{TextRange, TokenAtOffset};
 use std::str::FromStr;
@@ -41,6 +41,16 @@ pub(crate) fn to_format_options(
         info!(
             "Using user setting indent style: {}",
             default_options.indent_style
+        );
+    }
+
+    let custom_ident_style =
+        QuoteStyle::from_str(workspace_settings.quote_style.as_str()).unwrap_or(QuoteStyle::Double);
+    if custom_ident_style != default_options.quote_style {
+        default_options.quote_style = custom_ident_style;
+        info!(
+            "Using user setting quote style: {}",
+            default_options.quote_style
         );
     }
 

--- a/crates/rome_lsp/src/handlers/formatting.rs
+++ b/crates/rome_lsp/src/handlers/formatting.rs
@@ -29,7 +29,7 @@ pub(crate) fn to_format_options(
     };
 
     let custom_ident_style =
-        IndentStyle::from_str(workspace_settings.indent_style.as_str()).unwrap_or(IndentStyle::Tab);
+        IndentStyle::from_str(workspace_settings.indent_style.as_str()).unwrap_or_default();
 
     if custom_ident_style != default_options.indent_style {
         // merge settings with the ones provided by the editor
@@ -45,7 +45,7 @@ pub(crate) fn to_format_options(
     }
 
     let custom_quote_style =
-        QuoteStyle::from_str(workspace_settings.quote_style.as_str()).unwrap_or(QuoteStyle::Double);
+        QuoteStyle::from_str(workspace_settings.quote_style.as_str()).unwrap_or_default();
     if custom_quote_style != default_options.quote_style {
         default_options.quote_style = custom_quote_style;
         info!(

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -100,6 +100,18 @@
 					"minimum": 1,
 					"maximum": 12
 				},
+				"rome.formatter.quoteStyle": {
+					"type": "string",
+					"enum": [
+						"Double",
+						"Single"
+					],
+					"default": "Double",
+					"markdownEnumDescriptions": [
+						"**BETA**: applies **double** quotes while formatting",
+						"**BETA**: applies **single** quotes while formatting"
+					]
+				},
 				"rome.analysis.enableDiagnostics": {
 					"type": "boolean",
 					"default": false,

--- a/website/playground/src/App.tsx
+++ b/website/playground/src/App.tsx
@@ -8,8 +8,9 @@ import prettier from "prettier";
 import parserBabel from "prettier/esm/parser-babel";
 import IndentStyleSelect from "./IndentStyleSelect";
 import LineWidthInput from "./LineWidthInput";
-import { IndentStyle, SourceType } from "./types";
+import { IndentStyle, QuoteStyle, SourceType } from "./types";
 import SourceTypeSelect from "./SourceTypeSelect";
+import QuoteStyleSelect from "./QuoteStyleSelect";
 
 enum LoadingState { Loading, Success, Error }
 
@@ -20,6 +21,7 @@ function formatWithPrettier(
 		indentStyle: IndentStyle,
 		indentWidth: number,
 		language: "js" | "ts",
+		quoteStyle: QuoteStyle,
 	},
 ) {
 	try {
@@ -31,6 +33,7 @@ function formatWithPrettier(
 				printWidth: options.lineWidth,
 				parser: getPrettierParser(options.language),
 				plugins: [parserBabel],
+				singleQuote: options.quoteStyle === QuoteStyle.Single,
 			},
 		);
 	} catch (err) {
@@ -88,6 +91,9 @@ function App() {
 	const [indentStyle, setIndentStyle] = useState(
 		(searchParams.get("indentStyle") as IndentStyle) ?? IndentStyle.Tab,
 	);
+	const [quoteStyle, setQuoteStyle] = useState(
+		(searchParams.get("quoteStyle") as QuoteStyle) ?? QuoteStyle.Double,
+	);
 	const [indentWidth, setIndentWidth] = useState(
 		parseInt(searchParams.get("indentWidth") ?? "2"),
 	);
@@ -103,12 +109,21 @@ function App() {
 
 	useEffect(
 		() => {
-			const url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?lineWidth=${lineWidth}&indentStyle=${indentStyle}&indentWidth=${indentWidth}&typescript=${isTypeScript}&jsx=${isJsx}&sourceType=${sourceType}#${encodeCode(
+			const url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?lineWidth=${lineWidth}&indentStyle=${indentStyle}&quoteStyle=${quoteStyle}&indentWidth=${indentWidth}&typescript=${isTypeScript}&jsx=${isJsx}&sourceType=${sourceType}#${encodeCode(
 				code,
 			)}`;
 			window.history.pushState({ path: url }, "", url);
 		},
-		[lineWidth, indentStyle, indentWidth, code, isTypeScript, isJsx, sourceType],
+		[
+			lineWidth,
+			indentStyle,
+			quoteStyle,
+			indentWidth,
+			code,
+			isTypeScript,
+			isJsx,
+			sourceType,
+		],
 	);
 
 	switch (loadingState) {
@@ -125,6 +140,7 @@ function App() {
 				code,
 				lineWidth,
 				indentStyle === IndentStyle.Space ? indentWidth : undefined,
+				quoteStyle,
 				isTypeScript,
 				isJsx,
 				sourceType,
@@ -140,6 +156,10 @@ function App() {
 							setIndentWidth={setIndentWidth}
 							indentStyle={indentStyle}
 							setIndentStyle={setIndentStyle}
+						/>
+						<QuoteStyleSelect
+							quoteStyle={quoteStyle}
+							setQuoteStyle={setQuoteStyle}
 						/>
 						<SourceTypeSelect
 							isTypeScript={isTypeScript}
@@ -176,8 +196,7 @@ function App() {
 									<Tab selectedClassName="bg-slate-300">Formatter IR</Tab>
 									<Tab
 										disabled={errors === ""}
-										selectedClassName="bg-slate-300"
-									>
+										selectedClassName="bg-slate-300">
 										Errors
 									</Tab>
 								</TabList>
@@ -201,8 +220,17 @@ function App() {
 											lineWidth,
 											indentStyle,
 											indentWidth,
-											language: isTypeScript ? "ts" : "js"
+											language: isTypeScript ? "ts" : "js",
+											quoteStyle,
 										})}
+										key={
+											code +
+											lineWidth +
+											indentStyle +
+											indentWidth +
+											language +
+											quoteStyle
+										}
 										language={language}
 										placeholder="Prettier Output"
 										style={{

--- a/website/playground/src/QuoteStyleSelect.tsx
+++ b/website/playground/src/QuoteStyleSelect.tsx
@@ -1,0 +1,39 @@
+import { QuoteStyle } from "./types";
+
+interface Props {
+	setQuoteStyle: (v: QuoteStyle) => void,
+	quoteStyle: QuoteStyle,
+}
+
+export default function QuoteStyleSelect({ setQuoteStyle, quoteStyle }: Props) {
+	return (
+		<div className="pl-5">
+			<fieldset className="space-y-5">
+				<legend className="sr-only">File Type</legend>
+
+				<div className="relative flex items-start">
+					<div className="">
+						<label
+							htmlFor="quoteStyle"
+							className="block text-sm font-medium text-gray-700">
+							Quote type:
+						</label>
+						<span id="quote-type-description" className="text-gray-500">
+							<span className="sr-only">Quote type</span>
+						</span>
+						<select
+							id="quoteStyle"
+							aria-describedby="quote-type-description"
+							name="quoteStyle"
+							value={quoteStyle ?? ''}
+							onChange={(e) => setQuoteStyle(e.target.value as QuoteStyle)}
+							className="w-[100px] mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+							<option value={QuoteStyle.Double}>Double</option>
+							<option value={QuoteStyle.Single}>Single</option>
+						</select>
+					</div>
+				</div>
+			</fieldset>
+		</div>
+	);
+}

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -3,9 +3,10 @@
 use rome_diagnostics::file::SimpleFiles;
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::Emitter;
-use rome_js_formatter::{format as format_code, to_format_element, FormatOptions, IndentStyle};
+use rome_js_formatter::{format as format_code, to_format_element, FormatOptions, IndentStyle, QuoteStyle};
 use rome_js_parser::{parse, LanguageVariant, SourceType};
 use std::io;
+use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -76,6 +77,7 @@ pub fn run(
     code: String,
     line_width: u16,
     indent_width: Option<u8>, // If None, we use tabs
+    quote_style: String,
     is_typescript: bool,
     is_jsx: bool,
     source_type: String,
@@ -111,6 +113,7 @@ pub fn run(
     let options = FormatOptions {
         indent_style,
         line_width: line_width.try_into().unwrap_or_default(),
+        quote_style: QuoteStyle::from_str(&quote_style).unwrap_or_default(),
     };
 
     let cst = format!("{:#?}", syntax);

--- a/website/playground/src/lib.rs
+++ b/website/playground/src/lib.rs
@@ -3,10 +3,9 @@
 use rome_diagnostics::file::SimpleFiles;
 use rome_diagnostics::termcolor::{ColorSpec, WriteColor};
 use rome_diagnostics::Emitter;
-use rome_js_formatter::{format as format_code, to_format_element, FormatOptions, IndentStyle, QuoteStyle};
+use rome_js_formatter::{format as format_code, to_format_element, FormatOptions, IndentStyle};
 use rome_js_parser::{parse, LanguageVariant, SourceType};
 use std::io;
-use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -113,7 +112,7 @@ pub fn run(
     let options = FormatOptions {
         indent_style,
         line_width: line_width.try_into().unwrap_or_default(),
-        quote_style: QuoteStyle::from_str(&quote_style).unwrap_or_default(),
+        quote_style: quote_style.parse().unwrap_or_default(),
     };
 
     let cst = format!("{:#?}", syntax);

--- a/website/playground/src/types.ts
+++ b/website/playground/src/types.ts
@@ -1,2 +1,3 @@
 export enum IndentStyle { Tab = "tab", Space = "space" }
 export enum SourceType { Module = "module", Script = "script" }
+export enum QuoteStyle { Double = "double", Single = "single" }


### PR DESCRIPTION
## Summary
This PR adds a `--quote-style` option to the Rome Formatter so that users can choose between single and double quotes. Arguably, template literals should also be an available option, but that can be discussed later.

## Test Plan

* `cargo test`
* `cargo run -p rome_cli -- format --quote-style=single <file>` works.