### PR TITLE
fix(rome_js_formatter): line break before assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da408b722765c64aad796c666b756aa1dda2a6c1b44f98797f2d8ea8f197746f"
+checksum = "689960f187c43c01650c805fb6bc6f55ab944499d86d4ffe9474ad78991d8e94"
 dependencies = [
  "console",
  "globset",

--- a/crates/rome_formatter/src/printer.rs
+++ b/crates/rome_formatter/src/printer.rs
@@ -84,6 +84,7 @@ impl Default for PrinterOptions {
 
 /// Error returned if printing an item as a flat string fails because it either contains
 /// explicit line breaks or would otherwise exceed the specified line width.
+#[derive(Debug)]
 struct LineBreakRequiredError;
 
 /// Prints the format elements into a string

--- a/crates/rome_js_formatter/Cargo.toml
+++ b/crates/rome_js_formatter/Cargo.toml
@@ -19,7 +19,7 @@ rome_js_parser = { path = "../rome_js_parser" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tests_macros = { path = "../tests_macros" }
-insta = { version = "1.10.0", features = ["glob"] }
+insta = { version = "1.14.0", features = ["glob"] }
 rome_diagnostics = { path = "../rome_diagnostics" }
 parking_lot = "0.12.0"
 similar = "2.1.0"

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -1,8 +1,7 @@
 use crate::formatter_traits::FormatTokenAndNode;
-
 use crate::{
-    format_elements, group_elements, soft_line_indent_or_space, space_token, FormatElement,
-    FormatResult, Formatter, ToFormatElement,
+    format_elements, group_elements, space_token, FormatElement, FormatResult, Formatter,
+    ToFormatElement,
 };
 
 use rome_js_syntax::JsAssignmentExpression;
@@ -20,7 +19,7 @@ impl ToFormatElement for JsAssignmentExpression {
             left.format(formatter)?,
             space_token(),
             operator_token.format(formatter)?,
-            group_elements(soft_line_indent_or_space(right.format(formatter)?)),
+            group_elements(format_elements![space_token(), right.format(formatter)?]),
         ]))
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -3,9 +3,8 @@ use crate::{
     format_elements, group_elements, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
-
-use rome_js_syntax::JsAssignmentExpression;
-use rome_js_syntax::JsAssignmentExpressionFields;
+use rome_formatter::soft_line_indent_or_space;
+use rome_js_syntax::{JsAnyExpression, JsAssignmentExpression, JsAssignmentExpressionFields};
 
 impl ToFormatElement for JsAssignmentExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -15,11 +14,19 @@ impl ToFormatElement for JsAssignmentExpression {
             right,
         } = self.as_fields();
 
+        let right = right?;
+
+        let right = if matches!(right, JsAnyExpression::JsAssignmentExpression(_)) {
+            soft_line_indent_or_space(right.format(formatter)?)
+        } else {
+            format_elements![space_token(), right.format(formatter)?]
+        };
+
         Ok(group_elements(format_elements![
             left.format(formatter)?,
             space_token(),
             operator_token.format(formatter)?,
-            group_elements(format_elements![space_token(), right.format(formatter)?]),
+            group_elements(right),
         ]))
     }
 }

--- a/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/assignment_expression.rs
@@ -3,7 +3,7 @@ use crate::{
     format_elements, group_elements, space_token, FormatElement, FormatResult, Formatter,
     ToFormatElement,
 };
