### PR TITLE
refactor(rome_rowan): Use associated types for `Ast*` traits

### DIFF
--- a/crates/rome_analyze/src/analysis_server.rs
+++ b/crates/rome_analyze/src/analysis_server.rs
@@ -46,13 +46,16 @@ impl AnalysisServer {
         suppressions::compute(tree)
     }
 
-    pub fn query_nodes<T: AstNode<JsLanguage>>(&self, file_id: FileId) -> impl Iterator<Item = T> {
+    pub fn query_nodes<T: AstNode<Language = JsLanguage>>(
+        &self,
+        file_id: FileId,
+    ) -> impl Iterator<Item = T> {
         trace!("Query nodes: {:?}", std::any::type_name::<T>());
         let tree = self.parse(file_id);
         tree.descendants().filter_map(|n| T::cast(n))
     }
 
-    pub fn find_node_at_range<T: AstNode<JsLanguage>>(
+    pub fn find_node_at_range<T: AstNode<Language = JsLanguage>>(
         &self,
         file_id: FileId,
         range: TextRange,

--- a/crates/rome_analyze/src/analyzers.rs
+++ b/crates/rome_analyze/src/analyzers.rs
@@ -47,12 +47,15 @@ impl<'a> AnalyzerContext<'a> {
     }
 
     /// Iterate over syntax nodes in this file that can be cast to T
-    pub fn query_nodes<T: AstNode<JsLanguage>>(&self) -> impl Iterator<Item = T> {
+    pub fn query_nodes<T: AstNode<Language = JsLanguage>>(&self) -> impl Iterator<Item = T> {
         self.analysis_server.query_nodes(self.file_id)
     }
 
     /// Find the deepest AST node of type T that covers a TextRange
-    pub fn find_node_at_range<T: AstNode<JsLanguage>>(&self, range: TextRange) -> Option<T> {
+    pub fn find_node_at_range<T: AstNode<Language = JsLanguage>>(
+        &self,
+        range: TextRange,
+    ) -> Option<T> {
         self.analysis_server.find_node_at_range(self.file_id, range)
     }
 

--- a/crates/rome_analyze/src/assists.rs
+++ b/crates/rome_analyze/src/assists.rs
@@ -55,17 +55,20 @@ impl<'a> AssistContext<'a> {
     }
 
     /// Iterate over syntax nodes in the file being analyzed that can be cast to T
-    pub fn query_nodes<T: AstNode<JsLanguage>>(&self) -> impl Iterator<Item = T> {
+    pub fn query_nodes<T: AstNode<Language = JsLanguage>>(&self) -> impl Iterator<Item = T> {
         self.analysis_server.query_nodes(self.file_id)
     }
 
     /// Find the deepest AST node of type T that covers a TextRange
-    pub fn find_node_at_range<T: AstNode<JsLanguage>>(&self, range: TextRange) -> Option<T> {
+    pub fn find_node_at_range<T: AstNode<Language = JsLanguage>>(
+        &self,
+        range: TextRange,
+    ) -> Option<T> {
         self.analysis_server.find_node_at_range(self.file_id, range)
     }
 
     /// Find the deepest AST node of type T that covers this AssistContext's cursor_range
-    pub fn find_node_at_cursor_range<T: AstNode<JsLanguage>>(&self) -> Option<T> {
+    pub fn find_node_at_cursor_range<T: AstNode<Language = JsLanguage>>(&self) -> Option<T> {
         self.analysis_server
             .find_node_at_range(self.file_id, self.cursor_range)
     }

--- a/crates/rome_css_syntax/src/generated/nodes.rs
+++ b/crates/rome_css_syntax/src/generated/nodes.rs
@@ -1439,7 +1439,8 @@ pub enum CssAnyValue {
     CssRatio(CssRatio),
     CssString(CssString),
 }
-impl AstNode<Language> for CssAnyFunction {
+impl AstNode for CssAnyFunction {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ANY_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1466,7 +1467,8 @@ impl From<CssAnyFunction> for SyntaxNode {
 impl From<CssAnyFunction> for SyntaxElement {
     fn from(n: CssAnyFunction) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtKeyframes {
+impl AstNode for CssAtKeyframes {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1497,7 +1499,8 @@ impl From<CssAtKeyframes> for SyntaxNode {
 impl From<CssAtKeyframes> for SyntaxElement {
     fn from(n: CssAtKeyframes) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtKeyframesBody {
+impl AstNode for CssAtKeyframesBody {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1529,7 +1532,8 @@ impl From<CssAtKeyframesBody> for SyntaxNode {
 impl From<CssAtKeyframesBody> for SyntaxElement {
     fn from(n: CssAtKeyframesBody) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMedia {
+impl AstNode for CssAtMedia {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1567,7 +1571,8 @@ impl From<CssAtMedia> for SyntaxNode {
 impl From<CssAtMedia> for SyntaxElement {
     fn from(n: CssAtMedia) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQuery {
+impl AstNode for CssAtMediaQuery {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1604,7 +1609,8 @@ impl From<CssAtMediaQuery> for SyntaxNode {
 impl From<CssAtMediaQuery> for SyntaxElement {
     fn from(n: CssAtMediaQuery) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryConsequent {
+impl AstNode for CssAtMediaQueryConsequent {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_CONSEQUENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1633,7 +1639,8 @@ impl From<CssAtMediaQueryConsequent> for SyntaxNode {
 impl From<CssAtMediaQueryConsequent> for SyntaxElement {
     fn from(n: CssAtMediaQueryConsequent) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryFeature {
+impl AstNode for CssAtMediaQueryFeature {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1665,7 +1672,8 @@ impl From<CssAtMediaQueryFeature> for SyntaxNode {
 impl From<CssAtMediaQueryFeature> for SyntaxElement {
     fn from(n: CssAtMediaQueryFeature) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryFeatureBoolean {
+impl AstNode for CssAtMediaQueryFeatureBoolean {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_BOOLEAN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1692,7 +1700,8 @@ impl From<CssAtMediaQueryFeatureBoolean> for SyntaxNode {
 impl From<CssAtMediaQueryFeatureBoolean> for SyntaxElement {
     fn from(n: CssAtMediaQueryFeatureBoolean) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryFeatureCompare {
+impl AstNode for CssAtMediaQueryFeatureCompare {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_COMPARE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1718,7 +1727,8 @@ impl From<CssAtMediaQueryFeatureCompare> for SyntaxNode {
 impl From<CssAtMediaQueryFeatureCompare> for SyntaxElement {
     fn from(n: CssAtMediaQueryFeatureCompare) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryFeaturePlain {
+impl AstNode for CssAtMediaQueryFeaturePlain {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_PLAIN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1747,7 +1757,8 @@ impl From<CssAtMediaQueryFeaturePlain> for SyntaxNode {
 impl From<CssAtMediaQueryFeaturePlain> for SyntaxElement {
     fn from(n: CssAtMediaQueryFeaturePlain) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryFeatureRange {
+impl AstNode for CssAtMediaQueryFeatureRange {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_FEATURE_RANGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1787,7 +1798,8 @@ impl From<CssAtMediaQueryFeatureRange> for SyntaxNode {
 impl From<CssAtMediaQueryFeatureRange> for SyntaxElement {
     fn from(n: CssAtMediaQueryFeatureRange) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAtMediaQueryRange {
+impl AstNode for CssAtMediaQueryRange {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_RANGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1826,7 +1838,8 @@ impl From<CssAtMediaQueryRange> for SyntaxNode {
 impl From<CssAtMediaQueryRange> for SyntaxElement {
     fn from(n: CssAtMediaQueryRange) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttribute {
+impl AstNode for CssAttribute {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1865,7 +1878,8 @@ impl From<CssAttribute> for SyntaxNode {
 impl From<CssAttribute> for SyntaxElement {
     fn from(n: CssAttribute) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttributeMatcher {
+impl AstNode for CssAttributeMatcher {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_MATCHER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1917,7 +1931,8 @@ impl From<CssAttributeMatcher> for SyntaxNode {
 impl From<CssAttributeMatcher> for SyntaxElement {
     fn from(n: CssAttributeMatcher) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttributeMeta {
+impl AstNode for CssAttributeMeta {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_META }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1948,7 +1963,8 @@ impl From<CssAttributeMeta> for SyntaxNode {
 impl From<CssAttributeMeta> for SyntaxElement {
     fn from(n: CssAttributeMeta) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttributeModifier {
+impl AstNode for CssAttributeModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1972,7 +1988,8 @@ impl From<CssAttributeModifier> for SyntaxNode {
 impl From<CssAttributeModifier> for SyntaxElement {
     fn from(n: CssAttributeModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttributeName {
+impl AstNode for CssAttributeName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1996,7 +2013,8 @@ impl From<CssAttributeName> for SyntaxNode {
 impl From<CssAttributeName> for SyntaxElement {
     fn from(n: CssAttributeName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssAttributeSelectorPattern {
+impl AstNode for CssAttributeSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2021,7 +2039,8 @@ impl From<CssAttributeSelectorPattern> for SyntaxNode {
 impl From<CssAttributeSelectorPattern> for SyntaxElement {
     fn from(n: CssAttributeSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssBlock {
+impl AstNode for CssBlock {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2053,7 +2072,8 @@ impl From<CssBlock> for SyntaxNode {
 impl From<CssBlock> for SyntaxElement {
     fn from(n: CssBlock) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssClassSelectorPattern {
+impl AstNode for CssClassSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_CLASS_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2078,7 +2098,8 @@ impl From<CssClassSelectorPattern> for SyntaxNode {
 impl From<CssClassSelectorPattern> for SyntaxElement {
     fn from(n: CssClassSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssCombinatorSelectorPattern {
+impl AstNode for CssCombinatorSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_COMBINATOR_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2116,7 +2137,8 @@ impl From<CssCombinatorSelectorPattern> for SyntaxNode {
 impl From<CssCombinatorSelectorPattern> for SyntaxElement {
     fn from(n: CssCombinatorSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssCustomProperty {
+impl AstNode for CssCustomProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_CUSTOM_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2143,7 +2165,8 @@ impl From<CssCustomProperty> for SyntaxNode {
 impl From<CssCustomProperty> for SyntaxElement {
     fn from(n: CssCustomProperty) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssDeclaration {
+impl AstNode for CssDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2180,7 +2203,8 @@ impl From<CssDeclaration> for SyntaxNode {
 impl From<CssDeclaration> for SyntaxElement {
     fn from(n: CssDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssDeclarationImportant {
+impl AstNode for CssDeclarationImportant {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION_IMPORTANT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2208,7 +2232,8 @@ impl From<CssDeclarationImportant> for SyntaxNode {
 impl From<CssDeclarationImportant> for SyntaxElement {
     fn from(n: CssDeclarationImportant) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssDimension {
+impl AstNode for CssDimension {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DIMENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2233,7 +2258,8 @@ impl From<CssDimension> for SyntaxNode {
 impl From<CssDimension> for SyntaxElement {
     fn from(n: CssDimension) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssIdSelectorPattern {
+impl AstNode for CssIdSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ID_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2258,7 +2284,8 @@ impl From<CssIdSelectorPattern> for SyntaxNode {
 impl From<CssIdSelectorPattern> for SyntaxElement {
     fn from(n: CssIdSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssIdentifier {
+impl AstNode for CssIdentifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2285,7 +2312,8 @@ impl From<CssIdentifier> for SyntaxNode {
 impl From<CssIdentifier> for SyntaxElement {
     fn from(n: CssIdentifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssKeyframesBlock {
+impl AstNode for CssKeyframesBlock {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2318,7 +2346,8 @@ impl From<CssKeyframesBlock> for SyntaxNode {
 impl From<CssKeyframesBlock> for SyntaxElement {
     fn from(n: CssKeyframesBlock) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssKeyframesSelector {
+impl AstNode for CssKeyframesSelector {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_SELECTOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2347,7 +2376,8 @@ impl From<CssKeyframesSelector> for SyntaxNode {
 impl From<CssKeyframesSelector> for SyntaxElement {
     fn from(n: CssKeyframesSelector) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssNumber {
+impl AstNode for CssNumber {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_NUMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2374,7 +2404,8 @@ impl From<CssNumber> for SyntaxNode {
 impl From<CssNumber> for SyntaxElement {
     fn from(n: CssNumber) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssParameter {
+impl AstNode for CssParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2401,7 +2432,8 @@ impl From<CssParameter> for SyntaxNode {
 impl From<CssParameter> for SyntaxElement {
     fn from(n: CssParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssPercentage {
+impl AstNode for CssPercentage {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PERCENTAGE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2429,7 +2461,8 @@ impl From<CssPercentage> for SyntaxNode {
 impl From<CssPercentage> for SyntaxElement {
     fn from(n: CssPercentage) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssPseudoClassSelectorPattern {
+impl AstNode for CssPseudoClassSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PSEUDO_CLASS_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2461,7 +2494,8 @@ impl From<CssPseudoClassSelectorPattern> for SyntaxNode {
 impl From<CssPseudoClassSelectorPattern> for SyntaxElement {
     fn from(n: CssPseudoClassSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssPseudoClassSelectorPatternParameters {
+impl AstNode for CssPseudoClassSelectorPatternParameters {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PSEUDO_CLASS_SELECTOR_PATTERN_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2493,7 +2527,8 @@ impl From<CssPseudoClassSelectorPatternParameters> for SyntaxNode {
 impl From<CssPseudoClassSelectorPatternParameters> for SyntaxElement {
     fn from(n: CssPseudoClassSelectorPatternParameters) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssRatio {
+impl AstNode for CssRatio {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_RATIO }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2521,7 +2556,8 @@ impl From<CssRatio> for SyntaxNode {
 impl From<CssRatio> for SyntaxElement {
     fn from(n: CssRatio) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssRule {
+impl AstNode for CssRule {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_RULE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2546,7 +2582,8 @@ impl From<CssRule> for SyntaxNode {
 impl From<CssRule> for SyntaxElement {
     fn from(n: CssRule) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssSelector {
+impl AstNode for CssSelector {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SELECTOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2570,7 +2607,8 @@ impl From<CssSelector> for SyntaxNode {
 impl From<CssSelector> for SyntaxElement {
     fn from(n: CssSelector) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssSimpleFunction {
+impl AstNode for CssSimpleFunction {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SIMPLE_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2603,7 +2641,8 @@ impl From<CssSimpleFunction> for SyntaxNode {
 impl From<CssSimpleFunction> for SyntaxElement {
     fn from(n: CssSimpleFunction) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssString {
+impl AstNode for CssString {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_STRING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2630,7 +2669,8 @@ impl From<CssString> for SyntaxNode {
 impl From<CssString> for SyntaxElement {
     fn from(n: CssString) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssTypeSelectorPattern {
+impl AstNode for CssTypeSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_TYPE_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2654,7 +2694,8 @@ impl From<CssTypeSelectorPattern> for SyntaxNode {
 impl From<CssTypeSelectorPattern> for SyntaxElement {
     fn from(n: CssTypeSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssUniversalSelectorPattern {
+impl AstNode for CssUniversalSelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_UNIVERSAL_SELECTOR_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2678,7 +2719,8 @@ impl From<CssUniversalSelectorPattern> for SyntaxNode {
 impl From<CssUniversalSelectorPattern> for SyntaxElement {
     fn from(n: CssUniversalSelectorPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssVarFunction {
+impl AstNode for CssVarFunction {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_VAR_FUNCTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2712,7 +2754,8 @@ impl From<CssVarFunction> for SyntaxNode {
 impl From<CssVarFunction> for SyntaxElement {
     fn from(n: CssVarFunction) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for CssVarFunctionValue {
+impl AstNode for CssVarFunctionValue {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_VAR_FUNCTION_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2760,7 +2803,8 @@ impl From<CssAtMediaQueryFeatureRange> for CssAnyAtMediaQueryFeatureType {
         CssAnyAtMediaQueryFeatureType::CssAtMediaQueryFeatureRange(node)
     }
 }
-impl AstNode<Language> for CssAnyAtMediaQueryFeatureType {
+impl AstNode for CssAnyAtMediaQueryFeatureType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -2849,7 +2893,8 @@ impl From<CssIdentifier> for CssAnyAtMediaQueryType {
         CssAnyAtMediaQueryType::CssIdentifier(node)
     }
 }
-impl AstNode<Language> for CssAnyAtMediaQueryType {
+impl AstNode for CssAnyAtMediaQueryType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, CSS_AT_MEDIA_QUERY_FEATURE | CSS_IDENTIFIER)
     }
@@ -2898,7 +2943,8 @@ impl From<CssAtKeyframes> for CssAnyAtRule {
 impl From<CssAtMedia> for CssAnyAtRule {
     fn from(node: CssAtMedia) -> CssAnyAtRule { CssAnyAtRule::CssAtMedia(node) }
 }
-impl AstNode<Language> for CssAnyAtRule {
+impl AstNode for CssAnyAtRule {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, CSS_AT_KEYFRAMES | CSS_AT_MEDIA) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -2940,7 +2986,8 @@ impl From<CssAnyAtRule> for SyntaxElement {
 impl From<CssRule> for CssAnyRule {
     fn from(node: CssRule) -> CssAnyRule { CssAnyRule::CssRule(node) }
 }
-impl AstNode<Language> for CssAnyRule {
+impl AstNode for CssAnyRule {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             CSS_RULE => true,
@@ -3024,7 +3071,8 @@ impl From<CssUniversalSelectorPattern> for CssAnySelectorPattern {
         CssAnySelectorPattern::CssUniversalSelectorPattern(node)
     }
 }
-impl AstNode<Language> for CssAnySelectorPattern {
+impl AstNode for CssAnySelectorPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -3137,7 +3185,8 @@ impl From<CssRatio> for CssAnyValue {
 impl From<CssString> for CssAnyValue {
     fn from(node: CssString) -> CssAnyValue { CssAnyValue::CssString(node) }
 }
-impl AstNode<Language> for CssAnyValue {
+impl AstNode for CssAnyValue {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -3466,7 +3515,8 @@ impl CssUnknown {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for CssUnknown {
+impl AstNode for CssUnknown {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_UNKNOWN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -3507,7 +3557,8 @@ impl CssAnySelectorPatternList {
         }
     }
 }
-impl AstNode<Language> for CssAnySelectorPatternList {
+impl AstNode for CssAnySelectorPatternList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ANY_SELECTOR_PATTERN_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAnySelectorPatternList> {
         if Self::can_cast(syntax.kind()) {
@@ -3520,7 +3571,9 @@ impl AstNode<Language> for CssAnySelectorPatternList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssAnySelectorPattern> for CssAnySelectorPatternList {
+impl AstNodeList for CssAnySelectorPatternList {
+    type Language = Language;
+    type Node = CssAnySelectorPattern;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssAnySelectorPatternList {
@@ -3556,7 +3609,8 @@ impl CssAtKeyframesItemList {
         }
     }
 }
-impl AstNode<Language> for CssAtKeyframesItemList {
+impl AstNode for CssAtKeyframesItemList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_KEYFRAMES_ITEM_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAtKeyframesItemList> {
         if Self::can_cast(syntax.kind()) {
@@ -3569,7 +3623,9 @@ impl AstNode<Language> for CssAtKeyframesItemList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssKeyframesBlock> for CssAtKeyframesItemList {
+impl AstNodeList for CssAtKeyframesItemList {
+    type Language = Language;
+    type Node = CssKeyframesBlock;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssAtKeyframesItemList {
@@ -3605,7 +3661,8 @@ impl CssAtMediaQueryList {
         }
     }
 }
-impl AstNode<Language> for CssAtMediaQueryList {
+impl AstNode for CssAtMediaQueryList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_AT_MEDIA_QUERY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAtMediaQueryList> {
         if Self::can_cast(syntax.kind()) {
@@ -3618,7 +3675,9 @@ impl AstNode<Language> for CssAtMediaQueryList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, CssAtMediaQuery> for CssAtMediaQueryList {
+impl AstSeparatedList for CssAtMediaQueryList {
+    type Language = Language;
+    type Node = CssAtMediaQuery;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssAtMediaQueryList {
@@ -3654,7 +3713,8 @@ impl CssAttributeList {
         }
     }
 }
-impl AstNode<Language> for CssAttributeList {
+impl AstNode for CssAttributeList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ATTRIBUTE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssAttributeList> {
         if Self::can_cast(syntax.kind()) {
@@ -3667,7 +3727,9 @@ impl AstNode<Language> for CssAttributeList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssAttribute> for CssAttributeList {
+impl AstNodeList for CssAttributeList {
+    type Language = Language;
+    type Node = CssAttribute;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssAttributeList {
@@ -3703,7 +3765,8 @@ impl CssDeclarationList {
         }
     }
 }
-impl AstNode<Language> for CssDeclarationList {
+impl AstNode for CssDeclarationList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_DECLARATION_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssDeclarationList> {
         if Self::can_cast(syntax.kind()) {
@@ -3716,7 +3779,9 @@ impl AstNode<Language> for CssDeclarationList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssDeclaration> for CssDeclarationList {
+impl AstNodeList for CssDeclarationList {
+    type Language = Language;
+    type Node = CssDeclaration;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssDeclarationList {
@@ -3752,7 +3817,8 @@ impl CssKeyframesSelectorList {
         }
     }
 }
-impl AstNode<Language> for CssKeyframesSelectorList {
+impl AstNode for CssKeyframesSelectorList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_KEYFRAMES_SELECTOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssKeyframesSelectorList> {
         if Self::can_cast(syntax.kind()) {
@@ -3765,7 +3831,9 @@ impl AstNode<Language> for CssKeyframesSelectorList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, CssKeyframesSelector> for CssKeyframesSelectorList {
+impl AstSeparatedList for CssKeyframesSelectorList {
+    type Language = Language;
+    type Node = CssKeyframesSelector;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssKeyframesSelectorList {
@@ -3801,7 +3869,8 @@ impl CssParameterList {
         }
     }
 }
-impl AstNode<Language> for CssParameterList {
+impl AstNode for CssParameterList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -3814,7 +3883,9 @@ impl AstNode<Language> for CssParameterList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssParameter> for CssParameterList {
+impl AstNodeList for CssParameterList {
+    type Language = Language;
+    type Node = CssParameter;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssParameterList {
@@ -3850,7 +3921,8 @@ impl CssRoot {
         }
     }
 }
-impl AstNode<Language> for CssRoot {
+impl AstNode for CssRoot {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_ROOT }
     fn cast(syntax: SyntaxNode) -> Option<CssRoot> {
         if Self::can_cast(syntax.kind()) {
@@ -3863,7 +3935,9 @@ impl AstNode<Language> for CssRoot {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, CssAnyRule> for CssRoot {
+impl AstNodeList for CssRoot {
+    type Language = Language;
+    type Node = CssAnyRule;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssRoot {
@@ -3899,7 +3973,8 @@ impl CssSelectorList {
         }
     }
 }
-impl AstNode<Language> for CssSelectorList {
+impl AstNode for CssSelectorList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == CSS_SELECTOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<CssSelectorList> {
         if Self::can_cast(syntax.kind()) {
@@ -3912,7 +3987,9 @@ impl AstNode<Language> for CssSelectorList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, CssSelector> for CssSelectorList {
+impl AstSeparatedList for CssSelectorList {
+    type Language = Language;
+    type Node = CssSelector;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for CssSelectorList {

--- a/crates/rome_js_formatter/src/formatter.rs
+++ b/crates/rome_js_formatter/src/formatter.rs
@@ -228,7 +228,7 @@ impl Formatter {
     /// Formats each child and returns the result as a list.
     ///
     /// Returns [None] if a child couldn't be formatted.
-    pub fn format_nodes<T: AstNode<JsLanguage> + ToFormatElement>(
+    pub fn format_nodes<T: AstNode<Language = JsLanguage> + ToFormatElement>(
         &self,
         nodes: impl IntoIterator<Item = T>,
     ) -> FormatResult<impl Iterator<Item = FormatElement>> {
@@ -259,8 +259,8 @@ impl Formatter {
         trailing_separator: TrailingSeparator,
     ) -> FormatResult<impl Iterator<Item = FormatElement>>
     where
-        T: AstNode<JsLanguage> + ToFormatElement + Clone,
-        L: AstSeparatedList<JsLanguage, T>,
+        T: AstNode<Language = JsLanguage> + ToFormatElement + Clone,
+        L: AstSeparatedList<Language = JsLanguage, Node = T>,
         F: Fn() -> FormatElement,
     {
         let mut result = Vec::with_capacity(list.len());
@@ -311,12 +311,12 @@ impl Formatter {
     /// end up separated by hard lines or empty lines.
     ///
     /// If the formatter fails to format an element, said element gets printed verbatim.
-    pub fn format_list<List, Node: AstNode<JsLanguage> + ToFormatElement>(
+    pub fn format_list<List, Node: AstNode<Language = JsLanguage> + ToFormatElement>(
         &self,
         list: List,
     ) -> FormatElement
     where
-        List: AstNodeList<JsLanguage, Node>,
+        List: AstNodeList<Language = JsLanguage, Node = Node>,
     {
         let formatted_list = list.iter().map(|module_item| {
             let snapshot = self.snapshot();

--- a/crates/rome_js_formatter/src/formatter_traits.rs
+++ b/crates/rome_js_formatter/src/formatter_traits.rs
@@ -278,7 +278,7 @@ impl FormatTokenAndNode for JsSyntaxToken {
     }
 }
 
-impl<N: AstNode<JsLanguage> + ToFormatElement> FormatTokenAndNode for N {
+impl<N: AstNode<Language = JsLanguage> + ToFormatElement> FormatTokenAndNode for N {
     fn format_with<With, WithResult>(
         &self,
         formatter: &Formatter,

--- a/crates/rome_js_formatter/src/utils/array.rs
+++ b/crates/rome_js_formatter/src/utils/array.rs
@@ -17,7 +17,7 @@ pub(crate) fn format_array_node<N, I>(
     formatter: &Formatter,
 ) -> FormatResult<FormatElement>
 where
-    N: AstSeparatedList<JsLanguage, I>,
+    N: AstSeparatedList<Language = JsLanguage, Node = I>,
     I: ArrayNodeElement,
 {
     // Specifically do not use format_separated as arrays need separators
@@ -71,7 +71,9 @@ pub(crate) enum TrailingSeparatorMode {
     Force,
 }
 
-pub(crate) trait ArrayNodeElement: AstNode<JsLanguage> + Clone + ToFormatElement {
+pub(crate) trait ArrayNodeElement:
+    AstNode<Language = JsLanguage> + Clone + ToFormatElement
+{
     /// Determines how the trailing separator should be printer for this element
     fn separator_mode(&self) -> TrailingSeparatorMode;
 }

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -732,7 +732,8 @@ impl JsAnyBinaryLikeExpression {
     }
 }
 
-impl AstNode<JsLanguage> for JsAnyBinaryLikeExpression {
+impl AstNode for JsAnyBinaryLikeExpression {
+    type Language = JsLanguage;
     fn can_cast(kind: JsSyntaxKind) -> bool
     where
         Self: Sized,
@@ -821,7 +822,8 @@ impl JsAnyBinaryLikeLeftExpression {
     }
 }
 
-impl AstNode<JsLanguage> for JsAnyBinaryLikeLeftExpression {
+impl AstNode for JsAnyBinaryLikeLeftExpression {
+    type Language = JsLanguage;
     fn can_cast(kind: JsSyntaxKind) -> bool
     where
         Self: Sized,

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -368,8 +368,8 @@ mod tests {
 /// This function consumes a list of modifiers and applies a predictable sorting.
 pub(crate) fn sort_modifiers_by_precedence<List, Node>(list: &List) -> Vec<Node>
 where
-    Node: AstNode<JsLanguage> + Clone,
-    List: AstNodeList<JsLanguage, Node>,
+    Node: AstNode<Language = JsLanguage> + Clone,
+    List: AstNodeList<Language = JsLanguage, Node = Node>,
     Modifiers: for<'a> From<&'a Node>,
 {
     let mut nodes_and_modifiers = list.iter().collect::<Vec<Node>>();

--- a/crates/rome_js_parser/src/parse.rs
+++ b/crates/rome_js_parser/src/parse.rs
@@ -34,7 +34,7 @@ impl<T> Parse<T> {
         }
     }
 
-    pub fn cast<N: AstNode<JsLanguage>>(self) -> Option<Parse<N>> {
+    pub fn cast<N: AstNode<Language = JsLanguage>>(self) -> Option<Parse<N>> {
         if N::can_cast(self.syntax().kind()) {
             Some(Parse::new(self.root, self.errors))
         } else {
@@ -81,7 +81,7 @@ impl<T> Parse<T> {
     }
 }
 
-impl<T: AstNode<JsLanguage>> Parse<T> {
+impl<T: AstNode<Language = JsLanguage>> Parse<T> {
     /// Convert this parse result into a typed AST node.
     ///
     /// # Panics

--- a/crates/rome_js_syntax/src/generated/nodes.rs
+++ b/crates/rome_js_syntax/src/generated/nodes.rs
@@ -9667,7 +9667,8 @@ pub enum TsType {
     TsUnknownType(TsUnknownType),
     TsVoidType(TsVoidType),
 }
-impl AstNode<Language> for ImportMeta {
+impl AstNode for ImportMeta {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == IMPORT_META }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9696,7 +9697,8 @@ impl From<ImportMeta> for SyntaxNode {
 impl From<ImportMeta> for SyntaxElement {
     fn from(n: ImportMeta) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayAssignmentPattern {
+impl AstNode for JsArrayAssignmentPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9728,7 +9730,8 @@ impl From<JsArrayAssignmentPattern> for SyntaxNode {
 impl From<JsArrayAssignmentPattern> for SyntaxElement {
     fn from(n: JsArrayAssignmentPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayAssignmentPatternRestElement {
+impl AstNode for JsArrayAssignmentPatternRestElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9756,7 +9759,8 @@ impl From<JsArrayAssignmentPatternRestElement> for SyntaxNode {
 impl From<JsArrayAssignmentPatternRestElement> for SyntaxElement {
     fn from(n: JsArrayAssignmentPatternRestElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayBindingPattern {
+impl AstNode for JsArrayBindingPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9788,7 +9792,8 @@ impl From<JsArrayBindingPattern> for SyntaxNode {
 impl From<JsArrayBindingPattern> for SyntaxElement {
     fn from(n: JsArrayBindingPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayBindingPatternRestElement {
+impl AstNode for JsArrayBindingPatternRestElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN_REST_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9816,7 +9821,8 @@ impl From<JsArrayBindingPatternRestElement> for SyntaxNode {
 impl From<JsArrayBindingPatternRestElement> for SyntaxElement {
     fn from(n: JsArrayBindingPatternRestElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayExpression {
+impl AstNode for JsArrayExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9848,7 +9854,8 @@ impl From<JsArrayExpression> for SyntaxNode {
 impl From<JsArrayExpression> for SyntaxElement {
     fn from(n: JsArrayExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrayHole {
+impl AstNode for JsArrayHole {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_HOLE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9870,7 +9877,8 @@ impl From<JsArrayHole> for SyntaxNode {
 impl From<JsArrayHole> for SyntaxElement {
     fn from(n: JsArrayHole) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsArrowFunctionExpression {
+impl AstNode for JsArrowFunctionExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARROW_FUNCTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9911,7 +9919,8 @@ impl From<JsArrowFunctionExpression> for SyntaxNode {
 impl From<JsArrowFunctionExpression> for SyntaxElement {
     fn from(n: JsArrowFunctionExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsAssignmentExpression {
+impl AstNode for JsAssignmentExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ASSIGNMENT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9940,7 +9949,8 @@ impl From<JsAssignmentExpression> for SyntaxNode {
 impl From<JsAssignmentExpression> for SyntaxElement {
     fn from(n: JsAssignmentExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsAssignmentWithDefault {
+impl AstNode for JsAssignmentWithDefault {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ASSIGNMENT_WITH_DEFAULT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9966,7 +9976,8 @@ impl From<JsAssignmentWithDefault> for SyntaxNode {
 impl From<JsAssignmentWithDefault> for SyntaxElement {
     fn from(n: JsAssignmentWithDefault) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsAwaitExpression {
+impl AstNode for JsAwaitExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_AWAIT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -9994,7 +10005,8 @@ impl From<JsAwaitExpression> for SyntaxNode {
 impl From<JsAwaitExpression> for SyntaxElement {
     fn from(n: JsAwaitExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBigIntLiteralExpression {
+impl AstNode for JsBigIntLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BIG_INT_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10021,7 +10033,8 @@ impl From<JsBigIntLiteralExpression> for SyntaxNode {
 impl From<JsBigIntLiteralExpression> for SyntaxElement {
     fn from(n: JsBigIntLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBinaryExpression {
+impl AstNode for JsBinaryExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINARY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10050,7 +10063,8 @@ impl From<JsBinaryExpression> for SyntaxNode {
 impl From<JsBinaryExpression> for SyntaxElement {
     fn from(n: JsBinaryExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBindingPatternWithDefault {
+impl AstNode for JsBindingPatternWithDefault {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BINDING_PATTERN_WITH_DEFAULT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10076,7 +10090,8 @@ impl From<JsBindingPatternWithDefault> for SyntaxNode {
 impl From<JsBindingPatternWithDefault> for SyntaxElement {
     fn from(n: JsBindingPatternWithDefault) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBlockStatement {
+impl AstNode for JsBlockStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BLOCK_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10108,7 +10123,8 @@ impl From<JsBlockStatement> for SyntaxNode {
 impl From<JsBlockStatement> for SyntaxElement {
     fn from(n: JsBlockStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBooleanLiteralExpression {
+impl AstNode for JsBooleanLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BOOLEAN_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10135,7 +10151,8 @@ impl From<JsBooleanLiteralExpression> for SyntaxNode {
 impl From<JsBooleanLiteralExpression> for SyntaxElement {
     fn from(n: JsBooleanLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsBreakStatement {
+impl AstNode for JsBreakStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_BREAK_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10170,7 +10187,8 @@ impl From<JsBreakStatement> for SyntaxNode {
 impl From<JsBreakStatement> for SyntaxElement {
     fn from(n: JsBreakStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsCallArguments {
+impl AstNode for JsCallArguments {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10202,7 +10220,8 @@ impl From<JsCallArguments> for SyntaxNode {
 impl From<JsCallArguments> for SyntaxElement {
     fn from(n: JsCallArguments) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsCallExpression {
+impl AstNode for JsCallExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10235,7 +10254,8 @@ impl From<JsCallExpression> for SyntaxNode {
 impl From<JsCallExpression> for SyntaxElement {
     fn from(n: JsCallExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsCaseClause {
+impl AstNode for JsCaseClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CASE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10265,7 +10285,8 @@ impl From<JsCaseClause> for SyntaxNode {
 impl From<JsCaseClause> for SyntaxElement {
     fn from(n: JsCaseClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsCatchClause {
+impl AstNode for JsCatchClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10297,7 +10318,8 @@ impl From<JsCatchClause> for SyntaxNode {
 impl From<JsCatchClause> for SyntaxElement {
     fn from(n: JsCatchClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsCatchDeclaration {
+impl AstNode for JsCatchDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CATCH_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10333,7 +10355,8 @@ impl From<JsCatchDeclaration> for SyntaxNode {
 impl From<JsCatchDeclaration> for SyntaxElement {
     fn from(n: JsCatchDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsClassDeclaration {
+impl AstNode for JsClassDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10386,7 +10409,8 @@ impl From<JsClassDeclaration> for SyntaxNode {
 impl From<JsClassDeclaration> for SyntaxElement {
     fn from(n: JsClassDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsClassExportDefaultDeclaration {
+impl AstNode for JsClassExportDefaultDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPORT_DEFAULT_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10439,7 +10463,8 @@ impl From<JsClassExportDefaultDeclaration> for SyntaxNode {
 impl From<JsClassExportDefaultDeclaration> for SyntaxElement {
     fn from(n: JsClassExportDefaultDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsClassExpression {
+impl AstNode for JsClassExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10488,7 +10513,8 @@ impl From<JsClassExpression> for SyntaxNode {
 impl From<JsClassExpression> for SyntaxElement {
     fn from(n: JsClassExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsComputedMemberAssignment {
+impl AstNode for JsComputedMemberAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10521,7 +10547,8 @@ impl From<JsComputedMemberAssignment> for SyntaxNode {
 impl From<JsComputedMemberAssignment> for SyntaxElement {
     fn from(n: JsComputedMemberAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsComputedMemberExpression {
+impl AstNode for JsComputedMemberExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10558,7 +10585,8 @@ impl From<JsComputedMemberExpression> for SyntaxNode {
 impl From<JsComputedMemberExpression> for SyntaxElement {
     fn from(n: JsComputedMemberExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsComputedMemberName {
+impl AstNode for JsComputedMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_COMPUTED_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10590,7 +10618,8 @@ impl From<JsComputedMemberName> for SyntaxNode {
 impl From<JsComputedMemberName> for SyntaxElement {
     fn from(n: JsComputedMemberName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsConditionalExpression {
+impl AstNode for JsConditionalExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONDITIONAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10624,7 +10653,8 @@ impl From<JsConditionalExpression> for SyntaxNode {
 impl From<JsConditionalExpression> for SyntaxElement {
     fn from(n: JsConditionalExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsConstructorClassMember {
+impl AstNode for JsConstructorClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10651,7 +10681,8 @@ impl From<JsConstructorClassMember> for SyntaxNode {
 impl From<JsConstructorClassMember> for SyntaxElement {
     fn from(n: JsConstructorClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsConstructorParameters {
+impl AstNode for JsConstructorParameters {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10683,7 +10714,8 @@ impl From<JsConstructorParameters> for SyntaxNode {
 impl From<JsConstructorParameters> for SyntaxElement {
     fn from(n: JsConstructorParameters) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsContinueStatement {
+impl AstNode for JsContinueStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONTINUE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10718,7 +10750,8 @@ impl From<JsContinueStatement> for SyntaxNode {
 impl From<JsContinueStatement> for SyntaxElement {
     fn from(n: JsContinueStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsDebuggerStatement {
+impl AstNode for JsDebuggerStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEBUGGER_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10749,7 +10782,8 @@ impl From<JsDebuggerStatement> for SyntaxNode {
 impl From<JsDebuggerStatement> for SyntaxElement {
     fn from(n: JsDebuggerStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsDefaultClause {
+impl AstNode for JsDefaultClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10781,7 +10815,8 @@ impl From<JsDefaultClause> for SyntaxNode {
 impl From<JsDefaultClause> for SyntaxElement {
     fn from(n: JsDefaultClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsDefaultImportSpecifier {
+impl AstNode for JsDefaultImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DEFAULT_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10809,7 +10844,8 @@ impl From<JsDefaultImportSpecifier> for SyntaxNode {
 impl From<JsDefaultImportSpecifier> for SyntaxElement {
     fn from(n: JsDefaultImportSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsDirective {
+impl AstNode for JsDirective {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10840,7 +10876,8 @@ impl From<JsDirective> for SyntaxNode {
 impl From<JsDirective> for SyntaxElement {
     fn from(n: JsDirective) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsDoWhileStatement {
+impl AstNode for JsDoWhileStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DO_WHILE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10882,7 +10919,8 @@ impl From<JsDoWhileStatement> for SyntaxNode {
 impl From<JsDoWhileStatement> for SyntaxElement {
     fn from(n: JsDoWhileStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsElseClause {
+impl AstNode for JsElseClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ELSE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10907,7 +10945,8 @@ impl From<JsElseClause> for SyntaxNode {
 impl From<JsElseClause> for SyntaxElement {
     fn from(n: JsElseClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsEmptyClassMember {
+impl AstNode for JsEmptyClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10934,7 +10973,8 @@ impl From<JsEmptyClassMember> for SyntaxNode {
 impl From<JsEmptyClassMember> for SyntaxElement {
     fn from(n: JsEmptyClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsEmptyStatement {
+impl AstNode for JsEmptyStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EMPTY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10961,7 +11001,8 @@ impl From<JsEmptyStatement> for SyntaxNode {
 impl From<JsEmptyStatement> for SyntaxElement {
     fn from(n: JsEmptyStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExport {
+impl AstNode for JsExport {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -10992,7 +11033,8 @@ impl From<JsExport> for SyntaxNode {
 impl From<JsExport> for SyntaxElement {
     fn from(n: JsExport) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportAsClause {
+impl AstNode for JsExportAsClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_AS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11020,7 +11062,8 @@ impl From<JsExportAsClause> for SyntaxNode {
 impl From<JsExportAsClause> for SyntaxElement {
     fn from(n: JsExportAsClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportDefaultDeclarationClause {
+impl AstNode for JsExportDefaultDeclarationClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_DEFAULT_DECLARATION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11055,7 +11098,8 @@ impl From<JsExportDefaultDeclarationClause> for SyntaxNode {
 impl From<JsExportDefaultDeclarationClause> for SyntaxElement {
     fn from(n: JsExportDefaultDeclarationClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportDefaultExpressionClause {
+impl AstNode for JsExportDefaultExpressionClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11087,7 +11131,8 @@ impl From<JsExportDefaultExpressionClause> for SyntaxNode {
 impl From<JsExportDefaultExpressionClause> for SyntaxElement {
     fn from(n: JsExportDefaultExpressionClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportFromClause {
+impl AstNode for JsExportFromClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_FROM_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11125,7 +11170,8 @@ impl From<JsExportFromClause> for SyntaxNode {
 impl From<JsExportFromClause> for SyntaxElement {
     fn from(n: JsExportFromClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportNamedClause {
+impl AstNode for JsExportNamedClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11165,7 +11211,8 @@ impl From<JsExportNamedClause> for SyntaxNode {
 impl From<JsExportNamedClause> for SyntaxElement {
     fn from(n: JsExportNamedClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportNamedFromClause {
+impl AstNode for JsExportNamedFromClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11211,7 +11258,8 @@ impl From<JsExportNamedFromClause> for SyntaxNode {
 impl From<JsExportNamedFromClause> for SyntaxElement {
     fn from(n: JsExportNamedFromClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportNamedFromSpecifier {
+impl AstNode for JsExportNamedFromSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11246,7 +11294,8 @@ impl From<JsExportNamedFromSpecifier> for SyntaxNode {
 impl From<JsExportNamedFromSpecifier> for SyntaxElement {
     fn from(n: JsExportNamedFromSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportNamedShorthandSpecifier {
+impl AstNode for JsExportNamedShorthandSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SHORTHAND_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11274,7 +11323,8 @@ impl From<JsExportNamedShorthandSpecifier> for SyntaxNode {
 impl From<JsExportNamedShorthandSpecifier> for SyntaxElement {
     fn from(n: JsExportNamedShorthandSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExportNamedSpecifier {
+impl AstNode for JsExportNamedSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11307,7 +11357,8 @@ impl From<JsExportNamedSpecifier> for SyntaxNode {
 impl From<JsExportNamedSpecifier> for SyntaxElement {
     fn from(n: JsExportNamedSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExpressionSnipped {
+impl AstNode for JsExpressionSnipped {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_SNIPPED }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11332,7 +11383,8 @@ impl From<JsExpressionSnipped> for SyntaxNode {
 impl From<JsExpressionSnipped> for SyntaxElement {
     fn from(n: JsExpressionSnipped) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExpressionStatement {
+impl AstNode for JsExpressionStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPRESSION_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11360,7 +11412,8 @@ impl From<JsExpressionStatement> for SyntaxNode {
 impl From<JsExpressionStatement> for SyntaxElement {
     fn from(n: JsExpressionStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsExtendsClause {
+impl AstNode for JsExtendsClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXTENDS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11395,7 +11448,8 @@ impl From<JsExtendsClause> for SyntaxNode {
 impl From<JsExtendsClause> for SyntaxElement {
     fn from(n: JsExtendsClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFinallyClause {
+impl AstNode for JsFinallyClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FINALLY_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11423,7 +11477,8 @@ impl From<JsFinallyClause> for SyntaxNode {
 impl From<JsFinallyClause> for SyntaxElement {
     fn from(n: JsFinallyClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsForInStatement {
+impl AstNode for JsForInStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_IN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11462,7 +11517,8 @@ impl From<JsForInStatement> for SyntaxNode {
 impl From<JsForInStatement> for SyntaxElement {
     fn from(n: JsForInStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsForOfStatement {
+impl AstNode for JsForOfStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_OF_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11505,7 +11561,8 @@ impl From<JsForOfStatement> for SyntaxNode {
 impl From<JsForOfStatement> for SyntaxElement {
     fn from(n: JsForOfStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsForStatement {
+impl AstNode for JsForStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11552,7 +11609,8 @@ impl From<JsForStatement> for SyntaxNode {
 impl From<JsForStatement> for SyntaxElement {
     fn from(n: JsForStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsForVariableDeclaration {
+impl AstNode for JsForVariableDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FOR_VARIABLE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11577,7 +11635,8 @@ impl From<JsForVariableDeclaration> for SyntaxNode {
 impl From<JsForVariableDeclaration> for SyntaxElement {
     fn from(n: JsForVariableDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFormalParameter {
+impl AstNode for JsFormalParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FORMAL_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11613,7 +11672,8 @@ impl From<JsFormalParameter> for SyntaxNode {
 impl From<JsFormalParameter> for SyntaxElement {
     fn from(n: JsFormalParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFunctionBody {
+impl AstNode for JsFunctionBody {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11646,7 +11706,8 @@ impl From<JsFunctionBody> for SyntaxNode {
 impl From<JsFunctionBody> for SyntaxElement {
     fn from(n: JsFunctionBody) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFunctionDeclaration {
+impl AstNode for JsFunctionDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11692,7 +11753,8 @@ impl From<JsFunctionDeclaration> for SyntaxNode {
 impl From<JsFunctionDeclaration> for SyntaxElement {
     fn from(n: JsFunctionDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFunctionExportDefaultDeclaration {
+impl AstNode for JsFunctionExportDefaultDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPORT_DEFAULT_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11738,7 +11800,8 @@ impl From<JsFunctionExportDefaultDeclaration> for SyntaxNode {
 impl From<JsFunctionExportDefaultDeclaration> for SyntaxElement {
     fn from(n: JsFunctionExportDefaultDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsFunctionExpression {
+impl AstNode for JsFunctionExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_FUNCTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11784,7 +11847,8 @@ impl From<JsFunctionExpression> for SyntaxNode {
 impl From<JsFunctionExpression> for SyntaxElement {
     fn from(n: JsFunctionExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsGetterClassMember {
+impl AstNode for JsGetterClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11823,7 +11887,8 @@ impl From<JsGetterClassMember> for SyntaxNode {
 impl From<JsGetterClassMember> for SyntaxElement {
     fn from(n: JsGetterClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsGetterObjectMember {
+impl AstNode for JsGetterObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_GETTER_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11861,7 +11926,8 @@ impl From<JsGetterObjectMember> for SyntaxNode {
 impl From<JsGetterObjectMember> for SyntaxElement {
     fn from(n: JsGetterObjectMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsIdentifierAssignment {
+impl AstNode for JsIdentifierAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11885,7 +11951,8 @@ impl From<JsIdentifierAssignment> for SyntaxNode {
 impl From<JsIdentifierAssignment> for SyntaxElement {
     fn from(n: JsIdentifierAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsIdentifierBinding {
+impl AstNode for JsIdentifierBinding {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11909,7 +11976,8 @@ impl From<JsIdentifierBinding> for SyntaxNode {
 impl From<JsIdentifierBinding> for SyntaxElement {
     fn from(n: JsIdentifierBinding) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsIdentifierExpression {
+impl AstNode for JsIdentifierExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IDENTIFIER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11933,7 +12001,8 @@ impl From<JsIdentifierExpression> for SyntaxNode {
 impl From<JsIdentifierExpression> for SyntaxElement {
     fn from(n: JsIdentifierExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsIfStatement {
+impl AstNode for JsIfStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IF_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -11971,7 +12040,8 @@ impl From<JsIfStatement> for SyntaxNode {
 impl From<JsIfStatement> for SyntaxElement {
     fn from(n: JsIfStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImport {
+impl AstNode for JsImport {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12006,7 +12076,8 @@ impl From<JsImport> for SyntaxNode {
 impl From<JsImport> for SyntaxElement {
     fn from(n: JsImport) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportAssertion {
+impl AstNode for JsImportAssertion {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12042,7 +12113,8 @@ impl From<JsImportAssertion> for SyntaxNode {
 impl From<JsImportAssertion> for SyntaxElement {
     fn from(n: JsImportAssertion) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportAssertionEntry {
+impl AstNode for JsImportAssertionEntry {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION_ENTRY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12074,7 +12146,8 @@ impl From<JsImportAssertionEntry> for SyntaxNode {
 impl From<JsImportAssertionEntry> for SyntaxElement {
     fn from(n: JsImportAssertionEntry) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportBareClause {
+impl AstNode for JsImportBareClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_BARE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12102,7 +12175,8 @@ impl From<JsImportBareClause> for SyntaxNode {
 impl From<JsImportBareClause> for SyntaxElement {
     fn from(n: JsImportBareClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportCallExpression {
+impl AstNode for JsImportCallExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_CALL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12130,7 +12204,8 @@ impl From<JsImportCallExpression> for SyntaxNode {
 impl From<JsImportCallExpression> for SyntaxElement {
     fn from(n: JsImportCallExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportDefaultClause {
+impl AstNode for JsImportDefaultClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_DEFAULT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12164,7 +12239,8 @@ impl From<JsImportDefaultClause> for SyntaxNode {
 impl From<JsImportDefaultClause> for SyntaxElement {
     fn from(n: JsImportDefaultClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportNamedClause {
+impl AstNode for JsImportNamedClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_NAMED_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12205,7 +12281,8 @@ impl From<JsImportNamedClause> for SyntaxNode {
 impl From<JsImportNamedClause> for SyntaxElement {
     fn from(n: JsImportNamedClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsImportNamespaceClause {
+impl AstNode for JsImportNamespaceClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_NAMESPACE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12241,7 +12318,8 @@ impl From<JsImportNamespaceClause> for SyntaxNode {
 impl From<JsImportNamespaceClause> for SyntaxElement {
     fn from(n: JsImportNamespaceClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsInExpression {
+impl AstNode for JsInExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IN_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12267,7 +12345,8 @@ impl From<JsInExpression> for SyntaxNode {
 impl From<JsInExpression> for SyntaxElement {
     fn from(n: JsInExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsInitializerClause {
+impl AstNode for JsInitializerClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_INITIALIZER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12292,7 +12371,8 @@ impl From<JsInitializerClause> for SyntaxNode {
 impl From<JsInitializerClause> for SyntaxElement {
     fn from(n: JsInitializerClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsInstanceofExpression {
+impl AstNode for JsInstanceofExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_INSTANCEOF_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12321,7 +12401,8 @@ impl From<JsInstanceofExpression> for SyntaxNode {
 impl From<JsInstanceofExpression> for SyntaxElement {
     fn from(n: JsInstanceofExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsLabeledStatement {
+impl AstNode for JsLabeledStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LABELED_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12353,7 +12434,8 @@ impl From<JsLabeledStatement> for SyntaxNode {
 impl From<JsLabeledStatement> for SyntaxElement {
     fn from(n: JsLabeledStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsLiteralExportName {
+impl AstNode for JsLiteralExportName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_EXPORT_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12377,7 +12459,8 @@ impl From<JsLiteralExportName> for SyntaxNode {
 impl From<JsLiteralExportName> for SyntaxElement {
     fn from(n: JsLiteralExportName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsLiteralMemberName {
+impl AstNode for JsLiteralMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LITERAL_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12401,7 +12484,8 @@ impl From<JsLiteralMemberName> for SyntaxNode {
 impl From<JsLiteralMemberName> for SyntaxElement {
     fn from(n: JsLiteralMemberName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsLogicalExpression {
+impl AstNode for JsLogicalExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_LOGICAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12430,7 +12514,8 @@ impl From<JsLogicalExpression> for SyntaxNode {
 impl From<JsLogicalExpression> for SyntaxElement {
     fn from(n: JsLogicalExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsMethodClassMember {
+impl AstNode for JsMethodClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12477,7 +12562,8 @@ impl From<JsMethodClassMember> for SyntaxNode {
 impl From<JsMethodClassMember> for SyntaxElement {
     fn from(n: JsMethodClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsMethodObjectMember {
+impl AstNode for JsMethodObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12519,7 +12605,8 @@ impl From<JsMethodObjectMember> for SyntaxNode {
 impl From<JsMethodObjectMember> for SyntaxElement {
     fn from(n: JsMethodObjectMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsModule {
+impl AstNode for JsModule {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12549,7 +12636,8 @@ impl From<JsModule> for SyntaxNode {
 impl From<JsModule> for SyntaxElement {
     fn from(n: JsModule) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsModuleSource {
+impl AstNode for JsModuleSource {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE_SOURCE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12576,7 +12664,8 @@ impl From<JsModuleSource> for SyntaxNode {
 impl From<JsModuleSource> for SyntaxElement {
     fn from(n: JsModuleSource) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsName {
+impl AstNode for JsName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12603,7 +12692,8 @@ impl From<JsName> for SyntaxNode {
 impl From<JsName> for SyntaxElement {
     fn from(n: JsName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNamedImportSpecifier {
+impl AstNode for JsNamedImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12633,7 +12723,8 @@ impl From<JsNamedImportSpecifier> for SyntaxNode {
 impl From<JsNamedImportSpecifier> for SyntaxElement {
     fn from(n: JsNamedImportSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNamedImportSpecifiers {
+impl AstNode for JsNamedImportSpecifiers {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12665,7 +12756,8 @@ impl From<JsNamedImportSpecifiers> for SyntaxNode {
 impl From<JsNamedImportSpecifiers> for SyntaxElement {
     fn from(n: JsNamedImportSpecifiers) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNamespaceImportSpecifier {
+impl AstNode for JsNamespaceImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMESPACE_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12691,7 +12783,8 @@ impl From<JsNamespaceImportSpecifier> for SyntaxNode {
 impl From<JsNamespaceImportSpecifier> for SyntaxElement {
     fn from(n: JsNamespaceImportSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNewExpression {
+impl AstNode for JsNewExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NEW_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12724,7 +12817,8 @@ impl From<JsNewExpression> for SyntaxNode {
 impl From<JsNewExpression> for SyntaxElement {
     fn from(n: JsNewExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNullLiteralExpression {
+impl AstNode for JsNullLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NULL_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12751,7 +12845,8 @@ impl From<JsNullLiteralExpression> for SyntaxNode {
 impl From<JsNullLiteralExpression> for SyntaxElement {
     fn from(n: JsNullLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsNumberLiteralExpression {
+impl AstNode for JsNumberLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NUMBER_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12778,7 +12873,8 @@ impl From<JsNumberLiteralExpression> for SyntaxNode {
 impl From<JsNumberLiteralExpression> for SyntaxElement {
     fn from(n: JsNumberLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectAssignmentPattern {
+impl AstNode for JsObjectAssignmentPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12810,7 +12906,8 @@ impl From<JsObjectAssignmentPattern> for SyntaxNode {
 impl From<JsObjectAssignmentPattern> for SyntaxElement {
     fn from(n: JsObjectAssignmentPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectAssignmentPatternProperty {
+impl AstNode for JsObjectAssignmentPatternProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12840,7 +12937,8 @@ impl From<JsObjectAssignmentPatternProperty> for SyntaxNode {
 impl From<JsObjectAssignmentPatternProperty> for SyntaxElement {
     fn from(n: JsObjectAssignmentPatternProperty) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectAssignmentPatternRest {
+impl AstNode for JsObjectAssignmentPatternRest {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_REST }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12868,7 +12966,8 @@ impl From<JsObjectAssignmentPatternRest> for SyntaxNode {
 impl From<JsObjectAssignmentPatternRest> for SyntaxElement {
     fn from(n: JsObjectAssignmentPatternRest) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectAssignmentPatternShorthandProperty {
+impl AstNode for JsObjectAssignmentPatternShorthandProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == JS_OBJECT_ASSIGNMENT_PATTERN_SHORTHAND_PROPERTY
     }
@@ -12895,7 +12994,8 @@ impl From<JsObjectAssignmentPatternShorthandProperty> for SyntaxNode {
 impl From<JsObjectAssignmentPatternShorthandProperty> for SyntaxElement {
     fn from(n: JsObjectAssignmentPatternShorthandProperty) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectBindingPattern {
+impl AstNode for JsObjectBindingPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12927,7 +13027,8 @@ impl From<JsObjectBindingPattern> for SyntaxNode {
 impl From<JsObjectBindingPattern> for SyntaxElement {
     fn from(n: JsObjectBindingPattern) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectBindingPatternProperty {
+impl AstNode for JsObjectBindingPatternProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12957,7 +13058,8 @@ impl From<JsObjectBindingPatternProperty> for SyntaxNode {
 impl From<JsObjectBindingPatternProperty> for SyntaxElement {
     fn from(n: JsObjectBindingPatternProperty) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectBindingPatternRest {
+impl AstNode for JsObjectBindingPatternRest {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_REST }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -12985,7 +13087,8 @@ impl From<JsObjectBindingPatternRest> for SyntaxNode {
 impl From<JsObjectBindingPatternRest> for SyntaxElement {
     fn from(n: JsObjectBindingPatternRest) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectBindingPatternShorthandProperty {
+impl AstNode for JsObjectBindingPatternShorthandProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13010,7 +13113,8 @@ impl From<JsObjectBindingPatternShorthandProperty> for SyntaxNode {
 impl From<JsObjectBindingPatternShorthandProperty> for SyntaxElement {
     fn from(n: JsObjectBindingPatternShorthandProperty) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsObjectExpression {
+impl AstNode for JsObjectExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13042,7 +13146,8 @@ impl From<JsObjectExpression> for SyntaxNode {
 impl From<JsObjectExpression> for SyntaxElement {
     fn from(n: JsObjectExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsParameters {
+impl AstNode for JsParameters {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13074,7 +13179,8 @@ impl From<JsParameters> for SyntaxNode {
 impl From<JsParameters> for SyntaxElement {
     fn from(n: JsParameters) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsParenthesizedAssignment {
+impl AstNode for JsParenthesizedAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13106,7 +13212,8 @@ impl From<JsParenthesizedAssignment> for SyntaxNode {
 impl From<JsParenthesizedAssignment> for SyntaxElement {
     fn from(n: JsParenthesizedAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsParenthesizedExpression {
+impl AstNode for JsParenthesizedExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARENTHESIZED_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13138,7 +13245,8 @@ impl From<JsParenthesizedExpression> for SyntaxNode {
 impl From<JsParenthesizedExpression> for SyntaxElement {
     fn from(n: JsParenthesizedExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPostUpdateExpression {
+impl AstNode for JsPostUpdateExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_POST_UPDATE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13166,7 +13274,8 @@ impl From<JsPostUpdateExpression> for SyntaxNode {
 impl From<JsPostUpdateExpression> for SyntaxElement {
     fn from(n: JsPostUpdateExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPreUpdateExpression {
+impl AstNode for JsPreUpdateExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRE_UPDATE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13194,7 +13303,8 @@ impl From<JsPreUpdateExpression> for SyntaxNode {
 impl From<JsPreUpdateExpression> for SyntaxElement {
     fn from(n: JsPreUpdateExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPrivateClassMemberName {
+impl AstNode for JsPrivateClassMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_CLASS_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13219,7 +13329,8 @@ impl From<JsPrivateClassMemberName> for SyntaxNode {
 impl From<JsPrivateClassMemberName> for SyntaxElement {
     fn from(n: JsPrivateClassMemberName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPrivateName {
+impl AstNode for JsPrivateName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PRIVATE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13247,7 +13358,8 @@ impl From<JsPrivateName> for SyntaxNode {
 impl From<JsPrivateName> for SyntaxElement {
     fn from(n: JsPrivateName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPropertyClassMember {
+impl AstNode for JsPropertyClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13281,7 +13393,8 @@ impl From<JsPropertyClassMember> for SyntaxNode {
 impl From<JsPropertyClassMember> for SyntaxElement {
     fn from(n: JsPropertyClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsPropertyObjectMember {
+impl AstNode for JsPropertyObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13310,7 +13423,8 @@ impl From<JsPropertyObjectMember> for SyntaxNode {
 impl From<JsPropertyObjectMember> for SyntaxElement {
     fn from(n: JsPropertyObjectMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsReferenceIdentifier {
+impl AstNode for JsReferenceIdentifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REFERENCE_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13337,7 +13451,8 @@ impl From<JsReferenceIdentifier> for SyntaxNode {
 impl From<JsReferenceIdentifier> for SyntaxElement {
     fn from(n: JsReferenceIdentifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsRegexLiteralExpression {
+impl AstNode for JsRegexLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REGEX_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13364,7 +13479,8 @@ impl From<JsRegexLiteralExpression> for SyntaxNode {
 impl From<JsRegexLiteralExpression> for SyntaxElement {
     fn from(n: JsRegexLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsRestParameter {
+impl AstNode for JsRestParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_REST_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13396,7 +13512,8 @@ impl From<JsRestParameter> for SyntaxNode {
 impl From<JsRestParameter> for SyntaxElement {
     fn from(n: JsRestParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsReturnStatement {
+impl AstNode for JsReturnStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_RETURN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13428,7 +13545,8 @@ impl From<JsReturnStatement> for SyntaxNode {
 impl From<JsReturnStatement> for SyntaxElement {
     fn from(n: JsReturnStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsScript {
+impl AstNode for JsScript {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SCRIPT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13458,7 +13576,8 @@ impl From<JsScript> for SyntaxNode {
 impl From<JsScript> for SyntaxElement {
     fn from(n: JsScript) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSequenceExpression {
+impl AstNode for JsSequenceExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SEQUENCE_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13487,7 +13606,8 @@ impl From<JsSequenceExpression> for SyntaxNode {
 impl From<JsSequenceExpression> for SyntaxElement {
     fn from(n: JsSequenceExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSetterClassMember {
+impl AstNode for JsSetterClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13523,7 +13643,8 @@ impl From<JsSetterClassMember> for SyntaxNode {
 impl From<JsSetterClassMember> for SyntaxElement {
     fn from(n: JsSetterClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSetterObjectMember {
+impl AstNode for JsSetterObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SETTER_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13558,7 +13679,8 @@ impl From<JsSetterObjectMember> for SyntaxNode {
 impl From<JsSetterObjectMember> for SyntaxElement {
     fn from(n: JsSetterObjectMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsShorthandNamedImportSpecifier {
+impl AstNode for JsShorthandNamedImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13586,7 +13708,8 @@ impl From<JsShorthandNamedImportSpecifier> for SyntaxNode {
 impl From<JsShorthandNamedImportSpecifier> for SyntaxElement {
     fn from(n: JsShorthandNamedImportSpecifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsShorthandPropertyObjectMember {
+impl AstNode for JsShorthandPropertyObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SHORTHAND_PROPERTY_OBJECT_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13610,7 +13733,8 @@ impl From<JsShorthandPropertyObjectMember> for SyntaxNode {
 impl From<JsShorthandPropertyObjectMember> for SyntaxElement {
     fn from(n: JsShorthandPropertyObjectMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSpread {
+impl AstNode for JsSpread {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SPREAD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13638,7 +13762,8 @@ impl From<JsSpread> for SyntaxNode {
 impl From<JsSpread> for SyntaxElement {
     fn from(n: JsSpread) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsStaticInitializationBlockClassMember {
+impl AstNode for JsStaticInitializationBlockClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13674,7 +13799,8 @@ impl From<JsStaticInitializationBlockClassMember> for SyntaxNode {
 impl From<JsStaticInitializationBlockClassMember> for SyntaxElement {
     fn from(n: JsStaticInitializationBlockClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsStaticMemberAssignment {
+impl AstNode for JsStaticMemberAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13700,7 +13826,8 @@ impl From<JsStaticMemberAssignment> for SyntaxNode {
 impl From<JsStaticMemberAssignment> for SyntaxElement {
     fn from(n: JsStaticMemberAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsStaticMemberExpression {
+impl AstNode for JsStaticMemberExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MEMBER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13729,7 +13856,8 @@ impl From<JsStaticMemberExpression> for SyntaxNode {
 impl From<JsStaticMemberExpression> for SyntaxElement {
     fn from(n: JsStaticMemberExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsStaticModifier {
+impl AstNode for JsStaticModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATIC_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13756,7 +13884,8 @@ impl From<JsStaticModifier> for SyntaxNode {
 impl From<JsStaticModifier> for SyntaxElement {
     fn from(n: JsStaticModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsStringLiteralExpression {
+impl AstNode for JsStringLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STRING_LITERAL_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13783,7 +13912,8 @@ impl From<JsStringLiteralExpression> for SyntaxNode {
 impl From<JsStringLiteralExpression> for SyntaxElement {
     fn from(n: JsStringLiteralExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSuperExpression {
+impl AstNode for JsSuperExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SUPER_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13810,7 +13940,8 @@ impl From<JsSuperExpression> for SyntaxNode {
 impl From<JsSuperExpression> for SyntaxElement {
     fn from(n: JsSuperExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsSwitchStatement {
+impl AstNode for JsSwitchStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13858,7 +13989,8 @@ impl From<JsSwitchStatement> for SyntaxNode {
 impl From<JsSwitchStatement> for SyntaxElement {
     fn from(n: JsSwitchStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsTemplate {
+impl AstNode for JsTemplate {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13895,7 +14027,8 @@ impl From<JsTemplate> for SyntaxNode {
 impl From<JsTemplate> for SyntaxElement {
     fn from(n: JsTemplate) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsTemplateChunkElement {
+impl AstNode for JsTemplateChunkElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_CHUNK_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13922,7 +14055,8 @@ impl From<JsTemplateChunkElement> for SyntaxNode {
 impl From<JsTemplateChunkElement> for SyntaxElement {
     fn from(n: JsTemplateChunkElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsTemplateElement {
+impl AstNode for JsTemplateElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13954,7 +14088,8 @@ impl From<JsTemplateElement> for SyntaxNode {
 impl From<JsTemplateElement> for SyntaxElement {
     fn from(n: JsTemplateElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsThisExpression {
+impl AstNode for JsThisExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THIS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -13978,7 +14113,8 @@ impl From<JsThisExpression> for SyntaxNode {
 impl From<JsThisExpression> for SyntaxElement {
     fn from(n: JsThisExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsThrowStatement {
+impl AstNode for JsThrowStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_THROW_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14010,7 +14146,8 @@ impl From<JsThrowStatement> for SyntaxNode {
 impl From<JsThrowStatement> for SyntaxElement {
     fn from(n: JsThrowStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsTryFinallyStatement {
+impl AstNode for JsTryFinallyStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_FINALLY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14043,7 +14180,8 @@ impl From<JsTryFinallyStatement> for SyntaxNode {
 impl From<JsTryFinallyStatement> for SyntaxElement {
     fn from(n: JsTryFinallyStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsTryStatement {
+impl AstNode for JsTryStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TRY_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14072,7 +14210,8 @@ impl From<JsTryStatement> for SyntaxNode {
 impl From<JsTryStatement> for SyntaxElement {
     fn from(n: JsTryStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsUnaryExpression {
+impl AstNode for JsUnaryExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNARY_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14100,7 +14239,8 @@ impl From<JsUnaryExpression> for SyntaxNode {
 impl From<JsUnaryExpression> for SyntaxElement {
     fn from(n: JsUnaryExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsVariableDeclaration {
+impl AstNode for JsVariableDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14125,7 +14265,8 @@ impl From<JsVariableDeclaration> for SyntaxNode {
 impl From<JsVariableDeclaration> for SyntaxElement {
     fn from(n: JsVariableDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsVariableDeclarationClause {
+impl AstNode for JsVariableDeclarationClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATION_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14156,7 +14297,8 @@ impl From<JsVariableDeclarationClause> for SyntaxNode {
 impl From<JsVariableDeclarationClause> for SyntaxElement {
     fn from(n: JsVariableDeclarationClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsVariableDeclarator {
+impl AstNode for JsVariableDeclarator {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14188,7 +14330,8 @@ impl From<JsVariableDeclarator> for SyntaxNode {
 impl From<JsVariableDeclarator> for SyntaxElement {
     fn from(n: JsVariableDeclarator) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsVariableStatement {
+impl AstNode for JsVariableStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14219,7 +14362,8 @@ impl From<JsVariableStatement> for SyntaxNode {
 impl From<JsVariableStatement> for SyntaxElement {
     fn from(n: JsVariableStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsWhileStatement {
+impl AstNode for JsWhileStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WHILE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14256,7 +14400,8 @@ impl From<JsWhileStatement> for SyntaxNode {
 impl From<JsWhileStatement> for SyntaxElement {
     fn from(n: JsWhileStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsWithStatement {
+impl AstNode for JsWithStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_WITH_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14290,7 +14435,8 @@ impl From<JsWithStatement> for SyntaxNode {
 impl From<JsWithStatement> for SyntaxElement {
     fn from(n: JsWithStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsYieldArgument {
+impl AstNode for JsYieldArgument {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_ARGUMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14318,7 +14464,8 @@ impl From<JsYieldArgument> for SyntaxNode {
 impl From<JsYieldArgument> for SyntaxElement {
     fn from(n: JsYieldArgument) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsYieldExpression {
+impl AstNode for JsYieldExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_YIELD_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14346,7 +14493,8 @@ impl From<JsYieldExpression> for SyntaxNode {
 impl From<JsYieldExpression> for SyntaxElement {
     fn from(n: JsYieldExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxAttribute {
+impl AstNode for JsxAttribute {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14374,7 +14522,8 @@ impl From<JsxAttribute> for SyntaxNode {
 impl From<JsxAttribute> for SyntaxElement {
     fn from(n: JsxAttribute) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxAttributeInitializerClause {
+impl AstNode for JsxAttributeInitializerClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE_INITIALIZER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14399,7 +14548,8 @@ impl From<JsxAttributeInitializerClause> for SyntaxNode {
 impl From<JsxAttributeInitializerClause> for SyntaxElement {
     fn from(n: JsxAttributeInitializerClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxClosingElement {
+impl AstNode for JsxClosingElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CLOSING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14435,7 +14585,8 @@ impl From<JsxClosingElement> for SyntaxNode {
 impl From<JsxClosingElement> for SyntaxElement {
     fn from(n: JsxClosingElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxClosingFragment {
+impl AstNode for JsxClosingFragment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CLOSING_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14470,7 +14621,8 @@ impl From<JsxClosingFragment> for SyntaxNode {
 impl From<JsxClosingFragment> for SyntaxElement {
     fn from(n: JsxClosingFragment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxElement {
+impl AstNode for JsxElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14502,7 +14654,8 @@ impl From<JsxElement> for SyntaxNode {
 impl From<JsxElement> for SyntaxElement {
     fn from(n: JsxElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxExpressionAttributeValue {
+impl AstNode for JsxExpressionAttributeValue {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_EXPRESSION_ATTRIBUTE_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14534,7 +14687,8 @@ impl From<JsxExpressionAttributeValue> for SyntaxNode {
 impl From<JsxExpressionAttributeValue> for SyntaxElement {
     fn from(n: JsxExpressionAttributeValue) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxExpressionChild {
+impl AstNode for JsxExpressionChild {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_EXPRESSION_CHILD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14569,7 +14723,8 @@ impl From<JsxExpressionChild> for SyntaxNode {
 impl From<JsxExpressionChild> for SyntaxElement {
     fn from(n: JsxExpressionChild) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxFragment {
+impl AstNode for JsxFragment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14601,7 +14756,8 @@ impl From<JsxFragment> for SyntaxNode {
 impl From<JsxFragment> for SyntaxElement {
     fn from(n: JsxFragment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxMemberName {
+impl AstNode for JsxMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_MEMBER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14627,7 +14783,8 @@ impl From<JsxMemberName> for SyntaxNode {
 impl From<JsxMemberName> for SyntaxElement {
     fn from(n: JsxMemberName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxName {
+impl AstNode for JsxName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14654,7 +14811,8 @@ impl From<JsxName> for SyntaxNode {
 impl From<JsxName> for SyntaxElement {
     fn from(n: JsxName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxNamespaceName {
+impl AstNode for JsxNamespaceName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_NAMESPACE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14683,7 +14841,8 @@ impl From<JsxNamespaceName> for SyntaxNode {
 impl From<JsxNamespaceName> for SyntaxElement {
     fn from(n: JsxNamespaceName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxOpeningElement {
+impl AstNode for JsxOpeningElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_OPENING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14720,7 +14879,8 @@ impl From<JsxOpeningElement> for SyntaxNode {
 impl From<JsxOpeningElement> for SyntaxElement {
     fn from(n: JsxOpeningElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxOpeningFragment {
+impl AstNode for JsxOpeningFragment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_OPENING_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14751,7 +14911,8 @@ impl From<JsxOpeningFragment> for SyntaxNode {
 impl From<JsxOpeningFragment> for SyntaxElement {
     fn from(n: JsxOpeningFragment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxReferenceIdentifier {
+impl AstNode for JsxReferenceIdentifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_REFERENCE_IDENTIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14778,7 +14939,8 @@ impl From<JsxReferenceIdentifier> for SyntaxNode {
 impl From<JsxReferenceIdentifier> for SyntaxElement {
     fn from(n: JsxReferenceIdentifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxSelfClosingElement {
+impl AstNode for JsxSelfClosingElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SELF_CLOSING_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14819,7 +14981,8 @@ impl From<JsxSelfClosingElement> for SyntaxNode {
 impl From<JsxSelfClosingElement> for SyntaxElement {
     fn from(n: JsxSelfClosingElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxSpreadAttribute {
+impl AstNode for JsxSpreadAttribute {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SPREAD_ATTRIBUTE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14855,7 +15018,8 @@ impl From<JsxSpreadAttribute> for SyntaxNode {
 impl From<JsxSpreadAttribute> for SyntaxElement {
     fn from(n: JsxSpreadAttribute) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxSpreadChild {
+impl AstNode for JsxSpreadChild {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_SPREAD_CHILD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14891,7 +15055,8 @@ impl From<JsxSpreadChild> for SyntaxNode {
 impl From<JsxSpreadChild> for SyntaxElement {
     fn from(n: JsxSpreadChild) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxString {
+impl AstNode for JsxString {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_STRING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14918,7 +15083,8 @@ impl From<JsxString> for SyntaxNode {
 impl From<JsxString> for SyntaxElement {
     fn from(n: JsxString) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxTagExpression {
+impl AstNode for JsxTagExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_TAG_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14942,7 +15108,8 @@ impl From<JsxTagExpression> for SyntaxNode {
 impl From<JsxTagExpression> for SyntaxElement {
     fn from(n: JsxTagExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for JsxText {
+impl AstNode for JsxText {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_TEXT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14969,7 +15136,8 @@ impl From<JsxText> for SyntaxNode {
 impl From<JsxText> for SyntaxElement {
     fn from(n: JsxText) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for NewTarget {
+impl AstNode for NewTarget {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == NEW_TARGET }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -14998,7 +15166,8 @@ impl From<NewTarget> for SyntaxNode {
 impl From<NewTarget> for SyntaxElement {
     fn from(n: NewTarget) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAbstractModifier {
+impl AstNode for TsAbstractModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ABSTRACT_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15025,7 +15194,8 @@ impl From<TsAbstractModifier> for SyntaxNode {
 impl From<TsAbstractModifier> for SyntaxElement {
     fn from(n: TsAbstractModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAccessibilityModifier {
+impl AstNode for TsAccessibilityModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ACCESSIBILITY_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15052,7 +15222,8 @@ impl From<TsAccessibilityModifier> for SyntaxNode {
 impl From<TsAccessibilityModifier> for SyntaxElement {
     fn from(n: TsAccessibilityModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAnyType {
+impl AstNode for TsAnyType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ANY_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15076,7 +15247,8 @@ impl From<TsAnyType> for SyntaxNode {
 impl From<TsAnyType> for SyntaxElement {
     fn from(n: TsAnyType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsArrayType {
+impl AstNode for TsArrayType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ARRAY_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15111,7 +15283,8 @@ impl From<TsArrayType> for SyntaxNode {
 impl From<TsArrayType> for SyntaxElement {
     fn from(n: TsArrayType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAsAssignment {
+impl AstNode for TsAsAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_AS_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15137,7 +15310,8 @@ impl From<TsAsAssignment> for SyntaxNode {
 impl From<TsAsAssignment> for SyntaxElement {
     fn from(n: TsAsAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAsExpression {
+impl AstNode for TsAsExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_AS_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15163,7 +15337,8 @@ impl From<TsAsExpression> for SyntaxNode {
 impl From<TsAsExpression> for SyntaxElement {
     fn from(n: TsAsExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAssertsCondition {
+impl AstNode for TsAssertsCondition {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTS_CONDITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15188,7 +15363,8 @@ impl From<TsAssertsCondition> for SyntaxNode {
 impl From<TsAssertsCondition> for SyntaxElement {
     fn from(n: TsAssertsCondition) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsAssertsReturnType {
+impl AstNode for TsAssertsReturnType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ASSERTS_RETURN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15223,7 +15399,8 @@ impl From<TsAssertsReturnType> for SyntaxNode {
 impl From<TsAssertsReturnType> for SyntaxElement {
     fn from(n: TsAssertsReturnType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsBigIntLiteralType {
+impl AstNode for TsBigIntLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIG_INT_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15254,7 +15431,8 @@ impl From<TsBigIntLiteralType> for SyntaxNode {
 impl From<TsBigIntLiteralType> for SyntaxElement {
     fn from(n: TsBigIntLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsBigintType {
+impl AstNode for TsBigintType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BIGINT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15281,7 +15459,8 @@ impl From<TsBigintType> for SyntaxNode {
 impl From<TsBigintType> for SyntaxElement {
     fn from(n: TsBigintType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsBooleanLiteralType {
+impl AstNode for TsBooleanLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15305,7 +15484,8 @@ impl From<TsBooleanLiteralType> for SyntaxNode {
 impl From<TsBooleanLiteralType> for SyntaxElement {
     fn from(n: TsBooleanLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsBooleanType {
+impl AstNode for TsBooleanType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_BOOLEAN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15332,7 +15512,8 @@ impl From<TsBooleanType> for SyntaxNode {
 impl From<TsBooleanType> for SyntaxElement {
     fn from(n: TsBooleanType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsCallSignatureTypeMember {
+impl AstNode for TsCallSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CALL_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15368,7 +15549,8 @@ impl From<TsCallSignatureTypeMember> for SyntaxNode {
 impl From<TsCallSignatureTypeMember> for SyntaxElement {
     fn from(n: TsCallSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsConditionalType {
+impl AstNode for TsConditionalType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONDITIONAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15410,7 +15592,8 @@ impl From<TsConditionalType> for SyntaxNode {
 impl From<TsConditionalType> for SyntaxElement {
     fn from(n: TsConditionalType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsConstructSignatureTypeMember {
+impl AstNode for TsConstructSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCT_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15447,7 +15630,8 @@ impl From<TsConstructSignatureTypeMember> for SyntaxNode {
 impl From<TsConstructSignatureTypeMember> for SyntaxElement {
     fn from(n: TsConstructSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsConstructorSignatureClassMember {
+impl AstNode for TsConstructorSignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15477,7 +15661,8 @@ impl From<TsConstructorSignatureClassMember> for SyntaxNode {
 impl From<TsConstructorSignatureClassMember> for SyntaxElement {
     fn from(n: TsConstructorSignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsConstructorType {
+impl AstNode for TsConstructorType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_CONSTRUCTOR_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15518,7 +15703,8 @@ impl From<TsConstructorType> for SyntaxNode {
 impl From<TsConstructorType> for SyntaxElement {
     fn from(n: TsConstructorType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDeclareFunctionDeclaration {
+impl AstNode for TsDeclareFunctionDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_FUNCTION_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15563,7 +15749,8 @@ impl From<TsDeclareFunctionDeclaration> for SyntaxNode {
 impl From<TsDeclareFunctionDeclaration> for SyntaxElement {
     fn from(n: TsDeclareFunctionDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDeclareModifier {
+impl AstNode for TsDeclareModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15590,7 +15777,8 @@ impl From<TsDeclareModifier> for SyntaxNode {
 impl From<TsDeclareModifier> for SyntaxElement {
     fn from(n: TsDeclareModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDeclareStatement {
+impl AstNode for TsDeclareStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DECLARE_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15621,7 +15809,8 @@ impl From<TsDeclareStatement> for SyntaxNode {
 impl From<TsDeclareStatement> for SyntaxElement {
     fn from(n: TsDeclareStatement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDefaultTypeClause {
+impl AstNode for TsDefaultTypeClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFAULT_TYPE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15646,7 +15835,8 @@ impl From<TsDefaultTypeClause> for SyntaxNode {
 impl From<TsDefaultTypeClause> for SyntaxElement {
     fn from(n: TsDefaultTypeClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDefinitePropertyAnnotation {
+impl AstNode for TsDefinitePropertyAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFINITE_PROPERTY_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15674,7 +15864,8 @@ impl From<TsDefinitePropertyAnnotation> for SyntaxNode {
 impl From<TsDefinitePropertyAnnotation> for SyntaxElement {
     fn from(n: TsDefinitePropertyAnnotation) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsDefiniteVariableAnnotation {
+impl AstNode for TsDefiniteVariableAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_DEFINITE_VARIABLE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15702,7 +15893,8 @@ impl From<TsDefiniteVariableAnnotation> for SyntaxNode {
 impl From<TsDefiniteVariableAnnotation> for SyntaxElement {
     fn from(n: TsDefiniteVariableAnnotation) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsEmptyExternalModuleDeclarationBody {
+impl AstNode for TsEmptyExternalModuleDeclarationBody {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EMPTY_EXTERNAL_MODULE_DECLARATION_BODY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15729,7 +15921,8 @@ impl From<TsEmptyExternalModuleDeclarationBody> for SyntaxNode {
 impl From<TsEmptyExternalModuleDeclarationBody> for SyntaxElement {
     fn from(n: TsEmptyExternalModuleDeclarationBody) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsEnumDeclaration {
+impl AstNode for TsEnumDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15767,7 +15960,8 @@ impl From<TsEnumDeclaration> for SyntaxNode {
 impl From<TsEnumDeclaration> for SyntaxElement {
     fn from(n: TsEnumDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsEnumMember {
+impl AstNode for TsEnumMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15795,7 +15989,8 @@ impl From<TsEnumMember> for SyntaxNode {
 impl From<TsEnumMember> for SyntaxElement {
     fn from(n: TsEnumMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExportAsNamespaceClause {
+impl AstNode for TsExportAsNamespaceClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_AS_NAMESPACE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15828,7 +16023,8 @@ impl From<TsExportAsNamespaceClause> for SyntaxNode {
 impl From<TsExportAsNamespaceClause> for SyntaxElement {
     fn from(n: TsExportAsNamespaceClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExportAssignmentClause {
+impl AstNode for TsExportAssignmentClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_ASSIGNMENT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15857,7 +16053,8 @@ impl From<TsExportAssignmentClause> for SyntaxNode {
 impl From<TsExportAssignmentClause> for SyntaxElement {
     fn from(n: TsExportAssignmentClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExportDeclareClause {
+impl AstNode for TsExportDeclareClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXPORT_DECLARE_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15888,7 +16085,8 @@ impl From<TsExportDeclareClause> for SyntaxNode {
 impl From<TsExportDeclareClause> for SyntaxElement {
     fn from(n: TsExportDeclareClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExtendsClause {
+impl AstNode for TsExtendsClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTENDS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15916,7 +16114,8 @@ impl From<TsExtendsClause> for SyntaxNode {
 impl From<TsExtendsClause> for SyntaxElement {
     fn from(n: TsExtendsClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExternalModuleDeclaration {
+impl AstNode for TsExternalModuleDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15945,7 +16144,8 @@ impl From<TsExternalModuleDeclaration> for SyntaxNode {
 impl From<TsExternalModuleDeclaration> for SyntaxElement {
     fn from(n: TsExternalModuleDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsExternalModuleReference {
+impl AstNode for TsExternalModuleReference {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_EXTERNAL_MODULE_REFERENCE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -15981,7 +16181,8 @@ impl From<TsExternalModuleReference> for SyntaxNode {
 impl From<TsExternalModuleReference> for SyntaxElement {
     fn from(n: TsExternalModuleReference) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsFunctionType {
+impl AstNode for TsFunctionType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_FUNCTION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16017,7 +16218,8 @@ impl From<TsFunctionType> for SyntaxNode {
 impl From<TsFunctionType> for SyntaxElement {
     fn from(n: TsFunctionType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsGetterSignatureClassMember {
+impl AstNode for TsGetterSignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GETTER_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16059,7 +16261,8 @@ impl From<TsGetterSignatureClassMember> for SyntaxNode {
 impl From<TsGetterSignatureClassMember> for SyntaxElement {
     fn from(n: TsGetterSignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsGetterSignatureTypeMember {
+impl AstNode for TsGetterSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GETTER_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16100,7 +16303,8 @@ impl From<TsGetterSignatureTypeMember> for SyntaxNode {
 impl From<TsGetterSignatureTypeMember> for SyntaxElement {
     fn from(n: TsGetterSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsGlobalDeclaration {
+impl AstNode for TsGlobalDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_GLOBAL_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16128,7 +16332,8 @@ impl From<TsGlobalDeclaration> for SyntaxNode {
 impl From<TsGlobalDeclaration> for SyntaxElement {
     fn from(n: TsGlobalDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIdentifierBinding {
+impl AstNode for TsIdentifierBinding {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IDENTIFIER_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16152,7 +16357,8 @@ impl From<TsIdentifierBinding> for SyntaxNode {
 impl From<TsIdentifierBinding> for SyntaxElement {
     fn from(n: TsIdentifierBinding) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsImplementsClause {
+impl AstNode for TsImplementsClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPLEMENTS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16180,7 +16386,8 @@ impl From<TsImplementsClause> for SyntaxNode {
 impl From<TsImplementsClause> for SyntaxElement {
     fn from(n: TsImplementsClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsImportEqualsDeclaration {
+impl AstNode for TsImportEqualsDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_EQUALS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16221,7 +16428,8 @@ impl From<TsImportEqualsDeclaration> for SyntaxNode {
 impl From<TsImportEqualsDeclaration> for SyntaxElement {
     fn from(n: TsImportEqualsDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsImportType {
+impl AstNode for TsImportType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16272,7 +16480,8 @@ impl From<TsImportType> for SyntaxNode {
 impl From<TsImportType> for SyntaxElement {
     fn from(n: TsImportType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsImportTypeQualifier {
+impl AstNode for TsImportTypeQualifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_IMPORT_TYPE_QUALIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16297,7 +16506,8 @@ impl From<TsImportTypeQualifier> for SyntaxNode {
 impl From<TsImportTypeQualifier> for SyntaxElement {
     fn from(n: TsImportTypeQualifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIndexSignatureClassMember {
+impl AstNode for TsIndexSignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16338,7 +16548,8 @@ impl From<TsIndexSignatureClassMember> for SyntaxNode {
 impl From<TsIndexSignatureClassMember> for SyntaxElement {
     fn from(n: TsIndexSignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIndexSignatureParameter {
+impl AstNode for TsIndexSignatureParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16366,7 +16577,8 @@ impl From<TsIndexSignatureParameter> for SyntaxNode {
 impl From<TsIndexSignatureParameter> for SyntaxElement {
     fn from(n: TsIndexSignatureParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIndexSignatureTypeMember {
+impl AstNode for TsIndexSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16410,7 +16622,8 @@ impl From<TsIndexSignatureTypeMember> for SyntaxNode {
 impl From<TsIndexSignatureTypeMember> for SyntaxElement {
     fn from(n: TsIndexSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIndexedAccessType {
+impl AstNode for TsIndexedAccessType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEXED_ACCESS_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16446,7 +16659,8 @@ impl From<TsIndexedAccessType> for SyntaxNode {
 impl From<TsIndexedAccessType> for SyntaxElement {
     fn from(n: TsIndexedAccessType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsInferType {
+impl AstNode for TsInferType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INFER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16477,7 +16691,8 @@ impl From<TsInferType> for SyntaxNode {
 impl From<TsInferType> for SyntaxElement {
     fn from(n: TsInferType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsInterfaceDeclaration {
+impl AstNode for TsInterfaceDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERFACE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16522,7 +16737,8 @@ impl From<TsInterfaceDeclaration> for SyntaxNode {
 impl From<TsInterfaceDeclaration> for SyntaxElement {
     fn from(n: TsInterfaceDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsIntersectionType {
+impl AstNode for TsIntersectionType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16550,7 +16766,8 @@ impl From<TsIntersectionType> for SyntaxNode {
 impl From<TsIntersectionType> for SyntaxElement {
     fn from(n: TsIntersectionType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMappedType {
+impl AstNode for TsMappedType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16615,7 +16832,8 @@ impl From<TsMappedType> for SyntaxNode {
 impl From<TsMappedType> for SyntaxElement {
     fn from(n: TsMappedType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMappedTypeAsClause {
+impl AstNode for TsMappedTypeAsClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_AS_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16640,7 +16858,8 @@ impl From<TsMappedTypeAsClause> for SyntaxNode {
 impl From<TsMappedTypeAsClause> for SyntaxElement {
     fn from(n: TsMappedTypeAsClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMappedTypeOptionalModifierClause {
+impl AstNode for TsMappedTypeOptionalModifierClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_OPTIONAL_MODIFIER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16671,7 +16890,8 @@ impl From<TsMappedTypeOptionalModifierClause> for SyntaxNode {
 impl From<TsMappedTypeOptionalModifierClause> for SyntaxElement {
     fn from(n: TsMappedTypeOptionalModifierClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMappedTypeReadonlyModifierClause {
+impl AstNode for TsMappedTypeReadonlyModifierClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MAPPED_TYPE_READONLY_MODIFIER_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16702,7 +16922,8 @@ impl From<TsMappedTypeReadonlyModifierClause> for SyntaxNode {
 impl From<TsMappedTypeReadonlyModifierClause> for SyntaxElement {
     fn from(n: TsMappedTypeReadonlyModifierClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMethodSignatureClassMember {
+impl AstNode for TsMethodSignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16748,7 +16969,8 @@ impl From<TsMethodSignatureClassMember> for SyntaxNode {
 impl From<TsMethodSignatureClassMember> for SyntaxElement {
     fn from(n: TsMethodSignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsMethodSignatureTypeMember {
+impl AstNode for TsMethodSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16789,7 +17011,8 @@ impl From<TsMethodSignatureTypeMember> for SyntaxNode {
 impl From<TsMethodSignatureTypeMember> for SyntaxElement {
     fn from(n: TsMethodSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsModuleBlock {
+impl AstNode for TsModuleBlock {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_BLOCK }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16821,7 +17044,8 @@ impl From<TsModuleBlock> for SyntaxNode {
 impl From<TsModuleBlock> for SyntaxElement {
     fn from(n: TsModuleBlock) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsModuleDeclaration {
+impl AstNode for TsModuleDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_MODULE_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16850,7 +17074,8 @@ impl From<TsModuleDeclaration> for SyntaxNode {
 impl From<TsModuleDeclaration> for SyntaxElement {
     fn from(n: TsModuleDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNameWithTypeArguments {
+impl AstNode for TsNameWithTypeArguments {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAME_WITH_TYPE_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16878,7 +17103,8 @@ impl From<TsNameWithTypeArguments> for SyntaxNode {
 impl From<TsNameWithTypeArguments> for SyntaxElement {
     fn from(n: TsNameWithTypeArguments) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNamedTupleTypeElement {
+impl AstNode for TsNamedTupleTypeElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NAMED_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16915,7 +17141,8 @@ impl From<TsNamedTupleTypeElement> for SyntaxNode {
 impl From<TsNamedTupleTypeElement> for SyntaxElement {
     fn from(n: TsNamedTupleTypeElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNeverType {
+impl AstNode for TsNeverType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NEVER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16942,7 +17169,8 @@ impl From<TsNeverType> for SyntaxNode {
 impl From<TsNeverType> for SyntaxElement {
     fn from(n: TsNeverType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNonNullAssertionAssignment {
+impl AstNode for TsNonNullAssertionAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL_ASSERTION_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16967,7 +17195,8 @@ impl From<TsNonNullAssertionAssignment> for SyntaxNode {
 impl From<TsNonNullAssertionAssignment> for SyntaxElement {
     fn from(n: TsNonNullAssertionAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNonNullAssertionExpression {
+impl AstNode for TsNonNullAssertionExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_NULL_ASSERTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -16992,7 +17221,8 @@ impl From<TsNonNullAssertionExpression> for SyntaxNode {
 impl From<TsNonNullAssertionExpression> for SyntaxElement {
     fn from(n: TsNonNullAssertionExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNonPrimitiveType {
+impl AstNode for TsNonPrimitiveType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NON_PRIMITIVE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17019,7 +17249,8 @@ impl From<TsNonPrimitiveType> for SyntaxNode {
 impl From<TsNonPrimitiveType> for SyntaxElement {
     fn from(n: TsNonPrimitiveType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNullLiteralType {
+impl AstNode for TsNullLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NULL_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17046,7 +17277,8 @@ impl From<TsNullLiteralType> for SyntaxNode {
 impl From<TsNullLiteralType> for SyntaxElement {
     fn from(n: TsNullLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNumberLiteralType {
+impl AstNode for TsNumberLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17077,7 +17309,8 @@ impl From<TsNumberLiteralType> for SyntaxNode {
 impl From<TsNumberLiteralType> for SyntaxElement {
     fn from(n: TsNumberLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsNumberType {
+impl AstNode for TsNumberType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_NUMBER_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17104,7 +17337,8 @@ impl From<TsNumberType> for SyntaxNode {
 impl From<TsNumberType> for SyntaxElement {
     fn from(n: TsNumberType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsObjectType {
+impl AstNode for TsObjectType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OBJECT_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17136,7 +17370,8 @@ impl From<TsObjectType> for SyntaxNode {
 impl From<TsObjectType> for SyntaxElement {
     fn from(n: TsObjectType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsOptionalPropertyAnnotation {
+impl AstNode for TsOptionalPropertyAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OPTIONAL_PROPERTY_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17167,7 +17402,8 @@ impl From<TsOptionalPropertyAnnotation> for SyntaxNode {
 impl From<TsOptionalPropertyAnnotation> for SyntaxElement {
     fn from(n: TsOptionalPropertyAnnotation) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsOptionalTupleTypeElement {
+impl AstNode for TsOptionalTupleTypeElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OPTIONAL_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17195,7 +17431,8 @@ impl From<TsOptionalTupleTypeElement> for SyntaxNode {
 impl From<TsOptionalTupleTypeElement> for SyntaxElement {
     fn from(n: TsOptionalTupleTypeElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsOverrideModifier {
+impl AstNode for TsOverrideModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_OVERRIDE_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17222,7 +17459,8 @@ impl From<TsOverrideModifier> for SyntaxNode {
 impl From<TsOverrideModifier> for SyntaxElement {
     fn from(n: TsOverrideModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsParenthesizedType {
+impl AstNode for TsParenthesizedType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PARENTHESIZED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17254,7 +17492,8 @@ impl From<TsParenthesizedType> for SyntaxNode {
 impl From<TsParenthesizedType> for SyntaxElement {
     fn from(n: TsParenthesizedType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsPredicateReturnType {
+impl AstNode for TsPredicateReturnType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PREDICATE_RETURN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17283,7 +17522,8 @@ impl From<TsPredicateReturnType> for SyntaxNode {
 impl From<TsPredicateReturnType> for SyntaxElement {
     fn from(n: TsPredicateReturnType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsPropertyParameter {
+impl AstNode for TsPropertyParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17311,7 +17551,8 @@ impl From<TsPropertyParameter> for SyntaxNode {
 impl From<TsPropertyParameter> for SyntaxElement {
     fn from(n: TsPropertyParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsPropertySignatureClassMember {
+impl AstNode for TsPropertySignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17344,7 +17585,8 @@ impl From<TsPropertySignatureClassMember> for SyntaxNode {
 impl From<TsPropertySignatureClassMember> for SyntaxElement {
     fn from(n: TsPropertySignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsPropertySignatureTypeMember {
+impl AstNode for TsPropertySignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17384,7 +17626,8 @@ impl From<TsPropertySignatureTypeMember> for SyntaxNode {
 impl From<TsPropertySignatureTypeMember> for SyntaxElement {
     fn from(n: TsPropertySignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsQualifiedModuleName {
+impl AstNode for TsQualifiedModuleName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_MODULE_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17410,7 +17653,8 @@ impl From<TsQualifiedModuleName> for SyntaxNode {
 impl From<TsQualifiedModuleName> for SyntaxElement {
     fn from(n: TsQualifiedModuleName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsQualifiedName {
+impl AstNode for TsQualifiedName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_QUALIFIED_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17436,7 +17680,8 @@ impl From<TsQualifiedName> for SyntaxNode {
 impl From<TsQualifiedName> for SyntaxElement {
     fn from(n: TsQualifiedName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsReadonlyModifier {
+impl AstNode for TsReadonlyModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_READONLY_MODIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17463,7 +17708,8 @@ impl From<TsReadonlyModifier> for SyntaxNode {
 impl From<TsReadonlyModifier> for SyntaxElement {
     fn from(n: TsReadonlyModifier) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsReferenceType {
+impl AstNode for TsReferenceType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_REFERENCE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17491,7 +17737,8 @@ impl From<TsReferenceType> for SyntaxNode {
 impl From<TsReferenceType> for SyntaxElement {
     fn from(n: TsReferenceType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsRestTupleTypeElement {
+impl AstNode for TsRestTupleTypeElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_REST_TUPLE_TYPE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17519,7 +17766,8 @@ impl From<TsRestTupleTypeElement> for SyntaxNode {
 impl From<TsRestTupleTypeElement> for SyntaxElement {
     fn from(n: TsRestTupleTypeElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsReturnTypeAnnotation {
+impl AstNode for TsReturnTypeAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_RETURN_TYPE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17547,7 +17795,8 @@ impl From<TsReturnTypeAnnotation> for SyntaxNode {
 impl From<TsReturnTypeAnnotation> for SyntaxElement {
     fn from(n: TsReturnTypeAnnotation) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsSetterSignatureClassMember {
+impl AstNode for TsSetterSignatureClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SETTER_SIGNATURE_CLASS_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17586,7 +17835,8 @@ impl From<TsSetterSignatureClassMember> for SyntaxNode {
 impl From<TsSetterSignatureClassMember> for SyntaxElement {
     fn from(n: TsSetterSignatureClassMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsSetterSignatureTypeMember {
+impl AstNode for TsSetterSignatureTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SETTER_SIGNATURE_TYPE_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17624,7 +17874,8 @@ impl From<TsSetterSignatureTypeMember> for SyntaxNode {
 impl From<TsSetterSignatureTypeMember> for SyntaxElement {
     fn from(n: TsSetterSignatureTypeMember) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsStringLiteralType {
+impl AstNode for TsStringLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17651,7 +17902,8 @@ impl From<TsStringLiteralType> for SyntaxNode {
 impl From<TsStringLiteralType> for SyntaxElement {
     fn from(n: TsStringLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsStringType {
+impl AstNode for TsStringType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_STRING_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17678,7 +17930,8 @@ impl From<TsStringType> for SyntaxNode {
 impl From<TsStringType> for SyntaxElement {
     fn from(n: TsStringType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsSymbolType {
+impl AstNode for TsSymbolType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_SYMBOL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17705,7 +17958,8 @@ impl From<TsSymbolType> for SyntaxNode {
 impl From<TsSymbolType> for SyntaxElement {
     fn from(n: TsSymbolType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTemplateChunkElement {
+impl AstNode for TsTemplateChunkElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_CHUNK_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17732,7 +17986,8 @@ impl From<TsTemplateChunkElement> for SyntaxNode {
 impl From<TsTemplateChunkElement> for SyntaxElement {
     fn from(n: TsTemplateChunkElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTemplateElement {
+impl AstNode for TsTemplateElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17764,7 +18019,8 @@ impl From<TsTemplateElement> for SyntaxNode {
 impl From<TsTemplateElement> for SyntaxElement {
     fn from(n: TsTemplateElement) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTemplateLiteralType {
+impl AstNode for TsTemplateLiteralType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_LITERAL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17796,7 +18052,8 @@ impl From<TsTemplateLiteralType> for SyntaxNode {
 impl From<TsTemplateLiteralType> for SyntaxElement {
     fn from(n: TsTemplateLiteralType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsThisParameter {
+impl AstNode for TsThisParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17824,7 +18081,8 @@ impl From<TsThisParameter> for SyntaxNode {
 impl From<TsThisParameter> for SyntaxElement {
     fn from(n: TsThisParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsThisType {
+impl AstNode for TsThisType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_THIS_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17848,7 +18106,8 @@ impl From<TsThisType> for SyntaxNode {
 impl From<TsThisType> for SyntaxElement {
     fn from(n: TsThisType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTupleType {
+impl AstNode for TsTupleType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17880,7 +18139,8 @@ impl From<TsTupleType> for SyntaxNode {
 impl From<TsTupleType> for SyntaxElement {
     fn from(n: TsTupleType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeAliasDeclaration {
+impl AstNode for TsTypeAliasDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ALIAS_DECLARATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17918,7 +18178,8 @@ impl From<TsTypeAliasDeclaration> for SyntaxNode {
 impl From<TsTypeAliasDeclaration> for SyntaxElement {
     fn from(n: TsTypeAliasDeclaration) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeAnnotation {
+impl AstNode for TsTypeAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ANNOTATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17946,7 +18207,8 @@ impl From<TsTypeAnnotation> for SyntaxNode {
 impl From<TsTypeAnnotation> for SyntaxElement {
     fn from(n: TsTypeAnnotation) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeArguments {
+impl AstNode for TsTypeArguments {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -17978,7 +18240,8 @@ impl From<TsTypeArguments> for SyntaxNode {
 impl From<TsTypeArguments> for SyntaxElement {
     fn from(n: TsTypeArguments) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeAssertionAssignment {
+impl AstNode for TsTypeAssertionAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ASSERTION_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18011,7 +18274,8 @@ impl From<TsTypeAssertionAssignment> for SyntaxNode {
 impl From<TsTypeAssertionAssignment> for SyntaxElement {
     fn from(n: TsTypeAssertionAssignment) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeAssertionExpression {
+impl AstNode for TsTypeAssertionExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ASSERTION_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18044,7 +18308,8 @@ impl From<TsTypeAssertionExpression> for SyntaxNode {
 impl From<TsTypeAssertionExpression> for SyntaxElement {
     fn from(n: TsTypeAssertionExpression) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeConstraintClause {
+impl AstNode for TsTypeConstraintClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_CONSTRAINT_CLAUSE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18072,7 +18337,8 @@ impl From<TsTypeConstraintClause> for SyntaxNode {
 impl From<TsTypeConstraintClause> for SyntaxElement {
     fn from(n: TsTypeConstraintClause) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeOperatorType {
+impl AstNode for TsTypeOperatorType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_OPERATOR_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18100,7 +18366,8 @@ impl From<TsTypeOperatorType> for SyntaxNode {
 impl From<TsTypeOperatorType> for SyntaxElement {
     fn from(n: TsTypeOperatorType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeParameter {
+impl AstNode for TsTypeParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18129,7 +18396,8 @@ impl From<TsTypeParameter> for SyntaxNode {
 impl From<TsTypeParameter> for SyntaxElement {
     fn from(n: TsTypeParameter) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeParameterName {
+impl AstNode for TsTypeParameterName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18156,7 +18424,8 @@ impl From<TsTypeParameterName> for SyntaxNode {
 impl From<TsTypeParameterName> for SyntaxElement {
     fn from(n: TsTypeParameterName) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeParameters {
+impl AstNode for TsTypeParameters {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETERS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18188,7 +18457,8 @@ impl From<TsTypeParameters> for SyntaxNode {
 impl From<TsTypeParameters> for SyntaxElement {
     fn from(n: TsTypeParameters) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsTypeofType {
+impl AstNode for TsTypeofType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPEOF_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18219,7 +18489,8 @@ impl From<TsTypeofType> for SyntaxNode {
 impl From<TsTypeofType> for SyntaxElement {
     fn from(n: TsTypeofType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsUndefinedType {
+impl AstNode for TsUndefinedType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNDEFINED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18246,7 +18517,8 @@ impl From<TsUndefinedType> for SyntaxNode {
 impl From<TsUndefinedType> for SyntaxElement {
     fn from(n: TsUndefinedType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsUnionType {
+impl AstNode for TsUnionType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18274,7 +18546,8 @@ impl From<TsUnionType> for SyntaxNode {
 impl From<TsUnionType> for SyntaxElement {
     fn from(n: TsUnionType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsUnknownType {
+impl AstNode for TsUnknownType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNKNOWN_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18301,7 +18574,8 @@ impl From<TsUnknownType> for SyntaxNode {
 impl From<TsUnknownType> for SyntaxElement {
     fn from(n: TsUnknownType) -> SyntaxElement { n.syntax.into() }
 }
-impl AstNode<Language> for TsVoidType {
+impl AstNode for TsVoidType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_VOID_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -18340,7 +18614,8 @@ impl From<JsAssignmentWithDefault> for JsAnyArrayAssignmentPatternElement {
         JsAnyArrayAssignmentPatternElement::JsAssignmentWithDefault(node)
     }
 }
-impl AstNode<Language> for JsAnyArrayAssignmentPatternElement {
+impl AstNode for JsAnyArrayAssignmentPatternElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT
@@ -18436,7 +18711,8 @@ impl From<JsBindingPatternWithDefault> for JsAnyArrayBindingPatternElement {
         JsAnyArrayBindingPatternElement::JsBindingPatternWithDefault(node)
     }
 }
-impl AstNode<Language> for JsAnyArrayBindingPatternElement {
+impl AstNode for JsAnyArrayBindingPatternElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_BINDING_PATTERN_REST_ELEMENT
@@ -18515,7 +18791,8 @@ impl From<JsArrayHole> for JsAnyArrayElement {
 impl From<JsSpread> for JsAnyArrayElement {
     fn from(node: JsSpread) -> JsAnyArrayElement { JsAnyArrayElement::JsSpread(node) }
 }
-impl AstNode<Language> for JsAnyArrayElement {
+impl AstNode for JsAnyArrayElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_HOLE | JS_SPREAD => true,
@@ -18573,7 +18850,8 @@ impl From<JsParameters> for JsAnyArrowFunctionParameters {
         JsAnyArrowFunctionParameters::JsParameters(node)
     }
 }
-impl AstNode<Language> for JsAnyArrowFunctionParameters {
+impl AstNode for JsAnyArrowFunctionParameters {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_PARAMETERS => true,
@@ -18660,7 +18938,8 @@ impl From<TsTypeAssertionAssignment> for JsAnyAssignment {
         JsAnyAssignment::TsTypeAssertionAssignment(node)
     }
 }
-impl AstNode<Language> for JsAnyAssignment {
+impl AstNode for JsAnyAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -18761,7 +19040,8 @@ impl From<JsObjectAssignmentPattern> for JsAnyAssignmentPattern {
         JsAnyAssignmentPattern::JsObjectAssignmentPattern(node)
     }
 }
-impl AstNode<Language> for JsAnyAssignmentPattern {
+impl AstNode for JsAnyAssignmentPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_ASSIGNMENT_PATTERN | JS_OBJECT_ASSIGNMENT_PATTERN => true,
@@ -18828,7 +19108,8 @@ impl From<JsIdentifierBinding> for JsAnyBinding {
 impl From<JsUnknownBinding> for JsAnyBinding {
     fn from(node: JsUnknownBinding) -> JsAnyBinding { JsAnyBinding::JsUnknownBinding(node) }
 }
-impl AstNode<Language> for JsAnyBinding {
+impl AstNode for JsAnyBinding {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_IDENTIFIER_BINDING | JS_UNKNOWN_BINDING)
     }
@@ -18881,7 +19162,8 @@ impl From<JsObjectBindingPattern> for JsAnyBindingPattern {
         JsAnyBindingPattern::JsObjectBindingPattern(node)
     }
 }
-impl AstNode<Language> for JsAnyBindingPattern {
+impl AstNode for JsAnyBindingPattern {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_ARRAY_BINDING_PATTERN | JS_OBJECT_BINDING_PATTERN => true,
@@ -18941,7 +19223,8 @@ impl From<JsAnyBindingPattern> for SyntaxElement {
 impl From<JsSpread> for JsAnyCallArgument {
     fn from(node: JsSpread) -> JsAnyCallArgument { JsAnyCallArgument::JsSpread(node) }
 }
-impl AstNode<Language> for JsAnyCallArgument {
+impl AstNode for JsAnyCallArgument {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_SPREAD => true,
@@ -19001,7 +19284,8 @@ impl From<JsClassExportDefaultDeclaration> for JsAnyClass {
 impl From<JsClassExpression> for JsAnyClass {
     fn from(node: JsClassExpression) -> JsAnyClass { JsAnyClass::JsClassExpression(node) }
 }
-impl AstNode<Language> for JsAnyClass {
+impl AstNode for JsAnyClass {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -19121,7 +19405,8 @@ impl From<TsSetterSignatureClassMember> for JsAnyClassMember {
         JsAnyClassMember::TsSetterSignatureClassMember(node)
     }
 }
-impl AstNode<Language> for JsAnyClassMember {
+impl AstNode for JsAnyClassMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -19283,7 +19568,8 @@ impl From<JsPrivateClassMemberName> for JsAnyClassMemberName {
         JsAnyClassMemberName::JsPrivateClassMemberName(node)
     }
 }
-impl AstNode<Language> for JsAnyClassMemberName {
+impl AstNode for JsAnyClassMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -19347,7 +19633,8 @@ impl From<TsPropertyParameter> for JsAnyConstructorParameter {
         JsAnyConstructorParameter::TsPropertyParameter(node)
     }
 }
-impl AstNode<Language> for JsAnyConstructorParameter {
+impl AstNode for JsAnyConstructorParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_REST_PARAMETER | TS_PROPERTY_PARAMETER => true,
@@ -19461,7 +19748,8 @@ impl From<TsTypeAliasDeclaration> for JsAnyDeclaration {
         JsAnyDeclaration::TsTypeAliasDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyDeclaration {
+impl AstNode for JsAnyDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -19632,7 +19920,8 @@ impl From<TsTypeAliasDeclaration> for JsAnyDeclarationClause {
         JsAnyDeclarationClause::TsTypeAliasDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyDeclarationClause {
+impl AstNode for JsAnyDeclarationClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -19792,7 +20081,8 @@ impl From<TsExportDeclareClause> for JsAnyExportClause {
         JsAnyExportClause::TsExportDeclareClause(node)
     }
 }
-impl AstNode<Language> for JsAnyExportClause {
+impl AstNode for JsAnyExportClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_EXPORT_DEFAULT_DECLARATION_CLAUSE
@@ -19918,7 +20208,8 @@ impl From<TsInterfaceDeclaration> for JsAnyExportDefaultDeclaration {
         JsAnyExportDefaultDeclaration::TsInterfaceDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyExportDefaultDeclaration {
+impl AstNode for JsAnyExportDefaultDeclaration {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -20007,7 +20298,8 @@ impl From<JsExportNamedSpecifier> for JsAnyExportNamedSpecifier {
         JsAnyExportNamedSpecifier::JsExportNamedSpecifier(node)
     }
 }
-impl AstNode<Language> for JsAnyExportNamedSpecifier {
+impl AstNode for JsAnyExportNamedSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -20199,7 +20491,8 @@ impl From<TsTypeAssertionExpression> for JsAnyExpression {
         JsAnyExpression::TsTypeAssertionExpression(node)
     }
 }
-impl AstNode<Language> for JsAnyExpression {
+impl AstNode for JsAnyExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             IMPORT_META
@@ -20460,7 +20753,8 @@ impl From<JsForVariableDeclaration> for JsAnyForInOrOfInitializer {
         JsAnyForInOrOfInitializer::JsForVariableDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyForInOrOfInitializer {
+impl AstNode for JsAnyForInOrOfInitializer {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_FOR_VARIABLE_DECLARATION => true,
@@ -20520,7 +20814,8 @@ impl From<JsVariableDeclaration> for JsAnyForInitializer {
         JsAnyForInitializer::JsVariableDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyForInitializer {
+impl AstNode for JsAnyForInitializer {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_VARIABLE_DECLARATION => true,
@@ -20581,7 +20876,8 @@ impl From<JsUnknownParameter> for JsAnyFormalParameter {
         JsAnyFormalParameter::JsUnknownParameter(node)
     }
 }
-impl AstNode<Language> for JsAnyFormalParameter {
+impl AstNode for JsAnyFormalParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_FORMAL_PARAMETER | JS_UNKNOWN_PARAMETER)
     }
@@ -20646,7 +20942,8 @@ impl From<JsFunctionExpression> for JsAnyFunction {
         JsAnyFunction::JsFunctionExpression(node)
     }
 }
-impl AstNode<Language> for JsAnyFunction {
+impl AstNode for JsAnyFunction {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -20714,7 +21011,8 @@ impl From<JsAnyFunction> for SyntaxElement {
 impl From<JsFunctionBody> for JsAnyFunctionBody {
     fn from(node: JsFunctionBody) -> JsAnyFunctionBody { JsAnyFunctionBody::JsFunctionBody(node) }
 }
-impl AstNode<Language> for JsAnyFunctionBody {
+impl AstNode for JsAnyFunctionBody {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_FUNCTION_BODY => true,
@@ -20773,7 +21071,8 @@ impl From<JsUnknownImportAssertionEntry> for JsAnyImportAssertionEntry {
         JsAnyImportAssertionEntry::JsUnknownImportAssertionEntry(node)
     }
 }
-impl AstNode<Language> for JsAnyImportAssertionEntry {
+impl AstNode for JsAnyImportAssertionEntry {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -20845,7 +21144,8 @@ impl From<JsImportNamespaceClause> for JsAnyImportClause {
         JsAnyImportClause::JsImportNamespaceClause(node)
     }
 }
-impl AstNode<Language> for JsAnyImportClause {
+impl AstNode for JsAnyImportClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -20911,7 +21211,8 @@ impl From<JsAnyImportClause> for SyntaxElement {
 impl From<JsPrivateName> for JsAnyInProperty {
     fn from(node: JsPrivateName) -> JsAnyInProperty { JsAnyInProperty::JsPrivateName(node) }
 }
-impl AstNode<Language> for JsAnyInProperty {
+impl AstNode for JsAnyInProperty {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_PRIVATE_NAME => true,
@@ -20990,7 +21291,8 @@ impl From<JsStringLiteralExpression> for JsAnyLiteralExpression {
         JsAnyLiteralExpression::JsStringLiteralExpression(node)
     }
 }
-impl AstNode<Language> for JsAnyLiteralExpression {
+impl AstNode for JsAnyLiteralExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21092,7 +21394,8 @@ impl From<TsOverrideModifier> for JsAnyMethodModifier {
         JsAnyMethodModifier::TsOverrideModifier(node)
     }
 }
-impl AstNode<Language> for JsAnyMethodModifier {
+impl AstNode for JsAnyMethodModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21152,7 +21455,8 @@ impl From<JsExport> for JsAnyModuleItem {
 impl From<JsImport> for JsAnyModuleItem {
     fn from(node: JsImport) -> JsAnyModuleItem { JsAnyModuleItem::JsImport(node) }
 }
-impl AstNode<Language> for JsAnyModuleItem {
+impl AstNode for JsAnyModuleItem {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_EXPORT | JS_IMPORT => true,
@@ -21211,7 +21515,8 @@ impl From<JsName> for JsAnyName {
 impl From<JsPrivateName> for JsAnyName {
     fn from(node: JsPrivateName) -> JsAnyName { JsAnyName::JsPrivateName(node) }
 }
-impl AstNode<Language> for JsAnyName {
+impl AstNode for JsAnyName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_NAME | JS_PRIVATE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -21260,7 +21565,8 @@ impl From<JsNamespaceImportSpecifier> for JsAnyNamedImport {
         JsAnyNamedImport::JsNamespaceImportSpecifier(node)
     }
 }
-impl AstNode<Language> for JsAnyNamedImport {
+impl AstNode for JsAnyNamedImport {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21323,7 +21629,8 @@ impl From<JsUnknownNamedImportSpecifier> for JsAnyNamedImportSpecifier {
         JsAnyNamedImportSpecifier::JsUnknownNamedImportSpecifier(node)
     }
 }
-impl AstNode<Language> for JsAnyNamedImportSpecifier {
+impl AstNode for JsAnyNamedImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21409,7 +21716,8 @@ impl From<JsUnknownAssignment> for JsAnyObjectAssignmentPatternMember {
         JsAnyObjectAssignmentPatternMember::JsUnknownAssignment(node)
     }
 }
-impl AstNode<Language> for JsAnyObjectAssignmentPatternMember {
+impl AstNode for JsAnyObjectAssignmentPatternMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21517,7 +21825,8 @@ impl From<JsUnknownBinding> for JsAnyObjectBindingPatternMember {
         JsAnyObjectBindingPatternMember::JsUnknownBinding(node)
     }
 }
-impl AstNode<Language> for JsAnyObjectBindingPatternMember {
+impl AstNode for JsAnyObjectBindingPatternMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21634,7 +21943,8 @@ impl From<JsSpread> for JsAnyObjectMember {
 impl From<JsUnknownMember> for JsAnyObjectMember {
     fn from(node: JsUnknownMember) -> JsAnyObjectMember { JsAnyObjectMember::JsUnknownMember(node) }
 }
-impl AstNode<Language> for JsAnyObjectMember {
+impl AstNode for JsAnyObjectMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21726,7 +22036,8 @@ impl From<JsLiteralMemberName> for JsAnyObjectMemberName {
         JsAnyObjectMemberName::JsLiteralMemberName(node)
     }
 }
-impl AstNode<Language> for JsAnyObjectMemberName {
+impl AstNode for JsAnyObjectMemberName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_COMPUTED_MEMBER_NAME | JS_LITERAL_MEMBER_NAME)
     }
@@ -21777,7 +22088,8 @@ impl From<JsRestParameter> for JsAnyParameter {
 impl From<TsThisParameter> for JsAnyParameter {
     fn from(node: TsThisParameter) -> JsAnyParameter { JsAnyParameter::TsThisParameter(node) }
 }
-impl AstNode<Language> for JsAnyParameter {
+impl AstNode for JsAnyParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JS_REST_PARAMETER | TS_THIS_PARAMETER => true,
@@ -21852,7 +22164,8 @@ impl From<TsReadonlyModifier> for JsAnyPropertyModifier {
         JsAnyPropertyModifier::TsReadonlyModifier(node)
     }
 }
-impl AstNode<Language> for JsAnyPropertyModifier {
+impl AstNode for JsAnyPropertyModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -21924,7 +22237,8 @@ impl From<JsModule> for JsAnyRoot {
 impl From<JsScript> for JsAnyRoot {
     fn from(node: JsScript) -> JsAnyRoot { JsAnyRoot::JsScript(node) }
 }
-impl AstNode<Language> for JsAnyRoot {
+impl AstNode for JsAnyRoot {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_EXPRESSION_SNIPPED | JS_MODULE | JS_SCRIPT)
     }
@@ -22091,7 +22405,8 @@ impl From<TsTypeAliasDeclaration> for JsAnyStatement {
         JsAnyStatement::TsTypeAliasDeclaration(node)
     }
 }
-impl AstNode<Language> for JsAnyStatement {
+impl AstNode for JsAnyStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -22330,7 +22645,8 @@ impl From<JsCaseClause> for JsAnySwitchClause {
 impl From<JsDefaultClause> for JsAnySwitchClause {
     fn from(node: JsDefaultClause) -> JsAnySwitchClause { JsAnySwitchClause::JsDefaultClause(node) }
 }
-impl AstNode<Language> for JsAnySwitchClause {
+impl AstNode for JsAnySwitchClause {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_CASE_CLAUSE | JS_DEFAULT_CLAUSE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -22379,7 +22695,8 @@ impl From<JsTemplateElement> for JsAnyTemplateElement {
         JsAnyTemplateElement::JsTemplateElement(node)
     }
 }
-impl AstNode<Language> for JsAnyTemplateElement {
+impl AstNode for JsAnyTemplateElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_TEMPLATE_CHUNK_ELEMENT | JS_TEMPLATE_ELEMENT)
     }
@@ -22432,7 +22749,8 @@ impl From<JsxSpreadAttribute> for JsxAnyAttribute {
         JsxAnyAttribute::JsxSpreadAttribute(node)
     }
 }
-impl AstNode<Language> for JsxAnyAttribute {
+impl AstNode for JsxAnyAttribute {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_ATTRIBUTE | JSX_SPREAD_ATTRIBUTE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -22481,7 +22799,8 @@ impl From<JsxNamespaceName> for JsxAnyAttributeName {
         JsxAnyAttributeName::JsxNamespaceName(node)
     }
 }
-impl AstNode<Language> for JsxAnyAttributeName {
+impl AstNode for JsxAnyAttributeName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_NAME | JSX_NAMESPACE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -22530,7 +22849,8 @@ impl From<JsxExpressionAttributeValue> for JsxAnyAttributeValue {
 impl From<JsxString> for JsxAnyAttributeValue {
     fn from(node: JsxString) -> JsxAnyAttributeValue { JsxAnyAttributeValue::JsxString(node) }
 }
-impl AstNode<Language> for JsxAnyAttributeValue {
+impl AstNode for JsxAnyAttributeValue {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             JSX_EXPRESSION_ATTRIBUTE_VALUE | JSX_STRING => true,
@@ -22605,7 +22925,8 @@ impl From<JsxSpreadChild> for JsxAnyChild {
 impl From<JsxText> for JsxAnyChild {
     fn from(node: JsxText) -> JsxAnyChild { JsxAnyChild::JsxText(node) }
 }
-impl AstNode<Language> for JsxAnyChild {
+impl AstNode for JsxAnyChild {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -22688,7 +23009,8 @@ impl From<JsxReferenceIdentifier> for JsxAnyElementName {
         JsxAnyElementName::JsxReferenceIdentifier(node)
     }
 }
-impl AstNode<Language> for JsxAnyElementName {
+impl AstNode for JsxAnyElementName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -22748,7 +23070,8 @@ impl From<JsxName> for JsxAnyName {
 impl From<JsxNamespaceName> for JsxAnyName {
     fn from(node: JsxNamespaceName) -> JsxAnyName { JsxAnyName::JsxNamespaceName(node) }
 }
-impl AstNode<Language> for JsxAnyName {
+impl AstNode for JsxAnyName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JSX_NAME | JSX_NAMESPACE_NAME) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -22798,7 +23121,8 @@ impl From<JsxReferenceIdentifier> for JsxAnyObjectName {
         JsxAnyObjectName::JsxReferenceIdentifier(node)
     }
 }
-impl AstNode<Language> for JsxAnyObjectName {
+impl AstNode for JsxAnyObjectName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -22857,7 +23181,8 @@ impl From<JsxFragment> for JsxAnyTag {
 impl From<JsxSelfClosingElement> for JsxAnyTag {
     fn from(node: JsxSelfClosingElement) -> JsxAnyTag { JsxAnyTag::JsxSelfClosingElement(node) }
 }
-impl AstNode<Language> for JsxAnyTag {
+impl AstNode for JsxAnyTag {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JSX_ELEMENT | JSX_FRAGMENT | JSX_SELF_CLOSING_ELEMENT)
     }
@@ -22914,7 +23239,8 @@ impl From<TsModuleBlock> for TsAnyExternalModuleDeclarationBody {
         TsAnyExternalModuleDeclarationBody::TsModuleBlock(node)
     }
 }
-impl AstNode<Language> for TsAnyExternalModuleDeclarationBody {
+impl AstNode for TsAnyExternalModuleDeclarationBody {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -22980,7 +23306,8 @@ impl From<TsReadonlyModifier> for TsAnyIndexSignatureModifier {
         TsAnyIndexSignatureModifier::TsReadonlyModifier(node)
     }
 }
-impl AstNode<Language> for TsAnyIndexSignatureModifier {
+impl AstNode for TsAnyIndexSignatureModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_STATIC_MODIFIER | TS_READONLY_MODIFIER)
     }
@@ -23045,7 +23372,8 @@ impl From<TsOverrideModifier> for TsAnyMethodSignatureModifier {
         TsAnyMethodSignatureModifier::TsOverrideModifier(node)
     }
 }
-impl AstNode<Language> for TsAnyMethodSignatureModifier {
+impl AstNode for TsAnyMethodSignatureModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -23122,7 +23450,8 @@ impl From<TsQualifiedModuleName> for TsAnyModuleName {
         TsAnyModuleName::TsQualifiedModuleName(node)
     }
 }
-impl AstNode<Language> for TsAnyModuleName {
+impl AstNode for TsAnyModuleName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_IDENTIFIER_BINDING | TS_QUALIFIED_MODULE_NAME)
     }
@@ -23172,7 +23501,8 @@ impl From<TsExternalModuleReference> for TsAnyModuleReference {
         TsAnyModuleReference::TsExternalModuleReference(node)
     }
 }
-impl AstNode<Language> for TsAnyModuleReference {
+impl AstNode for TsAnyModuleReference {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_EXTERNAL_MODULE_REFERENCE => true,
@@ -23231,7 +23561,8 @@ impl From<JsReferenceIdentifier> for TsAnyName {
 impl From<TsQualifiedName> for TsAnyName {
     fn from(node: TsQualifiedName) -> TsAnyName { TsAnyName::TsQualifiedName(node) }
 }
-impl AstNode<Language> for TsAnyName {
+impl AstNode for TsAnyName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, JS_REFERENCE_IDENTIFIER | TS_QUALIFIED_NAME)
     }
@@ -23289,7 +23620,8 @@ impl From<TsTypeAnnotation> for TsAnyPropertyAnnotation {
         TsAnyPropertyAnnotation::TsTypeAnnotation(node)
     }
 }
-impl AstNode<Language> for TsAnyPropertyAnnotation {
+impl AstNode for TsAnyPropertyAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -23366,7 +23698,8 @@ impl From<TsReadonlyModifier> for TsAnyPropertyParameterModifier {
         TsAnyPropertyParameterModifier::TsReadonlyModifier(node)
     }
 }
-impl AstNode<Language> for TsAnyPropertyParameterModifier {
+impl AstNode for TsAnyPropertyParameterModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -23434,7 +23767,8 @@ impl From<TsTypeAnnotation> for TsAnyPropertySignatureAnnotation {
         TsAnyPropertySignatureAnnotation::TsTypeAnnotation(node)
     }
 }
-impl AstNode<Language> for TsAnyPropertySignatureAnnotation {
+impl AstNode for TsAnyPropertySignatureAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_OPTIONAL_PROPERTY_ANNOTATION | TS_TYPE_ANNOTATION)
     }
@@ -23513,7 +23847,8 @@ impl From<TsReadonlyModifier> for TsAnyPropertySignatureModifier {
         TsAnyPropertySignatureModifier::TsReadonlyModifier(node)
     }
 }
-impl AstNode<Language> for TsAnyPropertySignatureModifier {
+impl AstNode for TsAnyPropertySignatureModifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -23604,7 +23939,8 @@ impl From<TsPredicateReturnType> for TsAnyReturnType {
         TsAnyReturnType::TsPredicateReturnType(node)
     }
 }
-impl AstNode<Language> for TsAnyReturnType {
+impl AstNode for TsAnyReturnType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_ASSERTS_RETURN_TYPE | TS_PREDICATE_RETURN_TYPE => true,
@@ -23671,7 +24007,8 @@ impl From<TsTemplateElement> for TsAnyTemplateElement {
         TsAnyTemplateElement::TsTemplateElement(node)
     }
 }
-impl AstNode<Language> for TsAnyTemplateElement {
+impl AstNode for TsAnyTemplateElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_TEMPLATE_CHUNK_ELEMENT | TS_TEMPLATE_ELEMENT)
     }
@@ -23731,7 +24068,8 @@ impl From<TsRestTupleTypeElement> for TsAnyTupleTypeElement {
         TsAnyTupleTypeElement::TsRestTupleTypeElement(node)
     }
 }
-impl AstNode<Language> for TsAnyTupleTypeElement {
+impl AstNode for TsAnyTupleTypeElement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             TS_NAMED_TUPLE_TYPE_ELEMENT
@@ -23836,7 +24174,8 @@ impl From<TsSetterSignatureTypeMember> for TsAnyTypeMember {
         TsAnyTypeMember::TsSetterSignatureTypeMember(node)
     }
 }
-impl AstNode<Language> for TsAnyTypeMember {
+impl AstNode for TsAnyTypeMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -23939,7 +24278,8 @@ impl From<TsThisType> for TsAnyTypePredicateParameterName {
         TsAnyTypePredicateParameterName::TsThisType(node)
     }
 }
-impl AstNode<Language> for TsAnyTypePredicateParameterName {
+impl AstNode for TsAnyTypePredicateParameterName {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { matches!(kind, JS_REFERENCE_IDENTIFIER | TS_THIS_TYPE) }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
@@ -23994,7 +24334,8 @@ impl From<TsTypeAnnotation> for TsAnyVariableAnnotation {
         TsAnyVariableAnnotation::TsTypeAnnotation(node)
     }
 }
-impl AstNode<Language> for TsAnyVariableAnnotation {
+impl AstNode for TsAnyVariableAnnotation {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(kind, TS_DEFINITE_VARIABLE_ANNOTATION | TS_TYPE_ANNOTATION)
     }
@@ -24145,7 +24486,8 @@ impl From<TsUnknownType> for TsType {
 impl From<TsVoidType> for TsType {
     fn from(node: TsVoidType) -> TsType { TsType::TsVoidType(node) }
 }
-impl AstNode<Language> for TsType {
+impl AstNode for TsType {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
             kind,
@@ -26078,7 +26420,8 @@ impl JsUnknown {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknown {
+impl AstNode for JsUnknown {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26116,7 +26459,8 @@ impl JsUnknownAssignment {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownAssignment {
+impl AstNode for JsUnknownAssignment {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_ASSIGNMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26154,7 +26498,8 @@ impl JsUnknownBinding {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownBinding {
+impl AstNode for JsUnknownBinding {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_BINDING }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26192,7 +26537,8 @@ impl JsUnknownExpression {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownExpression {
+impl AstNode for JsUnknownExpression {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_EXPRESSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26230,7 +26576,8 @@ impl JsUnknownImportAssertionEntry {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownImportAssertionEntry {
+impl AstNode for JsUnknownImportAssertionEntry {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_IMPORT_ASSERTION_ENTRY }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26268,7 +26615,8 @@ impl JsUnknownMember {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownMember {
+impl AstNode for JsUnknownMember {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_MEMBER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26306,7 +26654,8 @@ impl JsUnknownNamedImportSpecifier {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownNamedImportSpecifier {
+impl AstNode for JsUnknownNamedImportSpecifier {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_NAMED_IMPORT_SPECIFIER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26344,7 +26693,8 @@ impl JsUnknownParameter {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownParameter {
+impl AstNode for JsUnknownParameter {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_PARAMETER }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26382,7 +26732,8 @@ impl JsUnknownStatement {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self { Self { syntax } }
     pub fn items(&self) -> SyntaxElementChildren { support::elements(&self.syntax) }
 }
-impl AstNode<Language> for JsUnknownStatement {
+impl AstNode for JsUnknownStatement {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_UNKNOWN_STATEMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -26423,7 +26774,8 @@ impl JsArrayAssignmentPatternElementList {
         }
     }
 }
-impl AstNode<Language> for JsArrayAssignmentPatternElementList {
+impl AstNode for JsArrayAssignmentPatternElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayAssignmentPatternElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -26436,9 +26788,9 @@ impl AstNode<Language> for JsArrayAssignmentPatternElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyArrayAssignmentPatternElement>
-    for JsArrayAssignmentPatternElementList
-{
+impl AstSeparatedList for JsArrayAssignmentPatternElementList {
+    type Language = Language;
+    type Node = JsAnyArrayAssignmentPatternElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsArrayAssignmentPatternElementList {
@@ -26474,7 +26826,8 @@ impl JsArrayBindingPatternElementList {
         }
     }
 }
-impl AstNode<Language> for JsArrayBindingPatternElementList {
+impl AstNode for JsArrayBindingPatternElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayBindingPatternElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -26487,9 +26840,9 @@ impl AstNode<Language> for JsArrayBindingPatternElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyArrayBindingPatternElement>
-    for JsArrayBindingPatternElementList
-{
+impl AstSeparatedList for JsArrayBindingPatternElementList {
+    type Language = Language;
+    type Node = JsAnyArrayBindingPatternElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsArrayBindingPatternElementList {
@@ -26525,7 +26878,8 @@ impl JsArrayElementList {
         }
     }
 }
-impl AstNode<Language> for JsArrayElementList {
+impl AstNode for JsArrayElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_ARRAY_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsArrayElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -26538,7 +26892,9 @@ impl AstNode<Language> for JsArrayElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyArrayElement> for JsArrayElementList {
+impl AstSeparatedList for JsArrayElementList {
+    type Language = Language;
+    type Node = JsAnyArrayElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsArrayElementList {
@@ -26574,7 +26930,8 @@ impl JsCallArgumentList {
         }
     }
 }
-impl AstNode<Language> for JsCallArgumentList {
+impl AstNode for JsCallArgumentList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CALL_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsCallArgumentList> {
         if Self::can_cast(syntax.kind()) {
@@ -26587,7 +26944,9 @@ impl AstNode<Language> for JsCallArgumentList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyCallArgument> for JsCallArgumentList {
+impl AstSeparatedList for JsCallArgumentList {
+    type Language = Language;
+    type Node = JsAnyCallArgument;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsCallArgumentList {
@@ -26623,7 +26982,8 @@ impl JsClassMemberList {
         }
     }
 }
-impl AstNode<Language> for JsClassMemberList {
+impl AstNode for JsClassMemberList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CLASS_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsClassMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -26636,7 +26996,9 @@ impl AstNode<Language> for JsClassMemberList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyClassMember> for JsClassMemberList {
+impl AstNodeList for JsClassMemberList {
+    type Language = Language;
+    type Node = JsAnyClassMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsClassMemberList {
@@ -26672,7 +27034,8 @@ impl JsConstructorModifierList {
         }
     }
 }
-impl AstNode<Language> for JsConstructorModifierList {
+impl AstNode for JsConstructorModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsConstructorModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -26685,7 +27048,9 @@ impl AstNode<Language> for JsConstructorModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAccessibilityModifier> for JsConstructorModifierList {
+impl AstNodeList for JsConstructorModifierList {
+    type Language = Language;
+    type Node = TsAccessibilityModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsConstructorModifierList {
@@ -26721,7 +27086,8 @@ impl JsConstructorParameterList {
         }
     }
 }
-impl AstNode<Language> for JsConstructorParameterList {
+impl AstNode for JsConstructorParameterList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_CONSTRUCTOR_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsConstructorParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -26734,7 +27100,9 @@ impl AstNode<Language> for JsConstructorParameterList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyConstructorParameter> for JsConstructorParameterList {
+impl AstSeparatedList for JsConstructorParameterList {
+    type Language = Language;
+    type Node = JsAnyConstructorParameter;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsConstructorParameterList {
@@ -26770,7 +27138,8 @@ impl JsDirectiveList {
         }
     }
 }
-impl AstNode<Language> for JsDirectiveList {
+impl AstNode for JsDirectiveList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_DIRECTIVE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsDirectiveList> {
         if Self::can_cast(syntax.kind()) {
@@ -26783,7 +27152,9 @@ impl AstNode<Language> for JsDirectiveList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsDirective> for JsDirectiveList {
+impl AstNodeList for JsDirectiveList {
+    type Language = Language;
+    type Node = JsDirective;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsDirectiveList {
@@ -26819,7 +27190,8 @@ impl JsExportNamedFromSpecifierList {
         }
     }
 }
-impl AstNode<Language> for JsExportNamedFromSpecifierList {
+impl AstNode for JsExportNamedFromSpecifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_FROM_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsExportNamedFromSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -26832,7 +27204,9 @@ impl AstNode<Language> for JsExportNamedFromSpecifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsExportNamedFromSpecifier> for JsExportNamedFromSpecifierList {
+impl AstSeparatedList for JsExportNamedFromSpecifierList {
+    type Language = Language;
+    type Node = JsExportNamedFromSpecifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsExportNamedFromSpecifierList {
@@ -26868,7 +27242,8 @@ impl JsExportNamedSpecifierList {
         }
     }
 }
-impl AstNode<Language> for JsExportNamedSpecifierList {
+impl AstNode for JsExportNamedSpecifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_EXPORT_NAMED_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsExportNamedSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -26881,7 +27256,9 @@ impl AstNode<Language> for JsExportNamedSpecifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyExportNamedSpecifier> for JsExportNamedSpecifierList {
+impl AstSeparatedList for JsExportNamedSpecifierList {
+    type Language = Language;
+    type Node = JsAnyExportNamedSpecifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsExportNamedSpecifierList {
@@ -26917,7 +27294,8 @@ impl JsImportAssertionEntryList {
         }
     }
 }
-impl AstNode<Language> for JsImportAssertionEntryList {
+impl AstNode for JsImportAssertionEntryList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_IMPORT_ASSERTION_ENTRY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsImportAssertionEntryList> {
         if Self::can_cast(syntax.kind()) {
@@ -26930,7 +27308,9 @@ impl AstNode<Language> for JsImportAssertionEntryList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyImportAssertionEntry> for JsImportAssertionEntryList {
+impl AstSeparatedList for JsImportAssertionEntryList {
+    type Language = Language;
+    type Node = JsAnyImportAssertionEntry;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsImportAssertionEntryList {
@@ -26966,7 +27346,8 @@ impl JsMethodModifierList {
         }
     }
 }
-impl AstNode<Language> for JsMethodModifierList {
+impl AstNode for JsMethodModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_METHOD_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsMethodModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -26979,7 +27360,9 @@ impl AstNode<Language> for JsMethodModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyMethodModifier> for JsMethodModifierList {
+impl AstNodeList for JsMethodModifierList {
+    type Language = Language;
+    type Node = JsAnyMethodModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsMethodModifierList {
@@ -27015,7 +27398,8 @@ impl JsModuleItemList {
         }
     }
 }
-impl AstNode<Language> for JsModuleItemList {
+impl AstNode for JsModuleItemList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_MODULE_ITEM_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsModuleItemList> {
         if Self::can_cast(syntax.kind()) {
@@ -27028,7 +27412,9 @@ impl AstNode<Language> for JsModuleItemList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyModuleItem> for JsModuleItemList {
+impl AstNodeList for JsModuleItemList {
+    type Language = Language;
+    type Node = JsAnyModuleItem;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsModuleItemList {
@@ -27064,7 +27450,8 @@ impl JsNamedImportSpecifierList {
         }
     }
 }
-impl AstNode<Language> for JsNamedImportSpecifierList {
+impl AstNode for JsNamedImportSpecifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_NAMED_IMPORT_SPECIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsNamedImportSpecifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27077,7 +27464,9 @@ impl AstNode<Language> for JsNamedImportSpecifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyNamedImportSpecifier> for JsNamedImportSpecifierList {
+impl AstSeparatedList for JsNamedImportSpecifierList {
+    type Language = Language;
+    type Node = JsAnyNamedImportSpecifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsNamedImportSpecifierList {
@@ -27113,7 +27502,8 @@ impl JsObjectAssignmentPatternPropertyList {
         }
     }
 }
-impl AstNode<Language> for JsObjectAssignmentPatternPropertyList {
+impl AstNode for JsObjectAssignmentPatternPropertyList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectAssignmentPatternPropertyList> {
         if Self::can_cast(syntax.kind()) {
@@ -27126,9 +27516,9 @@ impl AstNode<Language> for JsObjectAssignmentPatternPropertyList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyObjectAssignmentPatternMember>
-    for JsObjectAssignmentPatternPropertyList
-{
+impl AstSeparatedList for JsObjectAssignmentPatternPropertyList {
+    type Language = Language;
+    type Node = JsAnyObjectAssignmentPatternMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsObjectAssignmentPatternPropertyList {
@@ -27164,7 +27554,8 @@ impl JsObjectBindingPatternPropertyList {
         }
     }
 }
-impl AstNode<Language> for JsObjectBindingPatternPropertyList {
+impl AstNode for JsObjectBindingPatternPropertyList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectBindingPatternPropertyList> {
         if Self::can_cast(syntax.kind()) {
@@ -27177,9 +27568,9 @@ impl AstNode<Language> for JsObjectBindingPatternPropertyList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyObjectBindingPatternMember>
-    for JsObjectBindingPatternPropertyList
-{
+impl AstSeparatedList for JsObjectBindingPatternPropertyList {
+    type Language = Language;
+    type Node = JsAnyObjectBindingPatternMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsObjectBindingPatternPropertyList {
@@ -27215,7 +27606,8 @@ impl JsObjectMemberList {
         }
     }
 }
-impl AstNode<Language> for JsObjectMemberList {
+impl AstNode for JsObjectMemberList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_OBJECT_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsObjectMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -27228,7 +27620,9 @@ impl AstNode<Language> for JsObjectMemberList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyObjectMember> for JsObjectMemberList {
+impl AstSeparatedList for JsObjectMemberList {
+    type Language = Language;
+    type Node = JsAnyObjectMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsObjectMemberList {
@@ -27264,7 +27658,8 @@ impl JsParameterList {
         }
     }
 }
-impl AstNode<Language> for JsParameterList {
+impl AstNode for JsParameterList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -27277,7 +27672,9 @@ impl AstNode<Language> for JsParameterList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsAnyParameter> for JsParameterList {
+impl AstSeparatedList for JsParameterList {
+    type Language = Language;
+    type Node = JsAnyParameter;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsParameterList {
@@ -27313,7 +27710,8 @@ impl JsPropertyModifierList {
         }
     }
 }
-impl AstNode<Language> for JsPropertyModifierList {
+impl AstNode for JsPropertyModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_PROPERTY_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsPropertyModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27326,7 +27724,9 @@ impl AstNode<Language> for JsPropertyModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyPropertyModifier> for JsPropertyModifierList {
+impl AstNodeList for JsPropertyModifierList {
+    type Language = Language;
+    type Node = JsAnyPropertyModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsPropertyModifierList {
@@ -27362,7 +27762,8 @@ impl JsStatementList {
         }
     }
 }
-impl AstNode<Language> for JsStatementList {
+impl AstNode for JsStatementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_STATEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsStatementList> {
         if Self::can_cast(syntax.kind()) {
@@ -27375,7 +27776,9 @@ impl AstNode<Language> for JsStatementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyStatement> for JsStatementList {
+impl AstNodeList for JsStatementList {
+    type Language = Language;
+    type Node = JsAnyStatement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsStatementList {
@@ -27411,7 +27814,8 @@ impl JsSwitchCaseList {
         }
     }
 }
-impl AstNode<Language> for JsSwitchCaseList {
+impl AstNode for JsSwitchCaseList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_SWITCH_CASE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsSwitchCaseList> {
         if Self::can_cast(syntax.kind()) {
@@ -27424,7 +27828,9 @@ impl AstNode<Language> for JsSwitchCaseList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnySwitchClause> for JsSwitchCaseList {
+impl AstNodeList for JsSwitchCaseList {
+    type Language = Language;
+    type Node = JsAnySwitchClause;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsSwitchCaseList {
@@ -27460,7 +27866,8 @@ impl JsTemplateElementList {
         }
     }
 }
-impl AstNode<Language> for JsTemplateElementList {
+impl AstNode for JsTemplateElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_TEMPLATE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsTemplateElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -27473,7 +27880,9 @@ impl AstNode<Language> for JsTemplateElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsAnyTemplateElement> for JsTemplateElementList {
+impl AstNodeList for JsTemplateElementList {
+    type Language = Language;
+    type Node = JsAnyTemplateElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsTemplateElementList {
@@ -27509,7 +27918,8 @@ impl JsVariableDeclaratorList {
         }
     }
 }
-impl AstNode<Language> for JsVariableDeclaratorList {
+impl AstNode for JsVariableDeclaratorList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JS_VARIABLE_DECLARATOR_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsVariableDeclaratorList> {
         if Self::can_cast(syntax.kind()) {
@@ -27522,7 +27932,9 @@ impl AstNode<Language> for JsVariableDeclaratorList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, JsVariableDeclarator> for JsVariableDeclaratorList {
+impl AstSeparatedList for JsVariableDeclaratorList {
+    type Language = Language;
+    type Node = JsVariableDeclarator;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsVariableDeclaratorList {
@@ -27558,7 +27970,8 @@ impl JsxAttributeList {
         }
     }
 }
-impl AstNode<Language> for JsxAttributeList {
+impl AstNode for JsxAttributeList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_ATTRIBUTE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsxAttributeList> {
         if Self::can_cast(syntax.kind()) {
@@ -27571,7 +27984,9 @@ impl AstNode<Language> for JsxAttributeList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsxAnyAttribute> for JsxAttributeList {
+impl AstNodeList for JsxAttributeList {
+    type Language = Language;
+    type Node = JsxAnyAttribute;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsxAttributeList {
@@ -27607,7 +28022,8 @@ impl JsxChildList {
         }
     }
 }
-impl AstNode<Language> for JsxChildList {
+impl AstNode for JsxChildList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == JSX_CHILD_LIST }
     fn cast(syntax: SyntaxNode) -> Option<JsxChildList> {
         if Self::can_cast(syntax.kind()) {
@@ -27620,7 +28036,9 @@ impl AstNode<Language> for JsxChildList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, JsxAnyChild> for JsxChildList {
+impl AstNodeList for JsxChildList {
+    type Language = Language;
+    type Node = JsxAnyChild;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for JsxChildList {
@@ -27656,7 +28074,8 @@ impl TsEnumMemberList {
         }
     }
 }
-impl AstNode<Language> for TsEnumMemberList {
+impl AstNode for TsEnumMemberList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_ENUM_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsEnumMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -27669,7 +28088,9 @@ impl AstNode<Language> for TsEnumMemberList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsEnumMember> for TsEnumMemberList {
+impl AstSeparatedList for TsEnumMemberList {
+    type Language = Language;
+    type Node = TsEnumMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsEnumMemberList {
@@ -27705,7 +28126,8 @@ impl TsIndexSignatureModifierList {
         }
     }
 }
-impl AstNode<Language> for TsIndexSignatureModifierList {
+impl AstNode for TsIndexSignatureModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INDEX_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsIndexSignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27718,7 +28140,9 @@ impl AstNode<Language> for TsIndexSignatureModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyIndexSignatureModifier> for TsIndexSignatureModifierList {
+impl AstNodeList for TsIndexSignatureModifierList {
+    type Language = Language;
+    type Node = TsAnyIndexSignatureModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsIndexSignatureModifierList {
@@ -27754,7 +28178,8 @@ impl TsIntersectionTypeElementList {
         }
     }
 }
-impl AstNode<Language> for TsIntersectionTypeElementList {
+impl AstNode for TsIntersectionTypeElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_INTERSECTION_TYPE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsIntersectionTypeElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -27767,7 +28192,9 @@ impl AstNode<Language> for TsIntersectionTypeElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsType> for TsIntersectionTypeElementList {
+impl AstSeparatedList for TsIntersectionTypeElementList {
+    type Language = Language;
+    type Node = TsType;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsIntersectionTypeElementList {
@@ -27803,7 +28230,8 @@ impl TsMethodSignatureModifierList {
         }
     }
 }
-impl AstNode<Language> for TsMethodSignatureModifierList {
+impl AstNode for TsMethodSignatureModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_METHOD_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsMethodSignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27816,7 +28244,9 @@ impl AstNode<Language> for TsMethodSignatureModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyMethodSignatureModifier> for TsMethodSignatureModifierList {
+impl AstNodeList for TsMethodSignatureModifierList {
+    type Language = Language;
+    type Node = TsAnyMethodSignatureModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsMethodSignatureModifierList {
@@ -27852,7 +28282,8 @@ impl TsPropertyParameterModifierList {
         }
     }
 }
-impl AstNode<Language> for TsPropertyParameterModifierList {
+impl AstNode for TsPropertyParameterModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_PARAMETER_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsPropertyParameterModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27865,7 +28296,9 @@ impl AstNode<Language> for TsPropertyParameterModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyPropertyParameterModifier> for TsPropertyParameterModifierList {
+impl AstNodeList for TsPropertyParameterModifierList {
+    type Language = Language;
+    type Node = TsAnyPropertyParameterModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsPropertyParameterModifierList {
@@ -27901,7 +28334,8 @@ impl TsPropertySignatureModifierList {
         }
     }
 }
-impl AstNode<Language> for TsPropertySignatureModifierList {
+impl AstNode for TsPropertySignatureModifierList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_PROPERTY_SIGNATURE_MODIFIER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsPropertySignatureModifierList> {
         if Self::can_cast(syntax.kind()) {
@@ -27914,7 +28348,9 @@ impl AstNode<Language> for TsPropertySignatureModifierList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyPropertySignatureModifier> for TsPropertySignatureModifierList {
+impl AstNodeList for TsPropertySignatureModifierList {
+    type Language = Language;
+    type Node = TsAnyPropertySignatureModifier;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsPropertySignatureModifierList {
@@ -27950,7 +28386,8 @@ impl TsTemplateElementList {
         }
     }
 }
-impl AstNode<Language> for TsTemplateElementList {
+impl AstNode for TsTemplateElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TEMPLATE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTemplateElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -27963,7 +28400,9 @@ impl AstNode<Language> for TsTemplateElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyTemplateElement> for TsTemplateElementList {
+impl AstNodeList for TsTemplateElementList {
+    type Language = Language;
+    type Node = TsAnyTemplateElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTemplateElementList {
@@ -27999,7 +28438,8 @@ impl TsTupleTypeElementList {
         }
     }
 }
-impl AstNode<Language> for TsTupleTypeElementList {
+impl AstNode for TsTupleTypeElementList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TUPLE_TYPE_ELEMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTupleTypeElementList> {
         if Self::can_cast(syntax.kind()) {
@@ -28012,7 +28452,9 @@ impl AstNode<Language> for TsTupleTypeElementList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsAnyTupleTypeElement> for TsTupleTypeElementList {
+impl AstSeparatedList for TsTupleTypeElementList {
+    type Language = Language;
+    type Node = TsAnyTupleTypeElement;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTupleTypeElementList {
@@ -28048,7 +28490,8 @@ impl TsTypeArgumentList {
         }
     }
 }
-impl AstNode<Language> for TsTypeArgumentList {
+impl AstNode for TsTypeArgumentList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_ARGUMENT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeArgumentList> {
         if Self::can_cast(syntax.kind()) {
@@ -28061,7 +28504,9 @@ impl AstNode<Language> for TsTypeArgumentList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsType> for TsTypeArgumentList {
+impl AstSeparatedList for TsTypeArgumentList {
+    type Language = Language;
+    type Node = TsType;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTypeArgumentList {
@@ -28097,7 +28542,8 @@ impl TsTypeList {
         }
     }
 }
-impl AstNode<Language> for TsTypeList {
+impl AstNode for TsTypeList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeList> {
         if Self::can_cast(syntax.kind()) {
@@ -28110,7 +28556,9 @@ impl AstNode<Language> for TsTypeList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsNameWithTypeArguments> for TsTypeList {
+impl AstSeparatedList for TsTypeList {
+    type Language = Language;
+    type Node = TsNameWithTypeArguments;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTypeList {
@@ -28146,7 +28594,8 @@ impl TsTypeMemberList {
         }
     }
 }
-impl AstNode<Language> for TsTypeMemberList {
+impl AstNode for TsTypeMemberList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_MEMBER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeMemberList> {
         if Self::can_cast(syntax.kind()) {
@@ -28159,7 +28608,9 @@ impl AstNode<Language> for TsTypeMemberList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstNodeList<Language, TsAnyTypeMember> for TsTypeMemberList {
+impl AstNodeList for TsTypeMemberList {
+    type Language = Language;
+    type Node = TsAnyTypeMember;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTypeMemberList {
@@ -28195,7 +28646,8 @@ impl TsTypeParameterList {
         }
     }
 }
-impl AstNode<Language> for TsTypeParameterList {
+impl AstNode for TsTypeParameterList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_TYPE_PARAMETER_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsTypeParameterList> {
         if Self::can_cast(syntax.kind()) {
@@ -28208,7 +28660,9 @@ impl AstNode<Language> for TsTypeParameterList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsTypeParameter> for TsTypeParameterList {
+impl AstSeparatedList for TsTypeParameterList {
+    type Language = Language;
+    type Node = TsTypeParameter;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsTypeParameterList {
@@ -28244,7 +28698,8 @@ impl TsUnionTypeVariantList {
         }
     }
 }
-impl AstNode<Language> for TsUnionTypeVariantList {
+impl AstNode for TsUnionTypeVariantList {
+    type Language = Language;
     fn can_cast(kind: SyntaxKind) -> bool { kind == TS_UNION_TYPE_VARIANT_LIST }
     fn cast(syntax: SyntaxNode) -> Option<TsUnionTypeVariantList> {
         if Self::can_cast(syntax.kind()) {
@@ -28257,7 +28712,9 @@ impl AstNode<Language> for TsUnionTypeVariantList {
     }
     fn syntax(&self) -> &SyntaxNode { self.syntax_list.node() }
 }
-impl AstSeparatedList<Language, TsType> for TsUnionTypeVariantList {
+impl AstSeparatedList for TsUnionTypeVariantList {
+    type Language = Language;
+    type Node = TsType;
     fn syntax_list(&self) -> &SyntaxList { &self.syntax_list }
 }
 impl Debug for TsUnionTypeVariantList {

--- a/crates/rome_rowan/src/ast/mod.rs
+++ b/crates/rome_rowan/src/ast/mod.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use text_size::TextRange;
 
 use crate::syntax::{SyntaxSlot, SyntaxSlots};
-use crate::{ast, Language, SyntaxList, SyntaxNode, SyntaxToken};
+use crate::{Language, SyntaxList, SyntaxNode, SyntaxToken};
 
 /// The main trait to go from untyped `SyntaxNode`  to a typed ast. The
 /// conversion itself has zero runtime cost: ast and syntax nodes have exactly
@@ -21,7 +21,7 @@ pub trait AstNode {
     type Language: Language;
 
     /// Returns `true` if a node with the given kind can be cased to this AST node.
-    fn can_cast(kind: <<Self as ast::AstNode>::Language as Language>::Kind) -> bool;
+    fn can_cast(kind: <Self::Language as Language>::Kind) -> bool;
 
     /// Tries to cast the passed syntax node to this AST node.
     ///

--- a/crates/rome_rowan/src/raw_language.rs
+++ b/crates/rome_rowan/src/raw_language.rs
@@ -64,7 +64,9 @@ pub struct LiteralExpression {
     node: SyntaxNode<RawLanguage>,
 }
 
-impl AstNode<RawLanguage> for LiteralExpression {
+impl AstNode for LiteralExpression {
+    type Language = RawLanguage;
+
     fn can_cast(kind: RawLanguageKind) -> bool {
         kind == LITERAL_EXPRESSION
     }
@@ -96,7 +98,10 @@ impl SeparatedExpressionList {
     }
 }
 
-impl AstSeparatedList<RawLanguage, LiteralExpression> for SeparatedExpressionList {
+impl AstSeparatedList for SeparatedExpressionList {
+    type Language = RawLanguage;
+    type Node = LiteralExpression;
+
     fn syntax_list(&self) -> &SyntaxList<RawLanguage> {
         &self.syntax_list
     }

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -182,7 +182,9 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                     }
                 },
                 quote! {
-                    impl AstNode<Language> for #name {
+                    impl AstNode for #name {
+                        type Language = Language;
+
                         fn can_cast(kind: SyntaxKind) -> bool {
                             kind == #node_kind
                         }
@@ -399,7 +401,9 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                     }
                     )*
 
-                    impl AstNode<Language> for #name {
+                    impl AstNode for #name {
+                        type Language = Language;
+
                         fn can_cast(kind: SyntaxKind) -> bool {
                             #can_cast_fn
                         }
@@ -493,7 +497,8 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                 }
             }
 
-            impl AstNode<Language> for #name {
+            impl AstNode for #name {
+                type Language = Language;
                 fn can_cast(kind: SyntaxKind) -> bool {
                     kind == #kind
                 }
@@ -550,7 +555,8 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                 }
             }
 
-            impl AstNode<Language> for #list_name {
+            impl AstNode for #list_name {
+                type Language = Language;
                 fn can_cast(kind: SyntaxKind) -> bool {
                     kind == #list_kind
                 }
@@ -572,7 +578,9 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
         let padded_name = format!("{} ", name);
         let list_impl = if list.separator.is_some() {
             quote! {
-                impl AstSeparatedList<Language, #element_type> for #list_name {
+                impl AstSeparatedList for #list_name {
+                    type Language = Language;
+                    type Node = #element_type;
                     fn syntax_list(&self) -> &SyntaxList {
                         &self.syntax_list
                     }
@@ -605,7 +613,9 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
             }
         } else {
             quote! {
-                impl AstNodeList<Language, #element_type> for #list_name {
+                impl AstNodeList for #list_name {
+                    type Language = Language;
+                    type Node = #element_type;
                     fn syntax_list(&self) -> &SyntaxList {
                         &self.syntax_list
                     }


### PR DESCRIPTION
The `AstNode`, `AstNodeList`, and `AstSeparatedList` currently use generics to
parametrize the `Language` and `AstNode` (in case of the lists).

This PR changes the `Ast*` traits to use associated types instead. The semantic
difference of this change is that a single struct can no longer implement the traits for different languages.

Or, as explained in the Rust book:

> With associated types, we don’t need to annotate types because we can’t implement a trait on a type multiple times. In Listing 19-12 with the definition that uses associated types, we can only choose what the type of Item will be once, because there can only be one impl Iterator for Counter. We don’t have to specify that we want an iterator of u32 values everywhere that we call next on Counter. [source](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html)

For example, the following will no longer be possible:

```rust
impl AstNode<JsLanguage> for JsAnyExpression {... }
impl AstNode<CssLanguage> for JsAnyExpression { ... }
```

I don't see a use case where we want to implement `AstNode` for different languages for a specific node.
The only use case that I'm aware of that gets close are super languages, but I think this should instead use a different `Language` and be union types instead.

 Using associated types allows us to create generic trait implementations for `AstNodeList` that otherwise aren't possible because a single node could implement the same trait multiple times:

 ```rust
 impl<T> MyTrait for T
   where T: AstNodeList {
 }
 ```