### PR TITLE
perf(rome_rowan): `SyntaxTriviaPiece.text()`

### DIFF
--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -248,15 +248,9 @@ pub(crate) fn has_formatter_suppressions(node: &JsSyntaxNode) -> bool {
         .pieces()
         .filter_map(|trivia| trivia.as_comments())
         .any(|comment| {
-            for suppression in parse_suppression_comment(comment.text()) {
-                for (category, _) in suppression.categories {
-                    if category == CATEGORY_FORMAT {
-                        return true;
-                    }
-                }
-            }
-
-            false
+            parse_suppression_comment(comment.text())
+                .flat_map(|suppression| suppression.categories)
+                .any(|category| category.0 == CATEGORY_FORMAT)
         })
 }
 

--- a/crates/rome_rowan/src/cursor/token.rs
+++ b/crates/rome_rowan/src/cursor/token.rs
@@ -151,12 +151,12 @@ impl SyntaxToken {
 
     #[inline]
     pub fn leading_trivia(&self) -> SyntaxTrivia {
-        SyntaxTrivia::leading(self.data().offset, self.clone())
+        SyntaxTrivia::leading(self.clone())
     }
 
     #[inline]
     pub fn trailing_trivia(&self) -> SyntaxTrivia {
-        SyntaxTrivia::trailing(self.data().offset, self.clone())
+        SyntaxTrivia::trailing(self.clone())
     }
 }
 

--- a/crates/rome_rowan/src/green/trivia.rs
+++ b/crates/rome_rowan/src/green/trivia.rs
@@ -81,14 +81,13 @@ impl GreenTrivia {
 
     /// Returns the total length of all pieces
     pub fn text_len(&self) -> TextSize {
-        let mut len: Option<TextSize> = Some(TextSize::default());
+        let mut len = TextSize::default();
 
         for piece in self.pieces() {
-            len = len.and_then(|len| len.checked_add(piece.length))
+            len += piece.length
         }
 
-        // Realistically we will never have files bigger than usize::MAX, nor u32::MAX
-        len.unwrap_or_else(|| TextSize::from(u32::MAX))
+        len
     }
 
     /// Returns the pieces count

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -34,6 +34,7 @@ pub enum RawLanguageKind {
     LET_TOKEN = 13,
     CONDITION = 14,
     PLUS_TOKEN = 15,
+    WHITESPACE = 16,
     __LAST,
 }
 


### PR DESCRIPTION
The existing `SyntaxTriviaPiece.text()` method called into `SyntaxTrivia.text_range()` which is expensive because it must iterate over all pieces to get the absolute offset.

The result was that `fourslash/reallyLargeFile` took minutes on my computer to format.

This PR changes the `piece.text` implementation to instead retrieve the text directly from the token because the piece is already aware of its absolute offset in the file, making the operation `O(1)`. 

I don't expect this change to have any perf improvements for the majority of files. It's only relevant for files with a massive number of trivia pieces. 

There are still some places where the implementation calls into `text_range` to get the offsets which always requires iterating over all trivia pieces to get the total length. This happens when calling the `pieces` iterator. We may want to consider caching the total length on the `GreenTrivia`.

This PR further fixes an issue where `trivia.offset()` was not correctly computed for trailing trivia (always initialized to the start of the token)

## Tests

Formatting all TS files in the coverage directory now takes less than 2 seconds.