### PR TITLE
feat(xtask): Check for sub unions overlap

### DIFF
--- a/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
+++ b/crates/rome_js_formatter/src/js/any/array_assignment_pattern_element.rs
@@ -9,7 +9,6 @@ impl ToFormatElement for JsAnyArrayAssignmentPatternElement {
             Self::JsAnyAssignmentPattern(node) => node.to_format_element(formatter),
             Self::JsArrayAssignmentPatternRestElement(node) => node.to_format_element(formatter),
             Self::JsArrayHole(node) => node.to_format_element(formatter),
-            Self::JsUnknownAssignment(node) => node.to_format_element(formatter),
         }
     }
 }

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -9132,6 +9132,7 @@ pub enum JsAnyArrayAssignmentPatternElement {
     JsArrayAssignmentPatternRestElement(JsArrayAssignmentPatternRestElement),
     JsArrayHole(JsArrayHole),
     JsAssignmentWithDefault(JsAssignmentWithDefault),
+    JsUnknownAssignment(JsUnknownAssignment),
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyArrayBindingPatternElement {
@@ -18340,12 +18341,18 @@ impl From<JsAssignmentWithDefault> for JsAnyArrayAssignmentPatternElement {
         JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(node)
     }
 }
+impl From<JsUnknownAssignment> for JsAnyArrayAssignmentPatternElement {
+    fn from(node: JsUnknownAssignment) -> JsAnyArrayAssignmentPatternElement {
+        JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(node)
+    }
+}
 impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT
             | JS_ARRAY_HOLE
-            | JS_ASSIGNMENT_WITH_DEFAULT => true,
+            | JS_ASSIGNMENT_WITH_DEFAULT
+            | JS_UNKNOWN_ASSIGNMENT => true,
             k if JsAnyAssignmentPattern::can_cast(k) => true,
             _ => false,
         }
@@ -18365,6 +18372,11 @@ impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
                     JsAssignmentWithDefault { syntax },
                 )
             }
+            JS_UNKNOWN_ASSIGNMENT => {
+                JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(JsUnknownAssignment {
+                    syntax,
+                })
+            }
             _ => {
                 if let Some(js_any_assignment_pattern) = JsAnyAssignmentPattern::cast(syntax) {
                     return Some(JsAnyArrayAssignmentPatternElement::JsAnyAssignmentPattern(
@@ -18383,6 +18395,7 @@ impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
             }
             JsAnyArrayAssignmentPatternElement::JsArrayHole(it) => &it.syntax,
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => &it.syntax,
+            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => &it.syntax,
             JsAnyArrayAssignmentPatternElement::JsAnyAssignmentPattern(it) => it.syntax(),
         }
     }
@@ -18400,6 +18413,9 @@ impl std::fmt::Debug for JsAnyArrayAssignmentPatternElement {
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => {
                 std::fmt::Debug::fmt(it, f)
             }
+            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => {
+                std::fmt::Debug::fmt(it, f)
+            }
         }
     }
 }
@@ -18412,6 +18428,7 @@ impl From<JsAnyArrayAssignmentPatternElement> for SyntaxNode {
             }
             JsAnyArrayAssignmentPatternElement::JsArrayHole(it) => it.into(),
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => it.into(),
+            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => it.into(),
         }
     }
 }

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -9132,7 +9132,6 @@ pub enum JsAnyArrayAssignmentPatternElement {
     JsArrayAssignmentPatternRestElement(JsArrayAssignmentPatternRestElement),
     JsArrayHole(JsArrayHole),
     JsAssignmentWithDefault(JsAssignmentWithDefault),
-    JsUnknownAssignment(JsUnknownAssignment),
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum JsAnyArrayBindingPatternElement {
@@ -18341,18 +18340,12 @@ impl From<JsAssignmentWithDefault> for JsAnyArrayAssignmentPatternElement {
         JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(node)
     }
 }
-impl From<JsUnknownAssignment> for JsAnyArrayAssignmentPatternElement {
-    fn from(node: JsUnknownAssignment) -> JsAnyArrayAssignmentPatternElement {
-        JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(node)
-    }
-}
 impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT
             | JS_ARRAY_HOLE
-            | JS_ASSIGNMENT_WITH_DEFAULT
-            | JS_UNKNOWN_ASSIGNMENT => true,
+            | JS_ASSIGNMENT_WITH_DEFAULT => true,
             k if JsAnyAssignmentPattern::can_cast(k) => true,
             _ => false,
         }
