### PR TITLE
chore: Fix the expected Prettier output of the `binarish` test

### DIFF
--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/binaryish.js.prettier-snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/binaryish.js.prettier-snap
@@ -3,5 +3,11 @@ const computedDescriptionLines =
   (focused && !loading && descriptionLinesFocused) ||
   descriptionLines;
 
+const computedDescriptionLines2 =
+  (showConfirm && // comment
+    descriptionLinesConfirming) || // comment
+  (focused && !loading && descriptionLinesFocused) || // comment
+  descriptionLines; // comment
+
 computedDescriptionLines =
   (focused && !loading && descriptionLinesFocused) || descriptionLines;


### PR DESCRIPTION
The formatting for the `computedDescriptionLines2` is missing for whatever reason. I formatted the input in the Rome playground and pasted the expected prettier output.