### PR TITLE
feat(rome_console): redact Unicode control characters

### DIFF
--- a/crates/rome_console/src/fmt.rs
+++ b/crates/rome_console/src/fmt.rs
@@ -1,6 +1,12 @@
-use std::{borrow::Cow, fmt, io, time::Duration};
+use std::{
+    borrow::Cow,
+    fmt::{self, Write as _},
+    io,
+    time::Duration,
+};
 
 use termcolor::{ColorSpec, WriteColor};
+use unicode_width::UnicodeWidthChar;
 
 use crate::{markup, Markup, MarkupElement};
 
@@ -61,14 +67,47 @@ where
 {
     fn write_str(&mut self, elements: &MarkupElements, content: &str) -> io::Result<()> {
         with_format(&mut self.0, elements, |writer| {
-            io::Write::write_all(writer, content.as_bytes())
+            SanitizeAdapter(writer)
+                .write_str(content)
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "formatter error"))
         })
     }
 
     fn write_fmt(&mut self, elements: &MarkupElements, content: fmt::Arguments) -> io::Result<()> {
         with_format(&mut self.0, elements, |writer| {
-            io::Write::write_fmt(writer, content)
+            SanitizeAdapter(writer)
+                .write_fmt(content)
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "formatter error"))
         })
+    }
+}
+
+/// Adapter [fmt::Write] calls to [io::Write] with sanitization,
+/// implemented as an internal struct to avoid exposing [fmt::Write] on
+/// [Termcolor]
+struct SanitizeAdapter<W>(W);
+
+impl<W: io::Write> fmt::Write for SanitizeAdapter<W> {
+    fn write_str(&mut self, content: &str) -> fmt::Result {
+        let mut buffer = [0; 4];
+
+        for item in content.chars() {
+            // Replace non-whitespace, zero-width characters with the Unicode replacement character
+            let is_whitespace = item.is_whitespace();
+            let is_zero_width = UnicodeWidthChar::width(item).map_or(true, |width| width == 0);
+            let item = if !is_whitespace && is_zero_width {
+                char::REPLACEMENT_CHARACTER
+            } else {
+                item
+            };
+
+            item.encode_utf8(&mut buffer);
+            self.0
+                .write_all(&buffer[..item.len_utf8()])
+                .map_err(|_| fmt::Error)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -252,5 +291,31 @@ impl Display for Duration {
         fmt.write_markup(markup! {
             {nanos}<Dim>"ns"</Dim>
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fmt::Write, str::from_utf8};
+
+    use super::SanitizeAdapter;
+
+    #[test]
+    fn test_sanitize() {
+        // Sanitization should leave whitespace control characters (space,
+        // tabs, newline, ...) and non-ASCII unicode characters as-is but
+        // redact zero-width characters (RTL override, null character, bell,
+        // zero-width space, ...)
+        const INPUT: &str = "t\tes t\r\n\u{202D}t\0es\x07t\u{202E}\nt\u{200B}es🐛t";
+        const OUTPUT: &str = "t\tes t\r\n\u{FFFD}t\u{FFFD}es\u{FFFD}t\u{FFFD}\nt\u{FFFD}es🐛t";
+
+        let mut buffer = Vec::new();
+
+        {
+            let mut adapter = SanitizeAdapter(&mut buffer);
+            adapter.write_str(INPUT).unwrap();
+        }
+
+        assert_eq!(from_utf8(&buffer).unwrap(), OUTPUT);
     }
 }


### PR DESCRIPTION
## Summary

This change intercepts the writing logic of `rome_console` to replace on the fly any Unicode character with a width of zero (with the exception of code points with the `White_Space` property) with the `REPLACEMENT CHARACTER` code point. This should cover most code points in the `Cc` and `Cf` categories, and ensure they are explicitly visible in the terminal output (for instance when printing code spans)
