### PR TITLE
fix(rome_js_formatter): break object binding inside variable declarators

### DIFF
--- a/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
+++ b/crates/rome_js_formatter/src/js/bindings/object_binding_pattern.rs
@@ -1,9 +1,9 @@
 use crate::{
     formatter_traits::FormatTokenAndNode, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
-
-use rome_js_syntax::JsObjectBindingPattern;
-use rome_js_syntax::JsObjectBindingPatternFields;
+use rome_js_syntax::{JsAnyObjectBindingPatternMember, JsObjectBindingPatternFields};
+use rome_js_syntax::{JsObjectBindingPattern, JsSyntaxKind};
+use rome_rowan::{AstNode, SyntaxResult};
 
 impl ToFormatElement for JsObjectBindingPattern {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
@@ -13,10 +13,54 @@ impl ToFormatElement for JsObjectBindingPattern {
             r_curly_token,
         } = self.as_fields();
 
-        formatter.format_delimited_soft_block_spaces(
-            &l_curly_token?,
-            properties.format(formatter)?,
-            &r_curly_token?,
-        )
+        if should_hard_break(self)? {
+            formatter.format_delimited_block_indent(
+                &l_curly_token?,
+                properties.format(formatter)?,
+                &r_curly_token?,
+            )
+        } else {
+            formatter.format_delimited_soft_block_spaces(
+                &l_curly_token?,
+                properties.format(formatter)?,
+                &r_curly_token?,
+            )
+        }
     }
+}
+
+/// This function inspects the properties of a [JsObjectBindingPattern] and decides that should break when:
+/// - the node is inside a [JsVariableDeclaratorNode]
+/// - at least one of the properties is a [JsObjectBindingPatternProperty] or a [JsObjectBindingPatternShorthandProperty] with an
+/// initializer
+///
+/// [JsObjectBindingPattern]: rome_js_syntax::JsObjectBindingPattern
+/// [JsVariableDeclaratorNode]: rome_js_syntax::JsVariableDeclaratorNode
+/// [JsObjectBindingPatternProperty]: rome_js_syntax::JsObjectBindingPatternProperty
+/// [JsObjectBindingPatternShorthandProperty]: rome_js_syntax::JsObjectBindingPatternShorthandProperty
+fn should_hard_break(binding_pattern: &JsObjectBindingPattern) -> SyntaxResult<bool> {
+    let properties = binding_pattern.properties();
+    let parent_kind = binding_pattern.syntax().parent().map(|k| k.kind());
+
+    if let Some(parent_kind) = parent_kind {
+        if parent_kind != JsSyntaxKind::JS_VARIABLE_DECLARATOR {
+            return Ok(false);
+        }
+    }
+
+    for property in properties {
+        let property = property?;
+
+        if let JsAnyObjectBindingPatternMember::JsObjectBindingPatternProperty(_) = property {
+            return Ok(true);
+        } else if let JsAnyObjectBindingPatternMember::JsObjectBindingPatternShorthandProperty(
+            short_hand_property,
+        ) = property
+        {
+            if short_hand_property.init().is_some() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }

--- a/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
 expression: object_binding.js
+
 ---
 # Input
 let {a}=b
@@ -17,8 +19,16 @@ Line width: 80
 Quote style: Double Quotes
 -----
 let { a } = b;
-let { d, b: c } = d;
-let { x, y = c, z: pp = f, ...g } = h;
+let {
+	d,
+	b: c,
+} = d;
+let {
+	x,
+	y = c,
+	z: pp = f,
+	...g
+} = h;
 let {
 	aaaaaaaaaaaaaaaaaaaa,
 	bbbbbbbbbbbbbbbbbbbb = cccccccccccccccccccc,

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_pattern.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_pattern.js
@@ -1,0 +1,21 @@
+// Break over multiple lines if it contains a sub pattern
+const {b: {test}} = test;
+
+// non-shorthand and whole statement exceeds line width
+const { id, isStatic: isStatic, method, methodId, g } = privateNamesMap.get(name);
+
+// default and whole statement exceeds line width
+const { id, isStatic = true, method, methodId, gee } = privateNamesMap.get(name);
+
+// sub pattern
+const { id, isStatic: {sub}, method, methodId, gee } = privateNamesMap;
+
+
+const { id, //middle comment
+  isStatic, method, methodId, gee } = privateNamesMap;
+
+try {
+  // you should not break
+} catch ({ data: { message }}) {
+
+}

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object_pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object_pattern.js.snap
@@ -1,0 +1,80 @@
+---
+source: crates/rome_js_formatter/tests/spec_test.rs
+assertion_line: 223
+expression: object_pattern.js
+
+---
+# Input
+// Break over multiple lines if it contains a sub pattern
+const {b: {test}} = test;
+
+// non-shorthand and whole statement exceeds line width
+const { id, isStatic: isStatic, method, methodId, g } = privateNamesMap.get(name);
+
+// default and whole statement exceeds line width
+const { id, isStatic = true, method, methodId, gee } = privateNamesMap.get(name);
+
+// sub pattern
+const { id, isStatic: {sub}, method, methodId, gee } = privateNamesMap;
+
+
+const { id, //middle comment
+  isStatic, method, methodId, gee } = privateNamesMap;
+
+try {
+  // you should not break
+} catch ({ data: { message }}) {
+
+}
+=============================
+# Outputs
+## Output 1
+-----
+Indent style: Tab
+Line width: 80
+Quote style: Double Quotes
+-----
+// Break over multiple lines if it contains a sub pattern
+const {
+	b: { test },
+} = test;
+
+// non-shorthand and whole statement exceeds line width
+const {
+	id,
+	isStatic: isStatic,
+	method,
+	methodId,
+	g,
+} = privateNamesMap.get(name);
+
+// default and whole statement exceeds line width
+const {
+	id,
+	isStatic = true,
+	method,
+	methodId,
+	gee,
+} = privateNamesMap.get(name);
+
+// sub pattern
+const {
+	id,
+	isStatic: { sub },
+	method,
+	methodId,
+	gee,
+} = privateNamesMap;
+
+const {
+	id, //middle comment
+	isStatic,
+	method,
+	methodId,
+	gee,
+} = privateNamesMap;
+
+try {
+	// you should not break
+} catch ({ data: { message } }) {}
+

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-heuristic.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/destructuring-heuristic.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: destructuring-heuristic.js
 
 ---
@@ -41,19 +41,32 @@ expression: destructuring-heuristic.js
 ```js
 {
   {
-    const { id, static: isStatic, method: isMethod, methodId, getId, setId } = privateNamesMap.get(
-      name,
-    );
+    const {
+      id,
+      static: isStatic,
+      method: isMethod,
+      methodId,
+      getId,
+      setId,
+    } = privateNamesMap.get(name);
 
-    const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
+    const {
+      id1,
+      method: isMethod1,
+      methodId1,
+    } = privateNamesMap.get(name);
 
-    const { id2, method: isMethod2, methodId2 } = privateNamesMap.get(
-      bifornCringerMoshedPerplexSawder,
-    );
+    const {
+      id2,
+      method: isMethod2,
+      methodId2,
+    } = privateNamesMap.get(bifornCringerMoshedPerplexSawder);
 
-    const { id3, method: isMethod3, methodId3 } = anodyneCondosMalateOverateRetinol.get(
-      bifornCringerMoshedPerplexSawder,
-    );
+    const {
+      id3,
+      method: isMethod3,
+      methodId3,
+    } = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
   }
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-10218.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/issue-10218.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-10218.js
 
 ---
@@ -20,7 +20,9 @@ const _id1 = data.createTestMessageWithAReallyLongName.someVeryLongProperty.this
 
 const { _id2 } = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
 
-const { _id: id3 } = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+const {
+  _id: id3,
+} = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/assignment-pattern.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/assignment-pattern.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: assignment-pattern.js
 
 ---
@@ -17,9 +17,13 @@ let {d //comment
 
 # Output
 ```js
-const { a /* comment */ = 1 } = b;
+const {
+  a = 1, /* comment */
+} = b;
 
-const { c = 1 /* comment */ } = d;
+const {
+  c = 1, /* comment */
+} = d;
 
 let {
   d = b, //comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/destructuring.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/destructuring.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: destructuring.js
 
 ---
@@ -60,7 +60,9 @@ const [one, two = null, three = null] = arr;
 a = ([s = 1]) => 1;
 const { children, ...props } = this.props;
 
-const { user: { firstName, lastName } } = this.props;
+const {
+  user: { firstName, lastName },
+} = this.props;
 
 const {
   name: { first, last },
@@ -80,7 +82,12 @@ const UserComponent = function (
   return;
 };
 
-const { a, b, c, d: { e } } = someObject;
+const {
+  a,
+  b,
+  c,
+  d: { e },
+} = someObject;
 
 try {
   // code

--- a/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/issue-5988.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/destructuring/issue-5988.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: issue-5988.js
 
 ---
@@ -12,9 +12,11 @@ const { foo, bar: bazAndSomething, quxIsLong } = someBigFunctionName("foo")("bar
 
 # Output
 ```js
-const { foo, bar: bazAndSomething, quxIsLong } = someBigFunctionName("foo")(
-  "bar",
-);
+const {
+  foo,
+  bar: bazAndSomething,
+  quxIsLong,
+} = someBigFunctionName("foo")("bar");
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-member.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
+assertion_line: 153
 expression: break-last-member.js
 
 ---
@@ -40,9 +40,23 @@ expect(
   findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0].style.paddingRight,
 ).toBe("1000px");
 
-const { course, conflicts = [], index, scheduleId, studentId, something } = a.this.props;
+const {
+  course,
+  conflicts = [],
+  index,
+  scheduleId,
+  studentId,
+  something,
+} = a.this.props;
 
-const { course2, conflicts2 = [], index2, scheduleId2, studentId2, something2 } = this.props;
+const {
+  course2,
+  conflicts2 = [],
+  index2,
+  scheduleId2,
+  studentId2,
+  something2,
+} = this.props;
 
 const {
   updated,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #2424

We break object binding patterns when it's inside a variable declaration and the properties are of a certain type  

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

New tests to cover that case and we don't break other cases.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
