### PR TITLE
fix(rome_js_parser): Parsing of parenthesized `in` expression in `for` initializer

### DIFF
--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -1010,7 +1010,7 @@ fn parse_call_arguments(p: &mut Parser) -> ParsedSyntax {
 // ((foo))
 // (foo)
 
-fn parse_parenthesized_expression(p: &mut Parser, context: ExpressionContext) -> ParsedSyntax {
+fn parse_parenthesized_expression(p: &mut Parser) -> ParsedSyntax {
     if !p.at(T!['(']) {
         return Absent;
     }
@@ -1018,6 +1018,8 @@ fn parse_parenthesized_expression(p: &mut Parser, context: ExpressionContext) ->
     let m = p.start();
     p.bump(T!['(']);
 
+    // test for_with_in_in_parenthesized_expression
+    // for((true,"selectionStart"in true);;) {}
     if p.at(T![')']) {
         // test_err empty_parenthesized_expression
         // ();
@@ -1029,7 +1031,7 @@ fn parse_parenthesized_expression(p: &mut Parser, context: ExpressionContext) ->
         let first = parse_assignment_expression_or_higher(p, ExpressionContext::default());
 
         if p.at(T![,]) {
-            parse_sequence_expression_recursive(p, first, context)
+            parse_sequence_expression_recursive(p, first, ExpressionContext::default())
                 .or_add_diagnostic(p, expected_expression);
         }
     }
@@ -1170,7 +1172,7 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
         // test grouping_expr
         // ((foo))
         // (foo)
-        T!['('] => parse_parenthesized_expression(p, context).unwrap(),
+        T!['('] => parse_parenthesized_expression(p).unwrap(),
         T!['['] => parse_array_expr(p).unwrap(),
         T!['{'] if context.is_object_expression_allowed() => parse_object_expression(p).unwrap(),
 

--- a/crates/rome_js_parser/test_data/inline/ok/for_with_in_in_parenthesized_expression.js
+++ b/crates/rome_js_parser/test_data/inline/ok/for_with_in_in_parenthesized_expression.js
@@ -1,0 +1,1 @@
+for((true,"selectionStart"in true);;) {}

--- a/crates/rome_js_parser/test_data/inline/ok/for_with_in_in_parenthesized_expression.rast
+++ b/crates/rome_js_parser/test_data/inline/ok/for_with_in_in_parenthesized_expression.rast
@@ -1,0 +1,71 @@
+JsModule {
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsForStatement {
+            for_token: FOR_KW@0..3 "for" [] [],
+            l_paren_token: L_PAREN@3..4 "(" [] [],
+            initializer: JsParenthesizedExpression {
+                l_paren_token: L_PAREN@4..5 "(" [] [],
+                expression: JsSequenceExpression {
+                    left: JsBooleanLiteralExpression {
+                        value_token: TRUE_KW@5..9 "true" [] [],
+                    },
+                    comma_token: COMMA@9..10 "," [] [],
+                    right: JsInExpression {
+                        property: JsStringLiteralExpression {
+                            value_token: JS_STRING_LITERAL@10..26 "\"selectionStart\"" [] [],
+                        },
+                        in_token: IN_KW@26..29 "in" [] [Whitespace(" ")],
+                        object: JsBooleanLiteralExpression {
+                            value_token: TRUE_KW@29..33 "true" [] [],
+                        },
+                    },
+                },
+                r_paren_token: R_PAREN@33..34 ")" [] [],
+            },
+            first_semi_token: SEMICOLON@34..35 ";" [] [],
+            test: missing (optional),
+            second_semi_token: SEMICOLON@35..36 ";" [] [],
+            update: missing (optional),
+            r_paren_token: R_PAREN@36..38 ")" [] [Whitespace(" ")],
+            body: JsBlockStatement {
+                l_curly_token: L_CURLY@38..39 "{" [] [],
+                statements: JsStatementList [],
+                r_curly_token: R_CURLY@39..40 "}" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@40..41 "" [Newline("\n")] [],
+}
+
+0: JS_MODULE@0..41
+  0: (empty)
+  1: JS_DIRECTIVE_LIST@0..0
+  2: JS_MODULE_ITEM_LIST@0..40
+    0: JS_FOR_STATEMENT@0..40
+      0: FOR_KW@0..3 "for" [] []
+      1: L_PAREN@3..4 "(" [] []
+      2: JS_PARENTHESIZED_EXPRESSION@4..34
+        0: L_PAREN@4..5 "(" [] []
+        1: JS_SEQUENCE_EXPRESSION@5..33
+          0: JS_BOOLEAN_LITERAL_EXPRESSION@5..9
+            0: TRUE_KW@5..9 "true" [] []
+          1: COMMA@9..10 "," [] []
+          2: JS_IN_EXPRESSION@10..33
+            0: JS_STRING_LITERAL_EXPRESSION@10..26
+              0: JS_STRING_LITERAL@10..26 "\"selectionStart\"" [] []
+            1: IN_KW@26..29 "in" [] [Whitespace(" ")]
+            2: JS_BOOLEAN_LITERAL_EXPRESSION@29..33
+              0: TRUE_KW@29..33 "true" [] []
+        2: R_PAREN@33..34 ")" [] []
+      3: SEMICOLON@34..35 ";" [] []
+      4: (empty)
+      5: SEMICOLON@35..36 ";" [] []
+      6: (empty)
+      7: R_PAREN@36..38 ")" [] [Whitespace(" ")]
+      8: JS_BLOCK_STATEMENT@38..40
+        0: L_CURLY@38..39 "{" [] []
+        1: JS_STATEMENT_LIST@39..39
+        2: R_CURLY@39..40 "}" [] []
+  3: EOF@40..41 "" [Newline("\n")] []


### PR DESCRIPTION
`in` expressions aren't allowed in `for` initializers but are if the initializer is parenthesized [spec](https://tc39.es/ecma262/#prod-ParenthesizedExpression). 

Fixes #2395