### PR TITLE
fix(rome_js_formatter): Insert Space after `type` for import equals declaration

### DIFF
--- a/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/import_equals_declaration.rs
@@ -22,8 +22,8 @@ impl ToFormatElement for TsImportEqualsDeclaration {
                 import_token.format(formatter)?,
                 space_token(),
                 type_token.format_with_or_empty(formatter, |token| format_elements![
+                    token,
                     space_token(),
-                    token
                 ])?,
                 id.format(formatter)?,
                 space_token(),

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/import-require/type-imports.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/import-require/type-imports.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: type-imports.ts
-
 ---
 # Input
 ```js
@@ -29,16 +27,16 @@ b = require("b");
 
 # Output
 ```js
-import typeA = require("foo");
+import type A = require("foo");
 export import type = require("A");
 
-import typeA = require("A");
+import type A = require("A");
 
-import typea = require("a");
+import type a = require("a");
 
-export import typeB = require("B");
+export import type B = require("B");
 
-export import typeb = require("b");
+export import type b = require("b");
 
 ```
 


### PR DESCRIPTION
Insert a space after the `type` keyword for import equals declarations.