-use rome_formatter::soft_line_indent_or_space;
+use rome_formatter::{if_group_breaks, if_group_fits_on_single_line, soft_line_indent_or_space};
 use rome_js_syntax::{JsAnyExpression, JsAssignmentExpression, JsAssignmentExpressionFields};
 
 impl ToFormatElement for JsAssignmentExpression {
@@ -16,17 +16,17 @@ impl ToFormatElement for JsAssignmentExpression {
 
         let right = right?;
 
-        let right = if matches!(right, JsAnyExpression::JsAssignmentExpression(_)) {
-            soft_line_indent_or_space(right.format(formatter)?)
-        } else {
+        let right = if !matches!(right, JsAnyExpression::JsAssignmentExpression(_)) {
             format_elements![space_token(), right.format(formatter)?]
+        } else {
+            group_elements(soft_line_indent_or_space(right.format(formatter)?))
         };
 
         Ok(group_elements(format_elements![
             left.format(formatter)?,
             space_token(),
             operator_token.format(formatter)?,
-            group_elements(right),
+            right,
         ]))
     }
 }

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -400,21 +400,22 @@ mod check_reformat;
 #[cfg(test)]
 mod test {
     use crate::check_reformat::{check_reformat, CheckReformatParams};
-    use crate::format;
     use crate::FormatOptions;
+    use crate::{format, to_format_element};
     use rome_js_parser::{parse, SourceType};
 
     #[test]
     #[ignore]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
-        let src = r#"
-a = function () {
-  console.log(1);
-};
-"#;
+        let x = r#"
+computedDescriptionLines = function () {
+  return "something";
+}"#;
+        let src = x;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax.clone());
+        let root_element = to_format_element(FormatOptions::default(), &tree.syntax()).unwrap();
         let result = format(FormatOptions::default(), &tree.syntax()).unwrap();
         check_reformat(CheckReformatParams {
             root: &tree.syntax(),

--- a/crates/rome_js_formatter/src/lib.rs
+++ b/crates/rome_js_formatter/src/lib.rs
@@ -405,10 +405,13 @@ mod test {
     use rome_js_parser::{parse, SourceType};
 
     #[test]
+    #[ignore]
     // use this test check if your snippet prints as you wish, without using a snapshot
     fn quick_test() {
         let src = r#"
-a + b * c > 65 + 5;
+a = function () {
+  console.log(1);
+};
 "#;
         let syntax = SourceType::tsx();
         let tree = parse(src, 0, syntax.clone());

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js
@@ -24,3 +24,37 @@ a[ b ]  =  c[ d ]
 
 (s||(s=Object.create(null)))[i]=!0;
 (s||(s=Object.create(null))).test=!0;
+
+
+// Assigning to function/classes with an empty yields the desired formatting
+a = function() {}
+a = class {}
+
+// Assigning to a function/class with a non-empty body groups the whole assignment expression.
+a = function () {
+    console.log(1)
+};
+
+extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerAndLora = function () {
+    console.log(1)
+};
+
+a = function extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerfefefefefefefefeefAndara () {
+    console.log(1)
+};
+
+a = class {
+    prop;
+}
+
+// Function with non-empty body is printed on the next line
+A.prototype.f = function() {
+    console.log(1)
+}
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz)!!!!!;
+
+
+computedDescriptionLines = (focused && !loading && descriptionLinesFocused) || descriptionLines;
+
+this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: assignment.js
 ---
 # Input
@@ -29,6 +30,40 @@ a[ b ]  =  c[ d ]
 
 (s||(s=Object.create(null)))[i]=!0;
 (s||(s=Object.create(null))).test=!0;
+
+
+// Assigning to function/classes with an empty yields the desired formatting
+a = function() {}
+a = class {}
+
+// Assigning to a function/class with a non-empty body groups the whole assignment expression.
+a = function () {
+    console.log(1)
+};
+
+extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerAndLora = function () {
+    console.log(1)
+};
+
+a = function extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerfefefefefefefefeefAndara () {
+    console.log(1)
+};
+
+a = class {
+    prop;
+}
+
+// Function with non-empty body is printed on the next line
+A.prototype.f = function() {
+    console.log(1)
+}
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz)!!!!!;
+
+
+computedDescriptionLines = (focused && !loading && descriptionLinesFocused) || descriptionLines;
+
+this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 
 =============================
 # Outputs
@@ -76,4 +111,36 @@ a[b] = c[d];
 
 (s || (s = Object.create(null)))[i] = !0;
 (s || (s = Object.create(null))).test = !0;
+
+// Assigning to function/classes with an empty yields the desired formatting
+a = function () {};
+a = class {};
+
+// Assigning to a function/class with a non-empty body groups the whole assignment expression.
+a = function () {
+	console.log(1);
+};
+
+extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerAndLora = function () {
+	console.log(1);
+};
+
+a = function extraLongLeftHandSideLetsSeeHowPrettierBreaksThatAcrossMultipleLinesStillNotLongEnoughMustBeLongerfefefefefefefefeefAndara() {
+	console.log(1);
+};
+
+a = class {
+	prop;
+};
+
+// Function with non-empty body is printed on the next line
+A.prototype.f = function () {
+	console.log(1);
+};
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz)!!!!!;
+
+computedDescriptionLines = (focused && !loading && descriptionLinesFocused) || descriptionLines;
+
+this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/nested.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/nested.js
@@ -1,0 +1,25 @@
+// Fits
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayO = "test"
+
+// Exceeding:
+// One assignment
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber.m= "test"
+
+// Two assignments
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber = ab = "test"
+
+// More than two assignments and exceeding: Each assignment on their own line
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.array = p = ab = "tes"
+
+
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
+
+tt.parenR.updateContext =    tt.braceR.updateContext =        tt.braceR.updateContext = function () {
+            function a() {
+                if (this.state.context.length === 1) {
+                    if (this.state.context.length === 1) {
+                        return;
+                    }
+                }
+            };
+        }

--- a/crates/rome_js_formatter/tests/specs/js/module/assignment/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/assignment/nested.js.snap
@@ -1,0 +1,69 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
+expression: nested.js
+---
+# Input
+// Fits
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayO = "test"
+
+// Exceeding:
+// One assignment
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber.m= "test"
+
+// Two assignments
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber = ab = "test"
+
+// More than two assignments and exceeding: Each assignment on their own line
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.array = p = ab = "tes"
+
+
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test"
+
+tt.parenR.updateContext =    tt.braceR.updateContext =        tt.braceR.updateContext = function () {
+            function a() {
+                if (this.state.context.length === 1) {
+                    if (this.state.context.length === 1) {
+                        return;
+                    }
+                }
+            };
+        }
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+// Fits
+bifornCringerMoshedPerplex = bifornCringerMoshedPerplexSawder = arrayO = "test";
+
+// Exceeding:
+// One assignment
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber.m = "test";
+
+// Two assignments
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumber =
+	ab = "test";
+
+// More than two assignments and exceeding: Each assignment on their own line
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.array =
+	p = ab = "tes";
+
+bifornCringerMoshedPerplex =
+	bifornCringerMoshedPerplexSawder = arrayOfNumb = a = "test";
+
+tt.parenR.updateContext =
+	tt.braceR.updateContext =
+		tt.braceR.updateContext = function () {
+			function a() {
+				if (this.state.context.length === 1) {
+					if (this.state.context.length === 1) {
+						return;
+					}
+				}
+			}
+		};
+

--- a/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: class.js
 ---
 # Input
@@ -121,6 +122,5 @@ x = class {};
 
 x = class foo extends Boar {};
 
-x =
-	class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
+x = class aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa extends bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {};
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: import_meta_expression.js
 ---
 # Input
@@ -16,8 +17,7 @@ Line width: 80
 Quote style: Double Quotes
 -----
 console.log(import.meta);
-import.meta.field =
-	obj.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
+import.meta.field = obj.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
 import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
 ## Output 2
 -----
@@ -26,7 +26,6 @@ Line width: 120
 Quote style: Double Quotes
 -----
 console.log(import.meta);
-import.meta.field =
-    obj.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
+import.meta.field = obj.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
 import.meta.aReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariableName.andAnotherReallyLongVariable;
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: unary_expression.js
 ---
 # Input
@@ -36,12 +37,8 @@ x = !1;
 delete aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 void aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 typeof aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-x =
-	+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-x =
-	-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-x =
-	~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-x =
-	!aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+x = +aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+x = -aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+x = ~aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+x = !aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-in-assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-in-assignment.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 153
 expression: numbers-in-assignment.js
-
 ---
 # Input
 ```js
@@ -26,18 +25,18 @@ bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers2 = [
 
 # Output
 ```js
-bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers =
-  [1, 2, 3, 4, 5];
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers = [
+  1, 2, 3, 4, 5,
+];
 
-bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers2 =
-  [
-    66, 57, 45, 47, 33, 53, 82, 81, 76, 78, 10, 78, 15, 98, 24, 29, 32, 27, 28,
-    76, 41, 65, 84, 35, 97, 90, 75, 24, 88, 45, 23, 75, 63, 86, 24, 39, 9, 51,
-    33, 40, 58, 17, 49, 86, 63, 59, 97, 91, 98, 99, 5, 69, 51, 44, 34, 69, 17,
-    91, 27, 83, 26, 34, 93, 29, 66, 88, 49, 33, 49, 73, 9, 81, 4, 36, 5, 14, 43,
-    31, 86, 27, 39, 75, 98, 99, 55, 19, 39, 21, 85, 86, 46, 82, 11, 44, 48, 77,
-    35, 48, 78, 97,
-  ];
+bifornCringerMoshedPerplex.bifornCringerMoshedPerplexSawder.arrayOfNumbers2 = [
+  66, 57, 45, 47, 33, 53, 82, 81, 76, 78, 10, 78, 15, 98, 24, 29, 32, 27, 28,
+  76, 41, 65, 84, 35, 97, 90, 75, 24, 88, 45, 23, 75, 63, 86, 24, 39, 9, 51, 33,
+  40, 58, 17, 49, 86, 63, 59, 97, 91, 98, 99, 5, 69, 51, 44, 34, 69, 17, 91, 27,
+  83, 26, 34, 93, 29, 66, 88, 49, 33, 49, 73, 9, 81, 4, 36, 5, 14, 43, 31, 86,
+  27, 39, 75, 98, 99, 55, 19, 39, 21, 85, 86, 46, 82, 11, 44, 48, 77, 35, 48,
+  78, 97,
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-negative-comment-after-minus.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-negative-comment-after-minus.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: numbers-negative-comment-after-minus.js
-
 ---
 # Input
 ```js
@@ -66,28 +65,27 @@ const numbers = [
   -199875.28,
 ];
 
-c =
-  [
-    -66, /**/
-    66,
-    57,
-    45,
-    47,
-    33,
-    53,
-    82,
-    81,
-    76,
-    66,
-    57,
-    45,
-    47,
-    33,
-    53,
-    82,
-    81,
-    223323,
-  ];
+c = [
+  -66, /**/
+  66,
+  57,
+  45,
+  47,
+  33,
+  53,
+  82,
+  81,
+  76,
+  66,
+  57,
+  45,
+  47,
+  33,
+  53,
+  82,
+  81,
+  223323,
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-trailing-comma.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/numbers-trailing-comma.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
+assertion_line: 153
 expression: numbers-trailing-comma.js
-
 ---
 # Input
 ```js
@@ -16,11 +15,10 @@ c = [
 # Output
 ```js
 // --------------- print-width -------------------------------------------------
-c =
-  [
-    66, 66, 57, 45, 47, 33, 53, 82, 81, 76, 66, 57, 45, 47, 33, 53, 82, 81,
-    223323,
-  ];
+c = [
+  66, 66, 57, 45, 47, 33, 53, 82, 81, 76, 66, 57, 45, 47, 33, 53, 82, 81,
+  223323,
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/arrays/preserve_empty_lines.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/arrays/preserve_empty_lines.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: preserve_empty_lines.js
-
 ---
 # Input
 ```js
@@ -23,15 +22,14 @@ a = [
 
 # Output
 ```js
-a =
-  [
-    1,
-    2,
+a = [
+  1,
+  2,
 
-    3,
+  3,
 
-    4,
-  ];
+  4,
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/function.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: function.js
-
 ---
 # Input
 ```js
@@ -72,35 +71,31 @@ let f6 = /* comment */
 
 # Output
 ```js
-f1 =
-  (
-    a =
-    //comment
-    b,
-  ) => {};
+f1 = (
+  a =
+  //comment
+  b,
+) => {};
 
-f2 =
-  (
-    a = b, //comment
-  ) => {};
+f2 = (
+  a = b, //comment
+) => {};
 
-f3 =
-  (
-    a = b, //comment
-  ) => {};
+f3 = (
+  a = b, //comment
+) => {};
 
 f4 = () => {}; // Comment
 
 f5 =
-  // Comment
+// Comment
 
-  () => {};
+() => {};
 
-f6 =
-  /* comment */
-  // Comment
+f6 = /* comment */
+// Comment
 
-  () => {};
+() => {};
 
 let f1 = (
   a =

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/number.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: number.js
-
 ---
 # Input
 ```js
@@ -55,29 +54,28 @@ var fnNumber = /* comments0 */
 # Output
 ```js
 fnNumber =
-  // Comment
-  3;
+// Comment
+3;
 
 fnNumber =
-  // Comment
+// Comment
 
-  3;
+3;
 
 fnNumber =
-  // Comment0
-  // Comment1
-  3;
+// Comment0
+// Comment1
+3;
 
 fnNumber = /* comment */ 3;
 
-fnNumber =
-  /* comments0 */
-  /* comments1 */
-  3;
+fnNumber = /* comments0 */
+/* comments1 */
+3;
 
 fnNumber =
-  // Comment
-  3;
+// Comment
+3;
 
 var fnNumber =
 // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment-comments/string.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: string.js
-
 ---
 # Input
 ```js
@@ -81,53 +80,52 @@ var fnString = // Comment
 # Output
 ```js
 fnString =
-  // Comment
-  "some" + "long" + "string";
+// Comment
+"some" + "long" + "string";
 
 fnString =
-  // Comment
+// Comment
 
-  "some" + "long" + "string";
-
-fnString =
-  // Comment
-
-  "some" + "long" + "string";
+"some" + "long" + "string";
 
 fnString =
-  /* comment */
-  "some" + "long" + "string";
+// Comment
+
+"some" + "long" + "string";
 
 fnString =
-  /**
+/* comment */
+"some" + "long" + "string";
+
+fnString =
+/**
    * multi-line
    */
-  "some" + "long" + "string";
+"some" + "long" + "string";
 
 fnString =
-  /* inline */ "some" +
-    "long" +
-    "string" +
-    "some" +
-    "long" +
-    "string" +
-    "some" +
-    "long" +
-    "string" +
-    "some" +
-    "long" +
-    "string";
+/* inline */ "some" +
+  "long" +
+  "string" +
+  "some" +
+  "long" +
+  "string" +
+  "some" +
+  "long" +
+  "string" +
+  "some" +
+  "long" +
+  "string";
 
-fnString =
-  // Comment0
-  // Comment1
-  "some" + "long" + "string";
+fnString = // Comment0
+// Comment1
+"some" + "long" + "string";
 
 fnString = "some" + "long" + "string"; // Comment
 
 fnString =
-  // Comment
-  "some" + "long" + "string";
+// Comment
+"some" + "long" + "string";
 
 var fnString =
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/binaryish.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/binaryish.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: binaryish.js
-
 ---
 # Input
 ```js
@@ -38,8 +37,7 @@ const computedDescriptionLines2 =
   (focused && !loading && descriptionLinesFocused) || // comment
   descriptionLines; // comment
 
-computedDescriptionLines =
-  (focused && !loading && descriptionLinesFocused) || descriptionLines;
+computedDescriptionLines = (focused && !loading && descriptionLinesFocused) || descriptionLines;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
@@ -15,11 +15,12 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
 
 # Output
 ```js
-tt.parenR.updateContext = tt.braceR.updateContext = function () {
-  if (this.state.context.length === 1) {
-    return;
-  }
-};
+tt.parenR.updateContext =
+  tt.braceR.updateContext = function () {
+    if (this.state.context.length === 1) {
+      return;
+    }
+  };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain-two-segments.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: chain-two-segments.js
-
 ---
 # Input
 ```js
@@ -16,13 +15,11 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
 
 # Output
 ```js
-tt.parenR.updateContext =
-  tt.braceR.updateContext =
-    function () {
-      if (this.state.context.length === 1) {
-        return;
-      }
-    };
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.state.context.length === 1) {
+    return;
+  }
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -37,19 +37,27 @@ a=b=c;
 
 # Output
 ```js
-let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = averredBathersBoxroomBuggyNurl = anodyneCondosMalateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+    averredBathersBoxroomBuggyNurl =
+      anodyneCondosMalateOverateRetinol =
+        annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl = anodyneCondosMal(
-  sdsadsa,
-  dasdas,
-  asd(() => sdf),
-).ateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+    glimseGlyphsHazardNoopsTieTie =
+      x =
+        averredBathersBoxroomBuggyNurl =
+          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
+            annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl = anodyneCondosMal(
-  sdsadsa,
-  dasdas,
-  asd(() => sdf),
-).ateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+    glimseGlyphsHazardNoopsTieTie =
+      x =
+        averredBathersBoxroomBuggyNurl =
+          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
+            annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
 
 a = b = c;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/chain.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: chain.js
-
 ---
 # Input
 ```js
@@ -38,28 +37,19 @@ a=b=c;
 
 # Output
 ```js
-let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans =
-  glimseGlyphsHazardNoopsTieTie =
-    averredBathersBoxroomBuggyNurl =
-      anodyneCondosMalateOverateRetinol =
-        annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+let bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = averredBathersBoxroomBuggyNurl = anodyneCondosMalateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans =
-    glimseGlyphsHazardNoopsTieTie =
-      x =
-        averredBathersBoxroomBuggyNurl =
-          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-            annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl = anodyneCondosMal(
+  sdsadsa,
+  dasdas,
+  asd(() => sdf),
+).ateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave;
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans =
-    glimseGlyphsHazardNoopsTieTie =
-      x =
-        averredBathersBoxroomBuggyNurl =
-          anodyneCondosMal(sdsadsa, dasdas, asd(() => sdf)).ateOverateRetinol =
-            annularCooeedSplicesWalksWayWay =
-              kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = x = averredBathersBoxroomBuggyNurl = anodyneCondosMal(
+  sdsadsa,
+  dasdas,
+  asd(() => sdf),
+).ateOverateRetinol = annularCooeedSplicesWalksWayWay = kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
 
 a = b = c;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1419.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1419.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-1419.js
-
 ---
 # Input
 ```js
@@ -15,8 +14,7 @@ someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
 
 # Output
 ```js
-someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
-  _someVariableThatWeAreCheckingForFalsiness ? Date.now() - _someVariableThatWeAreCheckingForFalsiness : 0;
+someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] = _someVariableThatWeAreCheckingForFalsiness ? Date.now() - _someVariableThatWeAreCheckingForFalsiness : 0;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
@@ -19,7 +19,8 @@ const aVeryLongNameThatGoesOnAndOn = this.someOtherObject.someOtherNestedObject.
 
 this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 
-this.isaverylongmethodexpression.withmultiplelevels = this.isanotherverylongexpression.thatisalsoassigned = 0;
+this.isaverylongmethodexpression.withmultiplelevels =
+  this.isanotherverylongexpression.thatisalsoassigned = 0;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-1966.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-1966.js
-
 ---
 # Input
 ```js
@@ -18,11 +17,9 @@ this.isaverylongmethodexpression.withmultiplelevels = this.isanotherverylongexpr
 ```js
 const aVeryLongNameThatGoesOnAndOn = this.someOtherObject.someOtherNestedObject.someLongFunctionName();
 
-this.someObject.someOtherNestedObject =
-  this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
+this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
 
-this.isaverylongmethodexpression.withmultiplelevels =
-  this.isanotherverylongexpression.thatisalsoassigned = 0;
+this.isaverylongmethodexpression.withmultiplelevels = this.isanotherverylongexpression.thatisalsoassigned = 0;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2482-1.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2482-1.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-2482-1.js
-
 ---
 # Input
 ```js
@@ -26,20 +25,15 @@ aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
 
 # Output
 ```js
-aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-  anotherVeryLongNameForIllustrativePurposes;
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherVeryLongNameForIllustrativePurposes;
 
-aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-  "a very long string for illustrative purposes".length;
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes = "a very long string for illustrative purposes".length;
 
-aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-  anotherVeryLongNameForIllustrativePurposes();
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherVeryLongNameForIllustrativePurposes();
 
-aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-  anotherVeryLongNameForIllustrativePurposes.length;
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherVeryLongNameForIllustrativePurposes.length;
 
-aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
-  anotherVeryLongNameForIllustrativePurposes + 1;
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes = anotherVeryLongNameForIllustrativePurposes + 1;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2540.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-2540.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-2540.js
-
 ---
 # Input
 ```js
@@ -12,8 +11,10 @@ manifestCache[templateId] = readFileSync(`${MANIFESTS_PATH}/${templateId}.json`,
 
 # Output
 ```js
-manifestCache[templateId] =
-  readFileSync(`${MANIFESTS_PATH}/${templateId}.json`, { encoding: "utf-8" });
+manifestCache[templateId] = readFileSync(
+  `${MANIFESTS_PATH}/${templateId}.json`,
+  { encoding: "utf-8" },
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-3819.js
-
 ---
 # Input
 ```js
@@ -22,17 +21,9 @@ this.dummy.type1.dummyPropertyFunction
 
 # Output
 ```js
-this.dummy.type1.dummyPropertyFunction =
-  this.dummy.type2.dummyPropertyFunction =
-    this.dummy.type3.dummyPropertyFunction =
-      this.dummy.type4.dummyPropertyFunction =
-        this.dummy.type5.dummyPropertyFunction =
-          this.dummy.type6.dummyPropertyFunction =
-            this.dummy.type7.dummyPropertyFunction =
-              this.dummy.type8.dummyPropertyFunction =
-                () => {
-                  return "dummy";
-                };
+this.dummy.type1.dummyPropertyFunction = this.dummy.type2.dummyPropertyFunction = this.dummy.type3.dummyPropertyFunction = this.dummy.type4.dummyPropertyFunction = this.dummy.type5.dummyPropertyFunction = this.dummy.type6.dummyPropertyFunction = this.dummy.type7.dummyPropertyFunction = this.dummy.type8.dummyPropertyFunction = () => {
+  return "dummy";
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-3819.js.snap
@@ -21,9 +21,16 @@ this.dummy.type1.dummyPropertyFunction
 
 # Output
 ```js
-this.dummy.type1.dummyPropertyFunction = this.dummy.type2.dummyPropertyFunction = this.dummy.type3.dummyPropertyFunction = this.dummy.type4.dummyPropertyFunction = this.dummy.type5.dummyPropertyFunction = this.dummy.type6.dummyPropertyFunction = this.dummy.type7.dummyPropertyFunction = this.dummy.type8.dummyPropertyFunction = () => {
-  return "dummy";
-};
+this.dummy.type1.dummyPropertyFunction =
+  this.dummy.type2.dummyPropertyFunction =
+    this.dummy.type3.dummyPropertyFunction =
+      this.dummy.type4.dummyPropertyFunction =
+        this.dummy.type5.dummyPropertyFunction =
+          this.dummy.type6.dummyPropertyFunction =
+            this.dummy.type7.dummyPropertyFunction =
+              this.dummy.type8.dummyPropertyFunction = () => {
+                return "dummy";
+              };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-7961.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-7961.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-7961.js
-
 ---
 # Input
 ```js
@@ -17,12 +16,10 @@ something.veeeeeery.looooooooooooooooooooooooooong = some.other.rather.long.chai
 # Output
 ```js
 // works as expected
-something.veeeeeery.looooooooooooooooooooooooooong =
-  some.other.rather.long.chain;
+something.veeeeeery.looooooooooooooooooooooooooong = some.other.rather.long.chain;
 
 // does not work if it ends with a function call
-something.veeeeeery.looooooooooooooooooooooooooong =
-  some.other.rather.long.chain.functionCall();
+something.veeeeeery.looooooooooooooooooooooooooong = some.other.rather.long.chain.functionCall();
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: lone-arg.js
-
 ---
 # Input
 ```js
@@ -40,8 +39,10 @@ const bifornCringerMoshedPerplexSawderGlyphsHa = someBigFunctionName("foo")(
 );
 
 if (true) {
-  node.id =
-    this.flowParseTypeAnnotatableIdentifier( /*allowPrimitiveOverride*/ true);
+  node.id = this.flowParseTypeAnnotatableIdentifier(
+    /*allowPrimitiveOverride*/
+    true,
+  );
 }
 
 const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/comment.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: comment.js
-
 ---
 # Input
 ```js
@@ -64,13 +63,12 @@ foo[
 
 # Output
 ```js
-a =
-  (
-    // Comment 1
-    (Math.random() * (yRange * (1 - minVerticalFraction))) + (
-      minVerticalFraction * yRange
-    )
-  ) - offset;
+a = (
+  // Comment 1
+  (Math.random() * (yRange * (1 - minVerticalFraction))) + (
+    minVerticalFraction * yRange
+  )
+) - offset;
 
 a +
   a +

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: inline-object-array.js
-
 ---
 # Input
 ```js
@@ -100,8 +99,17 @@ const obj = {
 
 # Output
 ```js
-prevState =
-  prevState || {
+prevState = prevState || {
+  catalogs: [],
+  loadState: LOADED,
+  opened: false,
+  searchQuery: "",
+  selectedCatalog: null,
+};
+
+prevState = prevState ||
+  defaultState ||
+  {
     catalogs: [],
     loadState: LOADED,
     opened: false,
@@ -109,46 +117,35 @@ prevState =
     selectedCatalog: null,
   };
 
-prevState =
-  prevState ||
-    defaultState ||
-    {
-      catalogs: [],
-      loadState: LOADED,
-      opened: false,
-      searchQuery: "",
-      selectedCatalog: null,
-    };
+prevState = prevState || (
+  defaultState && {
+    catalogs: [],
+    loadState: LOADED,
+    opened: false,
+    searchQuery: "",
+    selectedCatalog: null,
+  }
+);
 
-prevState =
-  prevState || (
-    defaultState && {
-      catalogs: [],
-      loadState: LOADED,
-      opened: false,
-      searchQuery: "",
-      selectedCatalog: null,
-    }
-  );
-
-prevState =
-  prevState ||
-    (useDefault && defaultState) ||
-    {
-      catalogs: [],
-      loadState: LOADED,
-      opened: false,
-      searchQuery: "",
-      selectedCatalog: null,
-    };
+prevState = prevState ||
+  (useDefault && defaultState) ||
+  {
+    catalogs: [],
+    loadState: LOADED,
+    opened: false,
+    searchQuery: "",
+    selectedCatalog: null,
+  };
 
 this.steps = steps || [{ name: "mock-module", path: "/nux/mock-module" }];
 
-this.steps =
-  steps || (checkStep && [{ name: "mock-module", path: "/nux/mock-module" }]);
+this.steps = steps || (
+  checkStep && [{ name: "mock-module", path: "/nux/mock-module" }]
+);
 
-this.steps =
-  (steps && checkStep) || [{ name: "mock-module", path: "/nux/mock-module" }];
+this.steps = (steps && checkStep) || [
+  { name: "mock-module", path: "/nux/mock-module" },
+];
 
 const create = () => {
   const result = doSomething();

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/assignment.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: assignment.js
-
 ---
 # Input
 ```js
@@ -42,42 +41,37 @@ module.exports = class A extends B {
 
 # Output
 ```js
-aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 =
-  class extends (
-    aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
-  ) {
-    method() {
-      console.log("foo");
-    }
-  };
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method() {
+    console.log("foo");
+  }
+};
 
-foo =
-  class extends bar {
-    method() {
-      console.log("foo");
-    }
-  };
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
 
-aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 =
-  class extends bar {
-    method() {
-      console.log("foo");
-    }
-  };
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
 
-foo =
-  class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
-    method() {
-      console.log("foo");
-    }
-  };
+foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+  method() {
+    console.log("foo");
+  }
+};
 
-module.exports =
-  class A extends B {
-    method() {
-      console.log("foo");
-    }
-  };
+module.exports = class A extends B {
+  method() {
+    console.log("foo");
+  }
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/binary-expressions-block-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/binary-expressions-block-comments.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: binary-expressions-block-comments.js
-
 ---
 # Input
 ```js
@@ -51,56 +50,44 @@ a = b + /** TODO this is a very very very very long comment that makes it go > 8
 
 # Output
 ```js
-a =
-  b || /** Comment */
-  c;
+a = b || /** Comment */
+c;
 
 a = b /** Comment */ || c;
 
-a =
-  b || /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b || /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
-a =
-  b /** TODO this is a very very very very long comment that makes it go > 80 columns */ || c;
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ || c;
 
-a =
-  b || /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b || /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
-a =
-  b && /** Comment */
-  c;
+a = b && /** Comment */
+c;
 
 a = b /** Comment */ && c;
 
-a =
-  b && /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b && /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
-a =
-  b /** TODO this is a very very very very long comment that makes it go > 80 columns */ && c;
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ && c;
 
-a =
-  b && /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b && /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
-a =
-  b + /** Comment */
-  c;
+a = b + /** Comment */
+c;
 
 a = b /** Comment */ + c;
 
-a =
-  b + /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b + /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
-a =
-  b /** TODO this is a very very very very long comment that makes it go > 80 columns */ + c;
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ + c;
 
-a =
-  b + /** TODO this is a very very very very long comment that makes it go > 80 columns */
-  c;
+a = b + /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/binary-expressions-single-comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/binary-expressions-single-comments.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: binary-expressions-single-comments.js
-
 ---
 # Input
 ```js
@@ -27,29 +26,23 @@ c;
 
 # Output
 ```js
-a =
-  b || // Comment
-  c;
+a = b || // Comment
+c;
 
-a =
-  b || // TODO this is a very very very very long comment that makes it go > 80 columns
-  c;
+a = b || // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
 
-a =
-  b && // Comment
-  c;
+a = b && // Comment
+c;
 
-a =
-  b && // TODO this is a very very very very long comment that makes it go > 80 columns
-  c;
+a = b && // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
 
-a =
-  b + // Comment
-  c;
+a = b + // Comment
+c;
 
-a =
-  b + // TODO this is a very very very very long comment that makes it go > 80 columns
-  c;
+a = b + // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/trailing-jsdocs.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/trailing-jsdocs.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: trailing-jsdocs.js
-
 ---
 # Input
 ```js
@@ -33,13 +32,12 @@ const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
 
 # Output
 ```js
-const CONNECTION_STATUS = exports.CONNECTION_STATUS =
-  {
-    CLOSED: Object.freeze({ kind: "CLOSED" }),
-    CONNECTED: Object.freeze({ kind: "CONNECTED" }),
-    CONNECTING: Object.freeze({ kind: "CONNECTING" }),
-    NOT_CONNECTED: Object.freeze({ kind: "NOT_CONNECTED" }),
-  };
+const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: "CLOSED" }),
+  CONNECTED: Object.freeze({ kind: "CONNECTED" }),
+  CONNECTING: Object.freeze({ kind: "CONNECTING" }),
+  NOT_CONNECTED: Object.freeze({ kind: "NOT_CONNECTED" }),
+};
 /* A comment */ /**
 * A type that can be written to a buffer.
 */ /**

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/edge_case.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/edge_case.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 149
+assertion_line: 153
 expression: edge_case.js
-
 ---
 # Input
 ```js
@@ -77,14 +76,13 @@ a(
   ],
 );
 
-exports.examples =
-  [
-    {
-      render: withGraphQLQuery(
-        "node(1234567890){image{uri}}",
-        function (container, data) {
-          return (
-            <div>
+exports.examples = [
+  {
+    render: withGraphQLQuery(
+      "node(1234567890){image{uri}}",
+      function (container, data) {
+        return (
+          <div>
             <InlineBlock>
               <img
                 src={data[1234567890].image.uri}
@@ -92,11 +90,11 @@ exports.examples =
               />
             </InlineBlock>
           </div>
-          );
-        },
-      ),
-    },
-  ];
+        );
+      },
+    ),
+  },
+];
 
 someReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReally.a([
   [],

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/bracket_0.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/bracket_0.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: bracket_0.js
-
 ---
 # Input
 ```js
@@ -23,8 +22,7 @@ function a() {
 function a() {
   function b() {
     queryThenMutateDOM(() => {
-      title =
-        SomeThing.call(root, "someLongStringThatPushesThisTextReallyFar")[0];
+      title = SomeThing.call(root, "someLongStringThatPushesThisTextReallyFar")[0];
     });
   }
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/comment.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: comment.js
-
 ---
 # Input
 ```js
@@ -119,10 +118,9 @@ this
     },
   );
 
-ret =
-  __DEV__ ?
-  // $FlowFixMe: this type differs according to the env
-  vm.runInContext(source, ctx) : a;
+ret = __DEV__ ?
+// $FlowFixMe: this type differs according to the env
+vm.runInContext(source, ctx) : a;
 
 angular
   .module("AngularAppModule")

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: inline_merge.js
-
 ---
 # Input
 ```js
@@ -37,12 +36,11 @@ Object
     },
   );
 
-this.layoutPartsToHide =
-  this.utils.hashset(
-    _.flatMap(this.visibilityHandlers, (fn) => fn()).concat(
-      this.record.resolved_legacy_visrules,
-    ).filter(Boolean),
-  );
+this.layoutPartsToHide = this.utils.hashset(
+  _.flatMap(this.visibilityHandlers, (fn) => fn()).concat(
+    this.record.resolved_legacy_visrules,
+  ).filter(Boolean),
+);
 
 var jqxhr = $.ajax("example.php").done(doneFn).fail(failFn);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-comments/comment-inside.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: comment-inside.js
-
 ---
 # Input
 ```js
@@ -127,15 +126,14 @@ ${
 `;
 
 // https://github.com/prettier/prettier/pull/9278#issuecomment-700589195
-expr1 =
-  html`
+expr1 = html`
   <div>
     ${
-    x(
-      foo, // fg
-      bar,
-    )
-  }</div>
+  x(
+    foo, // fg
+    bar,
+  )
+}</div>
 `;
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-text/text.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-text/text.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: text.js
-
 ---
 # Input
 ```js
@@ -22,9 +21,8 @@ a = {
 
 # Output
 ```js
-a =
-  {
-    viewer: graphql`
+a = {
+  viewer: graphql`
     fragment x on Viewer {
       y(named: [
         "projects_feedback_ids" # PROJECTS_FEEDBACK_IDS
@@ -33,7 +31,7 @@ a =
       }
     }
   `,
-  };
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/new-expression/with-member-expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/new-expression/with-member-expression.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: with-member-expression.js
-
 ---
 # Input
 ```js
@@ -24,12 +23,11 @@ function functionName() {
 function functionName() {
   // indent to make the line break
   if (true) {
-    this._aVeryLongVariableNameToForceLineBreak =
-      new this.Promise(
-        (resolve, reject) => {
-          // do something
-        },
-      );
+    this._aVeryLongVariableNameToForceLineBreak = new this.Promise(
+      (resolve, reject) => {
+        // do something
+      },
+    );
   }
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/object-property-ignore/ignore.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
+assertion_line: 153
 expression: ignore.js
-
 ---
 # Input
 ```js
@@ -57,59 +56,52 @@ foo = {
 
 # Output
 ```js
-foo =
-  {
-    // prettier-ignore
+foo = {
+  // prettier-ignore
   bar:            1,
-  };
+};
 
-foo =
-  {
-    _: "",
-    // prettier-ignore
+foo = {
+  _: "",
+  // prettier-ignore
   bar:            1,
-  };
+};
 
 /* comments */
-foo =
-  {
-    _: "",
-    // prettier-ignore
+foo = {
+  _: "",
+  // prettier-ignore
   bar:            1, // comment
-  };
+};
 
-foo =
-  {
-    _: "",
-    // prettier-ignore
+foo = {
+  _: "",
+  // prettier-ignore
   bar:            1, /* comment */
-  };
+};
 
-foo =
-  {
-    _: "",
-    // prettier-ignore
+foo = {
+  _: "",
+  // prettier-ignore
   bar:            /* comment */          1,
-  };
+};
 
 /* SpreadElement */
-foo =
-  {
-    _: "",
-    // prettier-ignore
+foo = {
+  _: "",
+  // prettier-ignore
   ...bar,
-  };
+};
 
 // Nested
-foo =
-  {
-    baz: {
-      // prettier-ignore
-  foo: [1, 2,    3],
-    },
+foo = {
+  baz: {
     // prettier-ignore
+  foo: [1, 2,    3],
+  },
+  // prettier-ignore
   bar:            1,
-  };
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/right-break.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/right-break.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: right-break.js
-
 ---
 # Input
 ```js
@@ -40,8 +39,7 @@ const k = {
     "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf",
 };
 
-somethingThatsAReallyLongPropName =
-  this.props.cardType === AwesomizerCardEnum.SEEFIRST;
+somethingThatsAReallyLongPropName = this.props.cardType === AwesomizerCardEnum.SEEFIRST;
 
 const o = {
   somethingThatsAReallyLongPropName: this.props.cardType === AwesomizerCardEnum.SEEFIRST,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/sequence-break/break.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/sequence-break/break.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: break.js
-
 ---
 # Input
 ```js
@@ -39,36 +38,30 @@ a.then(
   ),
 );
 for (
-  aLongIdentifierName = 0, aLongIdentifierName = 0, aLongIdentifierName = 0, aLongIdentifierName =
-    0;
+  aLongIdentifierName = 0, aLongIdentifierName = 0, aLongIdentifierName = 0, aLongIdentifierName = 0;
   test;
   update
 ) {}
 (
-  a =
-    b ? c : function () {
-      return 0;
-    }
+  a = b ? c : function () {
+    return 0;
+  }
 ), (
-  a =
-    b ? c : function () {
-      return 0;
-    }
+  a = b ? c : function () {
+    return 0;
+  }
 ), (
-  a =
-    b ? c : function () {
-      return 0;
-    }
+  a = b ? c : function () {
+    return 0;
+  }
 ), (
-  a =
-    b ? c : function () {
-      return 0;
-    }
+  a = b ? c : function () {
+    return 0;
+  }
 ), (
-  a =
-    b ? c : function () {
-      return 0;
-    }
+  a = b ? c : function () {
+    return 0;
+  }
 );
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template-literals/expressions.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: expressions.js
-
 ---
 # Input
 ```js
@@ -78,10 +77,9 @@ console.log(
   ),
 );
 
-x =
-  `mdl-textfield mdl-js-textfield ${className} ${
-    content.length > 0 ? "is-dirty" : ""
-  } combo-box__input`;
+x = `mdl-textfield mdl-js-textfield ${className} ${
+  content.length > 0 ? "is-dirty" : ""
+} combo-box__input`;
 
 function testing() {
   const p = {};

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template/graphql.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template/graphql.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: graphql.js
-
 ---
 # Input
 ```js
@@ -29,24 +28,23 @@ module.exports = Relay.createContainer(
 
 # Output
 ```js
-module.exports =
-  Relay.createContainer(
-    // ...
-    {
-      fragments: {
-        nodes: ({ solution_type, time_frame }) =>
-          Relay.QL`
+module.exports = Relay.createContainer(
+  // ...
+  {
+    fragments: {
+      nodes: ({ solution_type, time_frame }) =>
+        Relay.QL`
         fragment on RelatedNode @relay(plural: true) {
           __typename
           ${OptimalSolutionsSection.getFragment(
-            "node",
-            { solution_type, time_frame },
-          )}
+          "node",
+          { solution_type, time_frame },
+        )}
         }
       `,
-      },
     },
-  );
+  },
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/binary.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 149
+assertion_line: 153
 expression: binary.js
-
 ---
 # Input
 ```js
@@ -29,21 +28,20 @@ const funnelSnapshotCard = (
   report === COMPANY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2_company_metrics
 ) ? <ReportMetricsFunnelSnapshotCard metrics={metrics} /> : null;
 
-room =
-  room.map(
-    (row, rowIndex) => (
-      row.map(
-        (col, colIndex) => (
-          (
-            rowIndex === 0 ||
-              colIndex === 0 ||
-              rowIndex === height ||
-              colIndex === width
-          ) ? 1 : 0
-        ),
-      )
-    ),
-  );
+room = room.map(
+  (row, rowIndex) => (
+    row.map(
+      (col, colIndex) => (
+        (
+          rowIndex === 0 ||
+            colIndex === 0 ||
+            rowIndex === height ||
+            colIndex === width
+        ) ? 1 : 0
+      ),
+    )
+  ),
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent-after-paren.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent-after-paren.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: indent-after-paren.js
-
 ---
 # Input
 ```js
@@ -303,10 +302,9 @@ fn?.[
 
 # Output
 ```js
-foo7 =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )[Fooooooooooo];
+foo7 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)[Fooooooooooo];
 
 foo8 = (condition ? firstValue : secondValue)[SomeType];
 
@@ -332,10 +330,9 @@ function foo12() {
   )[Fooooooooooo];
 }
 
-foo13 =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  ).Fooooooooooo.Fooooooooooo;
+foo13 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
 
 foo14 = (condition ? firstValue : secondValue)[SomeType];
 
@@ -361,10 +358,9 @@ function foo18() {
   ).Fooooooooooo.Fooooooooooo;
 }
 
-foo19 =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )(Fooooooooooo.Fooooooooooo);
+foo19 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
 
 foo20 = (condition ? firstValue : secondValue)[SomeType];
 
@@ -390,10 +386,9 @@ function foo24() {
   )(Fooooooooooo.Fooooooooooo);
 }
 
-foo25 =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )?.(Fooooooooooo.Fooooooooooo);
+foo25 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)?.(Fooooooooooo.Fooooooooooo);
 
 foo26 = (condition ? firstValue : secondValue)[SomeType];
 
@@ -456,72 +451,61 @@ function foo35() {
   )(Fooooooooooo.Fooooooooooo);
 }
 
-foo36 =
-  new (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )(Fooooooooooo.Fooooooooooo);
+foo36 = new (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    )[AnnularCooeedSplicesWalksWayWay]
-  );
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  )[AnnularCooeedSplicesWalksWayWay]
+);
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    )[AnnularCooeedSplicesWalksWayWay]
-  );
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ).Fooooooooooo.Fooooooooooo
-  );
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ).Fooooooooooo.Fooooooooooo
-  );
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    )(Fooooooooooo.Fooooooooooo)
-  );
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    )(Fooooooooooo.Fooooooooooo)
-  );
-
-bifornCringerMoshedPerplexSawder =
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
   (
     glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
-    annularCooeedSplicesWalksWayWay,
-  ).annularCooeedSplicesWalksWayWay();
+  )[AnnularCooeedSplicesWalksWayWay]
+);
 
-foo =
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
   (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )?.()?.()?.();
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ).Fooooooooooo.Fooooooooooo
+);
 
-foo =
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
   (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )()()();
+    glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ).Fooooooooooo.Fooooooooooo
+);
 
-foo =
-  foo.bar.baz[coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz];
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  )(Fooooooooooo.Fooooooooooo)
+);
+
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  )(Fooooooooooo.Fooooooooooo)
+);
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
+  annularCooeedSplicesWalksWayWay,
+).annularCooeedSplicesWalksWayWay();
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)?.()?.()?.();
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)()()();
+
+foo = foo.bar.baz[coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz];
 
 const decorated = (arg, ignoreRequestError) => {
   return (
@@ -534,12 +518,11 @@ const decorated = (arg, ignoreRequestError) => {
   ).foo();
 };
 
-bifornCringerMoshedPerplexSawder =
-  fn(
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ).prop,
-  );
+bifornCringerMoshedPerplexSawder = fn(
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
 
 fn(
   (
@@ -547,12 +530,11 @@ fn(
   ).prop,
 );
 
-bifornCringerMoshedPerplexSawder =
-  fn?.(
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ).prop,
-  );
+bifornCringerMoshedPerplexSawder = fn?.(
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
 
 fn?.(
   (
@@ -560,19 +542,17 @@ fn?.(
   ).prop,
 );
 
-bifornCringerMoshedPerplexSawder =
-  fn[(
-    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).prop];
+bifornCringerMoshedPerplexSawder = fn[(
+  glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).prop];
 
 fn[(
   glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
 ).prop];
 
-bifornCringerMoshedPerplexSawder =
-  fn?.[(
-    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).prop];
+bifornCringerMoshedPerplexSawder = fn?.[(
+  glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).prop];
 
 fn?.[(
   glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested-in-condition.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested-in-condition.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 149
+assertion_line: 153
 expression: nested-in-condition.js
-
 ---
 # Input
 ```js
@@ -47,10 +46,9 @@ const value = (bifornCringerMoshedPerplexSawder
 
 # Output
 ```js
-$var =
-  (
-    ($number % 10) >= 2 && (($number % 100) < 10 || ($number % 100) >= 20) ? kochabCooieGameOnOboleUnweave : annularCooeedSplicesWalksWayWay
-  ) ? anodyneCondosMalateOverateRetinol : averredBathersBoxroomBuggyNurl;
+$var = (
+  ($number % 10) >= 2 && (($number % 100) < 10 || ($number % 100) >= 20) ? kochabCooieGameOnOboleUnweave : annularCooeedSplicesWalksWayWay
+) ? anodyneCondosMalateOverateRetinol : averredBathersBoxroomBuggyNurl;
 
 const value = (
   bifornCringerMoshedPerplexSawder ? askTrovenaBeenaDependsRowans : glimseGlyphsHazardNoopsTieTie

--- a/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/trailing_whitespace.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/trailing_whitespace.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: trailing_whitespace.js
-
 ---
 # Input
 ```js
@@ -64,17 +63,15 @@ foo(
   // Comment
 );
 
-o =
-  {
-    state,
-    // Comment
-  };
+o = {
+  state,
+  // Comment
+};
 
-o =
-  {
-    state,
-    // Comment
-  };
+o = {
+  state,
+  // Comment
+};
 
 function supersupersupersuperLongF(
   supersupersupersuperLongA,

--- a/crates/rome_js_formatter/tests/specs/prettier/js/unary-expression/comments.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/unary-expression/comments.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: comments.js
-
 ---
 # Input
 ```js
@@ -453,8 +452,7 @@ async function bar2() {
   /* foo */
 );
 !(
-  x =
-    y // foo
+  x = y // foo
 );
 
 !x.y;

--- a/crates/rome_js_formatter/tests/specs/prettier/js/unary/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/unary/object.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: object.js
-
 ---
 # Input
 ```js
@@ -15,11 +14,10 @@ state = {
 
 # Output
 ```js
-state =
-  {
-    // students
-    hoverColumn: -1,
-  };
+state = {
+  // students
+  hoverColumn: -1,
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/unicode/nbsp-jsx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/unicode/nbsp-jsx.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 151
+assertion_line: 153
 expression: nbsp-jsx.js
-
 ---
 # Input
 ```js
@@ -14,8 +13,7 @@ x = <p> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Output
 ```js
 // Note: there are non breaking spaces in the JSX text
-x =
-  <p> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa </p>;
+x = <p> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa </p>;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/variable_declarator/string.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/variable_declarator/string.js.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: string.js
-
 ---
 # Input
 ```js
@@ -12,8 +11,7 @@ elements[0].innerHTML = '<div></div><div></div><div></div><div></div><div></div>
 
 # Output
 ```js
-elements[0].innerHTML =
-  "<div></div><div></div><div></div><div></div><div></div><div></div>";
+elements[0].innerHTML = "<div></div><div></div><div></div><div></div><div></div><div></div>";
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
+assertion_line: 153
 expression: assignment.ts
 ---
 # Input
@@ -59,28 +60,26 @@ const TYPE_MAP = {
   "symbolic link": "link",
 } as Foo;
 
-this.previewPlayerHandle =
-  (
-    setInterval(
-      async () => {
-        if (this.previewIsPlaying) {
-          await this.fetchNextPreviews();
-          this.currentPreviewIndex++;
-        }
-      },
-      this.refreshDelay,
-    ) as unknown
-  ) as number;
+this.previewPlayerHandle = (
+  setInterval(
+    async () => {
+      if (this.previewIsPlaying) {
+        await this.fetchNextPreviews();
+        this.currentPreviewIndex++;
+      }
+    },
+    this.refreshDelay,
+  ) as unknown
+) as number;
 
-this.intervalID =
-  (
-    setInterval(
-      () => {
-        self.step();
-      },
-      30,
-    ) as unknown
-  ) as number;
+this.intervalID = (
+  setInterval(
+    () => {
+      self.step();
+    },
+    30,
+  ) as unknown
+) as number;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: assignment2.ts
-
 ---
 # Input
 ```js
@@ -41,8 +40,7 @@ const originalPrototype = originalConstructor.prototype as TComponent & Injectio
 ```js
 const defaultMaskGetter = $parse(attrs[directiveName]) as (scope: ng.IScope) => Mask;
 
-(this.configuration as any) =
-  (this.editor as any) = (this.editorBody as any) = undefined;
+(this.configuration as any) = (this.editor as any) = (this.editorBody as any) = undefined;
 
 angular
   .module("foo")
@@ -58,8 +56,7 @@ angular
     },
   );
 
-(this.selectorElem as any) =
-  this.multiselectWidget = this.initialValues = undefined;
+(this.selectorElem as any) = this.multiselectWidget = this.initialValues = undefined;
 
 const extraRendererAttrs = (
   (attrs.rendererAttrs && this.utils.safeParseJsonString(attrs.rendererAttrs)) || Object.create(

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/assignment2.ts.snap
@@ -40,7 +40,8 @@ const originalPrototype = originalConstructor.prototype as TComponent & Injectio
 ```js
 const defaultMaskGetter = $parse(attrs[directiveName]) as (scope: ng.IScope) => Mask;
 
-(this.configuration as any) = (this.editor as any) = (this.editorBody as any) = undefined;
+(this.configuration as any) =
+  (this.editor as any) = (this.editorBody as any) = undefined;
 
 angular
   .module("foo")
@@ -56,7 +57,8 @@ angular
     },
   );
 
-(this.selectorElem as any) = this.multiselectWidget = this.initialValues = undefined;
+(this.selectorElem as any) =
+  this.multiselectWidget = this.initialValues = undefined;
 
 const extraRendererAttrs = (
   (attrs.rendererAttrs && this.utils.safeParseJsonString(attrs.rendererAttrs)) || Object.create(

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/long-identifiers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/long-identifiers.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 153
 expression: long-identifiers.ts
-
 ---
 # Input
 ```js
@@ -28,13 +27,11 @@ averredBathersBoxroomBuggyNurl(
 ```js
 const bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
 
-averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol = annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
 
-averredBathersBoxroomBuggyNurl =
-  {
-    anodyneCondosMalateOverateRetinol: annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
-  };
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol: annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+};
 
 averredBathersBoxroomBuggyNurl(
   anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/ternary.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/ternary.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: ternary.ts
-
 ---
 # Input
 ```js
@@ -51,10 +50,9 @@ bifornCringerMoshedPerplexSawder =
 
 # Output
 ```js
-foo =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  ) as Fooooooooooo;
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
 
 foo = (condition ? firstValue : secondValue) as SomeType;
 
@@ -82,19 +80,17 @@ function foo() {
   );
 }
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ) as AnnularCooeedSplicesWalksWayWay
-  );
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ) as AnnularCooeedSplicesWalksWayWay
+);
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    (
-      glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-    ) as AnnularCooeedSplicesWalksWayWay
-  );
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  (
+    glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+  ) as AnnularCooeedSplicesWalksWayWay
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments-2/last-arg.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments-2/last-arg.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 153
 expression: last-arg.ts
