### PR TITLE
chore(xtask): choose language when generating grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -2301,12 +2301,12 @@ name = "xtask_codegen"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "colored",
  "filetime",
  "git2",
  "pico-args",
  "proc-macro2",
  "quote",
+ "termcolor",
  "ungrammar",
  "ureq",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,6 @@ dependencies = [
  "pico-args",
  "proc-macro2",
  "quote",
- "termcolor",
  "ungrammar",
  "ureq",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,7 @@ name = "xtask_codegen"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "colored",
  "filetime",
  "git2",
  "pico-args",

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -15,4 +15,3 @@ walkdir = "2.3.2"
 ureq = "2.4.0"
 git2 = { version = "0.13.25", default-features = false }
 filetime = "0.2.15"
-termcolor = "1.1.3"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -15,4 +15,4 @@ walkdir = "2.3.2"
 ureq = "2.4.0"
 git2 = { version = "0.13.25", default-features = false }
 filetime = "0.2.15"
-colored = "2.0.0"
+termcolor = "1.1.3"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -15,3 +15,4 @@ walkdir = "2.3.2"
 ureq = "2.4.0"
 git2 = { version = "0.13.25", default-features = false }
 filetime = "0.2.15"
+colored = "2.0.0"

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -2,6 +2,7 @@
 //! This is derived from rust-analyzer/xtask/codegen
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::str::FromStr;
 use std::vec;
 
 use super::{
@@ -40,7 +41,7 @@ pub fn generate_ast(mode: Mode, args: Arguments) -> Result<()> {
     } else {
         arg_list
             .iter()
-            .filter_map(|kind| LanguageKind::from_string(kind.to_str().unwrap()))
+            .filter_map(|kind| LanguageKind::from_str(kind.to_str().unwrap()).ok())
             .collect::<Vec<_>>()
     };
     for kind in codegen_language_kinds {

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -13,6 +13,7 @@ use crate::css_kinds_src::CSS_KINDS_SRC;
 use crate::generate_syntax_factory::generate_syntax_factory;
 use crate::json_kinds_src::JSON_KINDS_SRC;
 use crate::kinds_src::{AstListSeparatorConfiguration, AstListSrc, TokenKind};
+use crate::println_string_with_fg_color;
 use crate::{
     generate_macros::generate_macros,
     generate_nodes::generate_nodes,
@@ -20,9 +21,6 @@ use crate::{
     kinds_src::{AstEnumSrc, AstNodeSrc, JS_KINDS_SRC},
     update, LanguageKind,
 };
-use std::io::Write;
-use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
-
 use pico_args::Arguments;
 use termcolor::Color;
 use ungrammar::{Grammar, Rule, Token};
@@ -41,18 +39,25 @@ pub fn generate_ast(mode: Mode, args: Arguments) -> Result<()> {
     } else {
         arg_list
             .iter()
-            .filter_map(|kind| LanguageKind::from_str(kind.to_str().unwrap()).ok())
+            .filter_map(
+                |kind| match LanguageKind::from_str(kind.to_str().unwrap()) {
+                    Ok(kind) => Some(kind),
+                    Err(err) => {
+                        println_string_with_fg_color(err, Color::Red).unwrap();
+                        None
+                    }
+                },
+            )
             .collect::<Vec<_>>()
     };
     for kind in codegen_language_kinds {
-        let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
-        writeln!(
-            &mut stdout,
-            "-------------------Generating AST for {:?}-------------------",
-            kind
+        println_string_with_fg_color(
+            format!(
+                "-------------------Generating AST for {:?}-------------------",
+                kind
+            ),
+            Color::Green,
         )?;
-        stdout.set_color(ColorSpec::new().set_fg(None))?;
         let mut ast = match kind {
             LanguageKind::Js => load_js_ast(),
             LanguageKind::Css => load_css_ast(),

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -48,8 +48,8 @@ pub fn generate_ast(mode: Mode, args: Arguments) -> Result<()> {
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
         writeln!(
             &mut stdout,
-            "-------------------{}-------------------",
-            format!("Generating AST for {:?}", kind)
+            "-------------------Generating AST for {:?}-------------------",
+            kind
         )?;
         stdout.set_color(ColorSpec::new().set_fg(None))?;
         let mut ast = match kind {

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -19,8 +19,11 @@ use crate::{
     kinds_src::{AstEnumSrc, AstNodeSrc, JS_KINDS_SRC},
     update, LanguageKind,
 };
-use colored::Colorize;
+use std::io::Write;
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
+
 use pico_args::Arguments;
+use termcolor::Color;
 use ungrammar::{Grammar, Rule, Token};
 use xtask::{project_root, Result};
 
@@ -41,10 +44,14 @@ pub fn generate_ast(mode: Mode, args: Arguments) -> Result<()> {
             .collect::<Vec<_>>()
     };
     for kind in codegen_language_kinds {
-        println!(
+        let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        writeln!(
+            &mut stdout,
             "-------------------{}-------------------",
-            format!("Generating AST for {:?}", kind).green()
-        );
+            format!("Generating AST for {:?}", kind)
+        )?;
+        stdout.set_color(ColorSpec::new().set_fg(None))?;
         let mut ast = match kind {
             LanguageKind::Js => load_js_ast(),
             LanguageKind::Css => load_css_ast(),

--- a/xtask/codegen/src/ast.rs
+++ b/xtask/codegen/src/ast.rs
@@ -13,7 +13,8 @@ use crate::css_kinds_src::CSS_KINDS_SRC;
 use crate::generate_syntax_factory::generate_syntax_factory;
 use crate::json_kinds_src::JSON_KINDS_SRC;
 use crate::kinds_src::{AstListSeparatorConfiguration, AstListSrc, TokenKind};
-use crate::println_string_with_fg_color;
+use crate::termcolorful::{println_string_with_fg_color, Color};
+use crate::ALL_LANGUAGE_KIND;
 use crate::{
     generate_macros::generate_macros,
     generate_nodes::generate_nodes,
@@ -21,43 +22,35 @@ use crate::{
     kinds_src::{AstEnumSrc, AstNodeSrc, JS_KINDS_SRC},
     update, LanguageKind,
 };
-use pico_args::Arguments;
-use termcolor::Color;
 use ungrammar::{Grammar, Rule, Token};
 use xtask::{project_root, Result};
 
 // these node won't generate any code
 pub const SYNTAX_ELEMENT_TYPE: &str = "SyntaxElement";
 
-pub const ALL_LANGUAGE_KIND: [LanguageKind; 3] =
-    [LanguageKind::Js, LanguageKind::Css, LanguageKind::Json];
-
-pub fn generate_ast(mode: Mode, args: Arguments) -> Result<()> {
-    let arg_list = args.finish();
-    let codegen_language_kinds = if arg_list.is_empty() {
+pub fn generate_ast(mode: Mode, language_kind_list: Vec<String>) -> Result<()> {
+    let codegen_language_kinds = if language_kind_list.is_empty() {
         ALL_LANGUAGE_KIND.clone().to_vec()
     } else {
-        arg_list
+        language_kind_list
             .iter()
-            .filter_map(
-                |kind| match LanguageKind::from_str(kind.to_str().unwrap()) {
-                    Ok(kind) => Some(kind),
-                    Err(err) => {
-                        println_string_with_fg_color(err, Color::Red).unwrap();
-                        None
-                    }
-                },
-            )
+            .filter_map(|kind| match LanguageKind::from_str(kind) {
+                Ok(kind) => Some(kind),
+                Err(err) => {
+                    println_string_with_fg_color(err, Color::Red);
+                    None
+                }
+            })
             .collect::<Vec<_>>()
     };
     for kind in codegen_language_kinds {
         println_string_with_fg_color(
             format!(
-                "-------------------Generating AST for {:?}-------------------",
+                "-------------------Generating AST for {}-------------------",
                 kind
             ),
             Color::Green,
-        )?;
+        );
         let mut ast = match kind {
             LanguageKind::Js => load_js_ast(),
             LanguageKind::Css => load_css_ast(),

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -11,15 +11,12 @@ mod generate_syntax_kinds;
 mod json_kinds_src;
 mod kinds_src;
 mod parser_tests;
+mod termcolorful;
 mod unicode;
-
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::path::Path;
 use std::str::FromStr;
-
-use termcolor::Color;
-use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use xtask::{glue::fs2, Mode, Result};
 
@@ -54,6 +51,19 @@ pub enum LanguageKind {
     Css,
     Json,
 }
+
+impl std::fmt::Display for LanguageKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LanguageKind::Js => write!(f, "js"),
+            LanguageKind::Css => write!(f, "css"),
+            LanguageKind::Json => write!(f, "json"),
+        }
+    }
+}
+
+pub const ALL_LANGUAGE_KIND: [LanguageKind; 3] =
+    [LanguageKind::Js, LanguageKind::Css, LanguageKind::Json];
 
 impl FromStr for LanguageKind {
     type Err = String;
@@ -174,14 +184,4 @@ pub fn to_lower_snake_case(s: &str) -> String {
         buf.push(c.to_ascii_lowercase());
     }
     buf
-}
-
-pub fn println_string_with_fg_color(content: String, color: Color) -> std::io::Result<()> {
-    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-    stdout
-        .set_color(ColorSpec::new().set_fg(Some(color)))
-        .unwrap();
-    println!("{}", content);
-    stdout.set_color(ColorSpec::new().set_fg(None)).unwrap();
-    Ok(())
 }

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -16,6 +16,7 @@ mod unicode;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::path::Path;
+use std::str::FromStr;
 
 use xtask::{glue::fs2, Mode, Result};
 
@@ -51,15 +52,20 @@ pub enum LanguageKind {
     Json,
 }
 
-impl LanguageKind {
-    pub(crate) fn from_string(kind: &str) -> Option<Self> {
+impl FromStr for LanguageKind {
+    type Err = ();
+
+    fn from_str(kind: &str) -> Result<Self, Self::Err> {
         match kind {
-            "js" => Some(LanguageKind::Js),
-            "css" => Some(LanguageKind::Css),
-            "json" => Some(LanguageKind::Json),
-            _ => None,
+            "js" => Ok(LanguageKind::Js),
+            "css" => Ok(LanguageKind::Css),
+            "json" => Ok(LanguageKind::Json),
+            _ => Err(()),
         }
     }
+}
+
+impl LanguageKind {
     pub(crate) fn syntax_kind(&self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxKind },

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -18,6 +18,9 @@ use quote::quote;
 use std::path::Path;
 use std::str::FromStr;
 
+use termcolor::Color;
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
+
 use xtask::{glue::fs2, Mode, Result};
 
 pub use self::ast::generate_ast;
@@ -53,14 +56,17 @@ pub enum LanguageKind {
 }
 
 impl FromStr for LanguageKind {
-    type Err = ();
+    type Err = String;
 
     fn from_str(kind: &str) -> Result<Self, Self::Err> {
         match kind {
             "js" => Ok(LanguageKind::Js),
             "css" => Ok(LanguageKind::Css),
             "json" => Ok(LanguageKind::Json),
-            _ => Err(()),
+            _ => Err(format!(
+                "Language {} not supported, please use: `js`, `css` or `json`",
+                kind
+            )),
         }
     }
 }
@@ -168,4 +174,14 @@ pub fn to_lower_snake_case(s: &str) -> String {
         buf.push(c.to_ascii_lowercase());
     }
     buf
+}
+
+pub fn println_string_with_fg_color(content: String, color: Color) -> std::io::Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+    stdout
+        .set_color(ColorSpec::new().set_fg(Some(color)))
+        .unwrap();
+    println!("{}", content);
+    stdout.set_color(ColorSpec::new().set_fg(None)).unwrap();
+    Ok(())
 }

--- a/xtask/codegen/src/lib.rs
+++ b/xtask/codegen/src/lib.rs
@@ -52,6 +52,14 @@ pub enum LanguageKind {
 }
 
 impl LanguageKind {
+    pub(crate) fn from_string(kind: &str) -> Option<Self> {
+        match kind {
+            "js" => Some(LanguageKind::Js),
+            "css" => Some(LanguageKind::Css),
+            "json" => Some(LanguageKind::Json),
+            _ => None,
+        }
+    }
     pub(crate) fn syntax_kind(&self) -> TokenStream {
         match self {
             LanguageKind::Js => quote! { JsSyntaxKind },

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -8,10 +8,9 @@ fn main() -> Result<()> {
 
     let mut args = Arguments::from_env();
     let command = args.subcommand()?.unwrap_or_default();
-
     match command.as_str() {
         "grammar" => {
-            generate_ast(Mode::Overwrite)?;
+            generate_ast(Mode::Overwrite, args)?;
             Ok(())
         }
         "formatter" => {

--- a/xtask/codegen/src/main.rs
+++ b/xtask/codegen/src/main.rs
@@ -10,7 +10,12 @@ fn main() -> Result<()> {
     let command = args.subcommand()?.unwrap_or_default();
     match command.as_str() {
         "grammar" => {
-            generate_ast(Mode::Overwrite, args)?;
+            let arg_list = args.finish();
+            let language_list = arg_list
+                .into_iter()
+                .filter_map(|arg| arg.to_str().map(|item| item.to_string()))
+                .collect::<Vec<_>>();
+            generate_ast(Mode::Overwrite, language_list)?;
             Ok(())
         }
         "formatter" => {

--- a/xtask/codegen/src/termcolorful.rs
+++ b/xtask/codegen/src/termcolorful.rs
@@ -1,0 +1,29 @@
+#[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) enum Color {
+    Red,
+    Green,
+    Black,
+    Yellow,
+    Blue,
+    Purple,
+    Cyan,
+    White,
+}
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Color::Black => write!(f, "30"),
+            Color::Red => write!(f, "31"),
+            Color::Green => write!(f, "32"),
+            Color::Yellow => write!(f, "33"),
+            Color::Blue => write!(f, "34"),
+            Color::Purple => write!(f, "35"),
+            Color::Cyan => write!(f, "36"),
+            Color::White => write!(f, "37"),
+        }
+    }
+}
+pub(crate) fn println_string_with_fg_color(content: String, color: Color) {
+    println!("\x1b[0;{}m{}\x1b[0m", color, content);
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

	Once created, your PR will be automatically labeled according to changed files.

	Learn more about contributing: https://github.com/rome/tools/blob/main/CONTRIBUTING.md
-->

## Summary
introduce ability to optional codegen for specific language kind

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
1.  run `cargo codegen grammar` should code gen all ungram just like before
2. run `cargo codegen Json css` should warn you `Json` language is not support, but code gen `css` ungram works just
fine
![image](https://user-images.githubusercontent.com/17974631/165033283-01a444b5-f556-45ee-a1e1-d5c5eb65901a.png)
![image](https://user-images.githubusercontent.com/17974631/165033323-bb26232e-dc69-4897-b9c9-e4e7b2ea52ea.png)

3. run `cargo codegen json css` should codegen `json` and `css` ungram 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
