### PR TITLE
docs: use dark and light logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-	<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="assets/PNG/logo_transparent_outlined.png" width="700">
+	<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="assets/PNG/logo_transparent.png#gh-light-mode-only" width="700">
+	<img alt="Rome's logo depicting an ancient Roman arch with the word Rome to its side" src="assets/PNG/logo_white_yellow_transparent.png#gh-dark-mode-only" width="700">
 </p>
 
 


### PR DESCRIPTION
## Summary

Throwback to #1302 and specifically https://github.com/rome/tools/pull/1302#issuecomment-773417481.

A few months ago GitHub did just that https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/!

This PR replaces the outlined logo with its dark and light version.
## Test Plan

See for yourself https://github.com/jer3m01/rome/tree/docs/readme-logo#readme
