### PR TITLE
chore: Fix syntax error in deploy playground workflow

### DIFF
--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -30,8 +30,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.1.0
-        run_install: |
-          args: [--prefix website/playground]
+        with:
+          version: 6
+          run_install: |
+            args: [--prefix website/playground]
       - run: pnpm build --prefix website/playground -- --base=/$GITHUB_SHA/
       - name: Publish
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/deploy_playground_on_main.yml
+++ b/.github/workflows/deploy_playground_on_main.yml
@@ -27,8 +27,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.1.0
-        run_install: |
-          args: [--prefix website/playground]
+        with:
+          version: 6
+          run_install: |
+            args: [--prefix website/playground]
       - run: pnpm build --prefix website/playground
       - name: Publish
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
Fixes a syntax error in the `playground*.yml` files.

## Test

Triggered the deploy main workflow manually [logs](https://github.com/rome/tools/runs/6003721158?check_suite_focus=true)