### PR TITLE
fix(rome_js_formatter): Use semicolons instead of commas for separating keys in a type member list

### DIFF
--- a/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
+++ b/crates/rome_js_formatter/src/ts/lists/type_member_list.rs
@@ -25,9 +25,9 @@ impl ToFormatElement for TsTypeMemberList {
                     // Children don't format the separator on purpose, so it's up to the parent - this node,
                     // to decide to print their separator
                     if index == last_index {
-                        if_group_breaks(token(","))
+                        if_group_breaks(token(";"))
                     } else {
-                        token(",")
+                        token(";")
                     }
                 } else {
                     empty_element()

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/array/comment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/array/comment.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: comment.ts
-
 ---
 # Input
 ```js
@@ -24,7 +22,7 @@ export class ViewTokensChangedEvent {
     /**
      * Start line number of range
      */
-    readonly fromLineNumber: number,
+    readonly fromLineNumber: number;
   }[];
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: as.ts
-
 ---
 # Input
 ```js
@@ -93,9 +91,9 @@ const value3 = thisIsAReallyLongIdentifier as (
   SomeInterface | SomeOtherInterface
 );
 const value4 = thisIsAReallyLongIdentifier as {
-  prop1: string,
-  prop2: number,
-  prop3: number,
+  prop1: string;
+  prop2: number;
+  prop3: number;
 }[];
 const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
   string,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10846.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10846.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: issue-10846.ts
-
 ---
 # Input
 ```js
@@ -49,14 +47,14 @@ const foo =
 
 # Output
 ```js
-const foo = call<{ prop1: string, prop2: string, prop3: string }>();
+const foo = call<{ prop1: string; prop2: string; prop3: string }>();
 
 export const CallRecorderContext = createContext<
-  { deleteRecording: (id: string) => void, deleteAll: () => void } | null
+  { deleteRecording: (id: string) => void; deleteAll: () => void } | null
 >(null);
 
 export const CallRecorderContext = createContext<
-  { deleteRecording: (id: string) => void, deleteAll: () => void } | null
+  { deleteRecording: (id: string) => void; deleteAll: () => void } | null
 >(null, "useless");
 
 const foo = call<Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo>();

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10848.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10848.tsx.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 151
 expression: issue-10848.tsx
-
 ---
 # Input
 ```js
@@ -101,9 +99,9 @@ const MyGenericComponent: React.VoidFunctionComponent<
 
 export const ExportToExcalidrawPlus: React.FC<
   {
-    elements: readonly NonDeletedExcalidrawElement[],
-    appState: AppState,
-    onError: (error: Error) => void,
+    elements: readonly NonDeletedExcalidrawElement[];
+    appState: AppState;
+    onError: (error: Error) => void;
   }
 > = ({ elements, appState, onError }) => {
   return null;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/class/methods.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/class/methods.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: methods.ts
-
 ---
 # Input
 ```js
@@ -26,7 +24,7 @@ class X {
   optionalMethod?() {}
 }
 
-interface Iterable<T> { export, [Symbol.iterator](): Iterator<T> }
+interface Iterable<T> { export; [Symbol.iterator](): Iterator<T> }
 
 export class Check {
   private static property = "test";

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/interface.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: interface.ts
-
 ---
 # Input
 ```js
@@ -43,25 +41,25 @@ interface Foo {
   bar(
     currentRequest: { a: number },
     // TODO this is a very very very very long comment that makes it go > 80 columns
-  ): number,
+  ): number;
   (
     currentRequest: { a: number },
     // TODO this is a very very very very long comment that makes it go > 80 columns
-  ): number,
+  ): number;
   new(
     currentRequest: { a: number },
     // TODO this is a very very very very long comment that makes it go > 80 columns
-  ): number,
+  ): number;
   foo: {
     x(
       currentRequest: { a: number },
       // TODO this is a very very very very long comment that makes it go > 80 columns
-    ): number,
+    ): number;
     y: (
       currentRequest: { a: number },
       // TODO this is a very very very very long comment that makes it go > 80 columns
-    ) => number,
-  },
+    ) => number;
+  };
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/issues.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/issues.ts.snap
@@ -43,10 +43,10 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 export type BuckWebSocketMessage =
   | {
     // Not actually from Buck - this is to let the receiver know that the socket is connected.
-    type: "SocketConnected",
+    type: "SocketConnected";
   }
-  | { type: "BuildProgressUpdated", progressValue: number }
-  | { type: "BuildFinished", exitCode: number }
+  | { type: "BuildProgressUpdated"; progressValue: number }
+  | { type: "BuildFinished"; exitCode: number }
   | { type: "BuildStarted" }
   | { type: "ParseStarted" }
   | { type: "ParseFinished" }
@@ -58,8 +58,8 @@ export type AsyncExecuteOptions =
   & child_process$execFileOpts
   & {
     // The contents to write to stdin.
-    stdin?: string,
-    dontLogInNuclide?: boolean,
+    stdin?: string;
+    dontLogInNuclide?: boolean;
   };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/location.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/location.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: location.ts
-
 ---
 # Input
 ```js
@@ -49,9 +47,9 @@ export type WrappedFormUtils = {
 function x(
   { x, y }: {
     // Hello world.
-    x: string,
+    x: string;
     // Yoyo.
-    y: string,
+    y: string;
   },
 ) {}
 
@@ -61,7 +59,7 @@ export interface ApplicationEventData {
       context: any, /* android.content.Context */
       intent: any, /* android.content.Intent */
     ) => void,
-  ): void,
+  ): void;
 }
 
 export type WrappedFormUtils = {
@@ -69,21 +67,21 @@ export type WrappedFormUtils = {
     id: string,
     options?: {
       /** 子节点的值的属性，如 Checkbox 的是 'checked' */
-      valuePropName?: string,
+      valuePropName?: string;
       /** 子节点的初始值，类型、可选值均由子节点决定 */
-      initialValue?: any,
+      initialValue?: any;
       /** 收集子节点的值的时机 */
-      trigger?: string,
+      trigger?: string;
       /** 可以把 onChange 的参数转化为控件的值，例如 DatePicker 可设为：(date, dateString) => dateString */
-      getValueFromEvent?: (...args: any[]) => any,
+      getValueFromEvent?: (...args: any[]) => any;
       /** 校验子节点值的时机 */
-      validateTrigger?: string | string[],
+      validateTrigger?: string | string[];
       /** 校验规则，参见 [async-validator](https://github.com/yiminghe/async-validator) */
-      rules?: ValidationRule[],
+      rules?: ValidationRule[];
       /** 是否和其他控件互斥，特别用于 Radio 单选控件 */
-      exclusive?: boolean,
+      exclusive?: boolean;
     },
-  ): (node: React.ReactNode) => React.ReactNode,
+  ): (node: React.ReactNode) => React.ReactNode;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/method_types.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: method_types.ts
-
 ---
 # Input
 ```js
@@ -51,29 +49,29 @@ abstract class Test {
 # Output
 ```js
 interface foo1 {
-  bar3( /* baz */ ), /* foo */ // bat
-  bar?( /* baz */ ), /* foo */ /* bar */ /* bat */
-  bar2( /* baz */ ), /* foo */ /* bat */
+  bar3( /* baz */ ); /* foo */ // bat
+  bar?( /* baz */ ); /* foo */ /* bar */ /* bat */
+  bar2( /* baz */ ); /* foo */ /* bat */
 }
 
 interface foo2 {
-  bar?(bar: /* baz */ string): string, /* foo */ /* bar */ /* bat */
+  bar?(bar: /* baz */ string): string; /* foo */ /* bar */ /* bat */
 }
 
 interface foo3 {
-  /* foo */ ( /* bar */ ): string, /* baz */
+  /* foo */ ( /* bar */ ): string; /* baz */
 }
 
 interface foo4 {
-  /* foo */ (bar: /* bar */ string): string, /* baz */
+  /* foo */ (bar: /* bar */ string): string; /* baz */
 }
 
 interface foo5 {
-  /* foo */ new(a: /* baz */ string): string, /* bar */ /* bat */
+  /* foo */ new(a: /* baz */ string): string; /* bar */ /* bat */
 }
 
 interface foo6 {
-  /* foo */ new( /* baz */ ): string, /* bar */ /* bat */
+  /* foo */ new( /* baz */ ): string; /* bar */ /* bat */
 }
 
 type foo7 = /* foo */ ( /* bar */ ) /* baz */ => void;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/type-parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/type-parameters.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: type-parameters.ts
