### PR TITLE
feat(rome_rowan): add `has_comments` API

### DIFF
--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -125,7 +125,7 @@ pub(crate) fn format_binary_like_expression(
             let left = parent.left()?;
 
             let formatted = left.format(formatter)?;
-            let has_comments = left.syntax().has_comments();
+            let has_comments = left.syntax().has_comments_direct();
 
             flatten_items.items.push(FlattenItem::regular(
                 formatted,
@@ -210,7 +210,7 @@ fn format_with_or_without_parenthesis(
     };
 
     let result = if operation_is_higher {
-        let formatted = if node.has_comments() {
+        let formatted = if node.has_comments_direct() {
             let (leading, content, trailing) = formatted_node.split_trivia();
             format_elements![
                 leading,
@@ -322,7 +322,7 @@ impl FlattenItems {
         formatter: &Formatter,
     ) -> FormatResult<()> {
         let right = binary_like_expression.right()?;
-        let has_comments = right.syntax().has_comments();
+        let has_comments = right.syntax().has_comments_direct();
         let right_formatted = right.format(formatter)?;
 
         let (formatted_node, _) = format_with_or_without_parenthesis(

--- a/crates/rome_js_formatter/src/utils/binary_like_expression.rs
+++ b/crates/rome_js_formatter/src/utils/binary_like_expression.rs
@@ -125,7 +125,7 @@ pub(crate) fn format_binary_like_expression(
             let left = parent.left()?;
 
             let formatted = left.format(formatter)?;
-            let has_comments = left.syntax().contains_comments();
+            let has_comments = left.syntax().has_comments();
 
             flatten_items.items.push(FlattenItem::regular(
                 formatted,
@@ -210,7 +210,7 @@ fn format_with_or_without_parenthesis(
     };
 
     let result = if operation_is_higher {
-        let formatted = if node.contains_comments() {
+        let formatted = if node.has_comments() {
             let (leading, content, trailing) = formatted_node.split_trivia();
             format_elements![
                 leading,
@@ -322,7 +322,7 @@ impl FlattenItems {
         formatter: &Formatter,
     ) -> FormatResult<()> {
         let right = binary_like_expression.right()?;
-        let has_comments = right.syntax().contains_comments();
+        let has_comments = right.syntax().has_comments();
         let right_formatted = right.format(formatter)?;
 
         let (formatted_node, _) = format_with_or_without_parenthesis(

--- a/crates/rome_js_formatter/src/utils/mod.rs
+++ b/crates/rome_js_formatter/src/utils/mod.rs
@@ -505,8 +505,12 @@ impl TemplateElement {
 
     fn has_comments(&self) -> bool {
         match self {
-            TemplateElement::Js(template_element) => template_element.syntax().contains_comments(),
-            TemplateElement::Ts(template_element) => template_element.syntax().contains_comments(),
+            TemplateElement::Js(template_element) => {
+                template_element.syntax().has_comments_descendants()
+            }
+            TemplateElement::Ts(template_element) => {
+                template_element.syntax().has_comments_descendants()
+            }
         }
     }
 }

--- a/crates/rome_js_formatter/src/utils/simple.rs
+++ b/crates/rome_js_formatter/src/utils/simple.rs
@@ -83,7 +83,7 @@ pub(crate) fn is_simple_function_expression(func: JsAnyFunction) -> SyntaxResult
     }
 
     if let Some(id) = func.id()? {
-        if id.syntax().has_comments() {
+        if id.syntax().has_comments_direct() {
             return Ok(false);
         }
     }

--- a/crates/rome_js_formatter/src/utils/simple.rs
+++ b/crates/rome_js_formatter/src/utils/simple.rs
@@ -83,7 +83,7 @@ pub(crate) fn is_simple_function_expression(func: JsAnyFunction) -> SyntaxResult
     }
 
     if let Some(id) = func.id()? {
-        if id.syntax().contains_comments() {
+        if id.syntax().has_comments() {
             return Ok(false);
         }
     }

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -369,3 +369,21 @@ pub fn node_contains_leading_comments() {
     assert!(right.syntax().has_leading_comments());
     assert!(!right.syntax().has_trailing_comments());
 }
+
+#[test]
+pub fn node_has_comments() {
+    let text = r"true &&
+// comment
+(3 - 2 == 0)";
+    let root = parse_module(text, 0);
+    let syntax = root.syntax();
+    let node = syntax
+        .descendants()
+        .find(|n| n.kind() == JsSyntaxKind::JS_LOGICAL_EXPRESSION)
+        .unwrap();
+
+    let logical_expression = JsLogicalExpression::cast(node).unwrap();
+    let right = logical_expression.right().unwrap();
+
+    assert!(right.syntax().has_comments());
+}

--- a/crates/rome_js_parser/src/tests.rs
+++ b/crates/rome_js_parser/src/tests.rs
@@ -318,7 +318,7 @@ pub fn node_contains_comments() {
     let root = parse_module(text, 0);
     let syntax = root.syntax();
 
-    assert!(syntax.contains_comments());
+    assert!(syntax.has_comments_descendants());
 }
 
 #[test]
@@ -385,5 +385,5 @@ pub fn node_has_comments() {
     let logical_expression = JsLogicalExpression::cast(node).unwrap();
     let right = logical_expression.right().unwrap();
 
-    assert!(right.syntax().has_comments());
+    assert!(right.syntax().has_comments_direct());
 }

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -374,10 +374,16 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxList::new(self)
     }
 
-    /// Whether the node contains any comments.
+    /// Whether the node contains any comments. This function checks
+    /// **all the descendants** of the current node.
     pub fn contains_comments(&self) -> bool {
         self.descendants_tokens()
             .any(|tok| tok.has_trailing_comments() || tok.has_leading_comments())
+    }
+
+    /// It checks if the current node has trailing or leading trivia
+    pub fn has_comments(&self) -> bool {
+        self.has_trailing_comments() || self.has_leading_comments()
     }
 
     /// Whether the node contains trailing comments.

--- a/crates/rome_rowan/src/syntax/node.rs
+++ b/crates/rome_rowan/src/syntax/node.rs
@@ -376,13 +376,13 @@ impl<L: Language> SyntaxNode<L> {
 
     /// Whether the node contains any comments. This function checks
     /// **all the descendants** of the current node.
-    pub fn contains_comments(&self) -> bool {
+    pub fn has_comments_descendants(&self) -> bool {
         self.descendants_tokens()
             .any(|tok| tok.has_trailing_comments() || tok.has_leading_comments())
     }
 
     /// It checks if the current node has trailing or leading trivia
-    pub fn has_comments(&self) -> bool {
+    pub fn has_comments_direct(&self) -> bool {
         self.has_trailing_comments() || self.has_leading_comments()
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new API to `rome_rowan` called `has_comments`.

This API does a shallow check if the current node contains trivia, it doesn't check the descendants.

I then updated the places where we meant to do a shallow check inside the formatter.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
