### PR TITLE
feat(playground): align options horizontally

### DIFF
--- a/website/playground/src/App.tsx
+++ b/website/playground/src/App.tsx
@@ -149,7 +149,7 @@ function App() {
 			return (
 				<div className="divide-y divide-slate-300">
 					<h1 className="p-4 text-xl">Rome Playground</h1>
-					<div>
+					<div className="flex items-baseline">
 						<LineWidthInput lineWidth={lineWidth} setLineWidth={setLineWidth} />
 						<IndentStyleSelect
 							indentWidth={indentWidth}


### PR DESCRIPTION
## Summary

The options at the top of the playground take up a lot of space and are pretty empty. This PR aligns the options horizontally instead of vertically to give more space to the code.
![image](https://user-images.githubusercontent.com/33844379/163294936-253d06f7-bf82-4b57-86f4-a1ffbd9fc752.png)
Into:
![image](https://user-images.githubusercontent.com/33844379/163294956-49a8c06b-41ba-435b-a5ce-0544c4d2267a.png)

## Test Plan

Tested on local playground.

PS: Awesome work team! Congrats 👏 
Really need to get back to contributing!