-
 ---
 # Input
 ```js
@@ -62,7 +60,7 @@ function foo<
 interface Foo {
   <
     A, // comment
-  >(arg): any,
+  >(arg): any;
 }
 type T = <
   // comment

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/union.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/union.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: union.ts
-
 ---
 # Input
 ```js
@@ -37,9 +35,9 @@ type UploadState<E, EM, D>
   // The upload timed out
   | { type: "Timed_out" }
   // Failed somewhere on the line
-  | { type: "Failed", error: E, errorMsg: EM }
+  | { type: "Failed"; error: E; errorMsg: EM }
   // Uploading to aws3 and CreatePostMutation succeeded
-  | { type: "Success", data: D };
+  | { type: "Success"; data: D };
 
 type UploadState2<E, EM, D>
 // The upload hasnt begun yet

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/anyIsAssignableToObject.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/anyIsAssignableToObject.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: anyIsAssignableToObject.ts
-
 ---
 # Input
 ```js
@@ -22,7 +20,7 @@ interface P { p: {} }
 
 interface Q extends P {
   // Check assignability here. Any is assignable to {}
-  p: any,
+  p: any;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/checkInfiniteExpansionTermination.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/checkInfiniteExpansionTermination.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: checkInfiniteExpansionTermination.ts
-
 ---
 # Input
 ```js