-
 ---
 # Input
 ```js
@@ -69,23 +68,20 @@ type f1 = (
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) => number;
 
-f2 =
-  (
-    currentRequest: { a: number },
-    // TODO this is a very very very very long comment that makes it go > 80 columns
-  ): number => {};
+f2 = (
+  currentRequest: { a: number },
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
 
-f3 =
-  (
-    currentRequest: { a: number },
-    // TODO this is a very very very very long comment that makes it go > 80 columns
-  ) => {};
+f3 = (
+  currentRequest: { a: number },
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
 
-f4 =
-  function (
-    currentRequest: { a: number },
-    // TODO this is a very very very very long comment that makes it go > 80 columns
-  ) {};
+f4 = function (
+  currentRequest: { a: number },
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};
 
 class X {
   f(

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/contextualSignatureInstantiation2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/contextualSignatureInstantiation2.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
+assertion_line: 153
 expression: contextualSignatureInstantiation2.ts
-
 ---
 # Input
 ```js
@@ -17,8 +16,8 @@ var r23 = dot(id)(id);
 ```js
 // dot f g x = f(g(x))
 var dot: <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T) => (_: U) => S;
-dot =
-  <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T): (r: U) => S => (x) => f(g(x));
+dot = <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T): (r: U) => S => (x) =>
+  f(g(x));
 var id: <T>(x: T) => T;
 var r23 = dot(id)(id);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/ternaries/indent.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/ternaries/indent.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
+assertion_line: 153
 expression: indent.ts
-
 ---
 # Input
 ```js
