### PR TITLE
fix(rome_js_formatter): Fix stackoverflow on Windows for nested seque…

### DIFF
--- a/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
+++ b/crates/rome_js_formatter/src/js/expressions/sequence_expression.rs
@@ -1,25 +1,59 @@
 use crate::formatter_traits::FormatTokenAndNode;
+use rome_formatter::concat_elements;
 
 use crate::{
     format_elements, space_token, FormatElement, FormatResult, Formatter, ToFormatElement,
 };
 
-use rome_js_syntax::JsSequenceExpression;
-use rome_js_syntax::JsSequenceExpressionFields;
+use rome_js_syntax::{JsSequenceExpression, JsSequenceExpressionFields};
+use rome_rowan::AstNode;
 
 impl ToFormatElement for JsSequenceExpression {
     fn to_format_element(&self, formatter: &Formatter) -> FormatResult<FormatElement> {
+        let mut current = self.clone();
+
+        // Find the left most sequence expression
+        while let Some(sequence_expression) =
+            JsSequenceExpression::cast(current.left()?.syntax().clone())
+        {
+            current = sequence_expression;
+        }
+
+        // Format the left most sequence expression
         let JsSequenceExpressionFields {
             left,
             comma_token,
             right,
-        } = self.as_fields();
+        } = current.as_fields();
 
-        Ok(format_elements![
+        let mut formatted = vec![
             left.format(formatter)?,
             comma_token.format(formatter)?,
             space_token(),
             right.format(formatter)?,
-        ])
+        ];
+
+        // Traverse upwards again and concatenate the sequence expression until we find the first non-sequence expression
+        while let Some(parent) = current.syntax().parent() {
+            if let Some(parent_sequence) = JsSequenceExpression::cast(parent) {
+                let JsSequenceExpressionFields {
+                    left: _left,
+                    comma_token,
+                    right,
+                } = parent_sequence.as_fields();
+
+                formatted.push(format_elements![
+                    comma_token.format(formatter)?,
+                    space_token(),
+                    right.format(formatter)?
+                ]);
+
+                current = parent_sequence;
+            } else {
+                break;
+            }
+        }
+
+        Ok(concat_elements(formatted))
     }
 }


### PR DESCRIPTION
…nce expressions

Formatting deeply nested sequence expressions is causing a stack overflow on Windows because they are parsed left-recursive:

```js
a, b,c,d
```

Parses to

```yaml
JsExpressionStatement {
    expression: JsSequenceExpression {
        left: JsSequenceExpression {
            left: JsSequenceExpression {
                left: JsIdentifierExpression {
                    name: JsReferenceIdentifier {
                        value_token: IDENT@0..1 "a" [] [],
                    },
                },
                comma_token: COMMA@1..3 "," [] [Whitespace(" ")],
                right: JsIdentifierExpression {
                    name: JsReferenceIdentifier {
                        value_token: IDENT@3..4 "b" [] [],
                    },
                },
            },
            comma_token: COMMA@4..5 "," [] [],
            right: JsIdentifierExpression {
                name: JsReferenceIdentifier {
                    value_token: IDENT@5..6 "c" [] [],
                },
            },
        },
        comma_token: COMMA@6..7 "," [] [],
        right: JsIdentifierExpression {
            name: JsReferenceIdentifier {
                value_token: IDENT@7..8 "d" [] [],
            },
        },
    },
    semicolon_token: missing (optional),
}
```

This PR changes the formatting of sequence expression to unwind the recursion by using a loop
that first finds the left most sequence expression and then concatenates the expressions.

## test

```
cargo bench_formatter --filter d3 --criterion=false
```

No longer panics on Windows
