### PR TITLE
fix(rome_js_parser): consume `...` in import expression

### DIFF
--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -1235,15 +1235,17 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
                         error_range_start = p.cur_range().start();
                     }
 
-                    if p.at(T![...]) {
+                    let expr = if p.at(T![...]) {
                         let err = p
                             .err_builder("`...` is not allowed in `import()`")
                             .primary(p.cur_range(), "");
                         p.error(err);
+                        parse_spread_element(p, context)
                     } else {
                         parse_assignment_expression_or_higher(p, ExpressionContext::default())
-                            .or_add_diagnostic(p, js_parse_error::expected_expression_assignment);
-                    }
+                    };
+
+                    expr.or_add_diagnostic(p, js_parse_error::expected_expression_assignment);
 
                     if p.at(T![,]) {
                         p.bump_any();

--- a/crates/rome_js_parser/src/syntax/expr.rs
+++ b/crates/rome_js_parser/src/syntax/expr.rs
@@ -1235,17 +1235,20 @@ fn parse_primary_expression(p: &mut Parser, context: ExpressionContext) -> Parse
                         error_range_start = p.cur_range().start();
                     }
 
-                    let expr = if p.at(T![...]) {
-                        let err = p
-                            .err_builder("`...` is not allowed in `import()`")
-                            .primary(p.cur_range(), "");
-                        p.error(err);
+                    if p.at(T![...]) {
                         parse_spread_element(p, context)
+                            .add_diagnostic_if_present(p, |p, range| {
+                                p.err_builder("`...` is not allowed in `import()`")
+                                    .primary(range, "")
+                            })
+                            .map(|mut marker| {
+                                marker.change_to_unknown(p);
+                                marker
+                            });
                     } else {
                         parse_assignment_expression_or_higher(p, ExpressionContext::default())
-                    };
-
-                    expr.or_add_diagnostic(p, js_parse_error::expected_expression_assignment);
+                            .or_add_diagnostic(p, js_parse_error::expected_expression_assignment);
+                    }
 
                     if p.at(T![,]) {
                         p.bump_any();

--- a/crates/rome_js_parser/test_data/inline/err/import_invalid_args.rast
+++ b/crates/rome_js_parser/test_data/inline/err/import_invalid_args.rast
@@ -14,26 +14,34 @@ JsModule {
             semicolon_token: missing (optional),
         },
         JsExpressionStatement {
-            expression: JsImportCallExpression {
-                import_token: IMPORT_KW@8..15 "import" [Newline("\n")] [],
-                arguments: JsCallArguments {
-                    l_paren_token: L_PAREN@15..16 "(" [] [],
-                    args: JsCallArgumentList [
-                        JsSpread {
-                            dotdotdot_token: DOT3@16..19 "..." [] [],
-                            argument: JsArrayExpression {
-                                l_brack_token: L_BRACK@19..20 "[" [] [],
-                                elements: JsArrayElementList [
-                                    JsStringLiteralExpression {
-                                        value_token: JS_STRING_LITERAL@20..25 "\"foo\"" [] [],
+            expression: JsUnknownExpression {
+                items: [
+                    IMPORT_KW@8..15 "import" [Newline("\n")] [],
+                    JsUnknown {
+                        items: [
+                            L_PAREN@15..16 "(" [] [],
+                            JsUnknown {
+                                items: [
+                                    JsUnknown {
+                                        items: [
+                                            DOT3@16..19 "..." [] [],
+                                            JsArrayExpression {
+                                                l_brack_token: L_BRACK@19..20 "[" [] [],
+                                                elements: JsArrayElementList [
+                                                    JsStringLiteralExpression {
+                                                        value_token: JS_STRING_LITERAL@20..25 "\"foo\"" [] [],
+                                                    },
+                                                ],
+                                                r_brack_token: R_BRACK@25..26 "]" [] [],
+                                            },
+                                        ],
                                     },
                                 ],
-                                r_brack_token: R_BRACK@25..26 "]" [] [],
                             },
-                        },
-                    ],
-                    r_paren_token: R_PAREN@26..27 ")" [] [],
-                },
+                            R_PAREN@26..27 ")" [] [],
+                        ],
+                    },
+                ],
             },
             semicolon_token: missing (optional),
         },
@@ -101,12 +109,12 @@ JsModule {
           2: R_PAREN@7..8 ")" [] []
       1: (empty)
     1: JS_EXPRESSION_STATEMENT@8..27
-      0: JS_IMPORT_CALL_EXPRESSION@8..27
+      0: JS_UNKNOWN_EXPRESSION@8..27
         0: IMPORT_KW@8..15 "import" [Newline("\n")] []
-        1: JS_CALL_ARGUMENTS@15..27
+        1: JS_UNKNOWN@15..27
           0: L_PAREN@15..16 "(" [] []
-          1: JS_CALL_ARGUMENT_LIST@16..26
-            0: JS_SPREAD@16..26
+          1: JS_UNKNOWN@16..26
+            0: JS_UNKNOWN@16..26
               0: DOT3@16..19 "..." [] []
               1: JS_ARRAY_EXPRESSION@19..26
                 0: L_BRACK@19..20 "[" [] []
@@ -161,7 +169,7 @@ error[SyntaxError]: `...` is not allowed in `import()`
   ┌─ import_invalid_args.js:2:8
   │
 2 │ import(...["foo"])
-  │        ^^^
+  │        ^^^^^^^^^^
 
 --
 error[SyntaxError]: `import()` requires exactly one or two arguments. 

--- a/crates/rome_js_parser/test_data/inline/err/import_invalid_args.rast
+++ b/crates/rome_js_parser/test_data/inline/err/import_invalid_args.rast
@@ -18,21 +18,22 @@ JsModule {
                 import_token: IMPORT_KW@8..15 "import" [Newline("\n")] [],
                 arguments: JsCallArguments {
                     l_paren_token: L_PAREN@15..16 "(" [] [],
-                    args: JsCallArgumentList [],
-                    r_paren_token: missing (required),
+                    args: JsCallArgumentList [
+                        JsSpread {
+                            dotdotdot_token: DOT3@16..19 "..." [] [],
+                            argument: JsArrayExpression {
+                                l_brack_token: L_BRACK@19..20 "[" [] [],
+                                elements: JsArrayElementList [
+                                    JsStringLiteralExpression {
+                                        value_token: JS_STRING_LITERAL@20..25 "\"foo\"" [] [],
+                                    },
+                                ],
+                                r_brack_token: R_BRACK@25..26 "]" [] [],
+                            },
+                        },
+                    ],
+                    r_paren_token: R_PAREN@26..27 ")" [] [],
                 },
-            },
-            semicolon_token: missing (optional),
-        },
-        JsExpressionStatement {
-            expression: JsUnknownExpression {
-                items: [
-                    DOT3@16..19 "..." [] [],
-                    L_BRACK@19..20 "[" [] [],
-                    JS_STRING_LITERAL@20..25 "\"foo\"" [] [],
-                    R_BRACK@25..26 "]" [] [],
-                    R_PAREN@26..27 ")" [] [],
-                ],
             },
             semicolon_token: missing (optional),
         },
@@ -99,23 +100,23 @@ JsModule {
           1: JS_CALL_ARGUMENT_LIST@7..7
           2: R_PAREN@7..8 ")" [] []
       1: (empty)
-    1: JS_EXPRESSION_STATEMENT@8..16
-      0: JS_IMPORT_CALL_EXPRESSION@8..16
+    1: JS_EXPRESSION_STATEMENT@8..27
+      0: JS_IMPORT_CALL_EXPRESSION@8..27
         0: IMPORT_KW@8..15 "import" [Newline("\n")] []
-        1: JS_CALL_ARGUMENTS@15..16
+        1: JS_CALL_ARGUMENTS@15..27
           0: L_PAREN@15..16 "(" [] []
-          1: JS_CALL_ARGUMENT_LIST@16..16
-          2: (empty)
+          1: JS_CALL_ARGUMENT_LIST@16..26
+            0: JS_SPREAD@16..26
+              0: DOT3@16..19 "..." [] []
+              1: JS_ARRAY_EXPRESSION@19..26
+                0: L_BRACK@19..20 "[" [] []
+                1: JS_ARRAY_ELEMENT_LIST@20..25
+                  0: JS_STRING_LITERAL_EXPRESSION@20..25
+                    0: JS_STRING_LITERAL@20..25 "\"foo\"" [] []
+                2: R_BRACK@25..26 "]" [] []
+          2: R_PAREN@26..27 ")" [] []
       1: (empty)
-    2: JS_EXPRESSION_STATEMENT@16..27
-      0: JS_UNKNOWN_EXPRESSION@16..27
-        0: DOT3@16..19 "..." [] []
-        1: L_BRACK@19..20 "[" [] []
-        2: JS_STRING_LITERAL@20..25 "\"foo\"" [] []
-        3: R_BRACK@25..26 "]" [] []
-        4: R_PAREN@26..27 ")" [] []
-      1: (empty)
-    3: JS_EXPRESSION_STATEMENT@27..78
+    2: JS_EXPRESSION_STATEMENT@27..78
       0: JS_IMPORT_CALL_EXPRESSION@27..78
         0: IMPORT_KW@27..34 "import" [Newline("\n")] []
         1: JS_CALL_ARGUMENTS@34..78


### PR DESCRIPTION
## Summary

Import expression forbids `...`, but the parser didn't consume it, so it created an invalid AST. 

This was noticed when I tried to format
```
import(x, ...y)
```

and it ended up as:
```
import(x,
...y)
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
Ran cargo `UPDATE_EXPECT=1 cargo test parser` and inspected the AST

## Rome Playground
https://play.rome.tools/?lineWidth=80&indentStyle=tab&quoteStyle=double&indentWidth=2&typescript=false&jsx=false&sourceType=module#aQBtAHAAbwByAHQAKAB4ACwAIAAuAC4ALgB5ACkA

p.s. I didn't understand what recoverable meant when I wrote this part of code three months ago.