@@ -61,54 +60,45 @@ foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
 
 # Output
 ```js
-foo =
-  (
-    callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
-  ).TSESTree!.BinaryExpression;
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
+).TSESTree!.BinaryExpression;
 
-foo =
-  (
-    callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
-  ).TSESTree!.BinaryExpression;
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
+).TSESTree!.BinaryExpression;
 
-bifornCringerMoshedPerplexSawder =
-  (
-    glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
-    annularCooeedSplicesWalksWayWay,
-  )!.annularCooeedSplicesWalksWayWay();
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
+  annularCooeedSplicesWalksWayWay,
+)!.annularCooeedSplicesWalksWayWay();
 
-foo =
-  (
-    callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
-  ).TSESTree!.BinaryExpression!;
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
+).TSESTree!.BinaryExpression!;
 
-foo =
-  (
-    callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
-  ).TSESTree!.BinaryExpression!;
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression ? callNode.parent.parent : callNode.parent
+).TSESTree!.BinaryExpression!;
 
-bifornCringerMoshedPerplexSawder =
-  (
-    glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
-    annularCooeedSplicesWalksWayWay,
-  )!.annularCooeedSplicesWalksWayWay()!;
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0 && kochabCooieGameOnOboleUnweave === Math.PI ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay.annularCooeedSplicesWalksWayWay(
+  annularCooeedSplicesWalksWayWay,
+)!.annularCooeedSplicesWalksWayWay()!;
 
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans + (
-    glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
-  ).Foo!.foo;
+bifornCringerMoshedPerplexSawder = askTrovenaBeenaDependsRowans + (
+  glimseGlyphsHazardNoopsTieTie === 0 ? averredBathersBoxroomBuggyNurl : anodyneCondosMalateOverateRetinol
+).Foo!.foo;
 
-foo =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )!;
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)!;
 
-foo =
-  (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
-  )!!!!!;
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond ? baaaaaaaaaaaaaaaaaaaaar : baaaaaaaaaaaaaaaaaaaaaz
+)!!!!!;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/webhost/webtsc.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/webhost/webtsc.ts.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
+assertion_line: 153
 expression: webtsc.ts
-
 ---
 # Input
 ```js