@@ -31,7 +29,7 @@ values = values2;
 // Before fix this code would cause infinite loop
 
 interface IObservable<T> {
-  n: IObservable<T[]>, // Needed, must be T[]
+  n: IObservable<T[]>; // Needed, must be T[]
 }
 
 // Needed

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/functionOverloadsOnGenericArity1.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/functionOverloadsOnGenericArity1.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: functionOverloadsOnGenericArity1.ts
-
 ---
 # Input
 ```js
@@ -24,12 +22,12 @@ interface C {
 ```js
 // overloading on arity not allowed
 interface C {
-  f<T>(): string,
-  f<T, U>(): string,
-  <T>(): string,
-  <T, U>(): string,
-  new<T>(): string,
-  new<T, U>(): string,
+  f<T>(): string;
+  f<T, U>(): string;
+  <T>(): string;
+  <T, U>(): string;
+  new<T>(): string;
+  new<T, U>(): string;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/mappedTypeWithCombinedTypeMappers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/mappedTypeWithCombinedTypeMappers.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: mappedTypeWithCombinedTypeMappers.ts
-
 ---
 # Input
 ```js
@@ -32,10 +30,10 @@ const shouldFail: { important: boolean } = output.x.children;
 // Repro from #13351
 
 type Meta<T, A> = {
-  [P in keyof T]: { value: T[P], also: A, readonly children: Meta<T[P], A> };
+  [P in keyof T]: { value: T[P]; also: A; readonly children: Meta<T[P], A> };
 };
 
-interface Input { x: string, y: number }
+interface Input { x: string; y: number }
 
 declare const output: Meta<Input, boolean>;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: interfaceWithMultipleBaseTypes2.ts
-
 ---
 # Input
 ```js
@@ -34,15 +32,15 @@ interface Derived3 extends Base, Base2 {
 
 # Output
 ```js
-interface Base { x: { a?: string, b: string } }
+interface Base { x: { a?: string; b: string } }
 
-interface Base2 { x: { b: string, c?: number } }
+interface Base2 { x: { b: string; c?: number } }
 
 interface Derived extends Base, Base2 { x: { b: string } }
 
-interface Derived2 extends Base, Base2 { x: { a: number, b: string } }
+interface Derived2 extends Base, Base2 { x: { a: number; b: string } }
 
-interface Derived3 extends Base, Base2 { x: { a: string, b: string } }
+interface Derived3 extends Base, Base2 { x: { a: string; b: string } }
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: exportImportAlias.ts
-
 ---
 # Input
 ```js
@@ -95,7 +93,7 @@ module C {
 }
 
 var a: string = C.a.x;
-var b: { x: number, y: number } = new C.a.Point(0, 0);
+var b: { x: number; y: number } = new C.a.Point(0, 0);
 var c: { name: string };
 var c: C.a.B.Id;
 
@@ -117,7 +115,7 @@ module Z {
 }
 
 var m: number = Z.y();
-var n: { x: number, y: number } = new Z.y.Point(0, 0);
+var n: { x: number; y: number } = new Z.y.Point(0, 0);
 
 module K {
   export class L {
@@ -126,7 +124,7 @@ module K {
 
   export module L {
     export var y = 12;
-    export interface Point { x: number, y: number }
+    export interface Point { x: number; y: number }
   }
 }
 
@@ -137,7 +135,7 @@ module M {
 var o: { name: string };
 var o = new M.D("Hello");
 
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 var p: M.D.Point;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: importAliasIdentifiers.ts
-
 ---
 # Input
 ```js
@@ -66,14 +64,14 @@ import alias = moduleA;
 
 var p: alias.Point;
 var p: moduleA.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 class clodule {
   name: string;
 }
 
 module clodule {
-  export interface Point { x: number, y: number }
+  export interface Point { x: number; y: number }
   var Point: Point = { x: 0, y: 0 };
 }
 
@@ -81,14 +79,14 @@ import clolias = clodule;
 
 var p: clolias.Point;
 var p: clodule.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 function fundule() {
   return { x: 0, y: 0 };
 }
 
 module fundule {
-  export interface Point { x: number, y: number }
+  export interface Point { x: number; y: number }
   var Point: Point = { x: 0, y: 0 };
 }
 
@@ -96,7 +94,7 @@ import funlias = fundule;
 
 var p: funlias.Point;
 var p: fundule.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: shadowedInternalModule.ts
-
 ---
 # Input
 ```js
@@ -47,7 +45,7 @@ module Z {
 
 module A {
   export var Point = { x: 0, y: 0 };
-  export interface Point { x: number, y: number }
+  export interface Point { x: number; y: number }
 }
 
 module B {
@@ -57,7 +55,7 @@ module B {
 
 module X {
   export module Y {
-    export interface Point { x: number, y: number }
+    export interface Point { x: number; y: number }
   }
 
   export class Y {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/functions/functionImplementations.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/functions/functionImplementations.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: functionImplementations.ts
-
 ---
 # Input
 ```js
@@ -286,7 +284,7 @@ function opt1(n = 4) {
 // Function signature with optional parameter, no type annotation and initializer has initializer's widened type
 function opt2(n = { x: null, y: undefined }) {
   var m = n;
-  var m: { x: any, y: any };
+  var m: { x: any; y: any };
 }
 
 // Function signature with initializer referencing other parameter to the left

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/interfaceDeclaration/interfaceDeclaration.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/interfaceDeclaration/interfaceDeclaration.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: interfaceDeclaration.ts
-
 ---
 # Input
 ```js
@@ -21,7 +19,7 @@ interface nil {}
 
 # Output
 ```js
-interface abstract { abstract(): void, concrete(): number }
+interface abstract { abstract(): void; concrete(): number }
 
 interface X { x }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/methodSignature/methodSignature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/methodSignature/methodSignature.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: methodSignature.ts
-
 ---
 # Input
 ```js
@@ -15,7 +13,7 @@ var logger: {
 
 # Output
 ```js
-var logger: { log(val: any, val2: any), error(val: any) };
+var logger: { log(val: any, val2: any); error(val: any) };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/typeParameter/typeParameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/typeParameter/typeParameter.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: typeParameter.ts
-
 ---
 # Input
 ```js
@@ -15,7 +13,7 @@ interface IObservable<T> {
 # Output
 ```js
 interface IObservable<T> {
-  n: IObservable<T[]>, // fails because of comment
+  n: IObservable<T[]>; // fails because of comment
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeCallSignatures.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeCallSignatures.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: unionTypeCallSignatures.ts
-
 ---
 # Input
 ```js
@@ -97,8 +95,8 @@ strOrBoolean = unionOfDifferentReturnType("hello"); // error
 unionOfDifferentReturnType1(true); // error in type of parameter
 
 var unionOfDifferentReturnType1:
-  | { (a: number): number, (a: string): string }
-  | { (a: number): Date, (a: string): boolean };
+  | { (a: number): number; (a: string): string }
+  | { (a: number): Date; (a: string): boolean };
 numOrDate = unionOfDifferentReturnType1(10);
 strOrBoolean = unionOfDifferentReturnType1("hello");
 unionOfDifferentReturnType1(true); // error in type of parameter
@@ -113,7 +111,7 @@ unionOfDifferentParameterTypes(); // error - no call signatures
 
 var unionOfDifferentNumberOfSignatures:
   | { (a: number): number }
-  | { (a: number): Date, (a: string): boolean };
+  | { (a: number): Date; (a: string): boolean };
 unionOfDifferentNumberOfSignatures(); // error - no call signatures
 unionOfDifferentNumberOfSignatures(10); // error - no call signatures
 unionOfDifferentNumberOfSignatures("hello"); // error - no call signatures

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeConstructSignatures.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeConstructSignatures.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: unionTypeConstructSignatures.ts
-
 ---
 # Input
 ```js
@@ -95,8 +93,8 @@ strOrBoolean = new unionOfDifferentReturnType("hello"); // error
 new unionOfDifferentReturnType1(true); // error in type of parameter
 
 var unionOfDifferentReturnType1:
-  | { new(a: number): number, new(a: string): string }
-  | { new(a: number): Date, new(a: string): boolean };
+  | { new(a: number): number; new(a: string): string }
+  | { new(a: number): Date; new(a: string): boolean };
 numOrDate = new unionOfDifferentReturnType1(10);
 strOrBoolean = new unionOfDifferentReturnType1("hello");
 new unionOfDifferentReturnType1(true); // error in type of parameter
@@ -111,7 +109,7 @@ new unionOfDifferentParameterTypes(); // error - no call signatures
 
 var unionOfDifferentNumberOfSignatures:
   | { new(a: number): number }
-  | { new(a: number): Date, new(a: string): boolean };
+  | { new(a: number): Date; new(a: string): boolean };
 new unionOfDifferentNumberOfSignatures(); // error - no call signatures
 new unionOfDifferentNumberOfSignatures(10); // error - no call signatures
 new unionOfDifferentNumberOfSignatures("hello"); // error - no call signatures

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeFromArrayLiteral.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeFromArrayLiteral.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: unionTypeFromArrayLiteral.ts
-
 ---
 # Input
 ```js
@@ -44,7 +42,7 @@ var arr2 = ["hello", true]; // (string | number)[]
 var arr3Tuple: [number, string] = [3, "three"]; // [number, string]
 var arr4Tuple: [number, string] = [3, "three", "hello"]; // [number, string, string]
 var arrEmpty = [];
-var arr5Tuple: { 0: string, 5: number } = [
+var arr5Tuple: { 0: string; 5: number } = [
   "hello", true, false, " hello", true, 10, "any",
 ]; // Tuple
 class C {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/call/callSignature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/call/callSignature.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: callSignature.ts
-
 ---
 # Input
 ```js
@@ -19,7 +17,7 @@ Promise.all<void>([]);
 
 # Output
 ```js
-interface I { (), (): void, <T, U>(arg: T), <T, U>(arg: T): U }
+interface I { (); (): void; <T, U>(arg: T); <T, U>(arg: T): U }
 
 Promise.all<void>([]);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/new/newKeyword.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/new/newKeyword.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: newKeyword.ts
-
 ---
 # Input
 ```js
@@ -20,7 +18,7 @@ interface I {
 ```js
 var x: { y: new<T, U>() => [T, U] };
 
-interface I { new<T>(x: string), new(x: string), new(x: number): number }
+interface I { new<T>(x: string); new(x: string); new(x: number): number }
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/typeParameters/callAndConstructSignatureLong.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/typeParameters/callAndConstructSignatureLong.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: callAndConstructSignatureLong.ts
-
 ---
 # Input
 ```js
@@ -29,13 +27,13 @@ interface Interface {
     Voila,
     InViewHumbleVaudevillianVeteran,
     CastVicariouslyAsBothVictimAndVillainByTheVicissitudesOfFate,
-  >(): V,
+  >(): V;
   new<
     ThisVisage,
     NoMereVeneerOfVanity,
     IsAVestigeOfTheVoxPopuliNowVacant,
     Vanished,
-  >(): V,
+  >(): V;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/declare/declare_interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/declare/declare_interface.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: declare_interface.ts
-
 ---
 # Input
 ```js
@@ -23,9 +21,9 @@ declare interface B {
 declare interface Dictionary<T> { [index: string]: T }
 
 declare interface B {
-  foo([]?): void,
-  bar({}, []?): any,
-  baz(a: string, b: number, []?): void,
+  foo([]?): void;
+  bar({}, []?): any;
+  baz(a: string, b: number, []?): void;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/error-recovery/index-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/error-recovery/index-signature.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
 expression: index-signature.ts
-
 ---
 # Input
 ```js
@@ -49,7 +47,7 @@ type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong:
 
 // note lack of trailing comma in the index signature
 type TooLongSingleParam = {
-  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string,
+  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/function-type/single-parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/function-type/single-parameter.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: single-parameter.ts
-
 ---
 # Input
 ```js
@@ -13,10 +11,10 @@ type Y = new (options:{ a: string; b: AbstractCompositeThingamabobberFactoryProv
 # Output
 ```js
 type X = (
-  options: { a: string, b: AbstractCompositeThingamabobberFactoryProvider },
+  options: { a: string; b: AbstractCompositeThingamabobberFactoryProvider },
 ) => {};
 type Y = new(
-  options: { a: string, b: AbstractCompositeThingamabobberFactoryProvider },
+  options: { a: string; b: AbstractCompositeThingamabobberFactoryProvider },
 ) => {};
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/generic/ungrouped-parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/generic/ungrouped-parameters.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: ungrouped-parameters.ts
-
 ---
 # Input
 ```js
@@ -28,8 +26,8 @@ function filterTooltipWithFoo<F extends Field>(oldEncoding: Encoding<F>): {
   customTooltipWithoutAggregatedField?:
     | StringFieldDefWithCondition<F>
     | StringValueDefWithCondition<F>
-    | StringFieldDef<F>[],
-  filteredEncoding: Encoding<F>,
+    | StringFieldDef<F>[];
+  filteredEncoding: Encoding<F>;
 } {
   const { tooltip, ...filteredEncoding } = oldEncoding;
   if (!tooltip) {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/comments.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: comments.ts
-
 ---
 # Input
 ```js
@@ -17,7 +15,7 @@ interface ScreenObject {
 ```js
 interface ScreenObject {
   // I make things weird.
-  at(point: Point): Screen | undefined,
+  at(point: Point): Screen | undefined;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/ignore.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/ignore.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 151
 expression: ignore.ts
-
 ---
 # Input
 ```js
@@ -122,14 +120,14 @@ interface Interface {
   prop: type
   // prettier-ignore
   prop: type;
-  prop: type,
+  prop: type;
 }
 
 // Last element
 interface Interface {
   // prettier-ignore
   prop: type
-  prop: type,
+  prop: type;
 }
 
 interface foo extends bar {
@@ -137,13 +135,13 @@ interface foo extends bar {
   f(): void;
   // prettier-ignore
   g(): void;
-  h(): void,
+  h(): void;
 }
 
 interface T<T> {
   // prettier-ignore
   new<T>(): T<T>;
-  new<T>(): T<T>,
+  new<T>(): T<T>;
 }
 
 interface I {
@@ -164,19 +162,19 @@ interface I {
 interface I {
   // prettier-ignore
   x: y;
-  y: x,
+  y: x;
 }
 
 interface I {
   // prettier-ignore
   x: y,
-  y: x,
+  y: x;
 }
 
 interface I {
   // prettier-ignore
   x: y
-  y: x,
+  y: x;
 }
 
 interface I {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/pattern-parameters.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/pattern-parameters.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: pattern-parameters.ts
-
 ---
 # Input
 ```js
@@ -17,9 +15,9 @@ interface B {
 # Output
 ```js
 interface B {
-  foo([]?): void,
-  bar({}, []?): any,
-  baz(a: string, b: number, []?): void,
+  foo([]?): void;
+  bar({}, []?): any;
+  baz(a: string, b: number, []?): void;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/separator.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/separator.ts.snap
@@ -26,14 +26,14 @@ interface Test { one: string, two: any[] }
 ```js
 declare module "selenium-webdriver" {
   export const until: {
-    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>,
-    alertIsPresent(): Condition<Alert>,
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>;
+    alertIsPresent(): Condition<Alert>;
   };
 }
 
-export interface Edge { cursor: {}, node: { id: {} } }
+export interface Edge { cursor: {}; node: { id: {} } }
 
-interface Test { one: string, two: any[] }
+interface Test { one: string; two: any[] }
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: comments.ts
-
 ---
 # Input
 ```js
@@ -63,7 +61,7 @@ interface A5
 // comment3
 {
   // comment4
-  foo(): bar,
+  foo(): bar;
 }
 
 interface A6
@@ -73,7 +71,7 @@ interface A6
 // comment3
 {
   // comment4
-  foo(): bar,
+  foo(): bar;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/issue-10352-consistency.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/issue-10352-consistency.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: issue-10352-consistency.ts
-
 ---
 # Input
 ```js
@@ -31,7 +29,7 @@ export interface Store {
   getRecord(collectionName: string, documentPath: string): TaskEither<
     Error,
     Option<GenericRecord>
-  >,
+  >;
 }
 
 export default class StoreImpl extends Service implements Store {
@@ -44,8 +42,8 @@ export default class StoreImpl extends Service implements Store {
 }
 
 export function loadPlugin(name: string, dirname: string): {
-  filepath: string,
-  value: mixed,
+  filepath: string;
+  value: mixed;
 } {
   // ...
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature-with-wrapped-return-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature-with-wrapped-return-type.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: method-signature-with-wrapped-return-type.ts
-
 ---
 # Input
 ```js
@@ -24,14 +22,14 @@ type ReleaseToolConfig2 = {
 ```js
 type ReleaseToolConfig = {
   get(key: "changelog"): {
-    get(key: "repo"): string,
-    get(key: "labels"): Map<string, string>,
-  },
+    get(key: "repo"): string;
+    get(key: "labels"): Map<string, string>;
+  };
 };
 
 type ReleaseToolConfig2 = {
   get(key: "changelog"): `
-  `,
+  `;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: method-signature.ts
-
 ---
 # Input
 ```js
@@ -29,7 +27,7 @@ type Bar = {
 ```js
 type Foo = {
   get(key: "foo"): `
-  `,
+  `;
 };
 type Foo = { get(key: "foo"): `` };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/semi.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/semi.ts.snap
@@ -21,8 +21,8 @@ declare module "foo" {
   function bar(namespace: string): void;
 }
 
-function pickCard(x: { suit: string, card: number }[]): number;
-function pickCard(x: number): { suit: string, card: number };
+function pickCard(x: { suit: string; card: number }[]): number;
+function pickCard(x: number): { suit: string; card: number };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/new/new-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/new/new-signature.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: new-signature.ts
-
 ---
 # Input
 ```js
@@ -84,7 +82,7 @@ interface FooConstructor {
     f: number,
     g: number,
     h: number,
-  ): Foo,
+  ): Foo;
 }
 
 interface BarConstructor {
@@ -97,7 +95,7 @@ interface BarConstructor {
     f: number,
     g: number,
     h: number,
-  ): Foo,
+  ): Foo;
 }
 
 type BazConstructor = {
@@ -110,7 +108,7 @@ type BazConstructor = {
     f: number,
     g: number,
     h: number,
-  ): Foo,
+  ): Foo;
 };
 
 interface ConstructorBigGenerics {
@@ -128,17 +126,17 @@ interface ConstructorBigGenerics {
     f: number,
     g: number,
     h: number,
-  ): Foo,
+  ): Foo;
 }
 
 interface ConstructorInline {
   // https://github.com/prettier/prettier/issues/2163
-  (i): any,
+  (i): any;
 }
 
 interface TimerConstructor {
   // Line-splitting comment
-  new(interval: number, callback: (handler: Timer) => void): Timer,
+  new(interval: number, callback: (handler: Timer) => void): Timer;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/template-literal-types/template-literal-types.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/template-literal-types/template-literal-types.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: template-literal-types.ts
-
 ---
 # Input
 ```js
@@ -29,13 +27,13 @@ declare function setAlignment(
   value: `${VerticalAlignment}-${HorizontalAlignment}`,
 ): void;
 type PropEventSource<T> = {
-  on(eventName: `${string & keyof T}Changed`, callback: () => void): void,
+  on(eventName: `${string & keyof T}Changed`, callback: () => void): void;
 };
 type PropEventSource<T> = {
   on<K extends string & keyof T>(
     eventName: `${K}Changed`,
     callback: (newValue: T[K]) => void,
-  ): void,
+  ): void;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/trailing-comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/trailing-comma.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: trailing-comma.ts
-
 ---
 # Input
 ```js
@@ -26,15 +24,15 @@ export interface ShopQueryResult {
 # Output
 ```js
 export interface ShopQueryResult {
-  chic: boolean,
-  location: number[],
-  menus: Menu[],
-  openingDays: number[],
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
   closingDays: [
-    { from: string, to: string }, // <== this one
-  ],
-  shop: string,
-  distance: number,
+    { from: string; to: string }, // <== this one
+  ];
+  shop: string;
+  distance: number;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/type-alias/issue-100857.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/type-alias/issue-100857.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: issue-100857.ts
-
 ---
 # Input
 ```js
@@ -55,33 +53,33 @@ type FieldLayoutWith<
 # Output
 ```js
 type FieldLayoutWith<T extends string, S extends unknown = { width: string }> = {
-  type: T,
-  code: string,
-  size: S,
+  type: T;
+  code: string;
+  size: S;
 };
 
 type FieldLayoutWith<T extends string, S extends unknown> = {
-  type: T,
-  code: string,
-  size: S,
+  type: T;
+  code: string;
+  size: S;
 };
 
 type FieldLayoutWith<S extends unknown = { width: string }> = {
-  type: T,
-  code: string,
-  size: S,
+  type: T;
+  code: string;
+  size: S;
 };
 
 type FieldLayoutWith<T extends stringggggggggggg, T extends stringggggggggggg> = {
-  type: T,
-  code: string,
-  size: S,
+  type: T;
+  code: string;
+  size: S;
 };
 
 type FieldLayoutWith<T extends stringggggggggggg, S = stringggggggggggggggggg> = {
-  type: T,
-  code: string,
-  size: S,
+  type: T;
+  code: string;
+  size: S;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/type-alias/pattern-parameter.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/type-alias/pattern-parameter.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: pattern-parameter.ts
-
 ---
 # Input
 ```js
@@ -17,9 +15,9 @@ type C = {
 # Output
 ```js
 type C = {
-  foo([]?): void,
-  bar({}, []?): any,
-  baz(a: string, b: number, []?): void,
+  foo([]?): void;
+  bar({}, []?): any;
+  baz(a: string, b: number, []?): void;
 };
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/type-member-get-set/type-member-get-set.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/type-member-get-set/type-member-get-set.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: type-member-get-set.ts
-
 ---
 # Input
 ```js
@@ -24,9 +22,9 @@ interface Foo {
 
 # Output
 ```js
-interface Foo { get foo(): string, set bar(v) }
+interface Foo { get foo(): string; set bar(v) }
 
-type Foo = { get foo(): string, set bar(v) };
+type Foo = { get foo(): string; set bar(v) };
 
 interface Foo { set bar(foo: string) }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/inlining.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/inlining.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: inlining.ts
-
 ---
 # Input
 ```js
@@ -62,9 +60,9 @@ type UploadState<E, EM, D>
   // The upload timed out
   | { type: "Timed_out" }
   // Failed somewhere on the line
-  | { type: "Failed", error: E, errorMsg: EM }
+  | { type: "Failed"; error: E; errorMsg: EM }
   // Uploading to aws3 and CreatePostMutation succeeded
-  | { type: "Success", data: D };
+  | { type: "Success"; data: D };
 
 type UploadState2<E, EM, D>
 // The upload hasnt begun yet

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: union-parens.ts
-
 ---
 # Input
 ```js
@@ -149,14 +147,14 @@ var y: ((string | number));
 
 class Foo<T extends (string | number)> {}
 
-interface Interface { i: (X | Y) & Z, j: Partial<(X | Y)> }
+interface Interface { i: (X | Y) & Z; j: Partial<(X | Y)> }
 
 type State =
   & { sharedProperty: any }
   & (
-      | { discriminant: "FOO", foo: any }
-      | { discriminant: "BAR", bar: any }
-      | { discriminant: "BAZ", baz: any }
+      | { discriminant: "FOO"; foo: any }
+      | { discriminant: "BAR"; bar: any }
+      | { discriminant: "BAZ"; baz: any }
   );
 
 const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (

--- a/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -55,11 +55,11 @@ interface D
 		G<string, number, symbol>,
 		H<string, number, symbol>
 {
-	something1: string,
-	something2: string,
-	something3: string,
-	something4: string,
-	something5: string,
+	something1: string;
+	something2: string;
+	something3: string;
+	something4: string;
+	something5: string;
 }
 // @ts-ignore
 interface D extends B<string, symbol>, F<string, symbol> {}

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -144,16 +144,16 @@ type U = 15;
 // @ts-ignore
 type V = infer U;
 type W = {
-	a: string,
-	b: symbol,
-	c: symbol,
-	d: symbol,
-	e: symbol,
-	f: symbol,
-	g: symbol,
+	a: string;
+	b: symbol;
+	c: symbol;
+	d: symbol;
+	e: symbol;
+	f: symbol;
+	g: symbol;
 };
-type X = { a: string, b: symbol };
-type Z = { a: string, b: symbol };
+type X = { a: string; b: symbol };
+type Z = { a: string; b: symbol };
 
 type OptionsFlags<Type> = {
 	+readonly [Property in keyof Type as string]-?: boolean;
@@ -195,12 +195,12 @@ type FunctionType = <
 	amet: string,
 	consectetur: symbol,
 ) => {
-	Lorem: string,
-	ipsum: symbol,
-	dolor: number,
-	sit: boolean,
-	amet: string,
-	consectetur: symbol,
+	Lorem: string;
+	ipsum: symbol;
+	dolor: number;
+	sit: boolean;
+	amet: string;
+	consectetur: symbol;
 };
 
 type FunctionTypeB = (loreum: string) => string;
@@ -214,7 +214,7 @@ function test(a: string): a is string {
 type AbstractCompositeThingamabobberFactoryProvider = string;
 
 type ConstructorType = new(
-	options: { a: string, b: AbstractCompositeThingamabobberFactoryProvider },
+	options: { a: string; b: AbstractCompositeThingamabobberFactoryProvider },
 ) => {};
 
 type Constructor<T> = new(...args: any[]) => T;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -71,7 +71,7 @@ type C = {
 		consequence: symbol,
 		something_with_long_name: symbol,
 		some_other_time: symbol,
-	),
+	);
 };
 type D = {
 	<
@@ -90,7 +90,7 @@ type D = {
 		consequence: symbol,
 		something_with_long_name: symbol,
 		some_other_time: symbol,
-	),
+	);
 };
 
 type E = { <Aaaaaaaaaaaaaaaaaaaaa>(loreum: string) };
@@ -104,7 +104,7 @@ type F = {
 		deeeeeeeeeeeeeee,
 		deeeeeeeeeeeeeeee,
 		deeeeeeeewweeeeee,
-	>(loreum: string),
+	>(loreum: string);
 };
 
 type G = {
@@ -116,20 +116,20 @@ type G = {
 		consequence: symbol,
 		something_with_long_name: symbol,
 		some_other_time: symbol,
-	),
+	);
 };
 
 type H = {
-	a?(): number,
-	b?(): number,
-	c?(): number,
-	d(): string,
+	a?(): number;
+	b?(): number;
+	c?(): number;
+	d(): string;
 	bvvvvvvvvvvvvvvvvvvvvvv?(
 		loreum: string,
 		ipsum: symbol,
 		lapis: symbol,
 		emerald: symbol,
-	): G,
+	): G;
 };
 
 type LoooooooooooooongTypeReturneeeeeeeeed = "0";
@@ -142,7 +142,7 @@ type I = {
 		consequence: symbol,
 		something_with_long_name: symbol,
 		some_other_time: symbol,
-	): LoooooooooooooongTypeReturneeeeeeeeed,
+	): LoooooooooooooongTypeReturneeeeeeeeed;
 };
 
 type J = { get something(): LoooooooooooooongTypeReturneeeeeeeeed };

--- a/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -21,6 +21,6 @@ Quote style: Double Quotes
 interface Suppressions {
 	// rome-ignore format: test
     a: void
-	b: void,
+	b: void;
 }
 


### PR DESCRIPTION
## Summary

I reported this earlier today. This aligns the printing style for type member lists with prettier.

Fixes https://github.com/rome/tools/issues/2404

## Test Plan

* Updated snapshot tests.