@@ -18372,11 +18365,6 @@ impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
                     JsAssignmentWithDefault { syntax },
                 )
             }
-            JS_UNKNOWN_ASSIGNMENT => {
-                JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(JsUnknownAssignment {
-                    syntax,
-                })
-            }
             _ => {
                 if let Some(js_any_assignment_pattern) = JsAnyAssignmentPattern::cast(syntax) {
                     return Some(JsAnyArrayAssignmentPatternElement::JsAnyAssignmentPattern(
@@ -18395,7 +18383,6 @@ impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
             }
             JsAnyArrayAssignmentPatternElement::JsArrayHole(it) => &it.syntax,
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => &it.syntax,
-            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => &it.syntax,
             JsAnyArrayAssignmentPatternElement::JsAnyAssignmentPattern(it) => it.syntax(),
         }
     }
@@ -18413,9 +18400,6 @@ impl std::fmt::Debug for JsAnyArrayAssignmentPatternElement {
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => {
                 std::fmt::Debug::fmt(it, f)
             }
-            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => {
-                std::fmt::Debug::fmt(it, f)
-            }
         }
     }
 }
@@ -18428,7 +18412,6 @@ impl From<JsAnyArrayAssignmentPatternElement> for SyntaxNode {
             }
             JsAnyArrayAssignmentPatternElement::JsArrayHole(it) => it.into(),
             JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(it) => it.into(),
-            JsAnyArrayAssignmentPatternElement::JsUnknownAssignment(it) => it.into(),
         }
     }
 }

--- a/xtask/codegen/js.ungram
+++ b/xtask/codegen/js.ungram
@@ -926,7 +926,6 @@ JsAnyArrayAssignmentPatternElement =
 	| JsAnyAssignmentPattern
 	| JsArrayAssignmentPatternRestElement
 	| JsArrayHole
-	| JsUnknownAssignment
 
 // [a, b, ...rest] = [];
 //        ^^^^^^^

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -76,7 +76,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
     // Setup a map to find the unions quickly
     let union_map: HashMap<_, _> = unions
         .iter()
-        .map(|en| -> (&str, &AstEnumSrc) { (en.name.as_str(), en) })
+        .map(|en| { (&en.name, en) })
         .collect();
 
     // Iterate over all unions
@@ -85,11 +85,11 @@ fn check_unions(unions: &[AstEnumSrc]) {
             "\n******** START ERROR STACK ********\nChecking {}, variants : {:?}",
             union.name, union.variants
         );
-        let mut union_set: HashSet<&str> = HashSet::from([union.name.as_str()]);
-        let mut union_queue: VecDeque<&str> = VecDeque::new();
+        let mut union_set: HashSet<&String> = HashSet::from([&union.name]);
+        let mut union_queue: VecDeque<&String> = VecDeque::new();
 
         // Init queue for BFS
