### PR TITLE
fix(rome_rowan): fix syntaxtokentext display infinite recursion

### DIFF
--- a/crates/rome_rowan/src/syntax/token.rs
+++ b/crates/rome_rowan/src/syntax/token.rs
@@ -48,6 +48,22 @@ impl<L: Language> SyntaxToken<L> {
     }
 
     /// Returns the text of a token, including all trivia as an owned value.
+    ///  
+    /// ```
+    /// use rome_rowan::*;
+    /// use rome_rowan::raw_language::{RawLanguage, RawLanguageKind, RawSyntaxTreeBuilder};
+    /// let mut token = RawSyntaxTreeBuilder::wrap_with_node(RawLanguageKind::ROOT,|builder| {
+    ///     builder.token_with_trivia(
+    ///         RawLanguageKind::LET_TOKEN,
+    ///         "\n\t let \t\t",
+    ///         &[TriviaPiece::whitespace(3)],
+    ///         &[TriviaPiece::whitespace(3)],
+    ///     );
+    /// }).first_token().unwrap();
+    /// assert_eq!("\n\t let \t\t", token.token_text());
+    /// assert_eq!(format!("{}", "\n\t let \t\t"), format!("{}", token.token_text()));
+    /// assert_eq!(format!("{:?}", "\n\t let \t\t"), format!("{:?}", token.token_text()));
+    /// ```
     pub fn token_text(&self) -> SyntaxTokenText {
         self.raw.token_text()
     }

--- a/crates/rome_rowan/src/syntax_token_text.rs
+++ b/crates/rome_rowan/src/syntax_token_text.rs
@@ -39,25 +39,29 @@ impl SyntaxTokenText {
         self.range = range;
         self
     }
+
+    pub fn text(&self) -> &str {
+        &self.token.text()[self.range]
+    }
 }
 
 impl Deref for SyntaxTokenText {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        &self.token.text()[self.range]
+        self.text()
     }
 }
 
 impl std::fmt::Display for SyntaxTokenText {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", *self)
+        write!(f, "{}", self.text())
     }
 }
 
 impl std::fmt::Debug for SyntaxTokenText {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", *self)
+        write!(f, "{:?}", self.text())
     }
 }
 impl PartialEq for SyntaxTokenText {


### PR DESCRIPTION
Fix the infinite recursion of the playground.

![image](https://user-images.githubusercontent.com/83425/164429838-4ec55edd-1da5-487d-ba2a-bd1661ecc6bd.png)
