### PR TITLE
Update GitHub Actions version

### DIFF
--- a/.github/workflows/bench_formatter.yml
+++ b/.github/workflows/bench_formatter.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Get PR SHA
         id: sha
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
@@ -27,7 +27,7 @@ jobs:
             return response.data.head.sha;
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
           ref: ${{ steps.sha.outputs.result }}
@@ -48,7 +48,7 @@ jobs:
         run: cargo bench_formatter --save-baseline pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           ref: main

--- a/.github/workflows/bench_parser.yml
+++ b/.github/workflows/bench_parser.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
       - name: Get PR SHA
         id: sha
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
             const response = await github.request(context.payload.issue.pull_request.url);
             return response.data.head.sha;
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
           ref: ${{ steps.sha.outputs.result }}
@@ -47,7 +47,7 @@ jobs:
         run: cargo bench_parser --save-baseline pr
 
       - name: Checkout Main Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           ref: main

--- a/.github/workflows/deploy_playground.yml
+++ b/.github/workflows/deploy_playground.yml
@@ -14,12 +14,12 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - uses: jetli/wasm-pack-action@v0.3.0
       - name: Cache pnpm modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/deploy_playground_on_main.yml
+++ b/.github/workflows/deploy_playground_on_main.yml
@@ -15,12 +15,12 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - uses: jetli/wasm-pack-action@v0.3.0
       - name: Cache pnpm modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
       - name: Support longpaths
         run: git config core.longpaths true
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
       - name: Cache
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
       - name: Cache
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
       - name: Cache
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install toolchain

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
 
@@ -34,7 +34,7 @@ jobs:
         run: git config core.longpaths true
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
         run: cargo coverage --json > new_results.json
 
       - name: Checkout main Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           clean: false
           ref: main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
       - name: Cache
@@ -36,7 +36,7 @@ jobs:
           version: preview
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Rome Format
         run: rome format --ci editors website
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: false
       - name: Install toolchain
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
       - name: Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       nightly: ${{ env.nightly }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check nightly status
         id: nightly
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -124,7 +124,7 @@ jobs:
 
       # Upload the CLI binary as a build artifact
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cli
           path: ./dist/rome-*
@@ -142,7 +142,7 @@ jobs:
           cp target/${{ matrix.target }}/release/rome_lsp editors/vscode/server/rome_lsp
 
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -174,7 +174,7 @@ jobs:
         if: needs.check.outputs.prerelease == 'true'
 
       - name: Upload VSCode extension artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: vscode_packages
           path: ./dist/rome_lsp-${{ matrix.code-target }}.vsix
@@ -186,19 +186,19 @@ jobs:
     needs: build
     environment: marketplace
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download CLI artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: cli
       - name: Download extension artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: vscode_packages
 
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

Update `actions/xxxxx@vx` to `actions/xxxxxx@v3 or 6` since Node12 will be out of life after Aril 30, 2022 [[Reference](https://nodejs.org/en/about/releases/)].  
`actions/xxxx@v3` or `actions/xxxx@v6`  use Node16 whose support lasts until April 30, 2024.

## Test Plan

Check if GitHub Actions workflows work well
