### PR TITLE
ci(website): fix deploy playground workflow

### DIFF
--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'crates'
-      - 'website/playground'
+      - "crates/*"
+      - "website/playground/*"
     branches:
       - main
 

--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -48,7 +48,7 @@ jobs:
         if: github.event_name == "pull_request"
         id: url
         run: |
-          url="[Playground for commit](http://play.rome.tools.s3-website-us-east-1.amazonaws.com/${{ GITHUB_SHA }}/index.html)"
+          url="[Playground for commit](https://play.rome.tools/${{ GITHUB_SHA }}/)"
           echo "::set-output name=url::$url"
 
       - name: Get the PR number

--- a/website/playground/src/App.tsx
+++ b/website/playground/src/App.tsx
@@ -266,6 +266,7 @@ function App() {
 	}
 }
 
+
 // See https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings
 function encodeCode(code: string): string {
 	return btoa(toBinary(code));

--- a/website/playground/src/App.tsx
+++ b/website/playground/src/App.tsx
@@ -266,7 +266,6 @@ function App() {
 	}
 }
 
-
 // See https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings
 function encodeCode(code: string): string {
 	return btoa(toBinary(code));


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
I *think* that the GitHub actions `paths` option requires a `*` after a folder, i.e. `crates/*` instead of `crates/`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
