### PR TITLE
feat(rome_js_formatter): Hard line breaks in object expressions.

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/object_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/object_expression.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-
+use crate::utils::has_leading_newline;
 use crate::FormatNodeFields;
 use rome_js_syntax::JsObjectExpression;
 use rome_js_syntax::JsObjectExpressionFields;
@@ -15,12 +15,18 @@ impl FormatNodeFields<JsObjectExpression> for FormatNodeRule<JsObjectExpression>
             r_curly_token,
         } = node.as_fields();
 
+        let has_newline = has_leading_newline(members.syntax());
         let members_content = formatted![formatter, [members.format()]]?;
 
         if members.is_empty() {
             formatter
                 .delimited(&l_curly_token?, members_content, &r_curly_token?)
                 .soft_block_indent()
+                .finish()
+        } else if has_newline {
+            formatter
+                .delimited(&l_curly_token?, members_content, &r_curly_token?)
+                .block_indent()
                 .finish()
         } else {
             formatter

--- a/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
+++ b/crates/rome_js_formatter/src/js/module/export_named_from_clause.rs
@@ -1,10 +1,11 @@
 use crate::prelude::*;
-
 use crate::utils::format_with_semicolon;
+use crate::utils::has_leading_newline;
 
 use crate::FormatNodeFields;
 use rome_js_syntax::JsExportNamedFromClause;
 use rome_js_syntax::JsExportNamedFromClauseFields;
+use rome_rowan::AstNode;
 
 impl FormatNodeFields<JsExportNamedFromClause> for FormatNodeRule<JsExportNamedFromClause> {
     fn format_fields(
@@ -22,14 +23,25 @@ impl FormatNodeFields<JsExportNamedFromClause> for FormatNodeRule<JsExportNamedF
             semicolon_token,
         } = node.as_fields();
 
-        let list = formatter
-            .delimited(
-                &l_curly_token?,
-                formatted![formatter, [specifiers.format()]]?,
-                &r_curly_token?,
-            )
-            .soft_block_spaces()
-            .finish()?;
+        let list = if has_leading_newline(specifiers.syntax()) {
+            formatter
+                .delimited(
+                    &l_curly_token?,
+                    formatted![formatter, [specifiers.format()]]?,
+                    &r_curly_token?,
+                )
+                .block_indent()
+                .finish()?
+        } else {
+            formatter
+                .delimited(
+                    &l_curly_token?,
+                    formatted![formatter, [specifiers.format()]]?,
+                    &r_curly_token?,
+                )
+                .soft_block_spaces()
+                .finish()?
+        };
 
         format_with_semicolon(
             formatter,

--- a/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
+++ b/crates/rome_js_formatter/src/ts/declarations/enum_declaration.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
+use crate::utils::has_leading_newline;
 use crate::FormatNodeFields;
 use rome_js_syntax::{TsEnumDeclaration, TsEnumDeclarationFields};
+use rome_rowan::AstNode;
 
 impl FormatNodeFields<TsEnumDeclaration> for FormatNodeRule<TsEnumDeclaration> {
     fn format_fields(
@@ -16,11 +18,16 @@ impl FormatNodeFields<TsEnumDeclaration> for FormatNodeRule<TsEnumDeclaration> {
             r_curly_token,
         } = node.as_fields();
 
+        let has_newline = has_leading_newline(members.syntax());
         let list = formatter
             .delimited(
                 &l_curly_token?,
                 join_elements(
-                    soft_line_break_or_space(),
+                    if has_newline {
+                        hard_line_break()
+                    } else {
+                        soft_line_break_or_space()
+                    },
                     formatter.format_separated(&members, || token(","))?,
                 ),
                 &r_curly_token?,

--- a/crates/rome_js_formatter/src/ts/types/object_type.rs
+++ b/crates/rome_js_formatter/src/ts/types/object_type.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::utils::has_leading_newline;
 use crate::FormatNodeFields;
 use rome_js_syntax::{TsObjectType, TsObjectTypeFields};
 
@@ -13,13 +14,24 @@ impl FormatNodeFields<TsObjectType> for FormatNodeRule<TsObjectType> {
             r_curly_token,
         } = node.as_fields();
 
-        formatter
-            .delimited(
-                &l_curly_token?,
-                formatted![formatter, [members.format()]]?,
-                &r_curly_token?,
-            )
-            .soft_block_spaces()
-            .finish()
+        if has_leading_newline(members.syntax()) {
+            formatter
+                .delimited(
+                    &l_curly_token?,
+                    formatted![formatter, [members.format()]]?,
+                    &r_curly_token?,
+                )
+                .block_indent()
+                .finish()
+        } else {
+            formatter
+                .delimited(
+                    &l_curly_token?,
+                    formatted![formatter, [members.format()]]?,
+                    &r_curly_token?,
+                )
+                .soft_block_spaces()
+                .finish()
+        }
     }
 }

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -105,6 +105,18 @@ pub(crate) fn has_formatter_trivia(node: &JsSyntaxNode) -> bool {
     false
 }
 
+/// Returns true if this node contains newlines in trivias.
+pub(crate) fn has_leading_newline(node: &JsSyntaxNode) -> bool {
+    if let Some(leading_trivia) = node.first_leading_trivia() {
+        for piece in leading_trivia.pieces() {
+            if piece.is_newline() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Format an element with a single line head and a body that might
 /// be either a block or a single statement
 ///

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -19,5 +19,10 @@ Quote style: Double Quotes
 -----
 nock(/test/)
 	.matchHeader("Accept", "application/json")[httpMethodNock(method)]("/foo")
-	.reply(200, { foo: "bar" });
+	.reply(
+		200,
+		{
+			foo: "bar",
+		},
+	);
 

--- a/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -28,7 +28,11 @@ _.flatMap(this.visibilityHandlers, (fn) => fn())
 	.concat(this.record.resolved_legacy_visrules)
 	.filter(Boolean);
 
-Object.keys(availableLocales({ test: true })).forEach(
+Object.keys(
+	availableLocales({
+		test: true,
+	}),
+).forEach(
 	(locale) => {
 		// ...
 	},

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js
@@ -1,5 +1,8 @@
 import { hey } from "hey"
 import { hey } from "hey";
+import {
+    apple,
+banana } from "fruits";
 import {test} from "foo.json" assert { for: "for" }
 import { // some funky comment
     loooooooooooooooooooong as moreeeeeeloooooooooooooooooooong,

--- a/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -5,6 +5,9 @@ expression: import_specifiers.js
 # Input
 import { hey } from "hey"
 import { hey } from "hey";
+import {
+    apple,
+banana } from "fruits";
 import {test} from "foo.json" assert { for: "for" }
 import { // some funky comment
     loooooooooooooooooooong as moreeeeeeloooooooooooooooooooong,
@@ -30,6 +33,7 @@ Quote style: Double Quotes
 -----
 import { hey } from "hey";
 import { hey } from "hey";
+import { apple, banana } from "fruits";
 import { test } from "foo.json" assert { for: "for" };
 import {
 	// some funky comment

--- a/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -18,6 +18,10 @@ Indent style: Tab
 Line width: 80
 Quote style: Double Quotes
 -----
-let a = { get foo() {} };
-let b = { set foo(a) {} };
+let a = {
+	get foo() {},
+};
+let b = {
+	set foo(a) {},
+};
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js
@@ -19,3 +19,14 @@ let a = {
 
 	...spread,
 }
+
+const x = {apple: "banana"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
+({
+	a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});

--- a/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -25,6 +25,17 @@ let a = {
 	...spread,
 }
 
+const x = {apple: "banana"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
+({
+	a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
 =============================
 # Outputs
 ## Output 1
@@ -52,4 +63,14 @@ let a = {
 
 	...spread,
 };
+
+const x = { apple: "banana" };
+
+const y = {
+	apple: "banana",
+};
+
+({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
+
+({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
 

--- a/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -22,6 +22,10 @@ Quote style: Double Quotes
 -----
 const foo = {
 	"foo-bar": true,
-	"bar": { "lorem_ispsum": { "lorem-ipsum": true } },
+	"bar": {
+		"lorem_ispsum": {
+			"lorem-ipsum": true,
+		},
+	},
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/call-with-template.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/call-with-template.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: call-with-template.js
-
 ---
 # Input
 ```js
@@ -25,9 +23,13 @@ const result = template(
   `
   if (SOME_VAR === "") {}
 `,
-)({ SOME_VAR: value });
+)({
+  SOME_VAR: value,
+});
 
-const output = template(`function f() %%A%%`)({ A: t.blockStatement([]) });
+const output = template(`function f() %%A%%`)({
+  A: t.blockStatement([]),
+});
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/assignment/lone-arg.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: lone-arg.js
-
 ---
 # Input
 ```js
@@ -31,7 +29,11 @@ const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(`foo
 
 # Output
 ```js
-let vgChannel = pointPositionDefaultRef({ model, defaultPos, channel })();
+let vgChannel = pointPositionDefaultRef({
+  model,
+  defaultPos,
+  channel,
+})();
 
 let vgChannel2 = pointPositionDefaultRef({ model, defaultPos, channel })();
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/async/async-shorthand-method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/async/async-shorthand-method.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: async-shorthand-method.js
-
 ---
 # Input
 ```js
@@ -15,7 +13,10 @@ expression: async-shorthand-method.js
 
 # Output
 ```js
-({ async get() {}, async set() {} });
+({
+  async get() {},
+  async set() {},
+});
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/optional-chaining.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/babel-plugins/optional-chaining.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
 expression: optional-chaining.js
-
 ---
 # Input
 ```js
@@ -75,7 +73,13 @@ const ret = delete obj?.foo?.bar?.baz; // true
 ```js
 // https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining
 
-const obj = { foo: { bar: { baz: 42 } } };
+const obj = {
+  foo: {
+    bar: {
+      baz: 42,
+    },
+  },
+};
 
 const baz = obj?.foo?.bar?.baz; // 42
 
@@ -113,9 +117,19 @@ test?.(); // 42
 
 exists?.(); // undefined
 
-const obj3 = { foo: { bar: { baz: class {} } } };
+const obj3 = {
+  foo: {
+    bar: {
+      baz: class {},
+    },
+  },
+};
 
-const obj4 = { foo: { bar: {} } };
+const obj4 = {
+  foo: {
+    bar: {},
+  },
+};
 
 const ret = delete obj?.foo?.bar?.baz; // true
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/arrow.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/arrow.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
 expression: arrow.js
-
 ---
 # Input
 ```js
@@ -44,7 +42,9 @@ function f2() {
       entity.isInstallAvailable() &&
       !entity.isQueue() &&
       entity.isDisabled() &&
-      { id: entity.id },
+      {
+        id: entity.id,
+      },
   );
 }
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/inline-object-array.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: inline-object-array.js
-
 ---
 # Input
 ```js
@@ -142,20 +140,42 @@ prevState =
       selectedCatalog: null,
     };
 
-this.steps = steps || [{ name: "mock-module", path: "/nux/mock-module" }];
+this.steps =
+  steps || [
+    {
+      name: "mock-module",
+      path: "/nux/mock-module",
+    },
+  ];
 
 this.steps =
-  steps || (checkStep && [{ name: "mock-module", path: "/nux/mock-module" }]);
+  steps || (
+    checkStep && [
+      {
+        name: "mock-module",
+        path: "/nux/mock-module",
+      },
+    ]
+  );
 
 this.steps =
-  (steps && checkStep) || [{ name: "mock-module", path: "/nux/mock-module" }];
+  (steps && checkStep) || [
+    {
+      name: "mock-module",
+      path: "/nux/mock-module",
+    },
+  ];
 
 const create = () => {
   const result = doSomething();
   return (
     shouldReturn &&
       result.ok &&
-      { status: "ok", createdAt: result.createdAt, updatedAt: result.updatedAt }
+      {
+        status: "ok",
+        createdAt: result.createdAt,
+        updatedAt: result.updatedAt,
+      }
   );
 };
 
@@ -171,8 +191,15 @@ const create2 = () => {
 };
 
 const obj = {
-  state: shouldHaveState && stateIsOK && { loadState: LOADED, opened: false },
-  loadNext: (stateIsOK && hasNext) || { skipNext: true },
+  state: shouldHaveState &&
+    stateIsOK &&
+    {
+      loadState: LOADED,
+      opened: false,
+    },
+  loadNext: (stateIsOK && hasNext) || {
+    skipNext: true,
+  },
   loaded: true,
 };
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/jsx_parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/binary-expressions/jsx_parent.js.snap
@@ -61,7 +61,10 @@ expression: jsx_parent.js
   style={
     !isJellyfishEnabled &&
       diffUpdateMessageInput &&
-      { fontSize: 14, color: "#fff" }
+      {
+        fontSize: 14,
+        color: "#fff",
+      }
   }
 />;
 
@@ -76,5 +79,3 @@ expression: jsx_parent.js
 </div>;
 
 ```
-
-

--- a/crates/rome_js_formatter/tests/specs/prettier/js/classes/method.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/classes/method.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
 expression: method.js
-
 ---
 # Input
 ```js
@@ -26,7 +24,9 @@ class C {
   name /*comment*/ () {}
 }
 
-({ name /*comment*/ () {} });
+({
+  name /*comment*/ () {},
+});
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/closure-compiler-type-cast.js.snap
@@ -118,13 +118,19 @@ const style = /** @type {{
   marginLeft: number,
   marginRight: number,
   marginBottom: number,
-}} */ ({ width, height, ...margins });
+}} */ ({
+  width,
+  height,
+  ...margins,
+});
 
 const style2 = /**
  * @type {{
  *   width: number,
  * }}
-*/ ({ width });
+*/ ({
+  width,
+});
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/object-with-comment.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments-closure-typecast/object-with-comment.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: object-with-comment.js
-
 ---
 # Input
 ```js
@@ -24,10 +22,17 @@ const objectWithComment2 = /** @type MyType */ (  /* comment */  {
 ```js
 const objectWithComment = /** @type MyType */ (
   /* comment */
-  { foo: bar }
+  {
+    foo: bar,
+  }
 );
 
-const objectWithComment2 = /** @type MyType */ ( /* comment */ { foo: bar });
+const objectWithComment2 = /** @type MyType */ (
+  /* comment */
+  {
+    foo: bar,
+  }
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/comments/variable_declarator.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/comments/variable_declarator.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 144
 expression: variable_declarator.js
-
 ---
 # Input
 ```js
@@ -77,9 +75,15 @@ const foo3 = 123
 
 # Output
 ```js
-let obj1 = { key: "val" }; // Comment
+let obj1 = {
+  // Comment
+  key: "val",
+};
 
-let obj2 = { key: "val" }; // Comment
+let obj2 = {
+  // Comment
+  key: "val",
+};
 
 let obj3 = {
   // Comment

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-first-param/function_expression.js.snap
@@ -36,7 +36,13 @@ db.collection('indexOptionDefault').createIndex({ a: 1 }, {
 //https://github.com/prettier/prettier/issues/3002
 beep.boop().baz(
   "foo",
-  { some: { thing: { nested: true } } },
+  {
+    some: {
+      thing: {
+        nested: true,
+      },
+    },
+  },
   { another: { thing: true } },
   () => {},
 );
@@ -44,7 +50,11 @@ beep.boop().baz(
 //https://github.com/prettier/prettier/issues/2984
 db.collection("indexOptionDefault").createIndex(
   { a: 1 },
-  { indexOptionDefaults: true, w: 2, wtimeout: 1000 },
+  {
+    indexOptionDefaults: true,
+    w: 2,
+    wtimeout: 1000,
+  },
   function (err) {
     test.equal(null, err);
     test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/function-single-destructuring/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/function-single-destructuring/object.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 151
 expression: object.js
-
 ---
 # Input
 ```js
@@ -109,7 +107,9 @@ function StatelessFunctionalComponent3(
     searchFilters = null,
     title = "",
     items = [],
-  } = { isActive: true },
+  } = {
+    isActive: true,
+  },
 ) {
   return <div />;
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/ramda_compose.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/functional-composition/ramda_compose.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
 expression: ramda_compose.js
-
 ---
 # Input
 ```js
@@ -74,7 +72,14 @@ var getStateCode = R.composeK(
 getStateCode({ user: { address: { state: "ny" } } }); //=> Maybe.Just("NY")
 getStateCode({}); //=> Maybe.Nothing()
 
-var db = { users: { JOE: { name: "Joe", followers: ["STEVE", "SUZY"] } } };
+var db = {
+  users: {
+    JOE: {
+      name: "Joe",
+      followers: ["STEVE", "SUZY"],
+    },
+  },
+};
 
 // We'll pretend to do a db lookup which returns a promise
 var lookupUser = (userId) => Promise.resolve(db.users[userId]);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/break-parent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/last-argument-expansion/break-parent.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 153
 expression: break-parent.js
-
 ---
 # Input
 ```js
@@ -40,7 +38,9 @@ true
   processors: [
     require(
       "autoprefixer",
-      { browsers: ["> 1%", "last 2 versions", "ie >= 11", "Firefox ESR"] },
+      {
+        browsers: ["> 1%", "last 2 versions", "ie >= 11", "Firefox ESR"],
+      },
     ),
     require("postcss-url")({
       url: (url) =>
@@ -49,7 +49,9 @@ true
   ],
 });
 
-true ? test({ a: 1 }) : <div
+true ? test({
+  a: 1,
+}) : <div
   a={123412342314}
   b={123412341234}
   c={123412341234}

--- a/crates/rome_js_formatter/tests/specs/prettier/js/member/expand.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/member/expand.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: expand.js
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-call.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/break-last-call.js.snap
@@ -46,7 +46,13 @@ it('should group messages with same created time', () => {
 ```js
 export default (store) => {
   return callApi(endpoint, schema).then(
-    (response) => next(actionWith({ response, type: successType })),
+    (response) =>
+      next(
+        actionWith({
+          response,
+          type: successType,
+        }),
+      ),
     (error) =>
       next(
         actionWith({

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/computed.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/computed.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: computed.js
 ---
 # Input
@@ -18,7 +17,12 @@ nock(/test/)
 ```js
 nock(/test/)
   .matchHeader("Accept", "application/json")[httpMethodNock(method)]("/foo")
-  .reply(200, { foo: "bar" });
+  .reply(
+    200,
+    {
+      foo: "bar",
+    },
+  );
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/first_long.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/first_long.js.snap
@@ -49,7 +49,11 @@ export default function theFunction(action$, store) {
       Observable.webSocket({
         url: THE_URL,
         more: stuff(),
-        evenMore: stuff({ value1: true, value2: false, value3: false }),
+        evenMore: stuff({
+          value1: true,
+          value2: false,
+          value3: false,
+        }),
       })
         .filter((data) => theFilter(data))
         .map(({ theType, ...data }) => theMap(theType, data))

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/inline_merge.js.snap
@@ -27,7 +27,11 @@ var jqxhr = $.ajax("example.php")
 
 # Output
 ```js
-Object.keys(availableLocales({ test: true })).forEach(
+Object.keys(
+  availableLocales({
+    test: true,
+  }),
+).forEach(
   (locale) => {
     // ...
   },

--- a/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/method-chain/issue-4125.js.snap
@@ -252,7 +252,10 @@ function HelloWorld() {
     authorizationToken: data.token,
   }).initVerify("foo_container");
 
-  fejax.ajax({ url: "/verification/", dataType: "json" }).then(
+  fejax.ajax({
+    url: "/verification/",
+    dataType: "json",
+  }).then(
     (data) => {
       this.setState({ isLoading: false });
       this.initWidget(data);

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-graphql/graphql-tag.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-graphql/graphql-tag.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
 expression: graphql-tag.js
-
 ---
 # Input
 ```js
@@ -307,7 +305,9 @@ ${USER_DETAILS_FRAGMENT}
    # and has a blank line in the middle
 
     ${FRIENDS_FRAGMENT}
-  ${generateFragment({ totally: "a good idea" })}
+  ${generateFragment({
+  totally: "a good idea",
+})}
 
 ${fragment}#comment
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-html/lit-html.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/multiparser-html/lit-html.js.snap
@@ -115,7 +115,9 @@ import { LitElement, html } from "@polymer/lit-element";
 
 class MyElement extends LitElement {
   static get properties() {
-    return { mood: { type: String } };
+    return {
+      mood: { type: String },
+    };
   }
 
   constructor() {
@@ -216,7 +218,7 @@ ${foo}:${bar};
 
 # Lines exceeding max width of 80 characters
 ```
-   68: const nestedFun = /* HTML */ `${outerExpr(1)} <script>const tpl = html\`<div>\${innerExpr( 1 )} ${outerExpr(
-   78: const closingScriptTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;
+   70: const nestedFun = /* HTML */ `${outerExpr(1)} <script>const tpl = html\`<div>\${innerExpr( 1 )} ${outerExpr(
+   80: const closingScriptTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/object-prop-break-in/test.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/object-prop-break-in/test.js.snap
@@ -51,9 +51,13 @@ const c = classnames({
   "some-prop": ["foo", "bar", "foo", "bar", "foo", "bar", "foo", "bar", "foo"],
 });
 
-const d = classnames({ "some-prop": () => {} });
+const d = classnames({
+  "some-prop": () => {},
+});
 
-const e = classnames({ "some-prop": function bar() {} });
+const e = classnames({
+  "some-prop": function bar() {},
+});
 
 const f = classnames({
   "some-prop": { foo: "bar", bar: "foo", foo: "bar", bar: "foo", foo: "bar" },
@@ -74,6 +78,6 @@ ipsum`,
 # Lines exceeding max width of 80 characters
 ```
     6:   "some-prop": this.state.longLongLongLongLongLongLongLongLongTooLongProp === true,
-   22:   "some-prop": longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337,
+   26:   "some-prop": longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337,
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/object-property-comment/after-key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/object-property-comment/after-key.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: after-key.js
-
 ---
 # Input
 ```js
@@ -18,9 +16,13 @@ let b = {
 
 # Output
 ```js
-let a = { a /* comment */ : () => 1 };
+let a = {
+  a: () => 1, /* comment */
+};
 
-let b = { "a" /* comment */ : () => 1 };
+let b = {
+  "a": () => 1, /* comment */
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/assignment-expression/object-property.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/assignment-expression/object-property.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: object-property.js
-
 ---
 # Input
 ```js
@@ -14,7 +12,10 @@ a = {
 
 # Output
 ```js
-a = { [this.resource = resource]: 1 };
+a =
+  {
+    [this.resource = resource]: 1,
+  };
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/assignment-expression/object-value.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/assignment-expression/object-value.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: object-value.js
-
 ---
 # Input
 ```js
@@ -18,9 +16,16 @@ map(([resource]) => ({
 
 # Output
 ```js
-a = { resource: (this.resource = resource) };
+a =
+  {
+    resource: (this.resource = resource),
+  };
 
-map(([resource]) => ({ resource: (this.resource = resource) }));
+map(
+  ([resource]) => ({
+    resource: (this.resource = resource),
+  }),
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/escape-sequence-key.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/escape-sequence-key.js.snap
@@ -18,9 +18,13 @@ const b = {
 # Output
 ```js
 // #6235
-const a = { "\u2139": 'why "\\u2139" is converted to "i"?' };
+const a = {
+  "\u2139": 'why "\\u2139" is converted to "i"?',
+};
 
-const b = { "\x66\x69\x73\x6b\x65\x72": "\x66\x69\x73\x6b\x65\x72" };
+const b = {
+  "\x66\x69\x73\x6b\x65\x72": "\x66\x69\x73\x6b\x65\x72",
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/expand.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/expand.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 149
 expression: expand.js
-
 ---
 # Input
 ```js

--- a/crates/rome_js_formatter/tests/specs/prettier/js/objects/expression.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/objects/expression.js.snap
@@ -45,7 +45,9 @@ a = () => ({}).x;
 ({} = 0);
 (({} = 0), 1);
 
-const a1 = { someKey: (shortName, shortName) };
+const a1 = {
+  someKey: (shortName, shortName),
+};
 
 const a2 = {
   someKey: (
@@ -80,6 +82,6 @@ error[SyntaxError]: expected `')'` but instead found `:`
 
 # Lines exceeding max width of 80 characters
 ```
-   23:     longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName
+   25:     longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/argument-list.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/preserve-line/argument-list.js.snap
@@ -256,7 +256,10 @@ differentArgTypes(
 
 moreArgTypes(
   [1, 2, 3],
-  { name: "Hello World", age: 29 },
+  {
+    name: "Hello World",
+    age: 29,
+  },
   doSomething(
     // Hello world
 
@@ -302,15 +305,29 @@ doSomething.apply(
   ["Hello world 1", "Hello world 2", "Hello world 3"],
 );
 
-doAnotherThing("node", { solution_type, time_frame });
+doAnotherThing(
+  "node",
+  {
+    solution_type,
+    time_frame,
+  },
+);
 
-stuff.doThing(someStuff, -1, { accept: (node) => doSomething(node) });
+stuff.doThing(
+  someStuff,
+  -1,
+  {
+    accept: (node) => doSomething(node),
+  },
+);
 
 doThing(
   someOtherStuff,
   // This is important
   true,
-  { decline: (creditCard) => takeMoney(creditCard) },
+  {
+    decline: (creditCard) => takeMoney(creditCard),
+  },
 );
 
 func(
@@ -335,6 +352,6 @@ function foo(one, two, three, four, five, six, seven, eight, nine, ten, eleven) 
 
 # Lines exceeding max width of 80 characters
 ```
-  115: function foo(one, two, three, four, five, six, seven, eight, nine, ten, eleven) {}
+  132: function foo(one, two, three, four, five, six, seven, eight, nine, ten, eleven) {}
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/quotes/objects.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/quotes/objects.js.snap
@@ -14,7 +14,11 @@ const obj = {
 
 # Output
 ```js
-const obj = { "a": true, b: true, "𐊧": true };
+const obj = {
+  "a": true,
+  b: true,
+  "𐊧": true,
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/range/object-expression2.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/range/object-expression2.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 121
 expression: object-expression2.js
-
 ---
 # Input
 ```js
@@ -26,7 +24,10 @@ const y =       [
     {
                 a: 1,
     },
-    { a: 1, b: 2 },
+    {
+      a: 1,
+      b: 2,
+    },
 ]
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/strings/template-literals.js.snap
@@ -159,7 +159,14 @@ const env = ${JSON.stringify(
 `;
 
 // https://github.com/prettier/prettier/issues/821#issue-210557749
-f(`${{ a: 4, b: 9 }}`);
+f(
+  `${
+    {
+      a: 4,
+      b: 9,
+    }
+  }`,
+);
 
 // https://github.com/prettier/prettier/issues/1183#issue-220863505
 const makeBody = (store, assets, html) =>
@@ -194,7 +201,7 @@ const Bar = styled.div`
 # Lines exceeding max width of 80 characters
 ```
    74:   `\n  ${chalk.dim(`\u203A and ${more} more ${more} more ${more} more ${more}`)}`,
-  105:         `window.__INITIAL_STATE__ = ${JSON.stringify(store.getState(), null, 2)};`,
-  117:     props.highlight.length > 0 ? palette(["text", "dark", "tertiary"])(props) : palette([
+  112:         `window.__INITIAL_STATE__ = ${JSON.stringify(store.getState(), null, 2)};`,
+  124:     props.highlight.length > 0 ? palette(["text", "dark", "tertiary"])(props) : palette([
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/template/indent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/template/indent.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: indent.js
-
 ---
 # Input
 ```js
@@ -40,7 +38,10 @@ line 1
 line 2
 ...
 line n
-${foo({ many: keys, many: keys })}
+${foo({
+          many: keys,
+          many: keys,
+        })}
 line n + 1
 line n + 2
 line n + n

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/indent.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
 expression: indent.js
-
 ---
 # Input
 ```js
@@ -194,33 +192,92 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 
-a ? { a: 0 } : {
-  a: { a: 0 } ? { a: 0 } : { y: { a: 0 } ? { a: 0 } : { a: 0 } },
+a ? {
+  a: 0,
+} : {
+  a: {
+    a: 0,
+  } ? {
+    a: 0,
+  } : {
+    y: {
+      a: 0,
+    } ? {
+      a: 0,
+    } : {
+      a: 0,
+    },
+  },
 };
 
 a ? {
   a: function () {
     return a ? {
       a: [
-        a ? { a: 0, b: [a ? [0, 1] : []] } : [
-          [0, { a: 0 }, a ? 0 : 1],
+        a ? {
+          a: 0,
+          b: [a ? [0, 1] : []],
+        } : [
+          [
+            0,
+            {
+              a: 0,
+            },
+            a ? 0 : 1,
+          ],
           function () {
-            return a ? { a: 0 } : [{ a: 0 }, {}];
+            return a ? {
+              a: 0,
+            } : [
+              {
+                a: 0,
+              },
+              {},
+            ];
           },
         ],
       ],
     } : [
       a ? function () {
         a ? a(
-          a ? { a: a({ a: 0 }) } : [
+          a ? {
+            a: a({
+              a: 0,
+            }),
+          } : [
             0,
             a(),
-            a(a(), { a: 0 }, a ? a() : a({ a: 0 })),
-            a() ? { a: a(), b: [] } : {},
+            a(
+              a(),
+              {
+                a: 0,
+              },
+              a ? a() : a({
+                a: 0,
+              }),
+            ),
+            a() ? {
+              a: a(),
+              b: [],
+            } : {},
           ],
         ) : a(
-          a() ? { a: 0 } : (function (a) {
-            return a() ? [{ a: 0, b: a() }] : a([a ? { a: 0 } : {}, { a: 0 }]);
+          a() ? {
+            a: 0,
+          } : (function (a) {
+            return a() ? [
+              {
+                a: 0,
+                b: a(),
+              },
+            ] : a([
+              a ? {
+                a: 0,
+              } : {},
+              {
+                a: 0,
+              },
+            ]);
           })(
             a ? function (a) {
               return function () {

--- a/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/ternaries/nested.js.snap
@@ -185,7 +185,9 @@ const foo = <div className={'match-achievement-medal-type type' + (medals[0].rec
 
 a
   ? literalline
-  : { 123: 12 }
+  : {
+    123: 12,
+  }
     ? line
     : softline;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/function-calls.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/function-calls.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 57
 expression: function-calls.js
-
 ---
 # Input
 ```js
@@ -45,7 +43,12 @@ a(
   a("long-nested-value", "long-nested-value2", "long-nested-value3"),
 );
 
-a.b().c({ d }, () => {});
+a.b().c(
+  {
+    d,
+  },
+  () => {},
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/jsx.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/jsx.js.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 153
 expression: jsx.js
-
 ---
 # Input
 ```js
@@ -18,7 +16,14 @@ expression: jsx.js
 
 # Output
 ```js
-<div onClick={() => doSomething({ foo: bar })} />;
+<div
+  onClick={
+    () =>
+      doSomething({
+        foo: bar,
+      })
+  }
+/>;
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/object.js.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/js/trailing-comma/object.js.snap
@@ -30,11 +30,20 @@ const bLong = {
 
 # Output
 ```js
-const a = { b: true, c: { c1: "hello" }, d: false };
+const a = {
+  b: true,
+  c: {
+    c1: "hello",
+  },
+  d: false,
+};
 
 const aLong = {
   bHasALongName: "a-long-value",
-  cHasALongName: { c1: "a-really-long-value", c2: "a-really-really-long-value" },
+  cHasALongName: {
+    c1: "a-really-long-value",
+    c2: "a-really-really-long-value",
+  },
   dHasALongName: "a-long-value-too",
 };
 
@@ -45,8 +54,4 @@ const bLong = {
 
 ```
 
-# Lines exceeding max width of 80 characters
-```
-    5:   cHasALongName: { c1: "a-really-long-value", c2: "a-really-really-long-value" },
-```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/as.ts.snap
@@ -78,7 +78,12 @@ async function g1() {
 }
 ({}) as X;
 () => ({}) as X;
-const state = JSON.stringify({ next: window.location.href, nonce } as State);
+const state = JSON.stringify(
+  {
+    next: window.location.href,
+    nonce,
+  } as State,
+);
 
 (foo.bar as Baz) = [bar];
 (foo.bar as any)++;
@@ -117,8 +122,8 @@ const iter2 = createIterator(
 # Lines exceeding max width of 80 characters
 ```
     3: (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
-   37: const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-   38: const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-   47: const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+   42: const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+   43: const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+   52: const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/as/return.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/as/return.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: return.ts
-
 ---
 # Input
 ```js
@@ -18,7 +16,10 @@ function foo() {
 # Output
 ```js
 function foo() {
-  return { foo: 1, bar: 2 } as Foo;
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assert/index.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assert/index.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: index.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10846.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-10846.ts.snap
@@ -47,14 +47,28 @@ const foo =
 
 # Output
 ```js
-const foo = call<{ prop1: string; prop2: string; prop3: string }>();
+const foo = call<
+  {
+    prop1: string;
+    prop2: string;
+    prop3: string;
+  }
+>();
 
 export const CallRecorderContext = createContext<
-  { deleteRecording: (id: string) => void; deleteAll: () => void } | null
+    | {
+      deleteRecording: (id: string) => void;
+      deleteAll: () => void;
+    }
+    | null
 >(null);
 
 export const CallRecorderContext = createContext<
-  { deleteRecording: (id: string) => void; deleteAll: () => void } | null
+    | {
+      deleteRecording: (id: string) => void;
+      deleteAll: () => void;
+    }
+    | null
 >(null, "useless");
 
 const foo = call<Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo>();
@@ -71,6 +85,6 @@ const foo = call<
 
 # Lines exceeding max width of 80 characters
 ```
-   11: const foo = call<Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo>();
+   25: const foo = call<Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo, Foooooo>();
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2482.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-2482.ts.snap
@@ -16,7 +16,10 @@ export function countriesReceived(countries: Array<Country>): CountryActionType 
 # Output
 ```js
 export function countriesReceived(countries: Array<Country>): CountryActionType {
-  return { type: ActionTypes.COUNTRIES_RECEIVED, countries: countries };
+  return {
+    type: ActionTypes.COUNTRIES_RECEIVED,
+    countries: countries,
+  };
 }
 
 ```

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-6783.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/assignment/issue-6783.ts.snap
@@ -16,7 +16,9 @@ export const enviromentProdValues: EnvironmentValues = assign<EnvironmentValues>
 # Output
 ```js
 export const enviromentProdValues: EnvironmentValues = assign<EnvironmentValues>(
-  { apiURL: "/api" },
+  {
+    apiURL: "/api",
+  },
   enviromentBaseValues,
 );
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/hug-args.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/cast/hug-args.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 125
 expression: hug-args.ts
-
 ---
 # Input
 ```js
@@ -33,13 +31,28 @@ postMessages(
 
 # Output
 ```js
-postMessage(<IActionMessage>{ context: item.context, topic: item.topic });
-
-window.postMessage(
-  { context: item.context, topic: item.topic } as IActionMessage,
+postMessage(
+  <IActionMessage>{
+    context: item.context,
+    topic: item.topic,
+  },
 );
 
-postMessages(<IActionMessage[]>[{ context: item.context, topic: item.topic }]);
+window.postMessage(
+  {
+    context: item.context,
+    topic: item.topic,
+  } as IActionMessage,
+);
+
+postMessages(
+  <IActionMessage[]>[
+    {
+      context: item.context,
+      topic: item.topic,
+    },
+  ],
+);
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/class/generics.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/class/generics.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: generics.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/classes/break.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/classes/break.ts.snap
@@ -79,7 +79,9 @@ class InMemoryAppender extends log4javascript.Appender
     ICachedLogMessageProvider
 {}
 
-class Foo extends Immutable.Record({ ipaddress: "" }) {
+class Foo extends Immutable.Record({
+  ipaddress: "",
+}) {
   ipaddress: string;
 }
 
@@ -96,6 +98,6 @@ export class VisTimelineComponent2
 
 # Lines exceeding max width of 80 characters
 ```
-   40: export class VisTimelineComponent implements AfterViewInit, OnChanges, OnDestroy {}
+   42: export class VisTimelineComponent implements AfterViewInit, OnChanges, OnDestroy {}
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/issues.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/comments/issues.ts.snap
@@ -45,13 +45,29 @@ export type BuckWebSocketMessage =
     // Not actually from Buck - this is to let the receiver know that the socket is connected.
     type: "SocketConnected";
   }
-  | { type: "BuildProgressUpdated"; progressValue: number }
-  | { type: "BuildFinished"; exitCode: number }
-  | { type: "BuildStarted" }
-  | { type: "ParseStarted" }
-  | { type: "ParseFinished" }
-  | { type: "RunStarted" }
-  | { type: "RunComplete" };
+  | {
+    type: "BuildProgressUpdated";
+    progressValue: number;
+  }
+  | {
+    type: "BuildFinished";
+    exitCode: number;
+  }
+  | {
+    type: "BuildStarted";
+  }
+  | {
+    type: "ParseStarted";
+  }
+  | {
+    type: "ParseFinished";
+  }
+  | {
+    type: "RunStarted";
+  }
+  | {
+    type: "RunComplete";
+  };
 
 // Two extra levels of indentation because of the comment
 export type AsyncExecuteOptions =

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/commentsInterface.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/commentsInterface.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: commentsInterface.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/globalIsContextualKeyword.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/globalIsContextualKeyword.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 119
 expression: globalIsContextualKeyword.ts
-
 ---
 # Input
 ```js
@@ -37,7 +35,9 @@ namespace global {}
 
 function foo(global: number) {}
 
-let obj = { global: "123" };
+let obj = {
+  global: "123",
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/indexSignatureWithInitializer.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/indexSignatureWithInitializer.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: indexSignatureWithInitializer.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/mappedTypeWithCombinedTypeMappers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/compiler/mappedTypeWithCombinedTypeMappers.ts.snap
@@ -31,7 +31,11 @@ const shouldFail: { important: boolean } = output.x.children;
 // Repro from #13351
 
 type Meta<T, A> = {
-  [P in keyof T]: { value: T[P]; also: A; readonly children: Meta<T[P], A> };
+  [P in keyof T]: {
+    value: T[P];
+    also: A;
+    readonly children: Meta<T[P], A>;
+  };
 };
 
 interface Input {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/classExpression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/classes/classExpression.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: classExpression.ts
-
 ---
 # Input
 ```js
@@ -23,7 +21,9 @@ var z = class C4 {
 ```js
 var x = class C {};
 
-var y = { foo: class C2 {} };
+var y = {
+  foo: class C2 {},
+};
 
 var z = class C4 {};
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/es6/Symbols/symbolProperty15.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/es6/Symbols/symbolProperty15.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: symbolProperty15.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/expressions/functionCalls/callWithSpreadES6.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/expressions/functionCalls/callWithSpreadES6.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: callWithSpreadES6.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: interfaceWithMultipleBaseTypes2.ts
 ---
 # Input
@@ -34,11 +33,17 @@ interface Derived3 extends Base, Base2 {
 # Output
 ```js
 interface Base {
-  x: { a?: string; b: string };
+  x: {
+    a?: string;
+    b: string;
+  };
 }
 
 interface Base2 {
-  x: { b: string; c?: number };
+  x: {
+    b: string;
+    c?: number;
+  };
 }
 
 interface Derived extends Base, Base2 {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: invalidImportAliasIdentifiers.ts
 ---
 # Input
@@ -45,7 +44,10 @@ class C {
 
 import c = C;
 
-enum E { Red, Blue }
+enum E {
+  Red,
+  Blue,
+}
 
 import e = E;
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/indexedAccesType/indexedAccesType.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/indexedAccesType/indexedAccesType.ts.snap
@@ -12,7 +12,9 @@ const a: Foo['bar'] = {
 
 # Output
 ```js
-const a: Foo["bar"] = { baz: "yawp" };
+const a: Foo["bar"] = {
+  baz: "yawp",
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/methodSignature/methodSignature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/methodSignature/methodSignature.ts.snap
@@ -13,7 +13,10 @@ var logger: {
 
 # Output
 ```js
-var logger: { log(val: any, val2: any); error(val: any) };
+var logger: {
+  log(val: any, val2: any);
+  error(val: any);
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeFromArrayLiteral.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/conformance/types/union/unionTypeFromArrayLiteral.ts.snap
@@ -42,9 +42,10 @@ var arr2 = ["hello", true]; // (string | number)[]
 var arr3Tuple: [number, string] = [3, "three"]; // [number, string]
 var arr4Tuple: [number, string] = [3, "three", "hello"]; // [number, string, string]
 var arrEmpty = [];
-var arr5Tuple: { 0: string; 5: number } = [
-  "hello", true, false, " hello", true, 10, "any",
-]; // Tuple
+var arr5Tuple: {
+  0: string;
+  5: number;
+} = ["hello", true, false, " hello", true, 10, "any"]; // Tuple
 class C {
   foo() {}
 }

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/computedProperties/string.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/computedProperties/string.ts.snap
@@ -29,13 +29,17 @@ interface I {
   "string": "I";
 }
 
-type T = { "string": "T" };
+type T = {
+  "string": "T";
+};
 
 interface A {
   "string": "A";
 }
 
-type B = { "string": "B" };
+type B = {
+  "string": "B";
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/computedProperties/symbol.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/computedProperties/symbol.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: symbol.ts
 ---
 # Input
@@ -21,7 +20,9 @@ interface I {
   [Symbol.toStringTag]: "I";
 }
 
-type T = { [Symbol.toStringTag]: "T" };
+type T = {
+  [Symbol.toStringTag]: "T";
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/module/global.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/module/global.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: global.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/new/newKeyword.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/custom/new/newKeyword.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: newKeyword.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/enum/enum.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/enum/enum.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: enum.ts
-
 ---
 # Input
 ```js
@@ -35,7 +33,12 @@ const enum Enum {
 
 # Output
 ```js
-enum Direction { Up = 1, Down, Left, Right }
+enum Direction {
+  Up = 1,
+  Down,
+  Left,
+  Right,
+}
 
 enum FileAccess {
   // constant members
@@ -49,7 +52,10 @@ enum FileAccess {
 
 enum Empty {}
 
-const enum Enum { A = 1, B = A * 2 }
+const enum Enum {
+  A = 1,
+  B = A * 2,
+}
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/error-recovery/generic.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: generic.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/export/default.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/export/default.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: default.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/import-type/import-type.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/import-type/import-type.ts.snap
@@ -31,7 +31,9 @@ export const x: import("./foo") = { x: 0, y: 0 };
 
 export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 
-export let shim: typeof import("./foo2") = { Bar: Bar2 };
+export let shim: typeof import("./foo2") = {
+  Bar: Bar2,
+};
 
 export interface Foo {
   bar: import("immutable").Map<string, int>;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/long-extends.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/long-extends.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: long-extends.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/separator.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface/separator.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: separator.ts
 ---
 # Input
@@ -34,7 +33,9 @@ declare module "selenium-webdriver" {
 
 export interface Edge {
   cursor: {};
-  node: { id: {} };
+  node: {
+    id: {};
+  };
 }
 
 interface Test {

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/break.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/break.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: break.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments-declare.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/comments-declare.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: comments-declare.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/module.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/interface2/module.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: module.ts
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/method/method-signature.ts.snap
@@ -29,10 +29,18 @@ type Foo = {
   get(key: "foo"): `
   `;
 };
-type Foo = { get(key: "foo"): `` };
+type Foo = {
+  get(key: "foo"): ``;
+};
 
-type Bar = { get(key: "bar"): { bar: "bar" } };
-type Bar = { get(key: "bar"): { bar: "bar" } };
+type Bar = {
+  get(key: "bar"): {
+    bar: "bar";
+  };
+};
+type Bar = {
+  get(key: "bar"): { bar: "bar" };
+};
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/braces.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/non-null/braces.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: braces.ts
-
 ---
 # Input
 ```js
@@ -26,7 +24,12 @@ class a extends ({}!) {}
 
 # Output
 ```js
-const myFunction2 = (key: string): number => ({ a: 42, b: 42 }[key]!);
+const myFunction2 = (key: string): number => (
+  {
+    a: 42,
+    b: 42,
+  }[key]!
+);
 
 const myFunction3 = (key) => ({}!.a);
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tsx/type-parameters.tsx.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tsx/type-parameters.tsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: type-parameters.tsx
 ---
 # Input

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/no-trailing-comma-after-rest.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/no-trailing-comma-after-rest.ts.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 123
 expression: no-trailing-comma-after-rest.ts
-
 ---
 # Input
 ```js
@@ -19,7 +17,14 @@ type ValidateArgs = [
 
 # Output
 ```js
-type ValidateArgs = [{ [key: string]: any }, string, string, ...string[]];
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  string,
+  ...string[],
+];
 
 ```
 

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/trailing-comma.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/tuple/trailing-comma.ts.snap
@@ -29,7 +29,10 @@ export interface ShopQueryResult {
   menus: Menu[];
   openingDays: number[];
   closingDays: [
-    { from: string; to: string }, // <== this one
+    {
+      from: string;
+      to: string;
+    }, // <== this one
   ];
   shop: string;
   distance: number;

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/type-member-get-set/type-member-get-set.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/type-member-get-set/type-member-get-set.ts.snap
@@ -28,7 +28,10 @@ interface Foo {
   set bar(v);
 }
 
-type Foo = { get foo(): string; set bar(v) };
+type Foo = {
+  get foo(): string;
+  set bar(v);
+};
 
 interface Foo {
   set bar(foo: string);

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/inlining.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/inlining.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rome_js_formatter/tests/prettier_tests.rs
-assertion_line: 175
 expression: inlining.ts
 ---
 # Input
@@ -55,7 +54,15 @@ interface RelayProps {
   articles: a | null;
 }
 interface RelayProps {
-  articles: Array<{ __id: string } | null> | null | void;
+  articles:
+    | Array<
+        | {
+          __id: string;
+        }
+        | null
+    >
+    | null
+    | void;
 }
 
 type UploadState<E, EM, D>
@@ -80,7 +87,11 @@ type UploadState2<E, EM, D>
   // Uploading to aws3 and CreatePostMutation succeeded
   | D;
 
-type window = Window & { __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function };
+type window =
+  & Window
+  & {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
+  };
 
 type T1 = (number | string)["toString"];
 type T2 = ((number | string))["toString"];

--- a/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/prettier/typescript/union/union-parens.ts.snap
@@ -154,7 +154,9 @@ interface Interface {
 }
 
 type State =
-  & { sharedProperty: any }
+  & {
+    sharedProperty: any;
+  }
   & (
       | { discriminant: "FOO"; foo: any }
       | { discriminant: "BAR"; bar: any }

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -153,7 +153,10 @@ type W = {
 	g: symbol;
 };
 type X = { a: string; b: symbol };
-type Z = { a: string; b: symbol };
+type Z = {
+	a: string;
+	b: symbol;
+};
 
 type OptionsFlags<Type> = {
 	+readonly [Property in keyof Type as string]-?: boolean;

--- a/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -61,7 +61,9 @@ Quote style: Double Quotes
 -----
 type A = { [a: string]: number };
 
-type B = { (a: string, b: symbol, c: symbol, d: symbol) };
+type B = {
+	(a: string, b: symbol, c: symbol, d: symbol);
+};
 
 type C = {
 	(
@@ -94,7 +96,9 @@ type D = {
 	);
 };
 
-type E = { <Aaaaaaaaaaaaaaaaaaaaa>(loreum: string) };
+type E = {
+	<Aaaaaaaaaaaaaaaaaaaaa>(loreum: string);
+};
 
 type F = {
 	<
@@ -146,7 +150,9 @@ type I = {
 	): LoooooooooooooongTypeReturneeeeeeeeed;
 };
 
-type J = { get something(): LoooooooooooooongTypeReturneeeeeeeeed };
+type J = {
+	get something(): LoooooooooooooongTypeReturneeeeeeeeed;
+};
 
 type K = { set something(something_with_long_name: string) };
 

--- a/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -32,7 +32,10 @@ Quote style: Double Quotes
 -----
 export type A = string;
 
-export enum B { A, B }
+export enum B {
+	A,
+	B,
+}
 
 export interface C {}
 

--- a/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/rome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -34,5 +34,11 @@ enum B {
 	f = "something",
 }
 
-const enum C { A, B, C, D, F }
+const enum C {
+	A,
+	B,
+	C,
+	D,
+	F,
+}
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/rome/tools/issues/2408.

This is the initial draft for respecting a newline in an object expression (or import specifier) in between an opening curly brace `{` and the first item in the member list. This should make Rome match prettier in this situation. Again, I have no idea what I'm doing :) 

**Open questions to get this over the line:**
* For some reason `formatter::js_module::specs::js::module::arrow::arrow_nested` fails and I'm unsure why. Please help!
* See some inline questions.

## Test Plan

* Added tests.
