### PR TITLE
fix(rome_js_parser): Assignment in decorator

### DIFF
--- a/crates/rome_js_parser/src/token_source.rs
+++ b/crates/rome_js_parser/src/token_source.rs
@@ -46,6 +46,11 @@ impl Trivia {
     pub fn trailing(&self) -> bool {
         self.trailing
     }
+
+    /// Returns the text range of this trivia
+    pub fn text_range(&self) -> TextRange {
+        self.range
+    }
 }
 
 /// Token source for the parser that skips over any non-trivia token.

--- a/crates/rome_js_parser/test_data/inline/err/js_invalid_assignment.rast
+++ b/crates/rome_js_parser/test_data/inline/err/js_invalid_assignment.rast
@@ -43,7 +43,7 @@ JsModule {
                                                                     value_token: IDENT@10..11 "p" [] [],
                                                                 },
                                                             },
-                                                            operator: PERCENT@11..12 "%" [] [],
+                                                            operator_token: PERCENT@11..12 "%" [] [],
                                                             right: missing (required),
                                                         },
                                                         r_paren_token: missing (required),
@@ -51,7 +51,7 @@ JsModule {
                                                 ],
                                                 r_brack_token: R_BRACK@12..13 "]" [] [],
                                             },
-                                            operator: R_ANGLE@13..14 ">" [] [],
+                                            operator_token: R_ANGLE@13..14 ">" [] [],
                                             right: JsParenthesizedExpression {
                                                 l_paren_token: L_PAREN@14..15 "(" [] [],
                                                 expression: JsArrayExpression {

--- a/crates/rome_js_parser/test_data/inline/ok/ts_decorator_assignment.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_decorator_assignment.rast
@@ -1,0 +1,37 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsClassDeclaration {
+            abstract_token: missing (optional),
+            class_token: CLASS_KW@0..17 "class" [Skipped("@"), Skipped("test"), Skipped("("), Skipped("--"), Skipped("a"), Skipped(")"), Newline("\n")] [Whitespace(" ")],
+            id: JsIdentifierBinding {
+                name_token: IDENT@17..22 "Test" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            extends_clause: missing (optional),
+            implements_clause: missing (optional),
+            l_curly_token: L_CURLY@22..23 "{" [] [],
+            members: JsClassMemberList [],
+            r_curly_token: R_CURLY@23..24 "}" [] [],
+        },
+    ],
+    eof_token: EOF@24..25 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..25
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..24
+    0: JS_CLASS_DECLARATION@0..24
+      0: (empty)
+      1: CLASS_KW@0..17 "class" [Skipped("@"), Skipped("test"), Skipped("("), Skipped("--"), Skipped("a"), Skipped(")"), Newline("\n")] [Whitespace(" ")]
+      2: JS_IDENTIFIER_BINDING@17..22
+        0: IDENT@17..22 "Test" [] [Whitespace(" ")]
+      3: (empty)
+      4: (empty)
+      5: (empty)
+      6: L_CURLY@22..23 "{" [] []
+      7: JS_CLASS_MEMBER_LIST@23..23
+      8: R_CURLY@23..24 "}" [] []
+  3: EOF@24..25 "" [Newline("\n")] []

--- a/crates/rome_js_parser/test_data/inline/ok/ts_decorator_assignment.ts
+++ b/crates/rome_js_parser/test_data/inline/ok/ts_decorator_assignment.ts
@@ -1,0 +1,2 @@
+@test(--a)
+class Test {}

--- a/xtask/codegen/src/parser_tests.rs
+++ b/xtask/codegen/src/parser_tests.rs
@@ -43,8 +43,7 @@ fn extract_comment_blocks(
 }
 
 pub fn generate_parser_tests(mode: Mode) -> Result<()> {
-    let tests =
-        tests_from_dir(&project_root().join(Path::new("crates/rome_js_parser/src/syntax")))?;
+    let tests = tests_from_dir(&project_root().join(Path::new("crates/rome_js_parser/src")))?;
     fn install_tests(tests: &HashMap<String, Test>, into: &str, mode: Mode) -> Result<bool> {
         let tests_dir = project_root().join(into);
         if !tests_dir.is_dir() {


### PR DESCRIPTION
Assignments are hard...

This PR fixes an issue where an assignment is used inside a decorator, e.g. `@test(--a)`

The parser used to panic when rewriting the assignment because any skipped tokens (the case for all tokens inside a decorator) are in the trivia collection and the parser events to ensure all parser methods work correctly.

However, this had the effect that `skip_trivia` in `rewrite_parser` moved the offset passed all skipped tokens, passed any not yet processed token (that ultimately get skipped).

This PR makes the rewrite parser aware of skipped tokens and only consumes them when the corresponding token gets bumped.

This prevents the parser from panicking for the following two snipped founds when fuzzing the parser  #1945 

```js
(-- @ (--(-((QQQQQ $
= 8?0 @ (--(-( A S=
```