@@ -124,7 +123,7 @@ namespace TypeScript.WebTsc {
     const fso = new RealActiveXObject("Scripting.FileSystemObject");
 
     const fileStream = new ActiveXObject("ADODB.Stream");
-    fileStream.Type = 2 /*text*/ ;
+    fileStream.Type = 2; /*text*/
 
     const args: string[] = [];
     for (let i = 0; i < WScript.Arguments.length; i++) {
@@ -156,12 +155,11 @@ namespace TypeScript.WebTsc {
             // Position must be at 0 before encoding can be changed
             fileStream.Position = 0;
             // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
-            fileStream.Charset =
-              bom.length >= 2 && (
-                (bom.charCodeAt(0) === 0xFF && bom.charCodeAt(1) === 0xFE) || (
-                  bom.charCodeAt(0) === 0xFE && bom.charCodeAt(1) === 0xFF
-                )
-              ) ? "unicode" : "utf-8";
+            fileStream.Charset = bom.length >= 2 && (
+              (bom.charCodeAt(0) === 0xFF && bom.charCodeAt(1) === 0xFE) || (
+                bom.charCodeAt(0) === 0xFE && bom.charCodeAt(1) === 0xFF
+              )
+            ) ? "unicode" : "utf-8";
           }
           // ReadText method always strips byte order mark from resulting string
           return fileStream.ReadText();

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: as_assignment.ts
 ---
 # Input
@@ -21,6 +22,5 @@ let binding;
 
 (binding as boolean) = true;
 
-(binding.very.long.chain.of.static.members as VeryLongTypeName) =
-	veryLongExpression();
+(binding.very.long.chain.of.static.members as VeryLongTypeName) = veryLongExpression();
 

--- a/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: type_assertion_assignment.ts
 ---
 # Input
@@ -30,8 +31,7 @@ let x;
 
 (<boolean>x) = true;
 
-(x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever as string) =
-	veryLongExpression();
+(x.very.long.chain.of.static.members.that.goes.on.for.ever.I.mean.it.for.ever as string) = veryLongExpression();
 
 for (<boolean>x of []) {}
 ({ x: <string>x } = { x: "test" });


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #2417

This actually fixes a loads of stuff, although it would be to know from @leops if my change actually makes sense.

I know that not having a soft line break has a small repercussion on how comments are printed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated snapshots and checked if they make sense

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