-        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| x.as_str()).collect());
+        union_queue.extend(&union.variants);
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
@@ -104,9 +104,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
                 // Try to insert the current variant into the set
                 if union_set.insert(&current_union.name) {
                     // Add all variants into the BFS queue
-                    union_queue.extend::<Vec<&str>>(
-                        current_union.variants.iter().map(|x| x.as_str()).collect(),
-                    );
+                    union_queue.extend(&current_union.variants);
                 } else {
                     // We either have a circular dependency or 2 variants referencing the same type
                     println!("{}", stack_string);

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -75,8 +75,8 @@ pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageK
 fn check_unions(unions: &[AstEnumSrc]) {
     // Setup a map to find the unions quickly
     let union_map: HashMap<_, _> = unions
-            .into_iter()
-            .map(|en| -> (&str, &AstEnumSrc) { (&en.name.as_str(), en) })
+            .iter()
+            .map(|en| -> (&str, &AstEnumSrc) { (en.name.as_str(), en) })
             .collect();
 
     // Iterate over all unions
@@ -86,7 +86,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
         let mut union_queue: VecDeque<&str> = VecDeque::new();
 
         // Init queue for BFS
-        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| -> &str { &x.as_str() }).collect());
+        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| -> &str { x.as_str() }).collect());
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
@@ -124,7 +124,7 @@ pub(crate) fn load_js_ast() -> AstSrc {
     let grammar: Grammar = grammar_src.parse().unwrap();
     let ast : AstSrc = make_ast(&grammar);
     check_unions(&ast.unions);
-    return ast;
+    ast
 }
 
 pub(crate) fn load_css_ast() -> AstSrc {

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -74,10 +74,7 @@ pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageK
 
 fn check_unions(unions: &[AstEnumSrc]) {
     // Setup a map to find the unions quickly
-    let union_map: HashMap<_, _> = unions
-        .iter()
-        .map(|en| { (&en.name, en) })
-        .collect();
+    let union_map: HashMap<_, _> = unions.iter().map(|en| (&en.name, en)).collect();
 
     // Iterate over all unions
     for union in unions {
@@ -85,8 +82,8 @@ fn check_unions(unions: &[AstEnumSrc]) {
             "\n******** START ERROR STACK ********\nChecking {}, variants : {:?}",
             union.name, union.variants
         );
-        let mut union_set: HashSet<&String> = HashSet::from([&union.name]);
-        let mut union_queue: VecDeque<&String> = VecDeque::new();
+        let mut union_set: HashSet<_> = HashSet::from([&union.name]);
+        let mut union_queue: VecDeque<_> = VecDeque::new();
 
         // Init queue for BFS
         union_queue.extend(&union.variants);

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -75,8 +75,8 @@ pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageK
 fn check_unions(unions: &[AstEnumSrc]) {
     // Setup a map to find the unions quickly
     let union_map: HashMap<_, _> = unions
-            .iter()
-            .map(|en| -> (&str, &AstEnumSrc) { (en.name.as_str(), en) })
+            .into_iter()
+            .map(|en| -> (&str, &AstEnumSrc) { (&en.name.as_str(), en) })
             .collect();
 
     // Iterate over all unions
@@ -86,7 +86,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
         let mut union_queue: VecDeque<&str> = VecDeque::new();
 
         // Init queue for BFS
-        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| -> &str { x.as_str() }).collect());
+        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| -> &str { &x.as_str() }).collect());
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
@@ -124,7 +124,7 @@ pub(crate) fn load_js_ast() -> AstSrc {
     let grammar: Grammar = grammar_src.parse().unwrap();
     let ast : AstSrc = make_ast(&grammar);
     check_unions(&ast.unions);
-    ast
+    return ast;
 }
 
 pub(crate) fn load_css_ast() -> AstSrc {

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -89,13 +89,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
         let mut union_queue: VecDeque<&str> = VecDeque::new();
 
         // Init queue for BFS
-        union_queue.extend::<Vec<&str>>(
-            union
-                .variants
-                .iter()
-                .map(|x| -> &str { x.as_str() })
-                .collect(),
-        );
+        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| x.as_str()).collect());
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
@@ -110,9 +104,9 @@ fn check_unions(unions: &[AstEnumSrc]) {
                 // Try to insert the current variant into the set
                 if union_set.insert(&current_union.name) {
                     // Add all variants into the BFS queue
-                    for child in &current_union.variants {
-                        union_queue.push_back(child);
-                    }
+                    union_queue.extend::<Vec<&str>>(
+                        current_union.variants.iter().map(|x| x.as_str()).collect(),
+                    );
                 } else {
                     // We either have a circular dependency or 2 variants referencing the same type
                     println!("{}", stack_string);

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -73,11 +73,10 @@ pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageK
 }
 
 fn check_unions(unions: &[AstEnumSrc]) {
-    // Setup a map to find the indices of unions quickly
-    let idx_map: HashMap<_, _> = unions
+    // Setup a map to find the unions quickly
+    let union_map: HashMap<_, _> = unions
             .into_iter()
-            .enumerate()
-            .map(|(idx, en)| -> (&str, usize) { (&en.name.as_str(), idx) })
+            .map(|en| -> (&str, &AstEnumSrc) { (&en.name.as_str(), en) })
             .collect();
 
     // Iterate over all unions
@@ -91,10 +90,10 @@ fn check_unions(unions: &[AstEnumSrc]) {
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
-            if idx_map.contains_key(variant) {
+            if union_map.contains_key(variant) {
                 // The variant is a compound variant
                 // Get the struct from the map
-                let current_union = &unions[idx_map[variant]];
+                let current_union = union_map[variant];
                 stack_string.push_str(&format!("\nSUB-ENUM CHECK : {}, variants : {:?}", current_union.name, current_union.variants));
                 // Try to insert the current variant into the set
                 if union_set.insert(&current_union.name) {

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -75,18 +75,27 @@ pub(crate) fn generate_syntax(ast: AstSrc, mode: &Mode, language_kind: LanguageK
 fn check_unions(unions: &[AstEnumSrc]) {
     // Setup a map to find the unions quickly
     let union_map: HashMap<_, _> = unions
-            .iter()
-            .map(|en| -> (&str, &AstEnumSrc) { (en.name.as_str(), en) })
-            .collect();
+        .iter()
+        .map(|en| -> (&str, &AstEnumSrc) { (en.name.as_str(), en) })
+        .collect();
 
     // Iterate over all unions
     for union in unions {
-        let mut stack_string = format!("\n******** START ERROR STACK ********\nChecking {}, variants : {:?}", union.name, union.variants);
+        let mut stack_string = format!(
+            "\n******** START ERROR STACK ********\nChecking {}, variants : {:?}",
+            union.name, union.variants
+        );
         let mut union_set: HashSet<&str> = HashSet::from([union.name.as_str()]);
         let mut union_queue: VecDeque<&str> = VecDeque::new();
 
         // Init queue for BFS
-        union_queue.extend::<Vec<&str>>(union.variants.iter().map(|x| -> &str { x.as_str() }).collect());
+        union_queue.extend::<Vec<&str>>(
+            union
+                .variants
+                .iter()
+                .map(|x| -> &str { x.as_str() })
+                .collect(),
+        );
 
         // Loop over the queue getting the first variant
         while let Some(variant) = union_queue.pop_front() {
@@ -94,7 +103,10 @@ fn check_unions(unions: &[AstEnumSrc]) {
                 // The variant is a compound variant
                 // Get the struct from the map
                 let current_union = union_map[variant];
-                stack_string.push_str(&format!("\nSUB-ENUM CHECK : {}, variants : {:?}", current_union.name, current_union.variants));
+                stack_string.push_str(&format!(
+                    "\nSUB-ENUM CHECK : {}, variants : {:?}",
+                    current_union.name, current_union.variants
+                ));
                 // Try to insert the current variant into the set
                 if union_set.insert(&current_union.name) {
                     // Add all variants into the BFS queue
@@ -122,7 +134,7 @@ fn check_unions(unions: &[AstEnumSrc]) {
 pub(crate) fn load_js_ast() -> AstSrc {
     let grammar_src = include_str!("../js.ungram");
     let grammar: Grammar = grammar_src.parse().unwrap();
-    let ast : AstSrc = make_ast(&grammar);
+    let ast: AstSrc = make_ast(&grammar);
     check_unions(&ast.unions);
     ast
 }


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Adding a BFS search implementation to check if unions trees contain circular dependencies or reuse types.
The goal is to prevent potential union circular dependencies as well as unions having the same type in multiple branches.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Based on https://github.com/rome/tools/issues/1765

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
Here are the test cases I used : 

**These should succeed : **
```
UnionA =
	JsIdentifierAssignment
	| JsStaticMemberAssignment
	| JsComputedMemberAssignment

UnionB =
	JsIdentifierAssignment
	| JsUnknownAssignment
```
```
UnionA =
	JsIdentifierAssignment
	| JsUnknownAssignment

UnionB =
	JsIdentifierAssignment
	| JsUnknownAssignment
```

**These should fail : **

```
UnionA =
	UnionA
	| JsUnknownAssignment
```
```
UnionA =
	UnionB
	| JsUnknownAssignment
UnionB =
	JsxText
	| UnionA
```
```
UnionA =
	UnionB
	| JsUnknownAssignment

UnionB =
	JsxText
	| JsUnknownAssignment
```
```
UnionA =
	UnionB
	| JsUnknownAssignment

UnionB =
	JsxText
	| JsAnyObjectAssignmentPatternMember
``` 
(`JsAnyObjectAssignmentPatternMember` contains `JsUnknownAssignment` )

```
UnionA =
	UnionB
	| JsxSelfClosingElement

UnionB =
	UnionD
	| UnionC

UnionC =
	JsxText
	| JsxExpressionChild

UnionD =
	JsxSelfClosingElement
	| JsAnyObjectAssignmentPatternMember
```
```
UnionA =
	JsxText
	| JsxText
```