### PR TITLE
fix(rome_js_parser): fix lexer panicking on unterminated unicode escape at EOF

### DIFF
--- a/crates/rome_js_parser/src/lexer/tests.rs
+++ b/crates/rome_js_parser/src/lexer/tests.rs
@@ -1047,6 +1047,15 @@ fn unicode_ident_separated_by_unicode_whitespace() {
 }
 
 #[test]
+fn err_on_unterminated_unicode() {
+    assert_lex! {
+        "+\\u{A",
+        PLUS:1
+        ERROR_TOKEN:4
+    }
+}
+
+#[test]
 fn issue_30() {
     assert_lex! {
         "let foo = { α: true }",


### PR DESCRIPTION
## Summary

Found via fuzzing https://github.com/rome/tools/issues/1945

It panics on unterminated unicode scape at EOF. e.g. `+\\u{A`

## Test Plan
Added a unit test.
